### PR TITLE
Fix to KV parsing.

### DIFF
--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -92,16 +92,14 @@ namespace SteamKit2
                 char next = ( char )Peek();
                 if ( next == '/' )
                 {
-                    Read();
-                    if ( next == '/' )
-                    {
-                        ReadLine();
-                        return true;
-                    }
-                    else
-                    {
-                        throw new Exception( "BARE / WHAT ARE YOU DOIOIOIINODGNOIGNONGOIGNGGGGGGG" );
-                    }
+		    ReadLine();
+		    return true;
+		    /*
+		     *  As came up in parsing the Dota 2 units.txt file, the reference (Valve) implementation
+		     *  of the KV format considers a single forward slash to be sufficient to comment out the
+		     *  entirety of a line. While they still _tend_ to use two, it's not required, and likely
+		     *  is just done out of habit.
+		     */
                 }
 
                 return false;


### PR DESCRIPTION
This came up in parsing some of the Dota 2 KV files, and from the existing exception message in the code it seemed like a case that had previously been untested. This should be a more correct implementation.