### PR TITLE
Set Receive/Send socket timeouts appropriately

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -188,6 +188,8 @@ namespace SteamKit2
                     cancellationToken = new CancellationTokenSource();
 
                     socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    socket.ReceiveTimeout = timeout;
+                    socket.SendTimeout = timeout;
 
                     endPointTask.ContinueWith( t =>
                     {


### PR DESCRIPTION
This is one of the issues I found "by the way" while looking for real cause of **[this](https://github.com/JustArchi/ArchiSteamFarm/issues/318)** bug. This report is not connected with ASF one in any way.

I've implemented a custom HeartBeat() function that executes ```await SteamApps.PICSGetProductInfo(0, null);``` every minute, and if request times out, while still being ```SteamClient.IsConnected```, function executes ```SteamClient.Connect();``` in order to initiate a reconnect sooner than SK2 would find out.

This uncovered some weird thing going on when network stability is not perfect:

```
2016-08-31 09:06:48|INFO|archi|OnDisconnected() Disconnected from Steam!
2016-08-31 09:06:48|INFO|archi|OnDisconnected() Reconnecting...
2016-08-31 09:06:58|INFO|archi|OnConnected() Connected to Steam!
2016-08-31 09:06:58|INFO|archi|OnConnected() Logging in...
2016-08-31 09:07:33|WARN|archi|HeartBeat() Connection to Steam Network lost, reconnecting...
2016-08-31 09:08:33|WARN|archi|HeartBeat() Connection to Steam Network lost, reconnecting...
> (repeat above 15 more times in 1-minute interval)
2016-08-31 09:24:33|WARN|archi|HeartBeat() Connection to Steam Network lost, reconnecting...
2016-08-31 09:24:50|INFO|archi|OnDisconnected() Disconnected from Steam!
2016-08-31 09:24:50|INFO|archi|OnDisconnected() Disconnected from Steam!
> (repeat above 15 more times)
2016-08-31 09:24:50|INFO|archi|OnDisconnected() Disconnected from Steam!
2016-08-31 09:24:50|INFO|archi|OnConnected() Connected to Steam!
2016-08-31 09:24:50|INFO|archi|OnConnected() Logging in...
2016-08-31 09:24:51|INFO|archi|OnLoggedOn() Successfully logged on!
```

This looked weird to me, that we sent last request to Steam network around ~09:07, then around ~15 ```SteamClient.Connect()``` function calls, and finally we received all callbacks at the same moment, eventually connecting at ~09:25. It's possible that network was down for a short while, but definitely not for more than half a minute.

We can analyze that also in nethook messages:

![image](https://cloud.githubusercontent.com/assets/1069029/18123334/b3eac1f8-6f6d-11e6-9379-f63d77a136d4.png)

So what happened: for some reason Steam sent us ```ChannelEncryptRequest``` without previous graceful disconnection (you can notice our heartbeats sent by SK2 a while before). We handled that properly and sent ```ClientLogon``` in 35901 (09:06:58). We didn't get any response for nearly ~20 minutes, and the next ```in``` packet is again ```ChannelEncryptRequest```in 35920 (09:24:50).

Debug log of SK2 since packet 35894 to 35924 can be found here:

```
CMClient | <- Recv'd EMsg: ClientClanState (822) (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientPICSProductInfoRequest (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
CMClient | Sent -> EMsg: ClientHeartBeat (Proto: True)
TcpConnection | Socket exception occurred while reading packet: System.IO.IOException: Unable to read data from the transport connection: Connection timed out. ---> System.Net.Sockets.SocketException: Connection timed out
  at System.Net.Sockets.Socket.Receive (System.Byte[] buffer, System.Int32 offset, System.Int32 size, System.Net.Sockets.SocketFlags socketFlags) <0x40eaad20 + 0x001a3> in <5cf7305791db4d5da2dbb66cb115547f>:0 
  at System.Net.Sockets.NetworkStream.Read (System.Byte[] buffer, System.Int32 offset, System.Int32 size) <0x40e8a890 + 0x000c7> in <5cf7305791db4d5da2dbb66cb115547f>:0 
   --- End of inner exception stack trace ---
  at System.Net.Sockets.NetworkStream.Read (System.Byte[] buffer, System.Int32 offset, System.Int32 size) <0x40e8a890 + 0x002b7> in <5cf7305791db4d5da2dbb66cb115547f>:0 
  at System.IO.BinaryReader.ReadBytes (System.Int32 count) [0x00041] in <f24f53297d1d465396b75be74d37e900>:0 
  at SteamKit2.TcpConnection.ReadPacket () <0x40eded20 + 0x000f8> in <22a5bf0f0df5491bb43e46408f01ce2f>:0 
  at SteamKit2.TcpConnection.NetLoop () <0x40eddfe0 + 0x0017b> in <22a5bf0f0df5491bb43e46408f01ce2f>:0 
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connection to 146.66.152.10:27020 cancelled by user
ServerList | Next server candidiate: 146.66.152.10:27020
TcpConnection | Connecting to 146.66.152.10:27020...
TcpConnection | Connected to 146.66.152.10:27020
CMClient | <- Recv'd EMsg: ChannelEncryptRequest (1303) (Proto: False)
CMClient | Got encryption request. Universe: Public Protocol ver: 1
CMClient | Sent -> EMsg: ChannelEncryptResponse (Proto: False)
CMClient | <- Recv'd EMsg: ChannelEncryptResult (1305) (Proto: False)
CMClient | Encryption result: OK
CMClient | Sent -> EMsg: ClientLogon (Proto: True)
CMClient | <- Recv'd EMsg: Multi (1) (Proto: True)
CMClient | <- Recv'd EMsg: ClientServersAvailable (5501) (Proto: True)
```

All cancellations are most likely done by ```SteamClient.Disconnect()``` executed by ```SteamClient.Connect()``` after client returned from nearly ~20 minutes of death.

(Don't worry about extra ```ClientHeartBeat```s, I have multiple steam clients running, those are misleading)

---

**So what happened?**

I think that such incident is caused by infinite timeout set by default in TCP socket's Receive/Send functions. UDP connection automatically is considered "dead" after 60 seconds, but with TCP one, we could in theory read given packet till something interrupts us, probably OS, and that's why the whole SK2 communication blocks if such incident happens, as the exception is thrown nearly ~20 minutes after TCP connection in fact should be considered dead.

I'm not yet sure about what values we should put, for now I sticked with user-provided timeout. While it works for me, I ask you to test it yourself and review the change, because I'm not that familiar with low-level SK2 things, and it's very likely that it might introduce unwanted behaviour. Otherwise, I think that this change is alright.

It's also possible that the culprit is in fact somewhere else and I got misleaded - in this case I'd appreciate if somebody else could look into that issue, because I'm trying to help most of the time, but I'm definitely not experienced with SK2 as much as you.