### PR TITLE
Add InMemoryServerListProvider

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace SteamKit2.Steam.Discovery
+namespace SteamKit2.Discovery
 {
 	/// <summary>
 	/// A server list provider that uses in-memory collection to persist the server list.

--- a/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
@@ -9,7 +9,7 @@ namespace SteamKit2.Discovery
 	/// A server list provider that uses in-memory collection to persist the server list.
 	/// It allows you to implement your own saving logic on <see cref="ServerListUpdated"/> event.
 	/// </summary>
-	public class InMemoryServerListProvider
+	public class InMemoryServerListProvider : IServerListProvider
 	{
 		/// <summary>
 		/// Actual collection used for keeping server list in memory.

--- a/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/InMemoryServerListProvider.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace SteamKit2.Steam.Discovery
+{
+	/// <summary>
+	/// A server list provider that uses in-memory collection to persist the server list.
+	/// It allows you to implement your own saving logic on <see cref="ServerListUpdated"/> event.
+	/// </summary>
+	public class InMemoryServerListProvider
+	{
+		/// <summary>
+		/// Actual collection used for keeping server list in memory.
+		/// </summary>
+		public HashSet<IPEndPoint> Servers { get; set; } = new HashSet<IPEndPoint>();
+
+		/// <summary>
+		/// Event being fired after <see cref="UpdateServerListAsync(IEnumerable{IPEndPoint})"/> gets executed.
+		/// You should use it for serializing <see cref="Servers"/> field for further re-use.
+		/// </summary>
+		public event EventHandler ServerListUpdated = delegate { };
+
+		/// <summary>
+		/// Returns servers from <see cref="Servers"/> collection.
+		/// </summary>
+		/// <returns>A list of IPEndPoints representing servers</returns>
+		public Task<IEnumerable<IPEndPoint>> FetchServerListAsync() => Task.FromResult<IEnumerable<IPEndPoint>>(Servers);
+
+		/// <summary>
+		/// Updates <see cref="Servers"/> collection. Fires <see cref="ServerListUpdated"/> event once done.
+		/// </summary>
+		/// <param name="endpoints">List of server endpoints</param>
+		/// <returns>Awaitable task for completion</returns>
+		public Task UpdateServerListAsync(IEnumerable<IPEndPoint> endpoints)
+		{
+			Servers.Clear();
+			foreach (IPEndPoint endpoint in endpoints)
+			{
+				Servers.Add(endpoint);
+			}
+
+			ServerListUpdated(this, EventArgs.Empty);
+
+			return Task.Delay(0);
+		}
+	}
+}

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Base\PacketBase.cs" />
     <Compile Include="Steam\Discovery\BasicServerListProto.cs" />
     <Compile Include="Steam\Discovery\FileStorageServerListProvider.cs" />
+    <Compile Include="Steam\Discovery\InMemoryServerListProvider.cs" />
     <Compile Include="Steam\Discovery\NullServerListProvider.cs" />
     <Compile Include="Steam\Discovery\SmartCMServerList.cs" />
     <Compile Include="Steam\CDNClient.cs" />


### PR DESCRIPTION
Initial idea that was adapted to being in SK2 library, don't feel obligated to merge - suggestions welcome.

Expected usage:
```IServerListProvider``` capable of holding list of the servers, providing ```ServerListUpdated``` event which can be used for serializing ```Servers``` field (or entire ```InMemoryServerListProvider``` object) using whatever preferred method (e.g. Json, Binary, Protobuf). This allows for custom file medium, such as using general-purpose file or a database.