### PR TITLE
Extend default EClientPersonaStateFlag info

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -495,7 +495,8 @@ namespace SteamKit2
         // the default details to request in most situations
         const EClientPersonaStateFlag defaultInfoRequest =
             EClientPersonaStateFlag.PlayerName | EClientPersonaStateFlag.Presence |
-            EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo;
+            EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo |
+            EClientPersonaStateFlag.LastSeen;
 
         /// <summary>
         /// Requests persona state for a list of specified SteamID.


### PR DESCRIPTION
Default value that steam client uses right now is equal to ```3154 = PlayerName, Presence, LastSeen, ClanTag, Facebook```. While I'm sure we don't really need ```ClanTag``` or ```Facebook``` info, ```LastSeen``` can be actually pretty useful, for example in my case when I'd like to remove friends that didn't log in since X time. This would allow me as well as every interested person to skip asking for that extra info in another request.

Since this request is default in steam client, and it results in generation of barely 2 extra fields (```LastLogOn``` and ```LastLogOff```), I think this should be added to default info.