### PR TITLE
Post DisconnectedCallback when SteamClient.Disconnect() is called

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/Connection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/Connection.cs
@@ -27,6 +27,16 @@ namespace SteamKit2
         }
     }
 
+    class DisconnectedEventArgs : EventArgs
+    {
+        public bool UserInitiated { get; private set; }
+
+        public DisconnectedEventArgs( bool userInitiated )
+        {
+            this.UserInitiated = userInitiated;
+        }
+    }
+
     class NetFilterEncryption
     {
         byte[] sessionKey;
@@ -90,8 +100,8 @@ namespace SteamKit2
         /// <summary>
         /// Occurs when the physical connection is broken.
         /// </summary>
-        public event EventHandler Disconnected;
-        protected void OnDisconnected( EventArgs e )
+        public event EventHandler<DisconnectedEventArgs> Disconnected;
+        protected void OnDisconnected( DisconnectedEventArgs e )
         {
             if ( Disconnected != null )
                 Disconnected( this, e );

--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -55,7 +55,7 @@ namespace SteamKit2
             }
         }
 
-        private void Release(bool notifyUser)
+        private void Release( bool userRequestedDisconnect )
         {
             lock (netLock)
             {
@@ -86,12 +86,9 @@ namespace SteamKit2
                 netFilter = null;
             }
 
-            connectionFree.Set();
+            OnDisconnected( new DisconnectedEventArgs( userRequestedDisconnect ) );
 
-            if (notifyUser)
-            {
-                OnDisconnected(EventArgs.Empty);
-            }
+            connectionFree.Set();
         }
 
         private void ConnectCompleted(bool success)
@@ -101,13 +98,13 @@ namespace SteamKit2
             {
                 DebugLog.WriteLine("TcpConnection", "Connection request to {0} was cancelled", destination);
                 if (success) Shutdown();
-                Release(false);
+                Release( userRequestedDisconnect: true );
                 return;
             }
             else if (!success)
             {
                 DebugLog.WriteLine("TcpConnection", "Timed out while connecting to {0}", destination);
-                Release(true);
+                Release( userRequestedDisconnect: false );
                 return;
             }
 
@@ -133,7 +130,7 @@ namespace SteamKit2
             catch (Exception ex)
             {
                 DebugLog.WriteLine("TcpConnection", "Exception while setting up connection to {0}: {1}", destination, ex);
-                Release(true);
+                Release( userRequestedDisconnect: false );
             }
         }
 
@@ -143,7 +140,7 @@ namespace SteamKit2
             if (cancellationToken.IsCancellationRequested)
             {
                 DebugLog.WriteLine("TcpConnection", "Connection to {0} cancelled by user", destination);
-                Release(false);
+                Release( userRequestedDisconnect: true );
                 return;
             }
 
@@ -272,8 +269,8 @@ namespace SteamKit2
             // Thread is shutting down, ensure socket is shut down and disposed
             bool userShutdown = cancellationToken.IsCancellationRequested;
 
-            if (userShutdown) Shutdown();
-            Release(!userShutdown);
+            if ( userShutdown ) Shutdown();
+            Release( userShutdown );
         }
 
         byte[] ReadPacket()

--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
@@ -364,6 +364,7 @@ namespace SteamKit2
             // Begin by sending off the challenge request
             SendPacket(new UdpPacket(EUdpPacketType.ChallengeReq));
             state = State.ChallengeReqSent;
+            var userRequestedDisconnect = false;
 
             while ( state != State.Disconnected )
             {
@@ -423,11 +424,12 @@ namespace SteamKit2
                     DebugLog.WriteLine("UdpConnection", "Graceful disconnect completed");
 
                     state = State.Disconnected;
+                    userRequestedDisconnect = true;
                 }
             }
 
             DebugLog.WriteLine("UdpConnection", "Calling OnDisconnected");
-            OnDisconnected(EventArgs.Empty);
+            OnDisconnected( new DisconnectedEventArgs( userRequestedDisconnect ) );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -313,7 +313,7 @@ namespace SteamKit2.Internal
         /// <summary>
         /// Called when the client is physically disconnected from Steam3.
         /// </summary>
-        protected abstract void OnClientDisconnected();
+        protected abstract void OnClientDisconnected( bool userInitiated );
 
 
         void NetMsgReceived( object sender, NetMsgEventArgs e )
@@ -321,13 +321,13 @@ namespace SteamKit2.Internal
             OnClientMsgReceived( GetPacketMsg( e.Data ) );
         }
 
-        void Disconnected( object sender, EventArgs e )
+        void Disconnected( object sender, DisconnectedEventArgs e )
         {
             ConnectedUniverse = EUniverse.Invalid;
 
             heartBeatFunc.Stop();
 
-            OnClientDisconnected();
+            OnClientDisconnected( e.UserInitiated );
         }
 
         internal static IPacketMsg GetPacketMsg( byte[] data )

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Callbacks.cs
@@ -43,6 +43,17 @@ namespace SteamKit2
         /// </summary>
         public sealed class DisconnectedCallback : CallbackMsg
         {
+            /// <summary>
+            /// If true, the disconnection was initiated by calling <see cref="CMClient.Disconnect"/>.
+            /// If false, the disconnection was the cause of something not user-controlled, such as a network failure or
+            /// a forcible disconnection by the remote server.
+            /// </summary>
+            public bool UserInitiated { get; private set; }
+
+            internal DisconnectedCallback( bool userInitiated )
+            {
+                this.UserInitiated = userInitiated;
+            }
         }
 
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -310,9 +310,9 @@ namespace SteamKit2
         /// <summary>
         /// Called when the client is physically disconnected from Steam3.
         /// </summary>
-        protected override void OnClientDisconnected()
+        protected override void OnClientDisconnected( bool userInitiated )
         {
-            this.PostCallback( new DisconnectedCallback() );
+            this.PostCallback( new DisconnectedCallback( userInitiated ) );
         }
 
 

--- a/SteamKit2/SteamKit2/Steam/UFSClient/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/UFSClient/Callbacks.cs
@@ -41,6 +41,17 @@ namespace SteamKit2
         /// </summary>
         public sealed class DisconnectedCallback : CallbackMsg
         {
+            /// <summary>
+            /// If true, the disconnection was initiated by calling <see cref="UFSClient.Disconnect"/>.
+            /// If false, the disconnection was the cause of something not user-controlled, such as a network failure or
+            /// a forcible disconnection by the remote server.
+            /// </summary>
+            public bool UserInitiated { get; private set; }
+
+            internal DisconnectedCallback( bool userInitiated )
+            {
+                this.UserInitiated = userInitiated;
+            }
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
+++ b/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
@@ -278,11 +278,11 @@ namespace SteamKit2
 
 
 
-        void Disconnected( object sender, EventArgs e )
+        void Disconnected( object sender, DisconnectedEventArgs e )
         {
             ConnectedUniverse = EUniverse.Invalid;
 
-            steamClient.PostCallback( new DisconnectedCallback() );
+            steamClient.PostCallback( new DisconnectedCallback( e.UserInitiated ) );
         }
 
         void NetMsgReceived( object sender, NetMsgEventArgs e )


### PR DESCRIPTION
I think this should be always true when tearing down an established NetLoop, but wanted to check before pushing.