### PR TITLE
Add extra two conversions

### DIFF
--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -307,6 +307,42 @@ namespace SteamKit2
         }
 
         /// <summary>
+        /// Attempts to convert and return the value of this instance as an unsigned byte.
+        /// If the conversion is invalid, the default value is returned.
+        /// </summary>
+        /// <param name="defaultValue">The default value to return if the conversion is invalid.</param>
+        /// <returns>The value of this instance as an unsigned byte.</returns>
+        public byte AsUnsignedByte( byte defaultValue = default( byte ) )
+        {
+            byte value;
+
+            if ( byte.TryParse( this.Value, out value ) == false )
+            {
+                return defaultValue;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Attempts to convert and return the value of this instance as an unsigned short.
+        /// If the conversion is invalid, the default value is returned.
+        /// </summary>
+        /// <param name="defaultValue">The default value to return if the conversion is invalid.</param>
+        /// <returns>The value of this instance as an unsigned short.</returns>
+        public ushort AsUnsignedShort( ushort defaultValue = default( ushort ) )
+        {
+            ushort value;
+
+            if ( ushort.TryParse( this.Value, out value ) == false )
+            {
+                return defaultValue;
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Attempts to convert and return the value of this instance as an integer.
         /// If the conversion is invalid, the default value is returned.
         /// </summary>
@@ -323,6 +359,7 @@ namespace SteamKit2
 
             return value;
         }
+
         /// <summary>
         /// Attempts to convert and return the value of this instance as an unsigned integer.
         /// If the conversion is invalid, the default value is returned.
@@ -358,6 +395,7 @@ namespace SteamKit2
 
             return value;
         }
+
         /// <summary>
         /// Attempts to convert and return the value of this instance as an unsigned long.
         /// If the conversion is invalid, the default value is returned.

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -501,27 +501,27 @@ namespace Tests
         }
 
         [Fact]
-		public void KeyValuesUnsignedByteConversion()
+        public void KeyValuesUnsignedByteConversion()
         {
             byte expectedValue = 37;
 
-			var kv = new KeyValue("key", "37");
-			Assert.Equal(kv.AsUnsignedByte(), expectedValue);
+            var kv = new KeyValue("key", "37");
+            Assert.Equal(kv.AsUnsignedByte(), expectedValue);
 
-			kv.Value = "256";
-			Assert.Equal(kv.AsUnsignedByte(expectedValue), expectedValue);
+            kv.Value = "256";
+            Assert.Equal(kv.AsUnsignedByte(expectedValue), expectedValue);
         }
 
-		[Fact]
-		public void KeyValuesUnsignedShortConversion()
+        [Fact]
+        public void KeyValuesUnsignedShortConversion()
         {
             ushort expectedValue = 1337;
 
-			var kv = new KeyValue("key", "1337");
-			Assert.Equal(kv.AsUnsignedShort(), expectedValue);
+            var kv = new KeyValue("key", "1337");
+            Assert.Equal(kv.AsUnsignedShort(), expectedValue);
 
-			kv.Value = "123456";
-			Assert.Equal(kv.AsUnsignedShort(expectedValue), expectedValue);
+            kv.Value = "123456";
+            Assert.Equal(kv.AsUnsignedShort(expectedValue), expectedValue);
         }
 
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -505,11 +505,11 @@ namespace Tests
         {
             byte expectedValue = 37;
 
-            var kv = new KeyValue("key", "37");
-            Assert.Equal(kv.AsUnsignedByte(), expectedValue);
+            var kv = new KeyValue( "key", "37" );
+            Assert.Equal( expectedValue, kv.AsUnsignedByte() );
 
             kv.Value = "256";
-            Assert.Equal(kv.AsUnsignedByte(expectedValue), expectedValue);
+            Assert.Equal( expectedValue, kv.AsUnsignedByte(expectedValue) );
         }
 
         [Fact]
@@ -517,11 +517,11 @@ namespace Tests
         {
             ushort expectedValue = 1337;
 
-            var kv = new KeyValue("key", "1337");
-            Assert.Equal(kv.AsUnsignedShort(), expectedValue);
+            var kv = new KeyValue( "key", "1337" );
+            Assert.Equal( expectedValue, kv.AsUnsignedShort() );
 
             kv.Value = "123456";
-            Assert.Equal(kv.AsUnsignedShort(expectedValue), expectedValue);
+            Assert.Equal( expectedValue, kv.AsUnsignedShort(expectedValue) );
         }
 
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -500,6 +500,30 @@ namespace Tests
             Assert.Equal( expected, text );
         }
 
+        [Fact]
+		public void KeyValuesUnsignedByteConversion()
+        {
+            byte expectedValue = 37;
+
+			var kv = new KeyValue("key", "37");
+			Assert.Equal(kv.AsUnsignedByte(), expectedValue);
+
+			kv.Value = "256";
+			Assert.Equal(kv.AsUnsignedByte(expectedValue), expectedValue);
+        }
+
+		[Fact]
+		public void KeyValuesUnsignedShortConversion()
+        {
+            ushort expectedValue = 1337;
+
+			var kv = new KeyValue("key", "1337");
+			Assert.Equal(kv.AsUnsignedShort(), expectedValue);
+
+			kv.Value = "123456";
+			Assert.Equal(kv.AsUnsignedShort(expectedValue), expectedValue);
+        }
+
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";
     }
 }


### PR DESCRIPTION
I like to keep memory usage of my SK2-based projects low.

It's pretty rare but sometimes key values returned by API call can be stored in 0-255 range or 0-65535. And it's even guaranteed according to Valve documentation.

It should be fine with you I guess :+1:. I kept naming convention just in case we'll want to add ```sbyte``` or ```short``` later.