### PR TITLE
Fix for memory leakages in SteamDB

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -178,6 +178,19 @@ namespace SteamKit2
             Handle( call );
         }
         /// <summary>
+        /// Blocks the current thread to run all queued callbacks.
+        /// If no callback is queued, the method will block for the given timeout.
+        /// </summary>
+        /// <param name="timeout">The length of time to block.</param>
+        public void RunWaitAllCallbacks( TimeSpan timeout )
+        {
+            var calls = client.GetAllCallbacks( true, timeout );
+            foreach ( var call in calls )
+            {
+                Handle( call );
+            }
+        }
+        /// <summary>
         /// Blocks the current thread to run a single queued callback.
         /// If no callback is queued, the method will block until one is posted.
         /// </summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using ProtoBuf;
@@ -225,7 +226,35 @@ namespace SteamKit2
                 return ( freeLast ? callbackQueue.Dequeue() : callbackQueue.Peek() );
             }
         }
+        /// <summary>
+        /// Blocks the calling thread until the queue contains a callback object. Returns all callbacks, and optionally frees them.
+        /// </summary>
+        /// <param name="freeLast">if set to <c>true</c> this function also frees all callbacks.</param>
+        /// <param name="timeout">The length of time to block.</param>
+        /// <returns>All current callback objects in the queue.</returns>
+        public IEnumerable<ICallbackMsg> GetAllCallbacks( bool freeLast, TimeSpan timeout )
+        {
+            IEnumerable<ICallbackMsg> callbacks;
 
+            lock ( callbackLock )
+            {
+                if ( callbackQueue.Count == 0 )
+                {
+                    if ( !Monitor.Wait( callbackLock, timeout ) )
+                    {
+                        return Enumerable.Empty<ICallbackMsg>();
+                    }
+                }
+
+                callbacks = callbackQueue.ToArray();
+                if ( freeLast )
+                {
+                    callbackQueue.Clear();
+                }
+            }
+
+            return callbacks;
+        }
         /// <summary>
         /// Frees the last callback in the queue.
         /// </summary>
@@ -333,6 +362,8 @@ namespace SteamKit2
         /// </summary>
         protected override void OnClientDisconnected( bool userInitiated )
         {
+            base.OnClientDisconnected( userInitiated );
+
             // if we are disconnected, cancel all pending jobs
             jobManager.CancelPendingJobs();
 

--- a/SteamKit2/Tests/CMClientFacts.cs
+++ b/SteamKit2/Tests/CMClientFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using SteamKit2;
 using SteamKit2.Internal;
 using Xunit;
@@ -63,12 +64,74 @@ namespace Tests
             Assert.Null(packetMsg);
         }
 
+        [Fact]
+        public void ServerLookupIsClearedWhenDisconnecting()
+        {
+            var msg = new ClientMsgProtobuf<CMsgClientServerList>( EMsg.ClientServerList );
+            msg.Body.servers.Add( new CMsgClientServerList.Server
+            {
+                server_type = ( int )EServerType.CM,
+                server_ip = 0x7F000001, // 127.0.0.1
+                server_port = 1234
+            });
+
+            var client = new DummyCMClient();
+            client.HandleClientMsg( msg );
+
+            Assert.Equal( 1, client.GetServersOfType( EServerType.CM ).Count );
+
+            client.DummyDisconnect();
+            Assert.Equal( 0, client.GetServersOfType( EServerType.CM ).Count );
+        }
+
+        [Fact]
+        public void ServerLookupDoesNotAccumulateDuplicates()
+        {
+            var msg = new ClientMsgProtobuf<CMsgClientServerList>( EMsg.ClientServerList );
+            msg.Body.servers.Add( new CMsgClientServerList.Server
+            {
+                server_type = ( int )EServerType.CM,
+                server_ip = 0x7F000001, // 127.0.0.1
+                server_port = 1234
+            });
+
+            var client = new DummyCMClient();
+            client.HandleClientMsg( msg );
+            Assert.Equal( 1, client.GetServersOfType( EServerType.CM ).Count );
+
+            client.HandleClientMsg( msg );
+            Assert.Equal( 1, client.GetServersOfType( EServerType.CM ).Count );
+        }
+
         static byte[] Serialize(ISteamSerializableHeader hdr)
         {
             using (var ms = new MemoryStream())
             {
                 hdr.Serialize(ms);
                 return ms.ToArray();
+            }
+        }
+
+        class DummyCMClient : CMClient
+        {
+            public DummyCMClient()
+            {
+                PretendEncryptionIsSetUp();
+            }
+
+            public void DummyDisconnect()
+            {
+                Disconnect();
+                OnClientDisconnected( true );
+            }
+
+            public void HandleClientMsg( IClientMsg clientMsg )
+                => OnClientMsgReceived( GetPacketMsg( clientMsg.Serialize() ) );
+
+            void PretendEncryptionIsSetUp()
+            {
+                var field = typeof( CMClient ).GetField( "encryptionSetup", BindingFlags.Instance | BindingFlags.NonPublic );
+                field.SetValue( this, true );
             }
         }
     }

--- a/SteamKit2/Tests/CallbackManagerFacts.cs
+++ b/SteamKit2/Tests/CallbackManagerFacts.cs
@@ -168,6 +168,34 @@ namespace Tests
             Assert.Equal(1, callCount);
         }
 
+        [Fact]
+        public void PostedCallbacksTriggerActions()
+        {
+            var callback = new CallbackForTest { UniqueID = Guid.NewGuid() };
+
+            var numCallbacksRun = 0;
+            Action<CallbackForTest> action = delegate (CallbackForTest cb)
+            {
+                Assert.Equal(callback.UniqueID, cb.UniqueID);
+                numCallbacksRun++;
+            };
+
+            using (mgr.Subscribe(action))
+            {
+                for (var i = 0; i < 10; i++)
+                {
+                    client.PostCallback(callback);
+                }
+
+                mgr.RunWaitAllCallbacks(TimeSpan.Zero);
+                Assert.Equal(10, numCallbacksRun);
+
+                // Callbacks should have been freed.
+                mgr.RunWaitAllCallbacks(TimeSpan.Zero);
+                Assert.Equal(10, numCallbacksRun);
+            }
+        }
+
         void PostAndRunCallback(CallbackMsg callback)
         {
             client.PostCallback(callback);


### PR DESCRIPTION
1. `serverMap` was never being cleared, so re-using the same `SteamClient` object when reconnecting to Steam caused memory to balloon.
2. There was no way to run all pending callbacks, which includes a `ServerListCallback`. If only running callbacks periodically, e.g. every tick of an application, it will take N ticks to clear a queue of N callbacks. I've added an API to run all pending callbacks, which should fix this issue.