### PR TITLE
Move duplicated dispatching code of ClientMsgHandlers to base class

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/ClientMsgMappingHandler.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/ClientMsgMappingHandler.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+
+using System;
+using System.Collections.Generic;
+
+namespace SteamKit2
+{
+    /// <summary>
+    /// This class implements the base requirements every message handler should inherit from.
+    /// Provides simple message dispatching logic based on dispatch map.
+    /// </summary>
+    public abstract class ClientMsgMappingHandler : ClientMsgHandler
+    {
+        /// <summary>
+        /// Stores action mapping for different message types.
+        /// </summary>
+        protected abstract Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
+        
+        /// <summary>
+        /// Handles a client message. This should not be called directly.
+        /// </summary>
+        /// <param name="packetMsg">The packet message that contains the data.</param>
+        public sealed override void HandleMsg( IPacketMsg packetMsg )
+        {
+            Action<IPacketMsg> handlerFunc;
+            bool haveFunc = DispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+
+            if ( !haveFunc )
+            {
+                // ignore messages that we don't have a handler function for
+                return;
+            }
+
+            handlerFunc( packetMsg );
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -14,7 +14,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for interacting with apps and packages on the Steam network.
     /// </summary>
-    public sealed partial class SteamApps : ClientMsgHandler
+    public sealed partial class SteamApps : ClientMsgMappingHandler
     {
 
 // Ambiguous reference in cref attribute: 'SteamApps.GetPackageInfo'. Assuming 'SteamKit2.SteamApps.GetPackageInfo(uint, bool)',
@@ -109,13 +109,13 @@ namespace SteamKit2
                 Public = only_public;
             }
         }
-
-
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamApps()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientLicenseList, HandleLicenseList },
                 { EMsg.ClientRequestFreeLicenseResponse, HandleFreeLicense },
@@ -500,25 +500,6 @@ namespace SteamKit2
 
             return new AsyncJob<FreeLicenseCallback>( this.Client, request.SourceJobID );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleAppOwnershipTicketResponse( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
@@ -14,13 +14,14 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for interacting with remote storage and user generated content.
     /// </summary>
-    public sealed partial class SteamCloud : ClientMsgHandler
+    public sealed partial class SteamCloud : ClientMsgMappingHandler
     {
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamCloud()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientUFSGetUGCDetailsResponse, HandleUGCDetailsResponse },
                 { EMsg.ClientUFSGetSingleFileInfoResponse, HandleSingleFileInfoResponse },
@@ -89,25 +90,6 @@ namespace SteamKit2
 
             return new AsyncJob<ShareFileCallback>( this.Client, request.SourceJobID );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleUGCDetailsResponse( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -16,7 +16,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler handles all interaction with other users on the Steam3 network.
     /// </summary>
-    public sealed partial class SteamFriends : ClientMsgHandler
+    public sealed partial class SteamFriends : ClientMsgMappingHandler
     {
         object listLock = new object();
         List<SteamID> friendList;
@@ -24,7 +24,8 @@ namespace SteamKit2
 
         AccountCache cache;
 
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamFriends()
         {
@@ -33,7 +34,7 @@ namespace SteamKit2
 
             cache = new AccountCache();
 
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientPersonaState, HandlePersonaState },
                 { EMsg.ClientClanState, HandleClanState },
@@ -591,26 +592,6 @@ namespace SteamKit2
             
             this.Client.Send( request );
         }
-
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleAccountInfo( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
@@ -8,13 +8,14 @@ namespace SteamKit2
     /// <summary>
     /// This handler handles all game coordinator messaging.
     /// </summary>
-    public sealed partial class SteamGameCoordinator : ClientMsgHandler
+    public sealed partial class SteamGameCoordinator : ClientMsgMappingHandler
     {
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamGameCoordinator()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientFromGC, HandleFromGC },
             };
@@ -38,26 +39,6 @@ namespace SteamKit2
 
             this.Client.Send( clientMsg );
         }
-
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleFromGC( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -14,7 +14,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for interacting with the Steam network as a game server.
     /// </summary>
-    public sealed partial class SteamGameServer : ClientMsgHandler
+    public sealed partial class SteamGameServer : ClientMsgMappingHandler
     {
         /// <summary>
         /// Represents the details required to log into Steam3 as a game server.
@@ -74,11 +74,12 @@ namespace SteamKit2
         }
 
 
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamGameServer()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.GSStatusReply, HandleStatusReply },
                 { EMsg.ClientTicketAuthComplete, HandleAuthComplete },
@@ -210,26 +211,7 @@ namespace SteamKit2
 
             this.Client.Send( status );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
-
+        
         #region Handlers
         void HandleStatusReply( IPacketMsg packetMsg )
         {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
@@ -13,7 +13,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for requesting server list details from Steam.
     /// </summary>
-    public sealed partial class SteamMasterServer : ClientMsgHandler
+    public sealed partial class SteamMasterServer : ClientMsgMappingHandler
     {
         /// <summary>
         /// Details used when performing a server list query.
@@ -48,11 +48,12 @@ namespace SteamKit2
         }
 
 
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamMasterServer()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.GMSClientServerQueryResponse, HandleServerQueryResponse },
             };
@@ -85,26 +86,6 @@ namespace SteamKit2
 
             return new AsyncJob<QueryCallback>( this.Client, query.SourceJobID );
         }
-
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleServerQueryResponse( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamScreenshots/SteamScreenshots.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamScreenshots/SteamScreenshots.cs
@@ -9,7 +9,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for initializing Steam trades with other clients.
     /// </summary>
-    public sealed partial class SteamScreenshots : ClientMsgHandler
+    public sealed partial class SteamScreenshots : ClientMsgMappingHandler
     {
         /// <summary>
         /// Width of a screenshot thumnail
@@ -79,13 +79,13 @@ namespace SteamKit2
             {
             }
         }
-
-
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamScreenshots()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientUCMAddScreenshotResponse, HandleUCMAddScreenshot },
             };
@@ -118,25 +118,6 @@ namespace SteamKit2
 
             return new AsyncJob<ScreenshotAddedCallback>( this.Client, msg.SourceJobID );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleUCMAddScreenshot( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamTrading/SteamTrading.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamTrading/SteamTrading.cs
@@ -14,13 +14,14 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for initializing Steam trades with other clients.
     /// </summary>
-    public sealed partial class SteamTrading : ClientMsgHandler
+    public sealed partial class SteamTrading : ClientMsgMappingHandler
     {
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamTrading()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.EconTrading_InitiateTradeProposed, HandleTradeProposed },
                 { EMsg.EconTrading_InitiateTradeResult, HandleTradeResult },
@@ -69,26 +70,6 @@ namespace SteamKit2
 
             Client.Send( cancelTrade );
         }
-
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleTradeProposed( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 
 namespace SteamKit2
 {
-    public partial class SteamUnifiedMessages : ClientMsgHandler
+    public partial class SteamUnifiedMessages
     {
         /// <summary>
         /// This callback is returned in response to a service method sent through <see cref="SteamUnifiedMessages"/>.

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -17,7 +17,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for interacting with Steamworks unified messaging
     /// </summary>
-    public partial class SteamUnifiedMessages : ClientMsgHandler
+    public partial class SteamUnifiedMessages : ClientMsgMappingHandler
     {
         /// <summary>
         /// This wrapper is used for expression-based RPC calls using Steam Unified Messaging.
@@ -71,13 +71,13 @@ namespace SteamKit2
                 return (AsyncJob<ServiceMethodResponse>)result;
             }
         }
-
-
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamUnifiedMessages()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientServiceMethodResponse, HandleClientServiceMethodResponse },
                 { EMsg.ServiceMethod, HandleServiceMethod },
@@ -123,26 +123,6 @@ namespace SteamKit2
         {
             return new UnifiedService<TService>( this );
         }
-
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleClientServiceMethodResponse( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -12,7 +12,7 @@ namespace SteamKit2
     /// <summary>
     /// This handler handles all user log on/log off related actions and callbacks.
     /// </summary>
-    public sealed partial class SteamUser : ClientMsgHandler
+    public sealed partial class SteamUser : ClientMsgMappingHandler
     {
 
         /// <summary>
@@ -252,13 +252,13 @@ namespace SteamKit2
         {
             get { return this.Client.SteamID; }
         }
-
-
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamUser()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientLogOnResponse, HandleLogOnResponse },
                 { EMsg.ClientLoggedOff, HandleLoggedOff },
@@ -465,25 +465,6 @@ namespace SteamKit2
 
             this.Client.Send( acceptance );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
         
         #region ClientMsg Handlers
         void HandleLoggedOff( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
@@ -14,13 +14,14 @@ namespace SteamKit2
     /// <summary>
     /// This handler handles Steam user statistic related actions.
     /// </summary>
-    public sealed partial class SteamUserStats : ClientMsgHandler
+    public sealed partial class SteamUserStats : ClientMsgMappingHandler
     {
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamUserStats()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.ClientGetNumberOfCurrentPlayersDPResponse, HandleNumberOfPlayersResponse },
                 { EMsg.ClientLBSFindOrCreateLBResponse, HandleFindOrCreateLBResponse },
@@ -141,25 +142,6 @@ namespace SteamKit2
 
             return new AsyncJob<LeaderboardEntriesCallback>( this.Client, msg.SourceJobID );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The <see cref="SteamKit2.IPacketMsg"/> instance containing the event data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleNumberOfPlayersResponse( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamWorkshop/SteamWorkshop.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamWorkshop/SteamWorkshop.cs
@@ -12,13 +12,14 @@ namespace SteamKit2
     /// <summary>
     /// This handler is used for requesting files published on the Steam Workshop.
     /// </summary>
-    public sealed partial class SteamWorkshop : ClientMsgHandler
+    public sealed partial class SteamWorkshop : ClientMsgMappingHandler
     {
-        Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+        /// <inheritdoc />
+        protected override Dictionary<EMsg, Action<IPacketMsg>> DispatchMap { get; }
 
         internal SteamWorkshop()
         {
-            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            DispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {
                 { EMsg.CREEnumeratePublishedFilesResponse, HandleEnumPublishedFiles },
                 { EMsg.ClientUCMEnumerateUserPublishedFilesResponse, HandleEnumUserPublishedFiles },
@@ -221,25 +222,6 @@ namespace SteamKit2
 
             return new AsyncJob<PublishedFilesCallback>( this.Client, enumRequest.SourceJobID );
         }
-
-        /// <summary>
-        /// Handles a client message. This should not be called directly.
-        /// </summary>
-        /// <param name="packetMsg">The packet message that contains the data.</param>
-        public override void HandleMsg( IPacketMsg packetMsg )
-        {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
-
-            if ( !haveFunc )
-            {
-                // ignore messages that we don't have a handler function for
-                return;
-            }
-
-            handlerFunc( packetMsg );
-        }
-
 
         #region ClientMsg Handlers
         void HandleEnumPublishedFiles( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Steam\CDNClient.cs" />
     <Compile Include="Steam\Discovery\IsolatedStorageServerListProvider.cs" />
     <Compile Include="Steam\Discovery\IServerListProvider.cs" />
+    <Compile Include="Steam\Handlers\ClientMsgMappingHandler.cs" />
     <Compile Include="Steam\Handlers\SteamCloud\Callbacks.cs" />
     <Compile Include="Steam\Handlers\SteamCloud\SteamCloud.cs" />
     <Compile Include="Steam\Handlers\SteamGameServer\Callbacks.cs" />


### PR DESCRIPTION
I needed to write my own `ClientMsgHandler`, but I think it's not neccessary to override `HandleMsg` method every time. Usually it's enough to follow the the approach that uses Dictionary for action mapping.

I moved redundant code to abstract `ClientMsgMappingHandler` class. I think it allows for easier creating extension Handlers for communication not supported in SteamKit.


