### PR TITLE
Made it easier to use ClientMsgProtobuf<BodyType> and ClientMsg<BodyType>

### DIFF
--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -96,14 +96,26 @@ namespace SteamKit2
         /// This is a client send constructor.
         /// </summary>
         /// <param name="eMsg">The network message type this client message represents.</param>
+        /// <param name="body">The body of the message, ex <see cref="CMsgClientGamesPlayed"/>.</param>
         /// <param name="payloadReserve">The number of bytes to initialize the payload capacity to.</param>
-        public ClientMsgProtobuf( EMsg eMsg, int payloadReserve = 64 )
-            : base( payloadReserve )
+        public ClientMsgProtobuf(EMsg eMsg, BodyType body, int payloadReserve = 64)
+            : base(payloadReserve)
         {
-            Body = new BodyType();
+            Body = body;
 
             // set our emsg
             Header.Msg = eMsg;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientMsgProtobuf&lt;BodyType&gt;"/> class with an empty body.
+        /// This is a client send constructor.
+        /// </summary>
+        /// <param name="eMsg">The network message type this client message represents.</param>
+        /// <param name="payloadReserve">The number of bytes to initialize the payload capacity to.</param>
+        public ClientMsgProtobuf( EMsg eMsg, int payloadReserve = 64 )
+            : this(eMsg, new BodyType(), payloadReserve )
+        {
         }
 
         /// <summary>
@@ -249,15 +261,29 @@ namespace SteamKit2
         /// Initializes a new instance of the <see cref="ClientMsg&lt;BodyType&gt;"/> class.
         /// This is a client send constructor.
         /// </summary>
+        /// <param name="body">The body this message should contain.</param>
         /// <param name="payloadReserve">The number of bytes to initialize the payload capacity to.</param>
-        public ClientMsg( int payloadReserve = 64 )
-            : base( payloadReserve )
+        public ClientMsg(BodyType body, int payloadReserve = 64)
+            : base(payloadReserve)
         {
-            Body = new BodyType();
+            Body = body;
 
             // assign our emsg
-            Header.SetEMsg( Body.GetEMsg() );
+            Header.SetEMsg(Body.GetEMsg());
         }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientMsg&lt;BodyType&gt;"/> class with an empty body.
+        /// This is a client send constructor.
+        /// </summary>
+        /// <param name="payloadReserve">The number of bytes to initialize the payload capacity to.</param>
+        public ClientMsg( int payloadReserve = 64 )
+            : this(new BodyType(), payloadReserve )
+        {
+            
+        }
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientMsg&lt;BodyType&gt;"/> class.


### PR DESCRIPTION
ClientMsgProtobuf<BodyType> and ClientMsg<BodyType> are in their current form makes it rather tedious to create wrapper APIs around specific game messages since you have to take all the relevant fields of a message as arguments to the function and manually assign each to the same field in the body.
This PR fixes that by adding an extra constructor that takes a BodyType instance as parameter so the wrapper API can simply do the same instead of a parameter for every single field in the message.

Essentailly this results in being able to wrap up resending and waiting for message responses in a neat generic class that can handle messages.

Example of how a wrapper function looks currently:

```
public async Task<CMsgSourceTVGamesResponse> FindSourceTVGames(ulong custGameId, uint heroId, uint leagueId, uint numGames, string searchKey, DateTime start, bool teamGames)
{
    CheckStatus();
    var req = new ClientGCMsgProtobuf<CMsgFindSourceTVGames>((uint)EDOTAGCMsg.k_EMsgGCFindSourceTVGames)
    {
        SourceJobID = _steam.GetNextJobID()
    };

    req.Body.custom_game_id = custGameId;
    req.Body.heroid = heroId;
    req.Body.leagueid = leagueId;
    req.Body.num_games = numGames;
    req.Body.search_key = searchKey;
    req.Body.start = ToUnixTime(start);
    req.Body.team_game = teamGames;

    return await _sourceTVGamesHandler.Request(req);
}
```

And how it would look with this PR:

```
public async Task<CMsgSourceTVGamesResponse> FindSourceTVGames(CMsgFindSourceTVGames msg)
{
    CheckStatus();

    var req = new ClientGCMsgProtobuf<CMsgFindSourceTVGames>((uint)EDOTAGCMsg.k_EMsgGCFindSourceTVGames, msg)
    {
        SourceJobID = _steam.GetNextJobID()
    };


    return await _sourceTVGamesHandler.Request(req);
}
```
