### PR TITLE
Change RSACrypto and KeyDictionary to be Public

### DIFF
--- a/SteamKit2/SteamKit2/Util/CryptoHelper.cs
+++ b/SteamKit2/SteamKit2/Util/CryptoHelper.cs
@@ -12,7 +12,7 @@ using System.Text;
 
 namespace SteamKit2
 {
-    class RSACrypto : IDisposable
+    public class RSACrypto : IDisposable
     {
         RSACryptoServiceProvider rsa;
 

--- a/SteamKit2/SteamKit2/Util/KeyDictionary.cs
+++ b/SteamKit2/SteamKit2/Util/KeyDictionary.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SteamKit2
 {
-    static class KeyDictionary
+    public static class KeyDictionary
     {
         static Dictionary<EUniverse, byte[]> keys = new Dictionary<EUniverse, byte[]>()
         {


### PR DESCRIPTION
We use these classes in SteamBot, and I'd much prefer to not have to add modifications to SteamKit before we can use it with SteamBot.  These classes are used to log in with their API interface (ISteamUserAuth/AuthenticateUser).  Sorry about the line endings, I can fix that if it's a problem.
