### PR TITLE
Implement machine id support for the future.

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -126,7 +126,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )details.AppID;
-            logon.Body.machine_id = MachineIdUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
 
             logon.Body.game_server_token = details.Token;
 
@@ -161,7 +161,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )appId;
-            logon.Body.machine_id = MachineIdUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -126,7 +126,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )details.AppID;
-            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID();
 
             logon.Body.game_server_token = details.Token;
 
@@ -161,7 +161,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )appId;
-            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID();
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -316,7 +316,7 @@ namespace SteamKit2
 
             // we're now using the latest steamclient package version, this is required to get a proper sentry file for steam guard
             logon.Body.client_package_version = 1771; // todo: determine if this is still required
-            logon.Body.machine_id = MachineIdUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
 
             // steam guard 
             logon.Body.auth_code = details.AuthCode;
@@ -366,7 +366,7 @@ namespace SteamKit2
             logon.Body.client_language = details.ClientLanguage;
             logon.Body.cell_id = details.CellID;
 
-            logon.Body.machine_id = MachineIdUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -260,6 +260,11 @@ namespace SteamKit2
             };
         }
 
+        static SteamUser()
+        {
+            HardwareUtils.Init();
+        }
+
 
         /// <summary>
         /// Logs the client into the Steam3 network.
@@ -316,7 +321,7 @@ namespace SteamKit2
 
             // we're now using the latest steamclient package version, this is required to get a proper sentry file for steam guard
             logon.Body.client_package_version = 1771; // todo: determine if this is still required
-            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID();
 
             // steam guard 
             logon.Body.auth_code = details.AuthCode;
@@ -366,7 +371,7 @@ namespace SteamKit2
             logon.Body.client_language = details.ClientLanguage;
             logon.Body.cell_id = details.CellID;
 
-            logon.Body.machine_id = HardwareUtils.GenerateMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID();
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Types\PubFile.cs" />
     <Compile Include="Util\AsnKeyParser.cs" />
     <Compile Include="Util\Crc32.cs" />
+    <Compile Include="Util\HardwareUtils.cs" />
     <Compile Include="Util\LZMA\Common\CRC.cs" />
     <Compile Include="Util\LZMA\Common\InBuffer.cs" />
     <Compile Include="Util\LZMA\Common\OutBuffer.cs" />

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Base\Generated\SteamMsgAppTicket.cs" />
     <Compile Include="Base\Generated\SteamMsgBase.cs" />
     <Compile Include="Base\Generated\SteamMsgClientServer.cs" />
+    <Compile Include="Util\MacHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="3rd party.txt">

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management;
+using System.Net.NetworkInformation;
+using System.Text;
+using Microsoft.Win32;
+
+namespace SteamKit2
+{
+    abstract class MachineInfoProvider
+    {
+        public static MachineInfoProvider GetProvider()
+        {
+            switch ( Environment.OSVersion.Platform )
+            {
+                case PlatformID.Win32NT:
+                case PlatformID.Win32Windows:
+                    return new WindowsInfoProvider();
+            }
+
+            return new DefaultInfoProvider();
+        }
+
+        public abstract byte[] GetMachineGuid();
+        public abstract byte[] GetMacAddress();
+        public abstract byte[] GetDiskId();
+    }
+
+    class DefaultInfoProvider : MachineInfoProvider
+    {
+        public override byte[] GetMachineGuid()
+        {
+            return Encoding.UTF8.GetBytes( "SteamKit-MachineGuid" );
+        }
+
+        public override byte[] GetMacAddress()
+        {
+            // mono seems to have a pretty solid implementation of NetworkInterface for our platforms
+            // if it turns out to be buggy we can always roll our own and poke into /sys/class/net on nix
+
+            var firstEth = NetworkInterface.GetAllNetworkInterfaces()
+                .Where( i => i.NetworkInterfaceType == NetworkInterfaceType.Ethernet )
+                .FirstOrDefault();
+
+            if ( firstEth == null )
+            {
+                // well...
+                return Encoding.UTF8.GetBytes( "SteamKit-MacAddress" );
+            }
+
+            return firstEth.GetPhysicalAddress().GetAddressBytes();
+        }
+
+        public override byte[] GetDiskId()
+        {
+            return Encoding.UTF8.GetBytes( "SteamKit-DiskId" );
+        }
+    }
+
+    class WindowsInfoProvider : DefaultInfoProvider
+    {
+        public override byte[] GetMachineGuid()
+        {
+            RegistryKey localKey = RegistryKey
+                .OpenBaseKey( Microsoft.Win32.RegistryHive.LocalMachine, RegistryView.Registry64 )
+                .OpenSubKey( @"SOFTWARE\Microsoft\Cryptography" );
+
+            if ( localKey == null )
+            {
+                return base.GetMachineGuid();
+            }
+
+            object guid = localKey.GetValue( "MachineGuid" );
+
+            if ( guid == null )
+            {
+                return base.GetMachineGuid();
+            }
+
+            return Encoding.UTF8.GetBytes( guid.ToString() );
+        }
+
+        public override byte[] GetDiskId()
+        {
+            var activePartition = WmiQuery(
+                @"SELECT DiskIndex FROM Win32_DiskPartition
+                  WHERE Bootable = 1"
+                ).FirstOrDefault();
+
+            if ( activePartition == null )
+            {
+                return base.GetDiskId();
+            }
+
+            uint index = (uint)activePartition["DiskIndex"];
+
+            var bootableDisk = WmiQuery(
+                @"SELECT SerialNumber FROM Win32_DiskDrive
+                  WHERE Index = {0}", index
+                ).FirstOrDefault();
+
+            if ( bootableDisk == null )
+            {
+                return base.GetDiskId();
+            }
+
+            string serialNumber = (string)bootableDisk["SerialNumber"];
+
+            return Encoding.UTF8.GetBytes( serialNumber );
+        }
+
+        IEnumerable<ManagementObject> WmiQuery( string queryFormat, params object[] args )
+        {
+            string query = string.Format( queryFormat, args );
+
+            var searcher = new ManagementObjectSearcher( query );
+
+            return searcher.Get().Cast<ManagementObject>();
+        }
+    }
+
+    static class HardwareUtils
+    {
+        class MachineID : MessageObject
+        {
+            public MachineID()
+                : base()
+            {
+                this.KeyValues["BB3"] = new KeyValue();
+                this.KeyValues["FF2"] = new KeyValue();
+                this.KeyValues["3B3"] = new KeyValue();
+            }
+
+
+            public void SetBB3( string value )
+            {
+                this.KeyValues["BB3"].Value = value;
+            }
+
+            public void SetFF2( string value )
+            {
+                this.KeyValues["FF2"].Value = value;
+            }
+
+            public void Set3B3( string value )
+            {
+                this.KeyValues["3B3"].Value = value;
+            }
+
+            public void Set333( string value )
+            {
+                this.KeyValues["333"] = new KeyValue( value: value );
+            }
+        }
+
+        public static byte[] GenerateMachineID()
+        {
+            // the aug 25th 2015 CM update made well-formed machine MessageObjects required for logon
+            // this was flipped off shortly after the update rolled out, likely due to linux steamclients running on distros without a way to build a machineid
+            // so while a valid MO isn't currently (as of aug 25th) required, they could be in the future and we'll abide by The Valve Law now
+
+            var machineId = new MachineID();
+
+            using ( var ms = new MemoryStream() )
+            {
+                MachineInfoProvider provider = MachineInfoProvider.GetProvider();
+
+                machineId.SetBB3( GetHexString( provider.GetMachineGuid() ) );
+                machineId.SetFF2( GetHexString( provider.GetMacAddress() ) );
+                machineId.Set3B3( GetHexString( provider.GetDiskId() ) );
+
+                // 333 is currently unused
+
+                machineId.WriteToStream( ms );
+
+                return ms.ToArray();
+            }
+        }
+
+        static string GetHexString( byte[] data )
+        {
+            data = CryptoHelper.SHAHash( data );
+
+            return BitConverter.ToString( data )
+                .Replace( "-", "" )
+                .ToLower();
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -6,6 +6,12 @@ using System.Management;
 using System.Net.NetworkInformation;
 using System.Text;
 using Microsoft.Win32;
+using SteamKit2.Util.MacHelpers;
+
+using static SteamKit2.Util.MacHelpers.LibC;
+using static SteamKit2.Util.MacHelpers.CoreFoundation;
+using static SteamKit2.Util.MacHelpers.DiskArbitration;
+using static SteamKit2.Util.MacHelpers.IOKit;
 
 namespace SteamKit2
 {
@@ -20,11 +26,14 @@ namespace SteamKit2
                     return new WindowsInfoProvider();
 
                 case PlatformID.Unix:
-                    if ( !Utils.IsRunningOnDarwin() )
+                    if ( Utils.IsRunningOnDarwin() )
+                    {
+                        return new OSXInfoProvider();
+                    }
+                    else
                     {
                         return new LinuxInfoProvider();
                     }
-                    break;
             }
 
             return new DefaultInfoProvider();
@@ -161,6 +170,64 @@ namespace SteamKit2
         public override byte[] GetDiskId()
         {
             // todo: need a not-so-painful way to get drive uuids
+            return base.GetDiskId();
+        }
+    }
+
+    class OSXInfoProvider : DefaultInfoProvider
+    {
+        public override byte[] GetMachineGuid()
+        {
+            uint platformExpert = IOServiceGetMatchingService( kIOMasterPortDefault, IOServiceMatching( "IOPlatformExpertDevice" ) );
+            if ( platformExpert != 0 )
+            {
+                try
+                {
+                    using ( var serialNumberKey = CFStringCreateWithCString( CFTypeRef.None, kIOPlatformSerialNumberKey, CFStringEncoding.kCFStringEncodingASCII ) )
+                    {
+                        var serialNumberAsString = IORegistryEntryCreateCFProperty( platformExpert, serialNumberKey, CFTypeRef.None, 0 );
+                        var sb = new StringBuilder( 64 );
+                        if ( CFStringGetCString( serialNumberAsString, sb, sb.Capacity, CFStringEncoding.kCFStringEncodingASCII ) )
+                        {
+                            return Encoding.ASCII.GetBytes( sb.ToString() );
+                        }
+                    }
+                }
+                finally
+                {
+                    IOKit.IOObjectRelease( platformExpert );
+                }
+            }
+
+            return base.GetMachineGuid();
+        }
+
+        public override byte[] GetDiskId()
+        {
+            var stat = new statfs();
+            var statted = statfs64( "/", ref stat );
+            if ( statted == 0 )
+            {
+                using ( var session = DASessionCreate( CFTypeRef.None ) )
+                using ( var disk = DADiskCreateFromBSDName( CFTypeRef.None, session, stat.f_mntfromname ) )
+                using ( var properties = DADiskCopyDescription( disk ) )
+                using ( var key = CFStringCreateWithCString( CFTypeRef.None, DiskArbitration.kDADiskDescriptionMediaUUIDKey, CFStringEncoding.kCFStringEncodingASCII ) )
+                {
+                    IntPtr cfuuid = IntPtr.Zero;
+                    if ( CFDictionaryGetValueIfPresent( properties, key, out cfuuid ) )
+                    {
+                        using ( var uuidString = CFUUIDCreateString( CFTypeRef.None, cfuuid ) )
+                        {
+                            var stringBuilder = new StringBuilder( 64 );
+                            if ( CFStringGetCString( uuidString, stringBuilder, stringBuilder.Capacity, CFStringEncoding.kCFStringEncodingASCII ) )
+                            {
+                                return Encoding.ASCII.GetBytes( stringBuilder.ToString() );
+                            }
+                        }
+                    }
+                }
+            }
+
             return base.GetDiskId();
         }
     }

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -195,7 +195,7 @@ namespace SteamKit2
                 }
                 finally
                 {
-                    IOKit.IOObjectRelease( platformExpert );
+                    IOObjectRelease( platformExpert );
                 }
             }
 

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -58,7 +58,7 @@ namespace SteamKit2
             // if it turns out to be buggy we can always roll our own and poke into /sys/class/net on nix
 
             var firstEth = NetworkInterface.GetAllNetworkInterfaces()
-                .Where( i => i.NetworkInterfaceType == NetworkInterfaceType.Ethernet )
+                .Where( i => i.NetworkInterfaceType == NetworkInterfaceType.Ethernet || i.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 )
                 .FirstOrDefault();
 
             if ( firstEth == null )

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -218,20 +218,20 @@ namespace SteamKit2
         }
         string[] GetDiskUUIDs()
         {
-            string[] files;
-
             try
             {
-                files = Directory.GetFiles( "/dev/disk/by-uuid" );
+                var dirInfo = new DirectoryInfo( "/dev/disk/by-uuid" );
+
+                // we want the oldest disk symlinks first
+                return dirInfo.GetFiles()
+                    .OrderBy( f => f.LastWriteTime )
+                    .Select( f => f.Name )
+                    .ToArray();
             }
             catch
             {
                 return new string[0];
             }
-
-            return files
-                .Select( f => Path.GetFileName( f ) )
-                .ToArray();
         }
         string GetParamValue( string[] bootOptions, string param )
         {

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -143,6 +143,7 @@ namespace SteamKit2
         {
             string[] machineFiles =
             {
+                "/etc/machine-id", // present on at least some gentoo systems
                 "/var/lib/dbus/machine-id",
                 "/sys/class/net/eth0/address",
                 "/sys/class/net/eth1/address",

--- a/SteamKit2/SteamKit2/Util/MacHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/MacHelpers.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SteamKit2.Util.MacHelpers
+{
+    class CFTypeRef : SafeHandle
+    {
+        CFTypeRef()
+            : base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (IsInvalid)
+            {
+                return false;
+            }
+
+            CoreFoundation.CFRelease(handle);
+            return true;
+        }
+
+        public override bool IsInvalid
+        {
+            get { return handle == IntPtr.Zero; }
+        }
+
+        public static CFTypeRef None
+        {
+            get { return new CFTypeRef(); }
+        }
+    }
+
+    // Taken from <sys/mount.h>
+    struct statfs
+    {
+        const int MFSTYPENAMELEN = 16;
+        const int PATH_MAX = 1024;
+
+        public uint    f_bsize;    /* fundamental file system block size */
+        public int     f_iosize;   /* optimal transfer block size */
+        public ulong   f_blocks;   /* total data blocks in file system */
+        public ulong   f_bfree;    /* free blocks in fs */
+        public ulong   f_bavail;   /* free blocks avail to non-superuser */
+        public ulong   f_files;    /* total file nodes in file system */
+        public ulong   f_ffree;    /* free file nodes in fs */
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+        public uint[]  f_fsid;     /* file system id */
+        public uint    f_owner;    /* user that mounted the filesystem */
+        public uint    f_type;     /* type of filesystem */
+        public uint    f_flags;    /* copy of mount exported flags */
+        public uint    f_fssubtype;    /* fs sub-type (flavor) */
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MFSTYPENAMELEN)]
+        public string  f_fstypename;  /* fs type name */
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = PATH_MAX)]
+        public string  f_mntonname;    /* directory on which mounted */
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = PATH_MAX)]
+        public string  f_mntfromname ; /* mounted filesystem */
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+        public uint[]  f_reserved;  /* For future use */
+    }
+
+    static class LibC
+    {
+        const string LibraryName = "libc";
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int statfs64(string path, ref statfs buf);
+    }
+
+    static class CoreFoundation
+    {
+        const string LibraryName = "CoreFoundation.framework/CoreFoundation";
+
+        public enum CFStringEncoding : uint
+        {
+            kCFStringEncodingASCII = 0x0600
+        }
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void CFRelease(IntPtr cf);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        public static extern bool CFDictionaryGetValueIfPresent(CFTypeRef theDict, CFTypeRef key, out IntPtr value);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef CFStringCreateWithCString(CFTypeRef allocator, string cStr, CFStringEncoding encoding);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [return:MarshalAs(UnmanagedType.U1)]
+        public static extern bool CFStringGetCString(CFTypeRef theString, StringBuilder buffer, long bufferSize, CFStringEncoding encoding);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef CFUUIDCreateString(CFTypeRef allocator, IntPtr uuid);
+    }
+
+    static class DiskArbitration
+    {
+        const string LibraryName = "DiskArbitration.framework/DiskArbitration";
+        public const string kDADiskDescriptionMediaUUIDKey = "DAMediaUUID";
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef DASessionCreate(CFTypeRef allocator);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef DADiskCreateFromBSDName(CFTypeRef allocator, CFTypeRef session, string name);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef DADiskCopyDescription(CFTypeRef disk);
+    }
+
+    static class IOKit
+    {
+        const string LibraryName = "IOKit.framework/IOKit";
+
+        public const uint kIOMasterPortDefault = 0;
+        public const string kIOPlatformSerialNumberKey = "IOPlatformSerialNumber";
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern CFTypeRef IORegistryEntryCreateCFProperty(uint entry, CFTypeRef key, CFTypeRef allocator, uint options);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern IntPtr IOServiceMatching(string name);
+
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int IOObjectRelease(uint @object);
+    }
+}
+

--- a/SteamKit2/SteamKit2/Util/Utils.cs
+++ b/SteamKit2/SteamKit2/Util/Utils.cs
@@ -149,7 +149,7 @@ namespace SteamKit2
             }
         }
 
-        static bool IsRunningOnDarwin()
+        public static bool IsRunningOnDarwin()
         {
             // Replace with a safer way if one exists in the future, such as if
             // Mono actually decides to use PlatformID.MacOSX

--- a/readme.md
+++ b/readme.md
@@ -32,9 +32,13 @@ SteamKit2 is released under the [LGPL-2.1 license](http://www.tldrlegal.com/lice
 
 ## Dependencies
 
-In order to compile and use SteamKit2, the following dependencies are required:
+In order to use SteamKit2 at runtime, the following dependencies are required:
 
   - .NET 4.0 or [Mono ≥2.8](http://mono-project.com)
+
+To compile SteamKit2, the following is required:
+
+  - C# 6.0 compiler &mdash; [Visual Studio 2015](https://www.visualstudio.com/en-us/products/vs-2015-product-editions.aspx) or [Mono ≥4.0](http://www.mono-project.com/docs/about-mono/releases/4.0.0/)
   - [protobuf-net](http://code.google.com/p/protobuf-net/) ([NuGet package](http://nuget.org/packages/protobuf-net))
 
 Note: If you're using the NuGet package, the protobuf-net dependency _should_ be resolved for you. See the [Installation Guide](https://github.com/SteamRE/SteamKit/wiki/Installation) for more information.


### PR DESCRIPTION
Any day that requires code changes to logon to Steam is a spooky day, so here's some work to make sure we don't need any changes in the future when valid machine ids are required for logon.

Things to note:
* WMI can be painfully slow. Valve spins up a separate thread at startup that gathers info, ~~we currently query for info at logon time. Not ideal, but this is still a WIP.~~
* For the linux machine id, valve primarily touches `/var/lib/dbus/machine-id`, but this may not be present on some systems (and may have been why certain linux steamclients were unable to logon today). Might need to look into alternatives for anybody not using systemd/dbus.
* ~~Nothing available for OSX. Haven't had much time to dig into the steamclient binary for it, but I'd imagine there aren't many consumers who need SteamKit on OSX.~~