### PR TITLE
Fix KeyValues binary deserialization

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
@@ -139,8 +139,7 @@ namespace NetHookAnalyzer2
 			}
 			else
 			{
-				var firstChild = kv.Children[0]; // Due to bug in KeyValues parser.
-				SetValueForDisplay(null, childNodes: new[] { new TreeNodeObjectExplorer(firstChild.Name, firstChild).TreeNode });
+				SetValueForDisplay(null, childNodes: new[] { new TreeNodeObjectExplorer(kv.Name, kv).TreeNode });
 			}
 
 			TreeNode.ExpandAll();

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
@@ -123,14 +123,7 @@ namespace NetHookAnalyzer2
 			bool didRead;
 			using (var ms = new MemoryStream(data))
 			{
-				try
-				{
-					didRead = kv.ReadAsBinary(ms);
-				}
-				catch (InvalidDataException)
-				{
-					didRead = false;
-				}
+				didRead = kv.TryReadAsBinary(ms);
 			}
 
 			if (!didRead)

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
@@ -229,7 +229,9 @@ namespace SteamKit2
 
                         using ( MemoryStream ms = new MemoryStream( section.section_kv ) )
                         {
+#pragma warning disable 0618
                             if ( kv.ReadAsBinary( ms ) )
+#pragma warning restore 0618
                             {
                                 Sections.Add( ( EAppInfoSection )section.section_id, kv );
                             }
@@ -338,8 +340,10 @@ namespace SteamKit2
                         // see: CPackageInfo::UpdateFromBuffer(CSHA const&,uint,CUtlBuffer &)
                         // todo: we've apparently ignored this with zero ill effects, but perhaps we want to respect it?
                         br.ReadUInt32();
-
+                        
+#pragma warning disable 0618
                         Data.ReadAsBinary( ms );
+#pragma warning restore 0618
                     }
                 }
 
@@ -709,7 +713,9 @@ namespace SteamKit2
                             // todo: we've apparently ignored this with zero ill effects, but perhaps we want to respect it?
                             br.ReadUInt32();
 
+#pragma warning disable 0618
                             this.KeyValues.ReadAsBinary( ms );
+#pragma warning restore 0618
                         }
                     }
                 }
@@ -797,7 +803,9 @@ namespace SteamKit2
                 for ( int i = 0; i < CountGuestPassesToGive + CountGuestPassesToRedeem; i++ )
                 {
                     var kv = new KeyValue();
+#pragma warning disable 0618
                     kv.ReadAsBinary( payload );
+#pragma warning restore 0618
                     GuestPasses.Add( kv );
                 }
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
@@ -229,9 +229,7 @@ namespace SteamKit2
 
                         using ( MemoryStream ms = new MemoryStream( section.section_kv ) )
                         {
-#pragma warning disable 0618
-                            if ( kv.ReadAsBinary( ms ) )
-#pragma warning restore 0618
+                            if ( kv.TryReadAsBinary( ms ) )
                             {
                                 Sections.Add( ( EAppInfoSection )section.section_id, kv );
                             }
@@ -341,9 +339,7 @@ namespace SteamKit2
                         // todo: we've apparently ignored this with zero ill effects, but perhaps we want to respect it?
                         br.ReadUInt32();
                         
-#pragma warning disable 0618
-                        Data.ReadAsBinary( ms );
-#pragma warning restore 0618
+                        Data.TryReadAsBinary( ms );
                     }
                 }
 
@@ -712,10 +708,8 @@ namespace SteamKit2
                             // see: CPackageInfo::UpdateFromBuffer(CSHA const&,uint,CUtlBuffer &)
                             // todo: we've apparently ignored this with zero ill effects, but perhaps we want to respect it?
                             br.ReadUInt32();
-
-#pragma warning disable 0618
-                            this.KeyValues.ReadAsBinary( ms );
-#pragma warning restore 0618
+                            
+                            this.KeyValues.TryReadAsBinary( ms );
                         }
                     }
                 }
@@ -803,9 +797,7 @@ namespace SteamKit2
                 for ( int i = 0; i < CountGuestPassesToGive + CountGuestPassesToRedeem; i++ )
                 {
                     var kv = new KeyValue();
-#pragma warning disable 0618
-                    kv.ReadAsBinary( payload );
-#pragma warning restore 0618
+                    kv.TryReadAsBinary( payload );
                     GuestPasses.Add( kv );
                 }
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
@@ -228,11 +228,11 @@ namespace SteamKit2
                         KeyValue kv = new KeyValue();
 
                         using ( MemoryStream ms = new MemoryStream( section.section_kv ) )
-                            kv.ReadAsBinary( ms );
-
-                        if ( kv.Children != null )
                         {
-                            Sections.Add( ( EAppInfoSection )section.section_id, kv.Children.FirstOrDefault() ?? KeyValue.Invalid );
+                            if ( kv.ReadAsBinary( ms ) )
+                            {
+                                Sections.Add( ( EAppInfoSection )section.section_id, kv );
+                            }
                         }
                     }
                 }
@@ -340,11 +340,6 @@ namespace SteamKit2
                         br.ReadUInt32();
 
                         Data.ReadAsBinary( ms );
-                    }
-
-                    if ( Data.Children != null )
-                    {
-                        Data = Data.Children.FirstOrDefault() ?? KeyValue.Invalid;
                     }
                 }
 
@@ -803,7 +798,7 @@ namespace SteamKit2
                 {
                     var kv = new KeyValue();
                     kv.ReadAsBinary( payload );
-                    GuestPasses.Add( kv.Children[0] );
+                    GuestPasses.Add( kv );
                 }
             }
         }

--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -667,63 +667,61 @@ namespace SteamKit2
                 }
                 
                 current.Name = input.ReadNullTermString( Encoding.UTF8 );
-
-                try
+                
+                switch ( type )
                 {
-                    switch ( type )
-                    {
-                        case Type.None:
+                    case Type.None:
+                        {
+                            var child = new KeyValue();
+                            current.Children.Add( child );
+                            var didReadChild = ReadAsBinaryCore( input, child );
+                            if ( !didReadChild )
                             {
-                                var child = new KeyValue();
-                                current.Children.Add( child );
-                                ReadAsBinaryCore( input, child );
-                                break;
+                                return false;
                             }
+                            break;
+                        }
 
-                        case Type.String:
-                            {
-                                current.Value = input.ReadNullTermString( Encoding.UTF8 );
-                                break;
-                            }
+                    case Type.String:
+                        {
+                            current.Value = input.ReadNullTermString( Encoding.UTF8 );
+                            break;
+                        }
 
-                        case Type.WideString:
-                            {
-                                throw new InvalidDataException( "wstring is unsupported" );
-                            }
+                    case Type.WideString:
+                        {
+                            DebugLog.WriteLine( "KeyValue", "Encountered WideString type when parsing binary KeyValue, which is unsupported. Returning false.");
+                            return false;
+                        }
 
-                        case Type.Int32:
-                        case Type.Color:
-                        case Type.Pointer:
-                            {
-                                current.Value = Convert.ToString( input.ReadInt32() );
-                                break;
-                            }
+                    case Type.Int32:
+                    case Type.Color:
+                    case Type.Pointer:
+                        {
+                            current.Value = Convert.ToString( input.ReadInt32() );
+                            break;
+                        }
 
-                        case Type.UInt64:
-                            {
-                                current.Value = Convert.ToString( input.ReadUInt64() );
-                                break;
-                            }
+                    case Type.UInt64:
+                        {
+                            current.Value = Convert.ToString( input.ReadUInt64() );
+                            break;
+                        }
 
-                        case Type.Float32:
-                            {
-                                current.Value = Convert.ToString( input.ReadFloat() );
-                                break;
-                            }
+                    case Type.Float32:
+                        {
+                            current.Value = Convert.ToString( input.ReadFloat() );
+                            break;
+                        }
 
-                        default:
-                            {
-                                throw new InvalidDataException( "Unknown KV type encountered." );
-                            }
-                    }
-                }
-                catch ( InvalidDataException ex )
-                {
-                    throw new InvalidDataException( string.Format( "An exception ocurred while reading KV '{0}'", current.Name ), ex );
+                    default:
+                        {
+                            return false;
+                        }
                 }
             }
 
-            return input.Position == input.Length;
+            return true;
         }
     }
 }

--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -650,19 +650,22 @@ namespace SteamKit2
         /// <returns><c>true</c> if the read was successful; otherwise, <c>false</c>.</returns>
         public bool ReadAsBinary( Stream input )
         {
-            this.Children = new List<KeyValue>();
+            return ReadAsBinaryCore( input, this );
+        }
+
+        static bool ReadAsBinaryCore( Stream input, KeyValue current )
+        {
+            current.Children = new List<KeyValue>();
 
             while ( true )
             {
-
                 var type = ( Type )input.ReadByte();
 
                 if ( type == Type.End )
                 {
                     break;
                 }
-
-                var current = new KeyValue();
+                
                 current.Name = input.ReadNullTermString( Encoding.UTF8 );
 
                 try
@@ -671,7 +674,9 @@ namespace SteamKit2
                     {
                         case Type.None:
                             {
-                                current.ReadAsBinary( input );
+                                var child = new KeyValue();
+                                current.Children.Add( child );
+                                ReadAsBinaryCore( input, child );
                                 break;
                             }
 
@@ -716,8 +721,6 @@ namespace SteamKit2
                 {
                     throw new InvalidDataException( string.Format( "An exception ocurred while reading KV '{0}'", current.Name ), ex );
                 }
-
-                this.Children.Add( current );
             }
 
             return input.Position == input.Length;

--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -396,6 +396,7 @@ namespace SteamKit2
         /// <remarks>
         /// This method will swallow any exceptions that occur when reading, use <see cref="ReadAsBinary"/> if you wish to handle exceptions.
         /// </remarks>
+        [Obsolete( "Warning: The behavior of this function has changed. See https://git.io/vYcR3 for details." )]
         public static KeyValue LoadAsBinary( string path )
         {
             return LoadFromFile( path, true );
@@ -417,7 +418,9 @@ namespace SteamKit2
 
                     if ( asBinary )
                     {
+#pragma warning disable 0618
                         if ( kv.ReadAsBinary( input ) == false )
+#pragma warning restore 0618
                         {
                             return null;
                         }
@@ -648,6 +651,7 @@ namespace SteamKit2
         /// </summary>
         /// <param name="input">The input <see cref="Stream"/> to read from.</param>
         /// <returns><c>true</c> if the read was successful; otherwise, <c>false</c>.</returns>
+        [Obsolete( "Warning: The behavior of this function has changed. See https://git.io/vYcR3 for details." )]
         public bool ReadAsBinary( Stream input )
         {
             return ReadAsBinaryCore( input, this );

--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -671,7 +671,7 @@ namespace SteamKit2
         {
             var dummyChild = new KeyValue();
             this.Children.Add( dummyChild );
-            return ReadAsBinaryCore( input, dummyChild );
+            return dummyChild.TryReadAsBinary( input );
         }
 
         /// <summary>
@@ -681,10 +681,10 @@ namespace SteamKit2
         /// <returns><c>true</c> if the read was successful; otherwise, <c>false</c>.</returns>
         public bool TryReadAsBinary( Stream input )
         {
-            return ReadAsBinaryCore( input, this );
+            return TryReadAsBinaryCore( input, this, null );
         }
 
-        static bool ReadAsBinaryCore( Stream input, KeyValue current )
+        static bool TryReadAsBinaryCore( Stream input, KeyValue current, KeyValue parent )
         {
             current.Children = new List<KeyValue>();
 
@@ -696,7 +696,7 @@ namespace SteamKit2
                 {
                     break;
                 }
-                
+
                 current.Name = input.ReadNullTermString( Encoding.UTF8 );
                 
                 switch ( type )
@@ -704,8 +704,7 @@ namespace SteamKit2
                     case Type.None:
                         {
                             var child = new KeyValue();
-                            current.Children.Add( child );
-                            var didReadChild = ReadAsBinaryCore( input, child );
+                            var didReadChild = TryReadAsBinaryCore( input, child, current );
                             if ( !didReadChild )
                             {
                                 return false;
@@ -750,6 +749,12 @@ namespace SteamKit2
                             return false;
                         }
                 }
+
+                if (parent != null)
+                {
+                    parent.Children.Add(current);
+                }
+                current = new KeyValue();
             }
 
             return true;

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -181,5 +181,37 @@ namespace Tests
                 }
             }
         }
+
+        [Fact]
+        public void KeyValueBinarySerializationIsSymmetric()
+        {
+            var kv = new KeyValue( "MessageObject" );
+            kv.Children.Add( new KeyValue( "key", "value" ) );
+
+            KeyValue deserializedKv;
+
+            var temporaryFile = Path.GetTempFileName();
+            try
+            {
+                kv.SaveToFile( temporaryFile, asBinary: true );
+                deserializedKv = KeyValue.LoadAsBinary( temporaryFile );
+            }
+            finally
+            {
+                File.Delete( temporaryFile );
+            }
+
+            Assert.Equal( kv.Name, deserializedKv.Name );
+            Assert.Equal( kv.Children.Count, deserializedKv.Children.Count );
+
+            for ( int i = 0; i < kv.Children.Count; i++ )
+            {
+                var originalChild = kv.Children[ i ];
+                var deserializedChild = deserializedKv.Children[ i ];
+                
+                Assert.Equal( originalChild.Name, deserializedChild.Name );
+                Assert.Equal( originalChild.Value, deserializedChild.Value );
+            }
+        }
     }
 }

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -341,6 +341,28 @@ namespace Tests
             }
         }
 
+        [Fact]
+        public void KeyValuesReadsBinaryWithMultipleChildren()
+        {
+            var hex = "00546573744f626a65637400016b6579310076616c75653100016b6579320076616c756532000808";
+            var binary = Utils.DecodeHexString( hex );
+            var kv = new KeyValue();
+            bool success;
+            using ( var ms = new MemoryStream( binary ) )
+            {
+                success = kv.TryReadAsBinary( ms );
+            }
+
+            Assert.True( success );
+            
+            Assert.Equal( "TestObject", kv.Name );
+            Assert.Equal( 2, kv.Children.Count );
+            Assert.Equal( "key1", kv.Children[ 0 ].Name );
+            Assert.Equal( "value1", kv.Children[ 0 ].Value );
+            Assert.Equal( "key2", kv.Children[ 1 ].Name );
+            Assert.Equal( "value2", kv.Children[ 1 ].Value );
+        }
+
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";
     }
 }

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -182,6 +182,8 @@ namespace Tests
             }
         }
 
+#pragma warning disable 0618
+
         [Fact]
         public void KeyValueBinarySerializationIsSymmetric()
         {
@@ -272,6 +274,7 @@ namespace Tests
             }
         }
 
+#pragma warning restore 0618
 
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";
     }


### PR DESCRIPTION
Now the deserialized element is the root element, not
the root element's single child.

Behavioural breaking change.