### PR TITLE
Add singular PICSGetAccessTokens overload

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -301,6 +301,24 @@ namespace SteamKit2
         }
 
         /// <summary>
+        /// Request PICS access tokens for an app or package.
+        /// Results are returned in a <see cref="PICSTokensCallback"/> callback.
+        /// </summary>
+        /// <param name="app">App id to request access token for.</param>
+        /// <param name="package">Package id to request access token for.</param>
+        /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSTokensCallback"/>.</returns>
+        public JobID PICSGetAccessTokens( uint? app, uint? package )
+        {
+            List<uint> apps = new List<uint>();
+            List<uint> packages = new List<uint>();
+
+            if ( app.HasValue ) apps.Add( app.Value );
+            if ( package.HasValue ) packages.Add( package.Value );
+
+            return PICSGetAccessTokens( apps, packages );
+        }
+
+        /// <summary>
         /// Request PICS access tokens for a list of app ids and package ids
         /// Results are returned in a <see cref="PICSTokensCallback"/> callback.
         /// </summary>


### PR DESCRIPTION
Matches `PICSGetProductInfo`.

This makes it easier to get a token for a single app and/or package, where instead of doing this:
```csharp
Steam.Instance.Apps.PICSGetAccessTokens(new List<uint> { appID }, Enumerable.Empty<uint>());
```
you can do this:
```csharp
Steam.Instance.Apps.PICSGetAccessTokens(appID, null);
```