### PR TITLE
Fix float parsing in different cultures

### DIFF
--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -425,7 +426,7 @@ namespace SteamKit2
         {
             float value;
 
-            if ( float.TryParse( this.Value, out value ) == false )
+            if ( float.TryParse( this.Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out value ) == false )
             {
                 return defaultValue;
             }


### PR DESCRIPTION
`KeyValueFacts.KeyValuesHandlesFloat()` test fails in cultures where comma `,` is used as decimal separator instead of dot `.`