### PR TITLE
Simplify build.sh

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,13 +1,5 @@
 #!/bin/bash -x
-
-function ExitIfNonZero {
-	if [ $1 -ne 0 ]; then
-		exit $1
-	fi
-}
+set -e
 
 xbuild /p:NoWarn=1584 SteamKit2/SteamKit2.sln /target:SteamKit2 /target:Tests
-ExitIfNonZero $?
-
 xbuild Samples/Samples.sln
-ExitIfNonZero $?


### PR DESCRIPTION
set -e causes script to automatically abort in case if any command fails.