### PR TITLE
SteamUser LoginID customization

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -38,6 +38,12 @@ namespace SteamKit2
             public uint CellID { get; set; }
 
             /// <summary>
+            /// Gets or sets the LoginID. This number is used for identifying logon session. Value of 0 will cause this to be automatically generated.
+            /// </summary>
+            /// <value>The LoginID.</value>
+            public uint LoginID { get; set; }
+
+            /// <summary>
             /// Gets or sets the Steam Guard auth code used to login. This is the code sent to the user's email.
             /// </summary>
             /// <value>The auth code.</value>
@@ -301,12 +307,16 @@ namespace SteamKit2
 
             SteamID steamId = new SteamID( details.AccountID, details.AccountInstance, Client.ConnectedUniverse, EAccountType.Individual );
 
-            uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP );
+            if ( details.LoginID == 0 )
+            {
+                uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP );
+                details.LoginID = localIp ^ MsgClientLogon.ObfuscationMask;
+            }
 
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = steamId.ConvertToUInt64();
 
-            logon.Body.obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+            logon.Body.obfustucated_private_ip = details.LoginID;
 
             logon.Body.account_name = details.Username;
             logon.Body.password = details.Password;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -313,14 +313,14 @@ namespace SteamKit2
 
             SteamID steamId = new SteamID( details.AccountID, details.AccountInstance, Client.ConnectedUniverse, EAccountType.Individual );
 
-            if ( details.LoginID == null )
+            if ( details.LoginID.HasValue )
             {
-                uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP );
-                logon.Body.obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+                logon.Body.obfustucated_private_ip = details.LoginID.Value;
             }
             else
             {
-                logon.Body.obfustucated_private_ip = details.LoginID.Value;
+                uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP );
+                logon.Body.obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
             }
 
             logon.ProtoHeader.client_sessionid = 0;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -38,10 +38,10 @@ namespace SteamKit2
             public uint CellID { get; set; }
 
             /// <summary>
-            /// Gets or sets the LoginID. This number is used for identifying logon session. Value of 0 will cause this to be automatically generated.
+            /// Gets or sets the LoginID. This number is used for identifying logon session. Null value will cause this to be automatically generated.
             /// </summary>
             /// <value>The LoginID.</value>
-            public uint LoginID { get; set; }
+            public uint? LoginID { get; set; }
 
             /// <summary>
             /// Gets or sets the Steam Guard auth code used to login. This is the code sent to the user's email.
@@ -307,16 +307,18 @@ namespace SteamKit2
 
             SteamID steamId = new SteamID( details.AccountID, details.AccountInstance, Client.ConnectedUniverse, EAccountType.Individual );
 
-            if ( details.LoginID == 0 )
+            if ( details.LoginID == null )
             {
                 uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP );
-                details.LoginID = localIp ^ MsgClientLogon.ObfuscationMask;
+                logon.Body.obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+            }
+            else
+            {
+                logon.Body.obfustucated_private_ip = details.LoginID.Value;
             }
 
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = steamId.ConvertToUInt64();
-
-            logon.Body.obfustucated_private_ip = details.LoginID;
 
             logon.Body.account_name = details.Username;
             logon.Body.password = details.Password;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -38,7 +38,13 @@ namespace SteamKit2
             public uint CellID { get; set; }
 
             /// <summary>
-            /// Gets or sets the LoginID. This number is used for identifying logon session. Null value will cause this to be automatically generated.
+            /// Gets or sets the LoginID. This number is used for identifying logon session.
+            /// The purpose of this field is to allow multiple sessions to the same steam account from the same machine.
+            /// This is because Steam Network doesn't allow more than one session with the same LoginID to access given account at the same time.
+            /// If you want to establish more than one active session to given account, you must make sure that every session (to that account) has unique LoginID.
+            /// By default LoginID is automatically generated based on machine's primary bind address, which is the same for all sessions.
+            /// Null value will cause this property to be automatically generated based on default behaviour.
+            /// If in doubt, set this property to null.
             /// </summary>
             /// <value>The LoginID.</value>
             public uint? LoginID { get; set; }


### PR DESCRIPTION
```obfustucated_private_ip``` is being used by Steam to tell which connection is made from the same client / application. Using the same value for second logon will cause first session to disconnect with ```EResult.LogonSessionReplaced```. In some scenarios we may actually want to establish second independent connection to the same account. This is especially useful for sharing the account between SteamKit-based Bot and Steam Client at the same time.

By default old logic is kept, I only made it possible to override it if ```LoginID``` is supplied in ```LogOnDetails```, shouldn't cause any problems or regressions.

Thank you.