### PR TITLE
Update protobuf download link

### DIFF
--- a/Resources/NetHook2/SetupDependencies.ps1
+++ b/Resources/NetHook2/SetupDependencies.ps1
@@ -2,7 +2,7 @@ $NetHook2DependenciesTemporaryDirectory = [System.IO.Path]::Combine([System.IO.P
 $ZLibSourceZipUrl = "http://zlib.net/zlib128.zip"
 $ZLibSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "zlib.zip")
 $ZLibSourceInnerFolderName = "zlib-1.2.8"
-$ProtobufSourceZipUrl = "https://protobuf.googlecode.com/files/protobuf-2.5.0.zip"
+$ProtobufSourceZipUrl = "https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.zip"
 $ProtobufSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "protobuf.zip")
 $ProtobufSourceInnerFolderName = "protobuf-2.5.0"
 


### PR DESCRIPTION
The project has been moved to GitHub - while old link works for now and redirects into new place properly, it might stop working anytime and we should track current location instead.