### PR TITLE
Enabled automatic deployment from AppVeyor

### DIFF
--- a/SteamKit2/SteamKit2.nuspec
+++ b/SteamKit2/SteamKit2.nuspec
@@ -19,8 +19,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="SteamKit2\bin\Release\SteamKit2.dll" target="lib\net45\SteamKit2.dll" />
-        <file src="SteamKit2\bin\Release\SteamKit2.xml" target="lib\net45\SteamKit2.xml" />
-        <file src="SteamKit2\bin\Release\changes.txt" target="readme.txt" />
+        <file src="SteamKit2\bin\*\SteamKit2.dll" target="lib\net45\SteamKit2.dll" />
+        <file src="SteamKit2\bin\*\SteamKit2.xml" target="lib\net45\SteamKit2.xml" />
+        <file src="SteamKit2\bin\*\changes.txt" target="readme.txt" />
     </files>
 </package>

--- a/SteamKit2/SteamKit2.nuspec
+++ b/SteamKit2/SteamKit2.nuspec
@@ -19,8 +19,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="SteamKit2\bin\*\SteamKit2.dll" target="lib\net45\SteamKit2.dll" />
-        <file src="SteamKit2\bin\*\SteamKit2.xml" target="lib\net45\SteamKit2.xml" />
+        <file src="SteamKit2\bin\*\SteamKit2.dll" target="lib\net45" />
+        <file src="SteamKit2\bin\*\SteamKit2.xml" target="lib\net45" />
         <file src="SteamKit2\bin\*\changes.txt" target="readme.txt" />
     </files>
 </package>

--- a/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
+++ b/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
@@ -29,17 +29,10 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid( "cd42d0bc-72e4-451e-bcd0-5d09c4bca2a9" )]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.8.0.*" )]
+// These are automatically modified by AppVeyor for CI builds and automated deployment.
+[assembly: AssemblyVersion( "1.8.0.0" )]
+[assembly: AssemblyFileVersion( "1.8.0.0" )]
+[assembly: AssemblyInformationalVersion( "1.8.0 - Development" )]
 
 #if DEBUG
 [assembly: InternalsVisibleTo( "Tests, PublicKey="+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}-Alpha
+version: 1.8.1.{build}
 os: Visual Studio 2015
 
 cache:
@@ -8,7 +8,9 @@ cache:
 assembly_info:
   patch: true
   file: AssemblyInfo.cs
-  assembly_informational_version: "{version} - CI (AppVeyor)"
+  assembly_version: "1.8.1"
+  assembly_file_version: "{version}"
+  assembly_informational_version: "{version} - CI (AppVeyor, branch: {branch})"
 
 configuration:
   - Debug
@@ -65,29 +67,31 @@ test_script:
 
 artifacts:
   - path: NetHook2.zip
-    name: NetHook2
   - path: 'SteamKit2.*.nupkg'
-    name: 'NuGet Package'
+    name: SteamKit2.nupkg
   - path: 'Resources\NetHookAnalyzer2\NetHookAnalyzer2\Bin\$(configuration)'
-    name: 'NetHook Analyzer 2'
+    name: NetHookAnalyzer2.zip
 
 deploy:
+
   - provider: NuGet
     api_key:
       secure: 'Qtxl16gv6dxg4FXOPLiNkLkTuVdPcso3IS99WgRO7IXyqgLJQJ3Ldrnymai2+1Uo'
     skip_symbols: false
-    artifact: 'NuGet Package'
+    artifact: SteamKit2.nupkg
     on:
       #branch: master
       configuration: Release
       appveyor_repo_tag: true
+
   - provider: GitHub
     auth_token:
       secure: 'KEOYmhFMh4Ea7RVYmX1Sv/1SWQW5uoNv6p3+aUtJXw/2Vbp2PEmbJxYJxO9xIuc9'
     release: 'SteamKit2 $(appveyor_repo_tag_name)'
-    artifact: 'NuGet Package, NetHook Analyzer 2'
+    artifact: /.*/
     draft: false
     prerelease: true
+    tag: $(appveyor_repo_tag_name)
     on:
       #branch: master
       configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,14 @@ build_script:
 
 after_build:
   - '7z a NetHook2.zip .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.dll .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.pdb'
-  - 'nuget pack SteamKit2\SteamKit2.nuspec -Version %APPVEYOR_REPO_TAG_NAME%'
+  - ps: >-
+      $args = @('pack', 'SteamKit2\SteamKit2.nuspec')
+      $version = Get-Item Env:APPVEYOR_REPO_TAG_NAME
+      if (![string]::IsNullOrEmpty($version))
+      {
+          $args += $('-Version', $version)
+      }
+      & nuget $args
 
 test_script:
   - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ deploy:
     skip_symbols: false
     artifact: SteamKit2.nupkg
     on:
-      #branch: master
+      branch: master
       configuration: Release
       appveyor_repo_tag: true
 
@@ -93,6 +93,6 @@ deploy:
     prerelease: true
     tag: $(appveyor_repo_tag_name)
     on:
-      #branch: master
+      branch: master
       configuration: Release
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,12 @@ after_build:
   - '7z a NetHook2.zip .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.dll .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.pdb'
   - ps: >-
       $args = @('pack', 'SteamKit2\SteamKit2.nuspec')
-      $version = Get-Item Env:APPVEYOR_REPO_TAG_NAME
+      $version = $null
+      if (Test-Path Env:APPVEYOR_REPO_TAG_NAME)
+      {
+        $version = (Get-Item Env:APPVEYOR_REPO_TAG_NAME).Value
+      }
+      
       if (![string]::IsNullOrEmpty($version))
       {
           $args += $('-Version', $version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,9 +66,9 @@ test_script:
 artifacts:
   - path: NetHook2.zip
     name: NetHook2
-  - path: '**\*.nupkg'
+  - path: 'SteamKit2.*.nupkg'
     name: 'NuGet Package'
-  - path: 'Resources\NetHookAnalyzer2\Bin\$(configuration)'
+  - path: 'Resources\NetHookAnalyzer2\NetHookAnalyzer2\Bin\$(configuration)'
     name: 'NetHook Analyzer 2'
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.8.1.{build}
+version: 1.8.0.{build}
 os: Visual Studio 2015
 
 cache:
@@ -8,7 +8,7 @@ cache:
 assembly_info:
   patch: true
   file: AssemblyInfo.cs
-  assembly_version: "1.8.1"
+  assembly_version: "1.8.0"
   assembly_file_version: "{version}"
   assembly_informational_version: "{version} - CI (AppVeyor, branch: {branch})"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,11 @@ cache:
   - '%LocalAppData%\NuGet\Cache'
   - '%Temp%\nethook2-dependencies -> Resources\NetHook2\SetupDependencies.ps1'
 
+assembly_info:
+  patch: true
+  file: AssemblyInfo.cs
+  assembly_informational_version: "{version} - CI (AppVeyor)"
+
 configuration:
   - Debug
   - Release
@@ -27,9 +32,11 @@ build_script:
   - msbuild SteamKit2\SteamKit2.sln
   - msbuild Samples\Samples.sln
   - msbuild Resources\NetHook2\NetHook2.sln
+  - msbuild Resources\NetHookAnalyzer2\NetHookAnalyzer2.sln
 
 after_build:
   - '7z a NetHook2.zip .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.dll .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.pdb'
+  - 'nuget pack SteamKit2\SteamKit2.nuspec -Version %APPVEYOR_REPO_TAG_NAME%'
 
 test_script:
   - ps: >-
@@ -47,3 +54,29 @@ test_script:
 artifacts:
   - path: NetHook2.zip
     name: NetHook2
+  - path: '**\*.nupkg'
+    name: 'NuGet Package'
+  - path: 'Resources\NetHookAnalyzer2\Bin\$(configuration)'
+    name: 'NetHook Analyzer 2'
+
+deploy:
+  - provider: NuGet
+    api_key:
+      secure: 'Qtxl16gv6dxg4FXOPLiNkLkTuVdPcso3IS99WgRO7IXyqgLJQJ3Ldrnymai2+1Uo'
+    skip_symbols: false
+    artifact: 'NuGet Package'
+    on:
+      #branch: master
+      configuration: Release
+      appveyor_repo_tag: true
+  - provider: GitHub
+    auth_token:
+      secure: 'KEOYmhFMh4Ea7RVYmX1Sv/1SWQW5uoNv6p3+aUtJXw/2Vbp2PEmbJxYJxO9xIuc9'
+    release: 'SteamKit2 $(appveyor_repo_tag_name)'
+    artifact: 'NuGet Package, NetHook Analyzer 2'
+    draft: false
+    prerelease: true
+    on:
+      #branch: master
+      configuration: Release
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ after_build:
       $version = $null
       if (Test-Path Env:APPVEYOR_REPO_TAG_NAME)
       {
-        $version = (Get-Item Env:APPVEYOR_REPO_TAG_NAME).Value
+          $version = (Get-Item Env:APPVEYOR_REPO_TAG_NAME).Value
       }
       
       if (![string]::IsNullOrEmpty($version))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ build_script:
 
 after_build:
   - '7z a NetHook2.zip .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.dll .\Resources\NetHook2\%SK_BUILD_CONFIGURATION%\*.pdb'
-  - ps: >-
+  - ps: |
       $args = @('pack', 'SteamKit2\SteamKit2.nuspec')
       $version = $null
       if (Test-Path Env:APPVEYOR_REPO_TAG_NAME)
@@ -51,7 +51,7 @@ after_build:
       & nuget $args
 
 test_script:
-  - ps: >-
+  - ps: |
       $TestAssembly = "SteamKit2\Tests\Bin\$env:SK_BUILD_CONFIGURATION\Tests.dll"
       
       if (Test-Path $TestAssembly)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ artifacts:
   - path: 'SteamKit2.*.nupkg'
     name: SteamKit2.nupkg
   - path: 'Resources\NetHookAnalyzer2\NetHookAnalyzer2\Bin\$(configuration)'
-    name: NetHookAnalyzer2.zip
+    name: NetHookAnalyzer2
 
 deploy:
 


### PR DESCRIPTION
With these changes, AppVeyor will automatically publish a new release on GitHub and deploy to NuGet.

To use this, you need to push a tag on `master` that is a supported NuGet version number, e.g. `1.9.0` or `1.9.0-alpha`.

It also requires changes to appveyor.yml to set the new version number (both `version` and `assembly_version`), and you still have to manually update changes.txt and copy it into the GitHub release description.

This does still simplify the process so that anyone (with push privileges) can cut a new release with little effort.