### PR TITLE
Mark LogOff-triggered disconnections as user-initiated

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -158,7 +158,7 @@ namespace SteamKit2.Internal
         /// The <see cref="IPEndPoint"/> of the CM server to connect to.
         /// If <c>null</c>, SteamKit will randomly select a CM server from its internal list.
         /// </param>
-        public virtual void Connect( IPEndPoint cmServer = null  )
+        public void Connect( IPEndPoint cmServer = null  )
         {
             this.Disconnect();
 

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -83,6 +83,13 @@ namespace SteamKit2.Internal
         /// </value>
         public TimeSpan ConnectionTimeout { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether or not this <see cref="CMClient"/> should imminently expect the server to close the connection.
+        /// If this is true when the connection is closed, the <see cref="SteamClient.DisconnectedCallback"/>'s <see cref="SteamClient.DisconnectedCallback.UserInitiated"/> property
+        /// will be set to <c>true</c>.
+        /// </summary>
+        public bool ExpectDisconnection { get; set; }
+
 
         Connection connection;
         bool encryptionSetup;
@@ -151,12 +158,13 @@ namespace SteamKit2.Internal
         /// The <see cref="IPEndPoint"/> of the CM server to connect to.
         /// If <c>null</c>, SteamKit will randomly select a CM server from its internal list.
         /// </param>
-        public void Connect( IPEndPoint cmServer = null  )
+        public virtual void Connect( IPEndPoint cmServer = null  )
         {
             this.Disconnect();
 
             encryptionSetup = false;
             pendingNetFilterEncryption = null;
+            ExpectDisconnection = false;
 
             if ( cmServer == null )
             {
@@ -315,7 +323,7 @@ namespace SteamKit2.Internal
 
             heartBeatFunc.Stop();
 
-            OnClientDisconnected( userInitiated: e.UserInitiated );
+            OnClientDisconnected( userInitiated: e.UserInitiated || ExpectDisconnection );
         }
 
         internal static IPacketMsg GetPacketMsg( byte[] data )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -167,12 +167,13 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Logs the game server off of the Steam3 network.
-        /// This method does not disconnect the client.
-        /// Results are returned in a <see cref="SteamUser.LoggedOffCallback"/>.
+        /// Informs the Steam servers that this client wishes to log off from the network.
+        /// The Steam server will disconnect the client, and a <see cref="SteamClient.DisconnectedCallback"/> will be posted.
         /// </summary>
         public void LogOff()
         {
+            this.Client.ExpectDisconnection = true;
+
             var logOff = new ClientMsgProtobuf<CMsgClientLogOff>( EMsg.ClientLogOff );
             this.Client.Send( logOff );
         }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -382,6 +382,8 @@ namespace SteamKit2
         /// </summary>
         public void LogOff()
         {
+            this.Client.ExpectDisconnection = true;
+
             var logOff = new ClientMsgProtobuf<CMsgClientLogOff>( EMsg.ClientLogOff );
             this.Client.Send( logOff );
         }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -7,11 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
-using SteamKit2.Internal;
-using System.Diagnostics;
 using ProtoBuf;
+using SteamKit2.Internal;
 
 namespace SteamKit2
 {


### PR DESCRIPTION
Had to do a few hacky things I don't particularly like. Any suggestions to improve this?

Ideally, this probably needs a full-blown state machine.