### PR TITLE
Update NetHookAnalyzer2 to handle more SO GC message, with specialization.

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
@@ -35,8 +35,10 @@ namespace NetHookAnalyzer2
 				new ClientServiceMethodResponseSpecialization(),
 				new GCGenericSpecialization()
 				{
-					GameCoordinatorSpecializations = new[]
+					GameCoordinatorSpecializations = new IGameCoordinatorSpecialization[]
 					{
+						new Dota2CacheSubscribedGCSpecialization(),
+						new Dota2SOSingleObjectGCSpecialization(),
 						new Dota2SOMultipleObjectsGCSpecialization(),
 					}
 				}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
@@ -66,8 +66,11 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtoBufFieldReader.cs" />
+    <Compile Include="Specializations\Dota2SOCacheSubscribedGCSpecialization.cs" />
     <Compile Include="Specializations\ClientServiceMethodResponseSpecialization.cs" />
     <Compile Include="Specializations\ClientServiceMethodSpecialization.cs" />
+    <Compile Include="Specializations\Dota2SOHelper.cs" />
+    <Compile Include="Specializations\Dota2SOSingleObjectGCSpecialization.cs" />
     <Compile Include="Specializations\Dota2SOMultipleObjectsGCSpecialization.cs" />
     <Compile Include="Specializations\GCGenericSpecialization.cs" />
     <Compile Include="Specializations\IGameCoordinatorSpecialization.cs" />

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOCacheSubscribedGCSpecialization.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOCacheSubscribedGCSpecialization.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using ProtoBuf;
+using ProtoBuf.Meta;
+using SteamKit2.GC.Dota.Internal;
+using SteamKit2.GC.Internal;
+
+namespace NetHookAnalyzer2.Specializations
+{
+    class Dota2CacheSubscribedGCSpecialization : IGameCoordinatorSpecialization
+    {
+        const uint Dota2AppID = 570;
+
+        public IEnumerable<KeyValuePair<string, object>> GetExtraObjects(object body, uint appID)
+        {
+            if (appID != Dota2AppID)
+            {
+                yield break;
+            }
+
+            var cacheSubscribed = body as CMsgSOCacheSubscribed;
+            if (cacheSubscribed == null)
+            {
+                yield break;
+            }
+
+            foreach (var bucket in cacheSubscribed.objects)
+            {
+                int typeId = bucket.type_id;
+                foreach (var singleObject in bucket.object_data)
+                {
+                    var extraNode = ReadExtraObject(singleObject, typeId);
+                    if (extraNode != null)
+                    {
+                        yield return new KeyValuePair<string, object>("SO", extraNode);
+                    }
+                }
+            }
+        }
+
+        object ReadExtraObject(byte[] sharedObject, int typeId)
+        {
+            try
+            {
+                using (var ms = new MemoryStream(sharedObject))
+                {
+                    Type t;
+                    if (Dota2SOHelper.SOTypes.TryGetValue(typeId, out t))
+                    {
+                        return RuntimeTypeModel.Default.Deserialize(ms, null, t);
+                    }
+                }
+            }
+            catch (ProtoException ex)
+            {
+                return "Error parsing SO data: " + ex.Message;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOHelper.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SteamKit2.GC.Dota.Internal;
+using SteamKit2.GC.Internal;
+using System.Collections.ObjectModel;
+
+namespace NetHookAnalyzer2.Specializations
+{
+    static class Dota2SOHelper
+    {
+        public static Dictionary<int, Type> SOTypes = new Dictionary<int, Type>()
+        {
+            {1, typeof(CSOEconItem)},
+            {5, typeof(CSOItemRecipe)},
+            {7, typeof(CSOEconGameAccountClient)},
+            {35, typeof(CSOSelectedItemPreset)},
+            {36, typeof(CSOEconItemPresetInstance)},
+            {38, typeof(CSOEconItemDropRateBonus)},
+            {39, typeof(CSOEconItemLeagueViewPass)},
+            {40, typeof(CSOEconItemEventTicket)},
+            {42, typeof(CSOEconItemTournamentPassport)},
+            {2002, typeof(CSODOTAGameAccountClient)},
+            {2003, typeof(CSODOTAParty)},
+            {2004, typeof(CSODOTALobby)},
+            {2006, typeof(CSODOTAPartyInvite)},
+            {2007, typeof(CSODOTAGameHeroFavorites)},
+            {2008, typeof(CSODOTAMapLocationState)},
+            {2009, typeof(CMsgDOTATournament)},
+            {2010, typeof(CSODOTAPlayerChallenge)},
+            {2011, typeof(CSODOTALobbyInvite)},
+        };
+    }
+}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOMultipleObjectsGCSpecialization.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOMultipleObjectsGCSpecialization.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using ProtoBuf;
 using ProtoBuf.Meta;
@@ -58,13 +59,10 @@ namespace NetHookAnalyzer2.Specializations
 			{
 				using (var ms = new MemoryStream(sharedObject.object_data))
 				{
-					switch (sharedObject.type_id)
+					Type t;
+					if (Dota2SOHelper.SOTypes.TryGetValue(sharedObject.type_id, out t))
 					{
-						case 2003:
-							return RuntimeTypeModel.Default.Deserialize(ms, null, typeof(CSODOTAParty));
-
-						case 2004:
-							return RuntimeTypeModel.Default.Deserialize(ms, null, typeof(CSODOTALobby));
+						return RuntimeTypeModel.Default.Deserialize(ms, null, t);
 					}
 				}
 			}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOSingleObjectGCSpecialization.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/Dota2SOSingleObjectGCSpecialization.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using ProtoBuf;
+using ProtoBuf.Meta;
+using SteamKit2.GC.Dota.Internal;
+using SteamKit2.GC.Internal;
+
+namespace NetHookAnalyzer2.Specializations
+{
+    class Dota2SOSingleObjectGCSpecialization : IGameCoordinatorSpecialization
+    {
+        const uint Dota2AppID = 570;
+
+        public IEnumerable<KeyValuePair<string, object>> GetExtraObjects(object body, uint appID)
+        {
+            if (appID != Dota2AppID)
+            {
+                yield break;
+            }
+
+            var updateSingle = body as CMsgSOSingleObject;
+            if (updateSingle == null)
+            {
+                yield break;
+            }
+
+            var extraNode = ReadExtraObject(updateSingle);
+            if (extraNode != null)
+            {
+                yield return new KeyValuePair<string, object>("SO", extraNode);
+            }
+        }
+
+        object ReadExtraObject(CMsgSOSingleObject sharedObject)
+        {
+            try
+            {
+                using (var ms = new MemoryStream(sharedObject.object_data))
+                {
+                    Type t;
+                    if (Dota2SOHelper.SOTypes.TryGetValue(sharedObject.type_id, out t))
+                    {
+                            return RuntimeTypeModel.Default.Deserialize(ms, null, t);
+                    }
+                }
+            }
+            catch (ProtoException ex)
+            {
+                return "Error parsing SO data: " + ex.Message;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This adds handling for 16 more Dota 2 SO object types, as well as using the specialization in two more Dota 2 SO-related GC messages.

This probably could have been done cleaner, but it does work. We could probably also split out into base types (the econ ones with low ids), and then have game-specific ones added onto that. Either way, this is progress.