### PR TITLE
CallbackMsgExtensions.Handle() now returns whether the handler was called

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMsg.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMsg.cs
@@ -49,10 +49,13 @@ namespace SteamKit2
         /// <typeparam name="T">The type to check against.</typeparam>
         /// <param name="msg">The callback in question.</param>
         /// <param name="handler">The handler to invoke.</param>
+        /// <returns>
+        /// 	<c>true</c> if the callback matches and the handler was called; otherwise, <c>false</c>.
+        /// </returns>
         /// <exception cref="ArgumentNullException">
         /// 	<c>msg</c> is null or <c>handler</c> is null.
         /// </exception>
-        public static void Handle<T>( this ICallbackMsg msg, Action<T> handler )
+        public static bool Handle<T>( this ICallbackMsg msg, Action<T> handler )
             where T : class, ICallbackMsg
         {
             if ( msg == null )
@@ -66,7 +69,10 @@ namespace SteamKit2
             if ( callback != null )
             {
                 handler( callback );
+                return true;
             }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
Currently, `CallbackMsgExtensions.Handle<T>(ICallbackMsg, Action<T>)` returns `void`. However, this significantly increases the complexity of code that needs to detect unhandled callbacks.

With this change, you can just do something like this:

``` csharp
if (!msg.Handle<SteamUser.UpdateMachineAuthCallback>(callback =>
{
    // handle UpdateMachineAuthCallback
}) && !msg.Handle<SteamUser.SessionTokenCallback>(callback =>
{
    // handle SessionTokenCallback
}))
{
    // unhandled callback
}
```
