### PR TITLE
Added Java package information to the .proto files

### DIFF
--- a/Resources/Protobufs/csgo/base_gcmessages.proto
+++ b/Resources/Protobufs/csgo/base_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum EGCBaseMsg {
 	k_EMsgGCSystemMessage = 4001;
 	k_EMsgGCReplicateConVars = 4002;

--- a/Resources/Protobufs/csgo/cstrike15_gcmessages.proto
+++ b/Resources/Protobufs/csgo/cstrike15_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum ECsgoGCMsg {
 	k_EMsgGCCStrike15_v2_Base = 9100;
 	k_EMsgGCCStrike15_v2_MatchmakingStart = 9101;

--- a/Resources/Protobufs/csgo/cstrike15_usermessages.proto
+++ b/Resources/Protobufs/csgo/cstrike15_usermessages.proto
@@ -5,6 +5,9 @@ import "cstrike15_gcmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum ECstrike15UserMessages {
 	CS_UM_VGUIMenu = 1;
 	CS_UM_Geiger = 2;

--- a/Resources/Protobufs/csgo/econ_gcmessages.proto
+++ b/Resources/Protobufs/csgo/econ_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum EGCItemMsg {
 	k_EMsgGCBase = 1000;
 	k_EMsgGCSetItemPosition = 1001;

--- a/Resources/Protobufs/csgo/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/csgo/gcsdk_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum GCConnectionStatus {
 	GCConnectionStatus_HAVE_SESSION = 0;
 	GCConnectionStatus_GC_GOING_DOWN = 1;

--- a/Resources/Protobufs/csgo/gcsystemmsgs.proto
+++ b/Resources/Protobufs/csgo/gcsystemmsgs.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum EGCSystemMsg {
 	k_EGCMsgInvalid = 0;
 	k_EGCMsgMulti = 1;

--- a/Resources/Protobufs/csgo/netmessages.proto
+++ b/Resources/Protobufs/csgo/netmessages.proto
@@ -2,6 +2,9 @@ import "google/protobuf/descriptor.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum NET_Messages {
 	net_NOP = 0;
 	net_Disconnect = 1;

--- a/Resources/Protobufs/csgo/network_connection.proto
+++ b/Resources/Protobufs/csgo/network_connection.proto
@@ -2,6 +2,9 @@ import "google/protobuf/descriptor.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 extend .google.protobuf.EnumValueOptions {
 	optional string network_connection_token = 50500;
 }

--- a/Resources/Protobufs/csgo/steamdatagram_messages.proto
+++ b/Resources/Protobufs/csgo/steamdatagram_messages.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 enum ESteamDatagramMsgID {
 	k_ESteamDatagramMsg_RouterPingRequest = 1;
 	k_ESteamDatagramMsg_RouterPingReply = 2;

--- a/Resources/Protobufs/csgo/steammessages.proto
+++ b/Resources/Protobufs/csgo/steammessages.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.csgo";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 60000 [default = false];
 }

--- a/Resources/Protobufs/cstrike/htmlmessages.proto
+++ b/Resources/Protobufs/cstrike/htmlmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.cstrike";
+option java_multiple_files = true;
+
 message CMsgKeyUp {
 	optional uint32 browser_handle = 1;
 	optional uint32 keyCode = 2;

--- a/Resources/Protobufs/cstrike_beta/base_gcmessages.proto
+++ b/Resources/Protobufs/cstrike_beta/base_gcmessages.proto
@@ -1,5 +1,8 @@
 import "steammessages.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.cstrike.beta";
+option java_multiple_files = true;
+
 message CSOPartyInvite {
 	optional uint64 group_id = 1 [(key_field) = true];
 	optional fixed64 sender_id = 2;

--- a/Resources/Protobufs/cstrike_beta/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/cstrike_beta/gcsdk_gcmessages.proto
@@ -1,3 +1,6 @@
+option java_package = "org.opensteamworks.steamkit.base.proto.cstrike.beta";
+option java_multiple_files = true;
+
 message CMsgSOSingleObject {
 	optional fixed64 owner = 1;
 	optional int32 type_id = 2;

--- a/Resources/Protobufs/cstrike_beta/steammessages.proto
+++ b/Resources/Protobufs/cstrike_beta/steammessages.proto
@@ -1,5 +1,8 @@
 import "google/protobuf/descriptor.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.cstrike.beta";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 50000 [default = false];
 	optional bool hidden = 50001 [default = false];

--- a/Resources/Protobufs/dod/htmlmessages.proto
+++ b/Resources/Protobufs/dod/htmlmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dod";
+option java_multiple_files = true;
+
 message CMsgKeyUp {
 	optional uint32 browser_handle = 1;
 	optional uint32 keyCode = 2;

--- a/Resources/Protobufs/dota test/ai_activity.proto
+++ b/Resources/Protobufs/dota test/ai_activity.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum Activity {
 	ACT_INVALID = -1;
 	ACT_RESET = 0;

--- a/Resources/Protobufs/dota test/base_gcmessages.proto
+++ b/Resources/Protobufs/dota test/base_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EGCBaseMsg {
 	k_EMsgGCSystemMessage = 4001;
 	k_EMsgGCReplicateConVars = 4002;

--- a/Resources/Protobufs/dota test/demo.proto
+++ b/Resources/Protobufs/dota test/demo.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDemoCommands {
 	DEM_Error = -1;
 	DEM_Stop = 0;

--- a/Resources/Protobufs/dota test/dota_broadcastmessages.proto
+++ b/Resources/Protobufs/dota test/dota_broadcastmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDotaBroadcastMessages {
 	DOTA_BM_LANLobbyRequest = 1;
 	DOTA_BM_LANLobbyReply = 2;

--- a/Resources/Protobufs/dota test/dota_clientmessages.proto
+++ b/Resources/Protobufs/dota test/dota_clientmessages.proto
@@ -3,6 +3,9 @@ import "dota_commonmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDotaClientMessages {
 	DOTA_CM_MapLine = 1;
 	DOTA_CM_AspectRatio = 2;

--- a/Resources/Protobufs/dota test/dota_commonmessages.proto
+++ b/Resources/Protobufs/dota test/dota_commonmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDOTAChatWheelMessage {
 	k_EDOTA_CW_Ok = 0;
 	k_EDOTA_CW_Care = 1;

--- a/Resources/Protobufs/dota test/dota_gcmessages_client.proto
+++ b/Resources/Protobufs/dota test/dota_gcmessages_client.proto
@@ -5,6 +5,9 @@ import "gcsdk_gcmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum ETournamentGameState {
 	k_ETournamentGameState_Unknown = 0;
 	k_ETournamentGameState_Scheduled = 1;

--- a/Resources/Protobufs/dota test/dota_gcmessages_client_fantasy.proto
+++ b/Resources/Protobufs/dota test/dota_gcmessages_client_fantasy.proto
@@ -3,6 +3,9 @@ import "dota_gcmessages_common.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 message CMsgGCPlayerInfo {
 	message PlayerInfo {
 		optional uint32 account_id = 1;

--- a/Resources/Protobufs/dota test/dota_gcmessages_common.proto
+++ b/Resources/Protobufs/dota test/dota_gcmessages_common.proto
@@ -4,6 +4,9 @@ import "gcsdk_gcmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDOTAGCMsg {
 	k_EMsgGCDOTABase = 7000;
 	k_EMsgGCGeneralResponse = 7001;

--- a/Resources/Protobufs/dota test/dota_gcmessages_server.proto
+++ b/Resources/Protobufs/dota test/dota_gcmessages_server.proto
@@ -6,6 +6,9 @@ import "network_connection.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EPoorNetworkConditionsType {
 	k_EPoorNetworkConditions_None = 0;
 	k_EPoorNetworkConditions_Unknown = 1;

--- a/Resources/Protobufs/dota test/dota_modifiers.proto
+++ b/Resources/Protobufs/dota test/dota_modifiers.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum DOTA_MODIFIER_ENTRY_TYPE {
 	DOTA_MODIFIER_ENTRY_TYPE_ACTIVE = 1;
 	DOTA_MODIFIER_ENTRY_TYPE_REMOVED = 2;

--- a/Resources/Protobufs/dota test/dota_usermessages.proto
+++ b/Resources/Protobufs/dota test/dota_usermessages.proto
@@ -5,6 +5,9 @@ import "dota_commonmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EDotaUserMessages {
 	DOTA_UM_AddUnitToSelection = 64;
 	DOTA_UM_AIDebugLine = 65;

--- a/Resources/Protobufs/dota test/econ_gcmessages.proto
+++ b/Resources/Protobufs/dota test/econ_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EGCItemMsg {
 	k_EMsgGCBase = 1000;
 	k_EMsgGCSetItemPosition = 1001;

--- a/Resources/Protobufs/dota test/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/dota test/gcsdk_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum ESourceEngine {
 	k_ESE_Source1 = 0;
 	k_ESE_Source2 = 1;

--- a/Resources/Protobufs/dota test/gcsystemmsgs.proto
+++ b/Resources/Protobufs/dota test/gcsystemmsgs.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EGCSystemMsg {
 	k_EGCMsgInvalid = 0;
 	k_EGCMsgMulti = 1;

--- a/Resources/Protobufs/dota test/netmessages.proto
+++ b/Resources/Protobufs/dota test/netmessages.proto
@@ -2,6 +2,9 @@ import "networkbasetypes.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum CLC_Messages {
 	clc_ClientInfo = 8;
 	clc_Move = 9;

--- a/Resources/Protobufs/dota test/network_connection.proto
+++ b/Resources/Protobufs/dota test/network_connection.proto
@@ -2,6 +2,9 @@ import "google/protobuf/descriptor.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 extend .google.protobuf.EnumValueOptions {
 	optional string network_connection_token = 50500;
 }

--- a/Resources/Protobufs/dota test/networkbasetypes.proto
+++ b/Resources/Protobufs/dota test/networkbasetypes.proto
@@ -2,6 +2,9 @@ import "network_connection.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum SIGNONSTATE {
 	SIGNONSTATE_NONE = 0;
 	SIGNONSTATE_CHALLENGE = 1;

--- a/Resources/Protobufs/dota test/steamdatagram_messages.proto
+++ b/Resources/Protobufs/dota test/steamdatagram_messages.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum ESteamDatagramMsgID {
 	k_ESteamDatagramMsg_RouterPingRequest = 1;
 	k_ESteamDatagramMsg_RouterPingReply = 2;

--- a/Resources/Protobufs/dota test/steammessages.proto
+++ b/Resources/Protobufs/dota test/steammessages.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 60000 [default = false];
 }

--- a/Resources/Protobufs/dota test/steammessages_cloud.steamworkssdk.proto
+++ b/Resources/Protobufs/dota test/steammessages_cloud.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 message CCloud_GetUploadServerInfo_Request {
 	optional uint32 appid = 1 [(description) = "App ID to which a file will be uploaded to."];
 }

--- a/Resources/Protobufs/dota test/steammessages_oauth.steamworkssdk.proto
+++ b/Resources/Protobufs/dota test/steammessages_oauth.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 message COAuthToken_ImplicitGrantNoPrompt_Request {
 	optional string clientid = 1 [(description) = "Client ID for which to count the number of issued tokens"];
 }

--- a/Resources/Protobufs/dota test/steammessages_publishedfile.steamworkssdk.proto
+++ b/Resources/Protobufs/dota test/steammessages_publishedfile.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 message CPublishedFile_Subscribe_Request {
 	optional uint64 publishedfileid = 1;
 	optional uint64 steamid = 2;

--- a/Resources/Protobufs/dota test/steammessages_unified_base.steamworkssdk.proto
+++ b/Resources/Protobufs/dota test/steammessages_unified_base.steamworkssdk.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional string description = 50000;
 }

--- a/Resources/Protobufs/dota test/usermessages.proto
+++ b/Resources/Protobufs/dota test/usermessages.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota.test";
+option java_multiple_files = true;
+
 enum EBaseUserMessages {
 	UM_AchievementEvent = 1;
 	UM_CloseCaption = 2;

--- a/Resources/Protobufs/dota/base_gcmessages.proto
+++ b/Resources/Protobufs/dota/base_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EGCBaseMsg {
 	k_EMsgGCSystemMessage = 4001;
 	k_EMsgGCReplicateConVars = 4002;

--- a/Resources/Protobufs/dota/c_peer2peer_netmessages.proto
+++ b/Resources/Protobufs/dota/c_peer2peer_netmessages.proto
@@ -2,6 +2,9 @@ import "netmessages.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum P2P_Messages {
 	p2p_TextMessage = 256;
 	p2p_Voice = 257;

--- a/Resources/Protobufs/dota/clientmessages.proto
+++ b/Resources/Protobufs/dota/clientmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EBaseClientMessages {
 	CM_CustomGameEvent = 280;
 	CM_TrackedControllerInput = 281;

--- a/Resources/Protobufs/dota/connectionless_netmessages.proto
+++ b/Resources/Protobufs/dota/connectionless_netmessages.proto
@@ -2,6 +2,9 @@ import "netmessages.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message C2S_CONNECT_Message {
 	optional uint32 host_version = 1;
 	optional uint32 auth_protocol = 2;

--- a/Resources/Protobufs/dota/demo.proto
+++ b/Resources/Protobufs/dota/demo.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDemoCommands {
 	DEM_Error = -1;
 	DEM_Stop = 0;

--- a/Resources/Protobufs/dota/dota_broadcastmessages.proto
+++ b/Resources/Protobufs/dota/dota_broadcastmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDotaBroadcastMessages {
 	DOTA_BM_LANLobbyRequest = 1;
 	DOTA_BM_LANLobbyReply = 2;

--- a/Resources/Protobufs/dota/dota_client_enums.proto
+++ b/Resources/Protobufs/dota/dota_client_enums.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ETournamentTemplate {
 	k_ETournamentTemplate_None = 0;
 	k_ETournamentTemplate_AutomatedWin3 = 1;

--- a/Resources/Protobufs/dota/dota_clientmessages.proto
+++ b/Resources/Protobufs/dota/dota_clientmessages.proto
@@ -3,6 +3,9 @@ import "dota_commonmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDotaClientMessages {
 	DOTA_CM_MapLine = 301;
 	DOTA_CM_AspectRatio = 302;

--- a/Resources/Protobufs/dota/dota_commonmessages.proto
+++ b/Resources/Protobufs/dota/dota_commonmessages.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDOTAChatWheelMessage {
 	k_EDOTA_CW_Ok = 0;
 	k_EDOTA_CW_Care = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client.proto
@@ -7,6 +7,9 @@ import "dota_gcmessages_common_match_management.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum DOTA_WatchReplayType {
 	DOTA_WATCH_REPLAY_NORMAL = 0;
 	DOTA_WATCH_REPLAY_HIGHLIGHTS = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_chat.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_chat.proto
@@ -3,6 +3,9 @@ import "dota_shared_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CMsgClientToGCPrivateChatInvite {
 	optional string private_chat_channel_name = 1;
 	optional uint32 invited_account_id = 2;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_fantasy.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_fantasy.proto
@@ -3,6 +3,9 @@ import "dota_shared_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum DOTA_2013PassportSelectionIndices {
 	PP13_SEL_ALLSTAR_PLAYER_0 = 0;
 	PP13_SEL_ALLSTAR_PLAYER_1 = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_guild.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_guild.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CMsgDOTAGuildSDO {
 	message Member {
 		optional uint32 account_id = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_match_management.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_match_management.proto
@@ -7,6 +7,9 @@ import "dota_gcmessages_common_match_management.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EStartFindingMatchResult {
 	k_EStartFindingMatchResult_Invalid = 0;
 	k_EStartFindingMatchResult_OK = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_team.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_team.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ETeamInviteResult {
 	TEAM_INVITE_SUCCESS = 0;
 	TEAM_INVITE_FAILURE_INVITE_REJECTED = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_tournament.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_tournament.proto
@@ -3,6 +3,9 @@ import "dota_client_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ETournamentEvent {
 	k_ETournamentEvent_None = 0;
 	k_ETournamentEvent_TournamentCreated = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_client_watch.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_client_watch.proto
@@ -4,6 +4,9 @@ import "dota_gcmessages_common.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CSourceTVGameSmall {
 	message Player {
 		optional uint32 account_id = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_common.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_common.proto
@@ -5,6 +5,9 @@ import "dota_shared_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ESpecialPingValue {
 	k_ESpecialPingValue_NoData = 16382;
 	k_ESpecialPingValue_Failed = 16383;

--- a/Resources/Protobufs/dota/dota_gcmessages_common_match_management.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_common_match_management.proto
@@ -5,6 +5,9 @@ import "dota_shared_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum LobbyDotaTVDelay {
 	LobbyDotaTV_10 = 0;
 	LobbyDotaTV_120 = 1;

--- a/Resources/Protobufs/dota/dota_gcmessages_msgid.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_msgid.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDOTAGCMsg {
 	k_EMsgGCDOTABase = 7000;
 	k_EMsgGCGeneralResponse = 7001;

--- a/Resources/Protobufs/dota/dota_gcmessages_server.proto
+++ b/Resources/Protobufs/dota/dota_gcmessages_server.proto
@@ -8,6 +8,9 @@ import "dota_gcmessages_common_match_management.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EPoorNetworkConditionsType {
 	k_EPoorNetworkConditions_None = 0;
 	k_EPoorNetworkConditions_Unknown = 1;

--- a/Resources/Protobufs/dota/dota_match_metadata.proto
+++ b/Resources/Protobufs/dota/dota_match_metadata.proto
@@ -3,6 +3,9 @@ import "dota_gcmessages_common_match_management.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CDOTAMatchMetadataFile {
 	required int32 version = 1;
 	required uint64 match_id = 2;

--- a/Resources/Protobufs/dota/dota_modifiers.proto
+++ b/Resources/Protobufs/dota/dota_modifiers.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum DOTA_MODIFIER_ENTRY_TYPE {
 	DOTA_MODIFIER_ENTRY_TYPE_ACTIVE = 1;
 	DOTA_MODIFIER_ENTRY_TYPE_REMOVED = 2;

--- a/Resources/Protobufs/dota/dota_shared_enums.proto
+++ b/Resources/Protobufs/dota/dota_shared_enums.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum DOTA_GameMode {
 	DOTA_GAMEMODE_NONE = 0;
 	DOTA_GAMEMODE_AP = 1;

--- a/Resources/Protobufs/dota/dota_usermessages.proto
+++ b/Resources/Protobufs/dota/dota_usermessages.proto
@@ -4,6 +4,9 @@ import "dota_commonmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EDotaUserMessages {
 	DOTA_UM_AddUnitToSelection = 464;
 	DOTA_UM_AIDebugLine = 465;

--- a/Resources/Protobufs/dota/econ_gcmessages.proto
+++ b/Resources/Protobufs/dota/econ_gcmessages.proto
@@ -4,6 +4,9 @@ import "econ_shared_enums.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EGCItemMsg {
 	k_EMsgGCBase = 1000;
 	k_EMsgGCSetItemPosition = 1001;

--- a/Resources/Protobufs/dota/econ_shared_enums.proto
+++ b/Resources/Protobufs/dota/econ_shared_enums.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EGCEconBaseMsg {
 	k_EMsgGCGenericResult = 2579;
 }

--- a/Resources/Protobufs/dota/gameevents.proto
+++ b/Resources/Protobufs/dota/gameevents.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EBaseGameEvents {
 	GE_VDebugGameSessionIDEvent = 200;
 	GE_PlaceDecalEvent = 201;

--- a/Resources/Protobufs/dota/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/dota/gcsdk_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ESourceEngine {
 	k_ESE_Source1 = 0;
 	k_ESE_Source2 = 1;

--- a/Resources/Protobufs/dota/gcsystemmsgs.proto
+++ b/Resources/Protobufs/dota/gcsystemmsgs.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EGCSystemMsg {
 	k_EGCMsgInvalid = 0;
 	k_EGCMsgMulti = 1;

--- a/Resources/Protobufs/dota/netmessages.proto
+++ b/Resources/Protobufs/dota/netmessages.proto
@@ -2,6 +2,9 @@ import "networkbasetypes.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum CLC_Messages {
 	clc_ClientInfo = 20;
 	clc_Move = 21;

--- a/Resources/Protobufs/dota/network_connection.proto
+++ b/Resources/Protobufs/dota/network_connection.proto
@@ -2,6 +2,9 @@ import "google/protobuf/descriptor.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 extend .google.protobuf.EnumValueOptions {
 	optional string network_connection_token = 50500;
 }

--- a/Resources/Protobufs/dota/networkbasetypes.proto
+++ b/Resources/Protobufs/dota/networkbasetypes.proto
@@ -2,6 +2,9 @@ import "network_connection.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum NET_Messages {
 	net_NOP = 0;
 	net_Disconnect = 1;

--- a/Resources/Protobufs/dota/networksystem_protomessages.proto
+++ b/Resources/Protobufs/dota/networksystem_protomessages.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message NetMessageSplitscreenUserChanged {
 	optional uint32 slot = 1;
 }

--- a/Resources/Protobufs/dota/rendermessages.proto
+++ b/Resources/Protobufs/dota/rendermessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CMsgBeginFrame {
 	optional double frame_paint_time = 1;
 	optional uint32 surface_width = 2;

--- a/Resources/Protobufs/dota/steamdatagram_messages.proto
+++ b/Resources/Protobufs/dota/steamdatagram_messages.proto
@@ -1,5 +1,8 @@
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ESteamDatagramMsgID {
 	k_ESteamDatagramMsg_RouterPingRequest = 1;
 	k_ESteamDatagramMsg_RouterPingReply = 2;

--- a/Resources/Protobufs/dota/steammessages.proto
+++ b/Resources/Protobufs/dota/steammessages.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 60000 [default = false];
 }

--- a/Resources/Protobufs/dota/steammessages_cloud.steamworkssdk.proto
+++ b/Resources/Protobufs/dota/steammessages_cloud.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CCloud_GetUploadServerInfo_Request {
 	optional uint32 appid = 1 [(description) = "App ID to which a file will be uploaded to."];
 }

--- a/Resources/Protobufs/dota/steammessages_oauth.steamworkssdk.proto
+++ b/Resources/Protobufs/dota/steammessages_oauth.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message COAuthToken_ImplicitGrantNoPrompt_Request {
 	optional string clientid = 1 [(description) = "Client ID for which to count the number of issued tokens"];
 }

--- a/Resources/Protobufs/dota/steammessages_publishedfile.steamworkssdk.proto
+++ b/Resources/Protobufs/dota/steammessages_publishedfile.steamworkssdk.proto
@@ -1,5 +1,8 @@
 import "steammessages_unified_base.steamworkssdk.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message CPublishedFile_Subscribe_Request {
 	optional uint64 publishedfileid = 1;
 	optional uint32 list_type = 2;

--- a/Resources/Protobufs/dota/steammessages_unified_base.steamworkssdk.proto
+++ b/Resources/Protobufs/dota/steammessages_unified_base.steamworkssdk.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional string description = 50000;
 }

--- a/Resources/Protobufs/dota/te.proto
+++ b/Resources/Protobufs/dota/te.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum ETEProtobufIds {
 	TE_EffectDispatchId = 400;
 	TE_ArmorRicochetId = 401;

--- a/Resources/Protobufs/dota/toolevents.proto
+++ b/Resources/Protobufs/dota/toolevents.proto
@@ -2,6 +2,9 @@ import "networkbasetypes.proto";
 
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 message ChangeMapToolEvent {
 	optional string mapname = 1;
 }

--- a/Resources/Protobufs/dota/usermessages.proto
+++ b/Resources/Protobufs/dota/usermessages.proto
@@ -3,6 +3,9 @@ import "networkbasetypes.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.dota";
+option java_multiple_files = true;
+
 enum EBaseUserMessages {
 	UM_AchievementEvent = 101;
 	UM_CloseCaption = 102;

--- a/Resources/Protobufs/gc/gc.proto
+++ b/Resources/Protobufs/gc/gc.proto
@@ -1,3 +1,6 @@
+option java_package = "org.opensteamworks.steamkit.base.proto.gc";
+option java_multiple_files = true;
+
 enum GCProtoBufMsgSrc {
 	GCProtoBufMsgSrc_Unspecified = 0;
 	GCProtoBufMsgSrc_FromSystem = 1;

--- a/Resources/Protobufs/portal/steammessages.proto
+++ b/Resources/Protobufs/portal/steammessages.proto
@@ -1,3 +1,6 @@
+option java_package = "org.opensteamworks.steamkit.base.proto.portal";
+option java_multiple_files = true;
+
 message CMsgProtoBufHeader {
 	optional fixed64 client_steam_id = 1;
 	optional int32 client_session_id = 2;

--- a/Resources/Protobufs/portal2/base_gcmessages.proto
+++ b/Resources/Protobufs/portal2/base_gcmessages.proto
@@ -1,5 +1,8 @@
 import "steammessages.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.portal2";
+option java_multiple_files = true;
+
 option optimize_for = SPEED;
 option cc_generic_services = false;
 

--- a/Resources/Protobufs/portal2/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/portal2/gcsdk_gcmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.portal2";
+option java_multiple_files = true;
+
 message CMsgSOSingleObject {
 	optional fixed64 owner = 1;
 	optional int32 type_id = 2;

--- a/Resources/Protobufs/portal2/steammessages.proto
+++ b/Resources/Protobufs/portal2/steammessages.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.portal2";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 50000 [default = false];
 	optional bool hidden = 50001 [default = false];

--- a/Resources/Protobufs/steamclient/content_manifest.proto
+++ b/Resources/Protobufs/steamclient/content_manifest.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message ContentManifestPayload {
 	message FileMapping {
 		message ChunkData {

--- a/Resources/Protobufs/steamclient/encrypted_app_ticket.proto
+++ b/Resources/Protobufs/steamclient/encrypted_app_ticket.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message EncryptedAppTicket {
 	optional uint32 ticket_version_no = 1;
 	optional uint32 crc_encryptedticket = 2;

--- a/Resources/Protobufs/steamclient/htmlmessages.proto
+++ b/Resources/Protobufs/steamclient/htmlmessages.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CMsgKeyUp {
 	optional uint32 browser_handle = 1;
 	optional uint32 keyCode = 2;

--- a/Resources/Protobufs/steamclient/steammessages_base.proto
+++ b/Resources/Protobufs/steamclient/steammessages_base.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 extend .google.protobuf.MessageOptions {
 	optional int32 msgpool_soft_limit = 50000 [default = 32];
 	optional int32 msgpool_hard_limit = 50001 [default = 384];

--- a/Resources/Protobufs/steamclient/steammessages_broadcast.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_broadcast.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CBroadcast_BeginBroadcastSession_Request {
 	optional int32 permission = 1;
 	optional uint64 gameid = 2;

--- a/Resources/Protobufs/steamclient/steammessages_clientserver.proto
+++ b/Resources/Protobufs/steamclient/steammessages_clientserver.proto
@@ -4,6 +4,9 @@ import "encrypted_app_ticket.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CMsgClientHeartBeat {
 }
 

--- a/Resources/Protobufs/steamclient/steammessages_clientserver_2.proto
+++ b/Resources/Protobufs/steamclient/steammessages_clientserver_2.proto
@@ -4,6 +4,9 @@ import "encrypted_app_ticket.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CMsgClientUCMAddScreenshot {
 	message Tag {
 		optional string tag_name = 1;

--- a/Resources/Protobufs/steamclient/steammessages_cloud.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_cloud.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CCloud_GetUploadServerInfo_Request {
 	optional uint32 appid = 1 [(description) = "App ID to which a file will be uploaded to."];
 }

--- a/Resources/Protobufs/steamclient/steammessages_credentials.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_credentials.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CCredentials_TestAvailablePassword_Request {
 	optional string password = 1;
 	optional bytes sha_digest_password = 2;

--- a/Resources/Protobufs/steamclient/steammessages_depotbuilder.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_depotbuilder.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CContentBuilder_InitDepotBuild_Request {
 	optional uint32 appid = 1;
 	optional uint32 depotid = 2;

--- a/Resources/Protobufs/steamclient/steammessages_deviceauth.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_deviceauth.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CDeviceAuth_GetOwnAuthorizedDevices_Request {
 	optional fixed64 steamid = 1;
 	optional bool include_canceled = 2;

--- a/Resources/Protobufs/steamclient/steammessages_econ.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_econ.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CEcon_ClientGetItemShopOverlayAuthURL_Request {
 	optional string return_url = 1;
 }

--- a/Resources/Protobufs/steamclient/steammessages_gamenotifications.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_gamenotifications.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CGameNotifications_Variable {
 	optional string key = 1 [(description) = "The name of the variable in the localized text -- anywhere that %variablename% is found within the text it will be substituded with the given value"];
 	optional string value = 2 [(description) = "The value of the variable to substitute in the localized text in place of the given variable.  Can itself be a localization token."];

--- a/Resources/Protobufs/steamclient/steammessages_gameservers.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_gameservers.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CGameServers_GetServerList_Request {
 	optional string filter = 1 [(description) = "Query filter string."];
 	optional uint32 limit = 2 [default = 100, (description) = "The maximum number of servers to return in the response"];

--- a/Resources/Protobufs/steamclient/steammessages_inventory.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_inventory.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CInventory_GetInventory_Request {
 	optional uint32 appid = 1;
 	optional uint64 steamid = 2;

--- a/Resources/Protobufs/steamclient/steammessages_linkfilter.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_linkfilter.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CCommunity_GetLinkFilterHashPrefixes_Request {
 	optional uint32 hit_type = 1 [(description) = "The retrieved hits will be filtered to this type."];
 	optional uint32 count = 2 [(description) = "The number of hits to retrieve in a single batch. Specify 0 for no limit."];

--- a/Resources/Protobufs/steamclient/steammessages_offline.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_offline.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message COffline_GetOfflineLogonTicket_Request {
 	optional uint32 priority = 1;
 }

--- a/Resources/Protobufs/steamclient/steammessages_parental.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_parental.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message ParentalApp {
 	optional uint32 appid = 1;
 	optional bool is_allowed = 2;

--- a/Resources/Protobufs/steamclient/steammessages_partnerapps.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_partnerapps.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CPartnerApps_RequestUploadToken_Request {
 	optional string filename = 1;
 	optional uint32 appid = 2;

--- a/Resources/Protobufs/steamclient/steammessages_physicalgoods.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_physicalgoods.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CPhysicalGoods_RegisterSteamController_Request {
 	optional string serial_number = 1;
 	optional string controller_code = 2;

--- a/Resources/Protobufs/steamclient/steammessages_player.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_player.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CPlayer_GetGameBadgeLevels_Request {
 	optional uint32 appid = 1;
 }

--- a/Resources/Protobufs/steamclient/steammessages_publishedfile.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_publishedfile.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CPublishedFile_Subscribe_Request {
 	optional uint64 publishedfileid = 1;
 	optional uint32 list_type = 2;

--- a/Resources/Protobufs/steamclient/steammessages_remoteclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_remoteclient.proto
@@ -4,6 +4,9 @@ import "steammessages_remoteclient_discovery.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CMsgRemoteClientAppStatus {
 	message AppUpdateInfo {
 		optional fixed32 time_update_start = 1;

--- a/Resources/Protobufs/steamclient/steammessages_remoteclient_discovery.proto
+++ b/Resources/Protobufs/steamclient/steammessages_remoteclient_discovery.proto
@@ -1,5 +1,8 @@
 option optimize_for = SPEED;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 enum ERemoteClientBroadcastMsg {
 	k_ERemoteClientBroadcastMsgDiscovery = 0;
 	k_ERemoteClientBroadcastMsgStatus = 1;

--- a/Resources/Protobufs/steamclient/steammessages_secrets.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_secrets.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 enum EKeyEscrowUsage {
 	k_EKeyEscrowUsageStreamingDevice = 0;
 }

--- a/Resources/Protobufs/steamclient/steammessages_twofactor.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_twofactor.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CTwoFactor_Status_Request {
 	optional fixed64 steamid = 1 [(description) = "steamid to use"];
 }

--- a/Resources/Protobufs/steamclient/steammessages_unified_base.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_unified_base.steamclient.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional string description = 50000;
 }

--- a/Resources/Protobufs/steamclient/steammessages_unified_test.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_unified_test.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CMsgTest_MessageToClient_Request {
 	optional string some_text = 1 [(description) = "Some string."];
 }

--- a/Resources/Protobufs/steamclient/steammessages_video.steamclient.proto
+++ b/Resources/Protobufs/steamclient/steammessages_video.steamclient.proto
@@ -2,6 +2,9 @@ import "steammessages_unified_base.steamclient.proto";
 
 option cc_generic_services = true;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient";
+option java_multiple_files = true;
+
 message CVideo_ClientGetVideoURL_Request {
 	optional uint64 video_id = 1 [(description) = "Video ID"];
 	optional uint32 client_cellid = 2 [(description) = "Cell ID of client, zero if unknown"];

--- a/Resources/Protobufs/steamclient_streaming_client/steammessages_remoteclient_discovery.proto
+++ b/Resources/Protobufs/steamclient_streaming_client/steammessages_remoteclient_discovery.proto
@@ -1,5 +1,8 @@
 option optimize_for = SPEED;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient.streaming";
+option java_multiple_files = true;
+
 enum ERemoteClientBroadcastMsg {
 	k_ERemoteClientBroadcastMsgDiscovery = 0;
 	k_ERemoteClientBroadcastMsgStatus = 1;

--- a/Resources/Protobufs/steamclient_streaming_client/stream.proto
+++ b/Resources/Protobufs/steamclient_streaming_client/stream.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.steamclient.streaming";
+option java_multiple_files = true;
+
 enum EStreamChannel {
 	k_EStreamChannelInvalid = -1;
 	k_EStreamChannelDiscovery = 0;

--- a/Resources/Protobufs/tf/base_gcmessages.proto
+++ b/Resources/Protobufs/tf/base_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 enum EGCBaseMsg {
 	k_EMsgGCSystemMessage = 4001;
 	k_EMsgGCReplicateConVars = 4002;

--- a/Resources/Protobufs/tf/econ_gcmessages.proto
+++ b/Resources/Protobufs/tf/econ_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 enum EGCItemMsg {
 	k_EMsgGCBase = 1000;
 	k_EMsgGCSetSingleItemPosition = 1001;

--- a/Resources/Protobufs/tf/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/tf/gcsdk_gcmessages.proto
@@ -3,6 +3,9 @@ import "steammessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 enum PartnerAccountType {
 	PARTNER_NONE = 0;
 	PARTNER_PERFECT_WORLD = 1;

--- a/Resources/Protobufs/tf/gcsystemmsgs.proto
+++ b/Resources/Protobufs/tf/gcsystemmsgs.proto
@@ -1,6 +1,9 @@
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 enum EGCSystemMsg {
 	k_EGCMsgInvalid = 0;
 	k_EGCMsgMulti = 1;

--- a/Resources/Protobufs/tf/steammessages.proto
+++ b/Resources/Protobufs/tf/steammessages.proto
@@ -3,6 +3,9 @@ import "google/protobuf/descriptor.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 60000 [default = false];
 }

--- a/Resources/Protobufs/tf/tf_gcmessages.proto
+++ b/Resources/Protobufs/tf/tf_gcmessages.proto
@@ -4,6 +4,9 @@ import "base_gcmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf";
+option java_multiple_files = true;
+
 enum ETFGCMsg {
 	k_EMsgGCReportWarKill = 5001;
 	k_EMsgGCVoteKickBanPlayer = 5018;

--- a/Resources/Protobufs/tf_beta/base_gcmessages.proto
+++ b/Resources/Protobufs/tf_beta/base_gcmessages.proto
@@ -1,5 +1,8 @@
 import "steammessages.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf.beta";
+option java_multiple_files = true;
+
 enum GCGoodbyeReason {
 	GCGoodbyeReason_GC_GOING_DOWN = 1;
 	GCGoodbyeReason_NO_SESSION = 2;

--- a/Resources/Protobufs/tf_beta/gcsdk_gcmessages.proto
+++ b/Resources/Protobufs/tf_beta/gcsdk_gcmessages.proto
@@ -1,3 +1,6 @@
+option java_package = "org.opensteamworks.steamkit.base.proto.tf.beta";
+option java_multiple_files = true;
+
 message CMsgSOSingleObject {
 	optional fixed64 owner = 1;
 	optional int32 type_id = 2;

--- a/Resources/Protobufs/tf_beta/htmlmessages.proto
+++ b/Resources/Protobufs/tf_beta/htmlmessages.proto
@@ -1,3 +1,6 @@
+option java_package = "org.opensteamworks.steamkit.base.proto.tf.beta";
+option java_multiple_files = true;
+
 message CMsgKeyUp {
 	optional uint32 browser_handle = 1;
 	optional uint32 keyCode = 2;

--- a/Resources/Protobufs/tf_beta/steammessages.proto
+++ b/Resources/Protobufs/tf_beta/steammessages.proto
@@ -1,5 +1,8 @@
 import "google/protobuf/descriptor.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf.beta";
+option java_multiple_files = true;
+
 extend .google.protobuf.FieldOptions {
 	optional bool key_field = 50000 [default = false];
 }

--- a/Resources/Protobufs/tf_beta/tf_gcmessages.proto
+++ b/Resources/Protobufs/tf_beta/tf_gcmessages.proto
@@ -1,5 +1,8 @@
 import "steammessages.proto";
 
+option java_package = "org.opensteamworks.steamkit.base.proto.tf.beta";
+option java_multiple_files = true;
+
 enum TF_MatchmakingMode {
 	TF_Matchmaking_INVALID = 0;
 	TF_Matchmaking_QUICKPLAY = 1;


### PR DESCRIPTION
In order to generate Java source based on the protocol buffers with protoc (or https://github.com/google/protobuf-gradle-plugin) additional Java options are needed.