### PR TITLE
Change RSACrypto and KeyDictionary to be Public

### DIFF
--- a/SteamKit2/SteamKit2/Util/CryptoHelper.cs
+++ b/SteamKit2/SteamKit2/Util/CryptoHelper.cs
@@ -12,11 +12,19 @@ using System.Text;
 
 namespace SteamKit2
 {
+
+    /// <summary>
+    /// Handles encrypting and decrypting using the RSA public key encryption
+    /// algorithm.
+    /// </summary>
     public class RSACrypto : IDisposable
     {
         RSACryptoServiceProvider rsa;
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SteamKit2.RSACrypto"/> class.
+        /// </summary>
+        /// <param name="key">The public key to encrypt with.</param>
         public RSACrypto( byte[] key )
         {
             AsnKeyParser keyParser = new AsnKeyParser( key );
@@ -25,13 +33,19 @@ namespace SteamKit2
             rsa.ImportParameters( keyParser.ParseRSAPublicKey() );
         }
 
-
+        /// <summary>
+        /// Encrypt the specified input.
+        /// </summary>
+        /// <returns>The encrypted input.</returns>
+        /// <param name="input">The input to encrypt.</param>
         public byte[] Encrypt( byte[] input )
         {
             return rsa.Encrypt( input, true );
         }
 
-
+        /// <summary>
+        /// Disposes of this class.
+        /// </summary>
         public void Dispose()
         {
             ( ( IDisposable )rsa ).Dispose();

--- a/SteamKit2/SteamKit2/Util/KeyDictionary.cs
+++ b/SteamKit2/SteamKit2/Util/KeyDictionary.cs
@@ -9,6 +9,10 @@ using System.Collections.Generic;
 
 namespace SteamKit2
 {
+    /// <summary>
+    /// Contains the public keys that Steam uses for each of the <see cref="EUniverse"/>
+    /// types.
+    /// </summary>
     public static class KeyDictionary
     {
         static Dictionary<EUniverse, byte[]> keys = new Dictionary<EUniverse, byte[]>()
@@ -61,7 +65,11 @@ namespace SteamKit2
            },
         };
 
-
+        /// <summary>
+        /// Gets the public key for the given universe.
+        /// </summary>
+        /// <returns>The public key.</returns>
+        /// <param name="eUniverse">The universe.</param>
         public static byte[] GetPublicKey( EUniverse eUniverse )
         {
             if ( keys.ContainsKey( eUniverse ) )


### PR DESCRIPTION
We use these classes in SteamBot, and I'd much prefer to not have to add modifications to SteamKit before we can use it with SteamBot.  These classes are used to log in with their API interface (ISteamUserAuth/AuthenticateUser).  I fixed the line endings in the files.
