### PR TITLE
Travis: Allow failure on Mono alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 sudo: false
 language: csharp
 mono:
+#   - weekly
     - alpha
+#   - beta
+    - latest
+
+matrix:
+    allow_failures:
+#       - mono: weekly
+        - mono: alpha
+#       - mono: beta
 
 solution: SteamKit2/SteamKit2.sln
 


### PR DESCRIPTION
Mono alpha is currently in version 4.6, and that version is affected by bug which I reported myself: https://bugzilla.xamarin.com/show_bug.cgi?id=42606

This will cause all builds to fail, such as **[this one](https://travis-ci.org/SteamRE/SteamKit/builds/156481780)** until the bug is solved and new version uploaded. I noticed that you're using alpha branch for CI, which is not yet stable and can't be reliable, so in order to fix the issue I allowed alpha branch to fail, but at the same time added latest for tests, which should be far more reliable and stable.

I also added some extra entries in case you want to use them - personally I use latest + weekly combo, with latest passing always, and weekly allowed to fail.
