### PR TITLE
ProtobufDumper improvements

### DIFF
--- a/Resources/ProtobufDumper/ProtobufDumper/Program.cs
+++ b/Resources/ProtobufDumper/ProtobufDumper/Program.cs
@@ -4,7 +4,7 @@ namespace ProtobufDumper
 {
     class Program
     {
-        static unsafe void Main( string[] args )
+        static void Main( string[] args )
         {
             Environment.ExitCode = 0;
 

--- a/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
+++ b/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
@@ -29,7 +29,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -40,7 +39,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
* Removes unsafe code and replaces it with MemoryStream.
* At least 4x speed up on `steamclient.dylib`
* Defers all protos until the end (to fix duplicate protos)