### PR TITLE
Correct SteamUser.LogOff documentation.

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -377,9 +377,8 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Logs the user off of the Steam3 network.
-        /// This method does not disconnect the client.
-        /// Results are returned in a <see cref="LoggedOffCallback"/>.
+        /// Informs the Steam servers that this client wishes to log off from the network.
+        /// The Steam server will disconnect the client, and a <see cref="SteamClient.DisconnectedCallback"/> will be posted.
         /// </summary>
         public void LogOff()
         {


### PR DESCRIPTION
Updating the documentation for `SteamUser.LogOff` to actually match the behavior that occurs.

See also: #202, #181

Also for reference, here is the steamclient implementation:

```C++
int __cdecl CCMInterface::LogOff(CCMInterface *this, bool bUserInitiated)
{
  uint v3; // [sp+4h] [bp-34h]@1
  uint msgLogOff; // [sp+10h] [bp-28h]@2

  CCMInterface::LogConnectionState(this, "LogOff()");
  if ( this->m_eLogonState == k_ELogonStateLoggedOn )
  {
    CProtoBufMsg<CMsgClientLogOff>::CProtoBufMsg(&msgLogOff, 706);
    CCMInterface::BSendMsgToCM(this, &msgLogOff);
    this->m_bUserInitiatedLogoff = bUserInitiated;
    this->m_eLogonState = k_ELogonStateLoggingOff;
    CProtoBufMsg<CMsgClientLogOff>::~CProtoBufMsg(&msgLogOff);
  }
  if ( this->m_CMConnection && CNet::BIsConnected(this->m_CMConnection, v3) )
    CCMInterface::AsyncDisconnect(this);
  CBaseScheduledFunction::Cancel(&this->m_SchedRetryLogonFunc.base);
  return CBaseScheduledFunction::Cancel(&this->m_SchedAttemptReconnectFunc.base);
}

int __cdecl CCMInterface::AsyncDisconnect(CCMInterface *this)
{
  int result; // eax@2
  unsigned int v2; // ST08_4@3

  if ( this->m_CMConnection
    || (result = AssertMsgImplementation(
                   "Assertion Failed: 0 != m_CMConnection.GetHConnection()",
                   0,
                   "/Users/buildbot/buildslave/steam_rel_client_osx/build/src/clientdll/cminterface.cpp",
                   1647,
                   0),
        this->m_CMConnection) )
  {
    CCMInterface::LogConnectionState(this, "AsyncDisconnect()");
    this->m_bInitiatedDisconnect = 1;
    CNet::BAsyncDisconnect(this->m_CMConnection, v2);
    this->field_16 = 0;
    result = CUtlMemoryBase::Purge(&this->field_15);
  }
  return result;
}
```

Valve's code goes a little further and actually initiates a client disconnection as well, but I have a feeling this might discard any messages still in transit.