### PR TITLE
[NHA2] Add support for showing difference between set fields and implied fields for proto msgs.

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
@@ -192,6 +192,8 @@
 			// showAllCheckBox
 			// 
 			this.showAllCheckBox.AutoSize = true;
+			this.showAllCheckBox.Checked = true;
+			this.showAllCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
 			this.showAllCheckBox.Location = new System.Drawing.Point(277, 19);
 			this.showAllCheckBox.Name = "showAllCheckBox";
 			this.showAllCheckBox.Size = new System.Drawing.Size(125, 17);

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
@@ -38,11 +38,13 @@
 			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
 			this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.automaticallySelectNewItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
 			this.splitContainer = new System.Windows.Forms.SplitContainer();
 			this.filterContainerPanel = new System.Windows.Forms.Panel();
 			this.filterGroupBox = new System.Windows.Forms.GroupBox();
+			this.showAllCheckBox = new System.Windows.Forms.CheckBox();
 			this.label1 = new System.Windows.Forms.Label();
 			this.searchTextBox = new System.Windows.Forms.TextBox();
 			this.outRadioButton = new System.Windows.Forms.RadioButton();
@@ -51,7 +53,6 @@
 			this.listViewContainerPanel = new System.Windows.Forms.Panel();
 			this.itemsListView = new System.Windows.Forms.ListView();
 			this.itemExplorerTreeView = new System.Windows.Forms.TreeView();
-			this.automaticallySelectNewItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			sequenceColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			directionColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			messageColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -121,6 +122,14 @@
 			this.openToolStripMenuItem.Text = "&Open...";
 			this.openToolStripMenuItem.Click += new System.EventHandler(this.OnOpenToolStripMenuItemClick);
 			// 
+			// automaticallySelectNewItemsToolStripMenuItem
+			// 
+			this.automaticallySelectNewItemsToolStripMenuItem.CheckOnClick = true;
+			this.automaticallySelectNewItemsToolStripMenuItem.Name = "automaticallySelectNewItemsToolStripMenuItem";
+			this.automaticallySelectNewItemsToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
+			this.automaticallySelectNewItemsToolStripMenuItem.Text = "&Automatically select new items";
+			this.automaticallySelectNewItemsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.OnAutomaticallySelectNewItemsCheckedChanged);
+			// 
 			// exitToolStripMenuItem
 			// 
 			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
@@ -166,6 +175,7 @@
 			// 
 			// filterGroupBox
 			// 
+			this.filterGroupBox.Controls.Add(this.showAllCheckBox);
 			this.filterGroupBox.Controls.Add(this.label1);
 			this.filterGroupBox.Controls.Add(this.searchTextBox);
 			this.filterGroupBox.Controls.Add(this.outRadioButton);
@@ -178,6 +188,17 @@
 			this.filterGroupBox.TabIndex = 1;
 			this.filterGroupBox.TabStop = false;
 			this.filterGroupBox.Text = "Filter";
+			// 
+			// showAllCheckBox
+			// 
+			this.showAllCheckBox.AutoSize = true;
+			this.showAllCheckBox.Location = new System.Drawing.Point(277, 19);
+			this.showAllCheckBox.Name = "showAllCheckBox";
+			this.showAllCheckBox.Size = new System.Drawing.Size(125, 17);
+			this.showAllCheckBox.TabIndex = 3;
+			this.showAllCheckBox.Text = "Show All Msg Values";
+			this.showAllCheckBox.UseVisualStyleBackColor = true;
+			this.showAllCheckBox.CheckedChanged += new System.EventHandler(this.OnShowAllCheckedChanged);
 			// 
 			// label1
 			// 
@@ -275,14 +296,6 @@
 			this.itemExplorerTreeView.Size = new System.Drawing.Size(455, 426);
 			this.itemExplorerTreeView.TabIndex = 0;
 			// 
-			// automaticallySelectNewItemsToolStripMenuItem
-			// 
-			this.automaticallySelectNewItemsToolStripMenuItem.CheckOnClick = true;
-			this.automaticallySelectNewItemsToolStripMenuItem.Name = "automaticallySelectNewItemsToolStripMenuItem";
-			this.automaticallySelectNewItemsToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
-			this.automaticallySelectNewItemsToolStripMenuItem.Text = "&Automatically select new items";
-			this.automaticallySelectNewItemsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.OnAutomaticallySelectNewItemsCheckedChanged);
-			// 
 			// MainForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -327,6 +340,7 @@
 		private System.Windows.Forms.RadioButton inOutRadioButton;
 		private System.Windows.Forms.Label label1;
 		private System.Windows.Forms.ToolStripMenuItem automaticallySelectNewItemsToolStripMenuItem;
-	}
+        private System.Windows.Forms.CheckBox showAllCheckBox;
+    }
 }
 

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
@@ -185,6 +185,12 @@ namespace NetHookAnalyzer2
 			RepopulateListBox();
 		}
 
+		void OnShowAllCheckedChanged(object sender, EventArgs e)
+		{
+			TreeNodeObjectExplorer.ShowAll = showAllCheckBox.Checked;
+			RepopulateTreeView();
+		}
+
 		void searchTextBox_TextChanged(object sender, EventArgs e)
 		{
 			RepopulateListBox();

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
@@ -14,7 +14,7 @@ namespace NetHookAnalyzer2
 {
 	class TreeNodeObjectExplorer
 	{
-		public static bool ShowAll = false;
+		public static bool ShowAll = true;
 
 		public TreeNodeObjectExplorer(string name, object value, bool showFaded = false)
 		{

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/TreeNodeObjectExplorer.cs
@@ -14,11 +14,17 @@ namespace NetHookAnalyzer2
 {
 	class TreeNodeObjectExplorer
 	{
-		public TreeNodeObjectExplorer(string name, object value)
+		public static bool ShowAll = false;
+
+		public TreeNodeObjectExplorer(string name, object value, bool showFaded = false)
 		{
 			this.name = name;
 			this.value = value;
 			this.treeNode = new TreeNode();
+			if (showFaded)
+			{
+			    treeNode.ForeColor = System.Drawing.Color.DarkGray;
+			}
 			this.treeNode.ContextMenu = new ContextMenu();
 			this.treeNode.ContextMenu.Popup += OnContextMenuPopup;
 
@@ -581,13 +587,32 @@ namespace NetHookAnalyzer2
 			{
 				var childNodes = new List<TreeNode>();
 
-				foreach (var property in value.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+				var properties = value.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).ToList();
+				if (typeof(ProtoBuf.IExtensible).IsAssignableFrom(value.GetType()))
+				{
+				    properties = properties.Where(x => {
+				        return !x.Name.EndsWith("Specified") || properties.FirstOrDefault(y => {
+				            return y.Name == x.Name.Remove(x.Name.Length - 9);
+				        }) == null;
+				    }).ToList();
+				}
+
+				foreach (var property in properties)
 				{
 					var childName = property.Name;
 					var childObject = property.GetValue(value, null);
-
-					var childObjectExplorer = new TreeNodeObjectExplorer(childName, childObject);
-					childNodes.Add(childObjectExplorer.TreeNode);
+					bool valueIsSet = true;
+					if (typeof(ProtoBuf.IExtensible).IsAssignableFrom(value.GetType()))
+					{
+						var propSpecified = value.GetType().GetProperty(property.Name + "Specified");
+						valueIsSet = propSpecified != null && (bool)propSpecified.GetValue(value);
+					}
+					
+					if (valueIsSet || ShowAll)
+					{
+					    var childObjectExplorer = new TreeNodeObjectExplorer(childName, childObject, !valueIsSet);
+					    childNodes.Add(childObjectExplorer.TreeNode);
+					}
 				}
 
 				SetValueForDisplay(null, childNodes: childNodes.ToArray());

--- a/Resources/Protobufs/csgo/generate-base.bat
+++ b/Resources/Protobufs/csgo/generate-base.bat
@@ -1,12 +1,12 @@
 @echo off
 
 echo Building CSGO GC base...
-..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
-..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
-..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
-..\..\Protogen\protogen -s:..\ -i:"engine_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCEngine.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
+..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"engine_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\SteamMsgGCEngine.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing
 
 echo Building CSGO messages...
-..\..\Protogen\protogen -s:..\ -i:"cstrike15_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\MsgGC.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal"
+..\..\Protogen\protogen -s:..\ -i:"cstrike15_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\CSGO\MsgGC.cs" -t:csharp -ns:"SteamKit2.GC.CSGO.Internal" -p:detectMissing

--- a/Resources/Protobufs/dota/generate-base.bat
+++ b/Resources/Protobufs/dota/generate-base.bat
@@ -1,30 +1,30 @@
 @echo off
 
 echo Building Dota GC base...
-..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"econ_shared_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCEconSharedEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
+..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"econ_shared_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCEconSharedEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
 
 echo Building Steamworks Unified Messages
-..\..\Protogen\protogen -s:..\ -i:"steammessages_oauth.steamworkssdk.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\Steamworks\SteamMsgOAuthSteamworks.cs" -t:csharp -ns:"SteamKit2.Unified.Internal.Steamworks"
+..\..\Protogen\protogen -s:..\ -i:"steammessages_oauth.steamworkssdk.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\Steamworks\SteamMsgOAuthSteamworks.cs" -t:csharp -ns:"SteamKit2.Unified.Internal.Steamworks" -p:detectMissing
 
 echo Building Dota messages...
-..\..\Protogen\protogen -s:..\ -i:"network_connection.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\NetworkConnection.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
+..\..\Protogen\protogen -s:..\ -i:"network_connection.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\NetworkConnection.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
 
-..\..\Protogen\protogen -s:..\ -i:"dota_client_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgClientEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_shared_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgSharedEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_common.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCCommon.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_common_match_management.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCCommonMatchMgmt.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_msgid.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCMsgId.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClient.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_chat.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientChat.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_fantasy.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientFantasy.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_guild.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientGuild.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_match_management.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientMatchMgmt.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_team.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientTeam.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_tournament.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientTournament.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_watch.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientWatch.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
-..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_server.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCServer.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal"
+..\..\Protogen\protogen -s:..\ -i:"dota_client_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgClientEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_shared_enums.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgSharedEnums.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_common.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCCommon.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_common_match_management.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCCommonMatchMgmt.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_msgid.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCMsgId.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClient.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_chat.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientChat.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_fantasy.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientFantasy.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_guild.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientGuild.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_match_management.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientMatchMgmt.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_team.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientTeam.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_tournament.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientTournament.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_client_watch.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCClientWatch.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"dota_gcmessages_server.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\Dota\MsgGCServer.cs" -t:csharp -ns:"SteamKit2.GC.Dota.Internal" -p:detectMissing

--- a/Resources/Protobufs/gc/generate.bat
+++ b/Resources/Protobufs/gc/generate.bat
@@ -1,3 +1,3 @@
 @echo off
 
-..\..\Protogen\protogen -s:..\ -i:"gc.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\MsgBaseGC.cs" -t:csharp -ns:"SteamKit2.GC.Internal"
+..\..\Protogen\protogen -s:..\ -i:"gc.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\MsgBaseGC.cs" -t:csharp -ns:"SteamKit2.GC.Internal" -p:detectMissing

--- a/Resources/Protobufs/steamclient/generate-base.bat
+++ b/Resources/Protobufs/steamclient/generate-base.bat
@@ -1,48 +1,48 @@
 @echo off
 
 echo Steam Messages Base
-..\..\Protogen\protogen -i:"steammessages_base.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.Internal"
+..\..\Protogen\protogen -i:"steammessages_base.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.Internal" -p:detectMissing
 echo.
 echo.
 
 echo Encrypted App Ticket
-..\..\Protogen\protogen -i:"encrypted_app_ticket.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgAppTicket.cs" -t:csharp -ns:"SteamKit2.Internal"
+..\..\Protogen\protogen -i:"encrypted_app_ticket.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgAppTicket.cs" -t:csharp -ns:"SteamKit2.Internal" -p:detectMissing
 echo.
 echo.
 
 echo Steam Messages ClientServer
-..\..\Protogen\protogen -i:"steammessages_clientserver.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgClientServer.cs" -t:csharp -ns:"SteamKit2.Internal"
-..\..\Protogen\protogen -i:"steammessages_clientserver_2.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgClientServer2.cs" -t:csharp -ns:"SteamKit2.Internal"
+..\..\Protogen\protogen -i:"steammessages_clientserver.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgClientServer.cs" -t:csharp -ns:"SteamKit2.Internal" -p:detectMissing
+..\..\Protogen\protogen -i:"steammessages_clientserver_2.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\SteamMsgClientServer2.cs" -t:csharp -ns:"SteamKit2.Internal" -p:detectMissing
 echo.
 echo.
 
 echo Content Manifest
-..\..\Protogen\protogen -i:"content_manifest.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\ContentManifest.cs" -t:csharp -ns:"SteamKit2.Internal"
+..\..\Protogen\protogen -i:"content_manifest.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\ContentManifest.cs" -t:csharp -ns:"SteamKit2.Internal" -p:detectMissing
 echo.
 echo.
 
 echo Unified Messages
-..\..\Protogen\protogen -s:..\ -i:"steammessages_unified_base.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgUnifiedBase.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
+..\..\Protogen\protogen -s:..\ -i:"steammessages_unified_base.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgUnifiedBase.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
 
-..\..\Protogen\protogen -s:..\ -i:"steammessages_broadcast.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgBroadcast.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_cloud.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgCloud.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_credentials.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgCredentials.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_depotbuilder.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgDepotBuilder.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_deviceauth.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgDeviceAuth.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_econ.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgEcon.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_gamenotifications.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgGameNotifications.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_gameservers.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgGameServers.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_linkfilter.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgLinkFilter.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_inventory.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgInventory.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_offline.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgOffline.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_parental.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgParental.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_partnerapps.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPartnerApps.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_physicalgoods.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPhysicalGoods.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_player.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPlayer.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_publishedfile.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPublishedFile.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_secrets.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgSecrets.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_site_license.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgSiteLicense.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_twofactor.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgTwoFactor.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
-..\..\Protogen\protogen -s:..\ -i:"steammessages_video.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgVideo.cs" -t:csharp -ns:"SteamKit2.Unified.Internal"
+..\..\Protogen\protogen -s:..\ -i:"steammessages_broadcast.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgBroadcast.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_cloud.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgCloud.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_credentials.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgCredentials.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_depotbuilder.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgDepotBuilder.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_deviceauth.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgDeviceAuth.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_econ.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgEcon.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_gamenotifications.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgGameNotifications.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_gameservers.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgGameServers.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_linkfilter.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgLinkFilter.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_inventory.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgInventory.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_offline.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgOffline.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_parental.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgParental.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_partnerapps.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPartnerApps.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_physicalgoods.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPhysicalGoods.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_player.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPlayer.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_publishedfile.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgPublishedFile.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_secrets.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgSecrets.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_site_license.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgSiteLicense.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_twofactor.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgTwoFactor.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"steammessages_video.steamclient.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\Unified\SteamMsgVideo.cs" -t:csharp -ns:"SteamKit2.Unified.Internal" -p:detectMissing
 
 pause

--- a/Resources/Protobufs/tf/generate-base.bat
+++ b/Resources/Protobufs/tf/generate-base.bat
@@ -1,11 +1,11 @@
 @echo off
 
 echo Building TF2 GC base...
-..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
-..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
-..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
-..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
+..\..\Protogen\protogen -s:..\ -i:"steammessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgBase.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsystemmsgs.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCSystem.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"base_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGC.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"gcsdk_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCSDK.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing
+..\..\Protogen\protogen -s:..\ -i:"econ_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\SteamMsgGCEcon.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing
 
 echo Building TF2 GC messages
-..\..\Protogen\protogen -s:..\ -i:"tf_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\MsgGC.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal"
+..\..\Protogen\protogen -s:..\ -i:"tf_gcmessages.proto" -o:"..\..\..\SteamKit2\SteamKit2\Base\Generated\GC\TF2\MsgGC.cs" -t:csharp -ns:"SteamKit2.GC.TF2.Internal" -p:detectMissing

--- a/Resources/Protogen/csharp.xslt
+++ b/Resources/Protogen/csharp.xslt
@@ -466,7 +466,7 @@ namespace <xsl:value-of select="translate($namespace,':-/\','__..')"/>
     public bool <xsl:value-of select="$nameNoKeyword"/>Specified
     {
       get { return <xsl:value-of select="$field"/> != null; }
-      set { if (value == (<xsl:value-of select="$field"/>== null)) <xsl:value-of select="$field"/> = value ? <xsl:value-of select="$name"/> : (<xsl:value-of select="$fieldType"/>)null; }
+      set { if (value == (<xsl:value-of select="$field"/>== null)) <xsl:value-of select="$field"/> = value ? this.<xsl:value-of select="$name"/> : (<xsl:value-of select="$fieldType"/>)null; }
     }
     private bool ShouldSerialize<xsl:value-of select="$nameNoKeyword"/>() { return <xsl:value-of select="$nameNoKeyword"/>Specified; }
     private void Reset<xsl:value-of select="$nameNoKeyword"/>() { <xsl:value-of select="$nameNoKeyword"/>Specified = false; }

--- a/SteamKit2/SteamKit2/Base/Generated/ContentManifest.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/ContentManifest.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: content_manifest.proto
 namespace SteamKit2.Internal
 {
@@ -29,50 +31,95 @@ namespace SteamKit2.Internal
     public FileMapping() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private ulong _size = default(ulong);
+    private ulong? _size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong size
     {
-      get { return _size; }
+      get { return _size?? default(ulong); }
       set { _size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sizeSpecified
+    {
+      get { return _size != null; }
+      set { if (value == (_size== null)) _size = value ? this.size : (ulong?)null; }
+    }
+    private bool ShouldSerializesize() { return sizeSpecified; }
+    private void Resetsize() { sizeSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private byte[] _sha_filename = null;
+    private byte[] _sha_filename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_filename
     {
-      get { return _sha_filename; }
+      get { return _sha_filename?? null; }
       set { _sha_filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_filenameSpecified
+    {
+      get { return _sha_filename != null; }
+      set { if (value == (_sha_filename== null)) _sha_filename = value ? this.sha_filename : (byte[])null; }
+    }
+    private bool ShouldSerializesha_filename() { return sha_filenameSpecified; }
+    private void Resetsha_filename() { sha_filenameSpecified = false; }
+    
 
-    private byte[] _sha_content = null;
+    private byte[] _sha_content;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sha_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_content
     {
-      get { return _sha_content; }
+      get { return _sha_content?? null; }
       set { _sha_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_contentSpecified
+    {
+      get { return _sha_content != null; }
+      set { if (value == (_sha_content== null)) _sha_content = value ? this.sha_content : (byte[])null; }
+    }
+    private bool ShouldSerializesha_content() { return sha_contentSpecified; }
+    private void Resetsha_content() { sha_contentSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ContentManifestPayload.FileMapping.ChunkData> _chunks = new global::System.Collections.Generic.List<ContentManifestPayload.FileMapping.ChunkData>();
     [global::ProtoBuf.ProtoMember(6, Name=@"chunks", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ContentManifestPayload.FileMapping.ChunkData> chunks
@@ -81,64 +128,118 @@ namespace SteamKit2.Internal
     }
   
 
-    private string _linktarget = "";
+    private string _linktarget;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"linktarget", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string linktarget
     {
-      get { return _linktarget; }
+      get { return _linktarget?? ""; }
       set { _linktarget = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool linktargetSpecified
+    {
+      get { return _linktarget != null; }
+      set { if (value == (_linktarget== null)) _linktarget = value ? this.linktarget : (string)null; }
+    }
+    private bool ShouldSerializelinktarget() { return linktargetSpecified; }
+    private void Resetlinktarget() { linktargetSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ChunkData")]
   public partial class ChunkData : global::ProtoBuf.IExtensible
   {
     public ChunkData() {}
     
 
-    private byte[] _sha = null;
+    private byte[] _sha;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha
     {
-      get { return _sha; }
+      get { return _sha?? null; }
       set { _sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shaSpecified
+    {
+      get { return _sha != null; }
+      set { if (value == (_sha== null)) _sha = value ? this.sha : (byte[])null; }
+    }
+    private bool ShouldSerializesha() { return shaSpecified; }
+    private void Resetsha() { shaSpecified = false; }
+    
 
-    private uint _crc = default(uint);
+    private uint? _crc;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc
     {
-      get { return _crc; }
+      get { return _crc?? default(uint); }
       set { _crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crcSpecified
+    {
+      get { return _crc != null; }
+      set { if (value == (_crc== null)) _crc = value ? this.crc : (uint?)null; }
+    }
+    private bool ShouldSerializecrc() { return crcSpecified; }
+    private void Resetcrc() { crcSpecified = false; }
+    
 
-    private ulong _offset = default(ulong);
+    private ulong? _offset;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong offset
     {
-      get { return _offset; }
+      get { return _offset?? default(ulong); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (ulong?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
 
-    private uint _cb_original = default(uint);
+    private uint? _cb_original;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cb_original", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cb_original
     {
-      get { return _cb_original; }
+      get { return _cb_original?? default(uint); }
       set { _cb_original = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_originalSpecified
+    {
+      get { return _cb_original != null; }
+      set { if (value == (_cb_original== null)) _cb_original = value ? this.cb_original : (uint?)null; }
+    }
+    private bool ShouldSerializecb_original() { return cb_originalSpecified; }
+    private void Resetcb_original() { cb_originalSpecified = false; }
+    
 
-    private uint _cb_compressed = default(uint);
+    private uint? _cb_compressed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cb_compressed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cb_compressed
     {
-      get { return _cb_compressed; }
+      get { return _cb_compressed?? default(uint); }
       set { _cb_compressed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_compressedSpecified
+    {
+      get { return _cb_compressed != null; }
+      set { if (value == (_cb_compressed== null)) _cb_compressed = value ? this.cb_compressed : (uint?)null; }
+    }
+    private bool ShouldSerializecb_compressed() { return cb_compressedSpecified; }
+    private void Resetcb_compressed() { cb_compressedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -160,86 +261,167 @@ namespace SteamKit2.Internal
     public ContentManifestMetadata() {}
     
 
-    private uint _depot_id = default(uint);
+    private uint? _depot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"depot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depot_id
     {
-      get { return _depot_id; }
+      get { return _depot_id?? default(uint); }
       set { _depot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_idSpecified
+    {
+      get { return _depot_id != null; }
+      set { if (value == (_depot_id== null)) _depot_id = value ? this.depot_id : (uint?)null; }
+    }
+    private bool ShouldSerializedepot_id() { return depot_idSpecified; }
+    private void Resetdepot_id() { depot_idSpecified = false; }
+    
 
-    private ulong _gid_manifest = default(ulong);
+    private ulong? _gid_manifest;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gid_manifest", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gid_manifest
     {
-      get { return _gid_manifest; }
+      get { return _gid_manifest?? default(ulong); }
       set { _gid_manifest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gid_manifestSpecified
+    {
+      get { return _gid_manifest != null; }
+      set { if (value == (_gid_manifest== null)) _gid_manifest = value ? this.gid_manifest : (ulong?)null; }
+    }
+    private bool ShouldSerializegid_manifest() { return gid_manifestSpecified; }
+    private void Resetgid_manifest() { gid_manifestSpecified = false; }
+    
 
-    private uint _creation_time = default(uint);
+    private uint? _creation_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"creation_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creation_time
     {
-      get { return _creation_time; }
+      get { return _creation_time?? default(uint); }
       set { _creation_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creation_timeSpecified
+    {
+      get { return _creation_time != null; }
+      set { if (value == (_creation_time== null)) _creation_time = value ? this.creation_time : (uint?)null; }
+    }
+    private bool ShouldSerializecreation_time() { return creation_timeSpecified; }
+    private void Resetcreation_time() { creation_timeSpecified = false; }
+    
 
-    private bool _filenames_encrypted = default(bool);
+    private bool? _filenames_encrypted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filenames_encrypted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool filenames_encrypted
     {
-      get { return _filenames_encrypted; }
+      get { return _filenames_encrypted?? default(bool); }
       set { _filenames_encrypted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenames_encryptedSpecified
+    {
+      get { return _filenames_encrypted != null; }
+      set { if (value == (_filenames_encrypted== null)) _filenames_encrypted = value ? this.filenames_encrypted : (bool?)null; }
+    }
+    private bool ShouldSerializefilenames_encrypted() { return filenames_encryptedSpecified; }
+    private void Resetfilenames_encrypted() { filenames_encryptedSpecified = false; }
+    
 
-    private ulong _cb_disk_original = default(ulong);
+    private ulong? _cb_disk_original;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cb_disk_original", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cb_disk_original
     {
-      get { return _cb_disk_original; }
+      get { return _cb_disk_original?? default(ulong); }
       set { _cb_disk_original = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_disk_originalSpecified
+    {
+      get { return _cb_disk_original != null; }
+      set { if (value == (_cb_disk_original== null)) _cb_disk_original = value ? this.cb_disk_original : (ulong?)null; }
+    }
+    private bool ShouldSerializecb_disk_original() { return cb_disk_originalSpecified; }
+    private void Resetcb_disk_original() { cb_disk_originalSpecified = false; }
+    
 
-    private ulong _cb_disk_compressed = default(ulong);
+    private ulong? _cb_disk_compressed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"cb_disk_compressed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cb_disk_compressed
     {
-      get { return _cb_disk_compressed; }
+      get { return _cb_disk_compressed?? default(ulong); }
       set { _cb_disk_compressed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_disk_compressedSpecified
+    {
+      get { return _cb_disk_compressed != null; }
+      set { if (value == (_cb_disk_compressed== null)) _cb_disk_compressed = value ? this.cb_disk_compressed : (ulong?)null; }
+    }
+    private bool ShouldSerializecb_disk_compressed() { return cb_disk_compressedSpecified; }
+    private void Resetcb_disk_compressed() { cb_disk_compressedSpecified = false; }
+    
 
-    private uint _unique_chunks = default(uint);
+    private uint? _unique_chunks;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"unique_chunks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unique_chunks
     {
-      get { return _unique_chunks; }
+      get { return _unique_chunks?? default(uint); }
       set { _unique_chunks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unique_chunksSpecified
+    {
+      get { return _unique_chunks != null; }
+      set { if (value == (_unique_chunks== null)) _unique_chunks = value ? this.unique_chunks : (uint?)null; }
+    }
+    private bool ShouldSerializeunique_chunks() { return unique_chunksSpecified; }
+    private void Resetunique_chunks() { unique_chunksSpecified = false; }
+    
 
-    private uint _crc_encrypted = default(uint);
+    private uint? _crc_encrypted;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"crc_encrypted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_encrypted
     {
-      get { return _crc_encrypted; }
+      get { return _crc_encrypted?? default(uint); }
       set { _crc_encrypted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_encryptedSpecified
+    {
+      get { return _crc_encrypted != null; }
+      set { if (value == (_crc_encrypted== null)) _crc_encrypted = value ? this.crc_encrypted : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_encrypted() { return crc_encryptedSpecified; }
+    private void Resetcrc_encrypted() { crc_encryptedSpecified = false; }
+    
 
-    private uint _crc_clear = default(uint);
+    private uint? _crc_clear;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"crc_clear", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_clear
     {
-      get { return _crc_clear; }
+      get { return _crc_clear?? default(uint); }
       set { _crc_clear = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_clearSpecified
+    {
+      get { return _crc_clear != null; }
+      set { if (value == (_crc_clear== null)) _crc_clear = value ? this.crc_clear : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_clear() { return crc_clearSpecified; }
+    private void Resetcrc_clear() { crc_clearSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -251,14 +433,23 @@ namespace SteamKit2.Internal
     public ContentManifestSignature() {}
     
 
-    private byte[] _signature = null;
+    private byte[] _signature;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signature
     {
-      get { return _signature; }
+      get { return _signature?? null; }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (byte[])null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/MsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/MsgGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: cstrike15_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,50 +20,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public GameServerPing() {}
     
 
-    private ulong _gameserver_id = default(ulong);
+    private ulong? _gameserver_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameserver_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameserver_id
     {
-      get { return _gameserver_id; }
+      get { return _gameserver_id?? default(ulong); }
       set { _gameserver_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameserver_idSpecified
+    {
+      get { return _gameserver_id != null; }
+      set { if (value == (_gameserver_id== null)) _gameserver_id = value ? this.gameserver_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegameserver_id() { return gameserver_idSpecified; }
+    private void Resetgameserver_id() { gameserver_idSpecified = false; }
+    
 
-    private int _ping = default(int);
+    private int? _ping;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ping", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ping
     {
-      get { return _ping; }
+      get { return _ping?? default(int); }
       set { _ping = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingSpecified
+    {
+      get { return _ping != null; }
+      set { if (value == (_ping== null)) _ping = value ? this.ping : (int?)null; }
+    }
+    private bool ShouldSerializeping() { return pingSpecified; }
+    private void Resetping() { pingSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _port = default(uint);
+    private uint? _port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint port
     {
-      get { return _port; }
+      get { return _port?? default(uint); }
       set { _port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool portSpecified
+    {
+      get { return _port != null; }
+      set { if (value == (_port== null)) _port = value ? this.port : (uint?)null; }
+    }
+    private bool ShouldSerializeport() { return portSpecified; }
+    private void Resetport() { portSpecified = false; }
+    
 
-    private uint _instances = default(uint);
+    private uint? _instances;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"instances", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint instances
     {
-      get { return _instances; }
+      get { return _instances?? default(uint); }
       set { _instances = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool instancesSpecified
+    {
+      get { return _instances != null; }
+      set { if (value == (_instances== null)) _instances = value ? this.instances : (uint?)null; }
+    }
+    private bool ShouldSerializeinstances() { return instancesSpecified; }
+    private void Resetinstances() { instancesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -73,32 +120,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public DetailedSearchStatistic() {}
     
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private uint _search_time_avg = default(uint);
+    private uint? _search_time_avg;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"search_time_avg", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_time_avg
     {
-      get { return _search_time_avg; }
+      get { return _search_time_avg?? default(uint); }
       set { _search_time_avg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_time_avgSpecified
+    {
+      get { return _search_time_avg != null; }
+      set { if (value == (_search_time_avg== null)) _search_time_avg = value ? this.search_time_avg : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_time_avg() { return search_time_avgSpecified; }
+    private void Resetsearch_time_avg() { search_time_avgSpecified = false; }
+    
 
-    private uint _players_searching = default(uint);
+    private uint? _players_searching;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"players_searching", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_searching
     {
-      get { return _players_searching; }
+      get { return _players_searching?? default(uint); }
       set { _players_searching = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_searchingSpecified
+    {
+      get { return _players_searching != null; }
+      set { if (value == (_players_searching== null)) _players_searching = value ? this.players_searching : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_searching() { return players_searchingSpecified; }
+    private void Resetplayers_searching() { players_searchingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -110,68 +184,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public TournamentPlayer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _player_nick = "";
+    private string _player_nick;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_nick", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_nick
     {
-      get { return _player_nick; }
+      get { return _player_nick?? ""; }
       set { _player_nick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nickSpecified
+    {
+      get { return _player_nick != null; }
+      set { if (value == (_player_nick== null)) _player_nick = value ? this.player_nick : (string)null; }
+    }
+    private bool ShouldSerializeplayer_nick() { return player_nickSpecified; }
+    private void Resetplayer_nick() { player_nickSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private uint _player_dob = default(uint);
+    private uint? _player_dob;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"player_dob", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_dob
     {
-      get { return _player_dob; }
+      get { return _player_dob?? default(uint); }
       set { _player_dob = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_dobSpecified
+    {
+      get { return _player_dob != null; }
+      set { if (value == (_player_dob== null)) _player_dob = value ? this.player_dob : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_dob() { return player_dobSpecified; }
+    private void Resetplayer_dob() { player_dobSpecified = false; }
+    
 
-    private string _player_flag = "";
+    private string _player_flag;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"player_flag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_flag
     {
-      get { return _player_flag; }
+      get { return _player_flag?? ""; }
       set { _player_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_flagSpecified
+    {
+      get { return _player_flag != null; }
+      set { if (value == (_player_flag== null)) _player_flag = value ? this.player_flag : (string)null; }
+    }
+    private bool ShouldSerializeplayer_flag() { return player_flagSpecified; }
+    private void Resetplayer_flag() { player_flagSpecified = false; }
+    
 
-    private string _player_location = "";
+    private string _player_location;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"player_location", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_location
     {
-      get { return _player_location; }
+      get { return _player_location?? ""; }
       set { _player_location = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_locationSpecified
+    {
+      get { return _player_location != null; }
+      set { if (value == (_player_location== null)) _player_location = value ? this.player_location : (string)null; }
+    }
+    private bool ShouldSerializeplayer_location() { return player_locationSpecified; }
+    private void Resetplayer_location() { player_locationSpecified = false; }
+    
 
-    private string _player_desc = "";
+    private string _player_desc;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"player_desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_desc
     {
-      get { return _player_desc; }
+      get { return _player_desc?? ""; }
       set { _player_desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_descSpecified
+    {
+      get { return _player_desc != null; }
+      set { if (value == (_player_desc== null)) _player_desc = value ? this.player_desc : (string)null; }
+    }
+    private bool ShouldSerializeplayer_desc() { return player_descSpecified; }
+    private void Resetplayer_desc() { player_descSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -183,41 +320,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public TournamentTeam() {}
     
 
-    private int _team_id = default(int);
+    private int? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(int); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private string _team_flag = "";
+    private string _team_flag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_flag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_flag
     {
-      get { return _team_flag; }
+      get { return _team_flag?? ""; }
       set { _team_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_flagSpecified
+    {
+      get { return _team_flag != null; }
+      set { if (value == (_team_flag== null)) _team_flag = value ? this.team_flag : (string)null; }
+    }
+    private bool ShouldSerializeteam_flag() { return team_flagSpecified; }
+    private void Resetteam_flag() { team_flagSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<TournamentPlayer> _players = new global::System.Collections.Generic.List<TournamentPlayer>();
     [global::ProtoBuf.ProtoMember(5, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<TournamentPlayer> players
@@ -236,86 +409,167 @@ namespace SteamKit2.GC.CSGO.Internal
     public TournamentEvent() {}
     
 
-    private int _event_id = default(int);
+    private int? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(int); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private string _event_tag = "";
+    private string _event_tag;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string event_tag
     {
-      get { return _event_tag; }
+      get { return _event_tag?? ""; }
       set { _event_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_tagSpecified
+    {
+      get { return _event_tag != null; }
+      set { if (value == (_event_tag== null)) _event_tag = value ? this.event_tag : (string)null; }
+    }
+    private bool ShouldSerializeevent_tag() { return event_tagSpecified; }
+    private void Resetevent_tag() { event_tagSpecified = false; }
+    
 
-    private string _event_name = "";
+    private string _event_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"event_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string event_name
     {
-      get { return _event_name; }
+      get { return _event_name?? ""; }
       set { _event_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_nameSpecified
+    {
+      get { return _event_name != null; }
+      set { if (value == (_event_name== null)) _event_name = value ? this.event_name : (string)null; }
+    }
+    private bool ShouldSerializeevent_name() { return event_nameSpecified; }
+    private void Resetevent_name() { event_nameSpecified = false; }
+    
 
-    private uint _event_time_start = default(uint);
+    private uint? _event_time_start;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_time_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_time_start
     {
-      get { return _event_time_start; }
+      get { return _event_time_start?? default(uint); }
       set { _event_time_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_time_startSpecified
+    {
+      get { return _event_time_start != null; }
+      set { if (value == (_event_time_start== null)) _event_time_start = value ? this.event_time_start : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_time_start() { return event_time_startSpecified; }
+    private void Resetevent_time_start() { event_time_startSpecified = false; }
+    
 
-    private uint _event_time_end = default(uint);
+    private uint? _event_time_end;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"event_time_end", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_time_end
     {
-      get { return _event_time_end; }
+      get { return _event_time_end?? default(uint); }
       set { _event_time_end = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_time_endSpecified
+    {
+      get { return _event_time_end != null; }
+      set { if (value == (_event_time_end== null)) _event_time_end = value ? this.event_time_end : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_time_end() { return event_time_endSpecified; }
+    private void Resetevent_time_end() { event_time_endSpecified = false; }
+    
 
-    private int _event_public = default(int);
+    private int? _event_public;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"event_public", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_public
     {
-      get { return _event_public; }
+      get { return _event_public?? default(int); }
       set { _event_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_publicSpecified
+    {
+      get { return _event_public != null; }
+      set { if (value == (_event_public== null)) _event_public = value ? this.event_public : (int?)null; }
+    }
+    private bool ShouldSerializeevent_public() { return event_publicSpecified; }
+    private void Resetevent_public() { event_publicSpecified = false; }
+    
 
-    private int _event_stage_id = default(int);
+    private int? _event_stage_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"event_stage_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_stage_id
     {
-      get { return _event_stage_id; }
+      get { return _event_stage_id?? default(int); }
       set { _event_stage_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_stage_idSpecified
+    {
+      get { return _event_stage_id != null; }
+      set { if (value == (_event_stage_id== null)) _event_stage_id = value ? this.event_stage_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_stage_id() { return event_stage_idSpecified; }
+    private void Resetevent_stage_id() { event_stage_idSpecified = false; }
+    
 
-    private string _event_stage_name = "";
+    private string _event_stage_name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"event_stage_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string event_stage_name
     {
-      get { return _event_stage_name; }
+      get { return _event_stage_name?? ""; }
       set { _event_stage_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_stage_nameSpecified
+    {
+      get { return _event_stage_name != null; }
+      set { if (value == (_event_stage_name== null)) _event_stage_name = value ? this.event_stage_name : (string)null; }
+    }
+    private bool ShouldSerializeevent_stage_name() { return event_stage_nameSpecified; }
+    private void Resetevent_stage_name() { event_stage_nameSpecified = false; }
+    
 
-    private uint _active_section_id = default(uint);
+    private uint? _active_section_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"active_section_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_section_id
     {
-      get { return _active_section_id; }
+      get { return _active_section_id?? default(uint); }
       set { _active_section_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_section_idSpecified
+    {
+      get { return _active_section_id != null; }
+      set { if (value == (_active_section_id== null)) _active_section_id = value ? this.active_section_id : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_section_id() { return active_section_idSpecified; }
+    private void Resetactive_section_id() { active_section_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -327,59 +581,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public GlobalStatistics() {}
     
 
-    private uint _players_online = default(uint);
+    private uint? _players_online;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"players_online", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_online
     {
-      get { return _players_online; }
+      get { return _players_online?? default(uint); }
       set { _players_online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_onlineSpecified
+    {
+      get { return _players_online != null; }
+      set { if (value == (_players_online== null)) _players_online = value ? this.players_online : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_online() { return players_onlineSpecified; }
+    private void Resetplayers_online() { players_onlineSpecified = false; }
+    
 
-    private uint _servers_online = default(uint);
+    private uint? _servers_online;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"servers_online", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint servers_online
     {
-      get { return _servers_online; }
+      get { return _servers_online?? default(uint); }
       set { _servers_online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool servers_onlineSpecified
+    {
+      get { return _servers_online != null; }
+      set { if (value == (_servers_online== null)) _servers_online = value ? this.servers_online : (uint?)null; }
+    }
+    private bool ShouldSerializeservers_online() { return servers_onlineSpecified; }
+    private void Resetservers_online() { servers_onlineSpecified = false; }
+    
 
-    private uint _players_searching = default(uint);
+    private uint? _players_searching;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"players_searching", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_searching
     {
-      get { return _players_searching; }
+      get { return _players_searching?? default(uint); }
       set { _players_searching = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_searchingSpecified
+    {
+      get { return _players_searching != null; }
+      set { if (value == (_players_searching== null)) _players_searching = value ? this.players_searching : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_searching() { return players_searchingSpecified; }
+    private void Resetplayers_searching() { players_searchingSpecified = false; }
+    
 
-    private uint _servers_available = default(uint);
+    private uint? _servers_available;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"servers_available", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint servers_available
     {
-      get { return _servers_available; }
+      get { return _servers_available?? default(uint); }
       set { _servers_available = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool servers_availableSpecified
+    {
+      get { return _servers_available != null; }
+      set { if (value == (_servers_available== null)) _servers_available = value ? this.servers_available : (uint?)null; }
+    }
+    private bool ShouldSerializeservers_available() { return servers_availableSpecified; }
+    private void Resetservers_available() { servers_availableSpecified = false; }
+    
 
-    private uint _ongoing_matches = default(uint);
+    private uint? _ongoing_matches;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ongoing_matches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ongoing_matches
     {
-      get { return _ongoing_matches; }
+      get { return _ongoing_matches?? default(uint); }
       set { _ongoing_matches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ongoing_matchesSpecified
+    {
+      get { return _ongoing_matches != null; }
+      set { if (value == (_ongoing_matches== null)) _ongoing_matches = value ? this.ongoing_matches : (uint?)null; }
+    }
+    private bool ShouldSerializeongoing_matches() { return ongoing_matchesSpecified; }
+    private void Resetongoing_matches() { ongoing_matchesSpecified = false; }
+    
 
-    private uint _search_time_avg = default(uint);
+    private uint? _search_time_avg;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"search_time_avg", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_time_avg
     {
-      get { return _search_time_avg; }
+      get { return _search_time_avg?? default(uint); }
       set { _search_time_avg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_time_avgSpecified
+    {
+      get { return _search_time_avg != null; }
+      set { if (value == (_search_time_avg== null)) _search_time_avg = value ? this.search_time_avg : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_time_avg() { return search_time_avgSpecified; }
+    private void Resetsearch_time_avg() { search_time_avgSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<DetailedSearchStatistic> _search_statistics = new global::System.Collections.Generic.List<DetailedSearchStatistic>();
     [global::ProtoBuf.ProtoMember(7, Name=@"search_statistics", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<DetailedSearchStatistic> search_statistics
@@ -388,59 +696,113 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private string _main_post_url = "";
+    private string _main_post_url;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"main_post_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string main_post_url
     {
-      get { return _main_post_url; }
+      get { return _main_post_url?? ""; }
       set { _main_post_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool main_post_urlSpecified
+    {
+      get { return _main_post_url != null; }
+      set { if (value == (_main_post_url== null)) _main_post_url = value ? this.main_post_url : (string)null; }
+    }
+    private bool ShouldSerializemain_post_url() { return main_post_urlSpecified; }
+    private void Resetmain_post_url() { main_post_urlSpecified = false; }
+    
 
-    private uint _required_appid_version = default(uint);
+    private uint? _required_appid_version;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"required_appid_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint required_appid_version
     {
-      get { return _required_appid_version; }
+      get { return _required_appid_version?? default(uint); }
       set { _required_appid_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool required_appid_versionSpecified
+    {
+      get { return _required_appid_version != null; }
+      set { if (value == (_required_appid_version== null)) _required_appid_version = value ? this.required_appid_version : (uint?)null; }
+    }
+    private bool ShouldSerializerequired_appid_version() { return required_appid_versionSpecified; }
+    private void Resetrequired_appid_version() { required_appid_versionSpecified = false; }
+    
 
-    private uint _pricesheet_version = default(uint);
+    private uint? _pricesheet_version;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"pricesheet_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pricesheet_version
     {
-      get { return _pricesheet_version; }
+      get { return _pricesheet_version?? default(uint); }
       set { _pricesheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pricesheet_versionSpecified
+    {
+      get { return _pricesheet_version != null; }
+      set { if (value == (_pricesheet_version== null)) _pricesheet_version = value ? this.pricesheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializepricesheet_version() { return pricesheet_versionSpecified; }
+    private void Resetpricesheet_version() { pricesheet_versionSpecified = false; }
+    
 
-    private uint _twitch_streams_version = default(uint);
+    private uint? _twitch_streams_version;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"twitch_streams_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint twitch_streams_version
     {
-      get { return _twitch_streams_version; }
+      get { return _twitch_streams_version?? default(uint); }
       set { _twitch_streams_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool twitch_streams_versionSpecified
+    {
+      get { return _twitch_streams_version != null; }
+      set { if (value == (_twitch_streams_version== null)) _twitch_streams_version = value ? this.twitch_streams_version : (uint?)null; }
+    }
+    private bool ShouldSerializetwitch_streams_version() { return twitch_streams_versionSpecified; }
+    private void Resettwitch_streams_version() { twitch_streams_versionSpecified = false; }
+    
 
-    private uint _active_tournament_eventid = default(uint);
+    private uint? _active_tournament_eventid;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"active_tournament_eventid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_tournament_eventid
     {
-      get { return _active_tournament_eventid; }
+      get { return _active_tournament_eventid?? default(uint); }
       set { _active_tournament_eventid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_tournament_eventidSpecified
+    {
+      get { return _active_tournament_eventid != null; }
+      set { if (value == (_active_tournament_eventid== null)) _active_tournament_eventid = value ? this.active_tournament_eventid : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_tournament_eventid() { return active_tournament_eventidSpecified; }
+    private void Resetactive_tournament_eventid() { active_tournament_eventidSpecified = false; }
+    
 
-    private uint _active_survey_id = default(uint);
+    private uint? _active_survey_id;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"active_survey_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_survey_id
     {
-      get { return _active_survey_id; }
+      get { return _active_survey_id?? default(uint); }
       set { _active_survey_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_survey_idSpecified
+    {
+      get { return _active_survey_id != null; }
+      set { if (value == (_active_survey_id== null)) _active_survey_id = value ? this.active_survey_id : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_survey_id() { return active_survey_idSpecified; }
+    private void Resetactive_survey_id() { active_survey_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -452,23 +814,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public OperationalStatisticDescription() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _idkey = default(uint);
+    private uint? _idkey;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"idkey", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint idkey
     {
-      get { return _idkey; }
+      get { return _idkey?? default(uint); }
       set { _idkey = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idkeySpecified
+    {
+      get { return _idkey != null; }
+      set { if (value == (_idkey== null)) _idkey = value ? this.idkey : (uint?)null; }
+    }
+    private bool ShouldSerializeidkey() { return idkeySpecified; }
+    private void Resetidkey() { idkeySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -480,14 +860,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public OperationalStatisticElement() {}
     
 
-    private uint _idkey = default(uint);
+    private uint? _idkey;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"idkey", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint idkey
     {
-      get { return _idkey; }
+      get { return _idkey?? default(uint); }
       set { _idkey = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idkeySpecified
+    {
+      get { return _idkey != null; }
+      set { if (value == (_idkey== null)) _idkey = value ? this.idkey : (uint?)null; }
+    }
+    private bool ShouldSerializeidkey() { return idkeySpecified; }
+    private void Resetidkey() { idkeySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<int> _values = new global::System.Collections.Generic.List<int>();
     [global::ProtoBuf.ProtoMember(2, Name=@"values", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<int> values
@@ -506,23 +895,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public OperationalStatisticsPacket() {}
     
 
-    private int _packetid = default(int);
+    private int? _packetid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packetid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int packetid
     {
-      get { return _packetid; }
+      get { return _packetid?? default(int); }
       set { _packetid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packetidSpecified
+    {
+      get { return _packetid != null; }
+      set { if (value == (_packetid== null)) _packetid = value ? this.packetid : (int?)null; }
+    }
+    private bool ShouldSerializepacketid() { return packetidSpecified; }
+    private void Resetpacketid() { packetidSpecified = false; }
+    
 
-    private int _mstimestamp = default(int);
+    private int? _mstimestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"mstimestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int mstimestamp
     {
-      get { return _mstimestamp; }
+      get { return _mstimestamp?? default(int); }
       set { _mstimestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mstimestampSpecified
+    {
+      get { return _mstimestamp != null; }
+      set { if (value == (_mstimestamp== null)) _mstimestamp = value ? this.mstimestamp : (int?)null; }
+    }
+    private bool ShouldSerializemstimestamp() { return mstimestampSpecified; }
+    private void Resetmstimestamp() { mstimestampSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<OperationalStatisticElement> _values = new global::System.Collections.Generic.List<OperationalStatisticElement>();
     [global::ProtoBuf.ProtoMember(3, Name=@"values", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<OperationalStatisticElement> values
@@ -541,41 +948,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public PlayerRankingInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _rank_id = default(uint);
+    private uint? _rank_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rank_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank_id
     {
-      get { return _rank_id; }
+      get { return _rank_id?? default(uint); }
       set { _rank_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_idSpecified
+    {
+      get { return _rank_id != null; }
+      set { if (value == (_rank_id== null)) _rank_id = value ? this.rank_id : (uint?)null; }
+    }
+    private bool ShouldSerializerank_id() { return rank_idSpecified; }
+    private void Resetrank_id() { rank_idSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private float _rank_change = default(float);
+    private float? _rank_change;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rank_change", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float rank_change
     {
-      get { return _rank_change; }
+      get { return _rank_change?? default(float); }
       set { _rank_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_changeSpecified
+    {
+      get { return _rank_change != null; }
+      set { if (value == (_rank_change== null)) _rank_change = value ? this.rank_change : (float?)null; }
+    }
+    private bool ShouldSerializerank_change() { return rank_changeSpecified; }
+    private void Resetrank_change() { rank_changeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -587,32 +1030,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public PlayerCommendationInfo() {}
     
 
-    private uint _cmd_friendly = default(uint);
+    private uint? _cmd_friendly;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"cmd_friendly", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cmd_friendly
     {
-      get { return _cmd_friendly; }
+      get { return _cmd_friendly?? default(uint); }
       set { _cmd_friendly = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_friendlySpecified
+    {
+      get { return _cmd_friendly != null; }
+      set { if (value == (_cmd_friendly== null)) _cmd_friendly = value ? this.cmd_friendly : (uint?)null; }
+    }
+    private bool ShouldSerializecmd_friendly() { return cmd_friendlySpecified; }
+    private void Resetcmd_friendly() { cmd_friendlySpecified = false; }
+    
 
-    private uint _cmd_teaching = default(uint);
+    private uint? _cmd_teaching;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cmd_teaching", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cmd_teaching
     {
-      get { return _cmd_teaching; }
+      get { return _cmd_teaching?? default(uint); }
       set { _cmd_teaching = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_teachingSpecified
+    {
+      get { return _cmd_teaching != null; }
+      set { if (value == (_cmd_teaching== null)) _cmd_teaching = value ? this.cmd_teaching : (uint?)null; }
+    }
+    private bool ShouldSerializecmd_teaching() { return cmd_teachingSpecified; }
+    private void Resetcmd_teaching() { cmd_teachingSpecified = false; }
+    
 
-    private uint _cmd_leader = default(uint);
+    private uint? _cmd_leader;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cmd_leader", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cmd_leader
     {
-      get { return _cmd_leader; }
+      get { return _cmd_leader?? default(uint); }
       set { _cmd_leader = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_leaderSpecified
+    {
+      get { return _cmd_leader != null; }
+      set { if (value == (_cmd_leader== null)) _cmd_leader = value ? this.cmd_leader : (uint?)null; }
+    }
+    private bool ShouldSerializecmd_leader() { return cmd_leaderSpecified; }
+    private void Resetcmd_leader() { cmd_leaderSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -624,50 +1094,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public PlayerMedalsInfo() {}
     
 
-    private uint _medal_team = default(uint);
+    private uint? _medal_team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"medal_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medal_team
     {
-      get { return _medal_team; }
+      get { return _medal_team?? default(uint); }
       set { _medal_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medal_teamSpecified
+    {
+      get { return _medal_team != null; }
+      set { if (value == (_medal_team== null)) _medal_team = value ? this.medal_team : (uint?)null; }
+    }
+    private bool ShouldSerializemedal_team() { return medal_teamSpecified; }
+    private void Resetmedal_team() { medal_teamSpecified = false; }
+    
 
-    private uint _medal_combat = default(uint);
+    private uint? _medal_combat;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"medal_combat", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medal_combat
     {
-      get { return _medal_combat; }
+      get { return _medal_combat?? default(uint); }
       set { _medal_combat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medal_combatSpecified
+    {
+      get { return _medal_combat != null; }
+      set { if (value == (_medal_combat== null)) _medal_combat = value ? this.medal_combat : (uint?)null; }
+    }
+    private bool ShouldSerializemedal_combat() { return medal_combatSpecified; }
+    private void Resetmedal_combat() { medal_combatSpecified = false; }
+    
 
-    private uint _medal_weapon = default(uint);
+    private uint? _medal_weapon;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"medal_weapon", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medal_weapon
     {
-      get { return _medal_weapon; }
+      get { return _medal_weapon?? default(uint); }
       set { _medal_weapon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medal_weaponSpecified
+    {
+      get { return _medal_weapon != null; }
+      set { if (value == (_medal_weapon== null)) _medal_weapon = value ? this.medal_weapon : (uint?)null; }
+    }
+    private bool ShouldSerializemedal_weapon() { return medal_weaponSpecified; }
+    private void Resetmedal_weapon() { medal_weaponSpecified = false; }
+    
 
-    private uint _medal_global = default(uint);
+    private uint? _medal_global;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"medal_global", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medal_global
     {
-      get { return _medal_global; }
+      get { return _medal_global?? default(uint); }
       set { _medal_global = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medal_globalSpecified
+    {
+      get { return _medal_global != null; }
+      set { if (value == (_medal_global== null)) _medal_global = value ? this.medal_global : (uint?)null; }
+    }
+    private bool ShouldSerializemedal_global() { return medal_globalSpecified; }
+    private void Resetmedal_global() { medal_globalSpecified = false; }
+    
 
-    private uint _medal_arms = default(uint);
+    private uint? _medal_arms;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"medal_arms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medal_arms
     {
-      get { return _medal_arms; }
+      get { return _medal_arms?? default(uint); }
       set { _medal_arms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medal_armsSpecified
+    {
+      get { return _medal_arms != null; }
+      set { if (value == (_medal_arms== null)) _medal_arms = value ? this.medal_arms : (uint?)null; }
+    }
+    private bool ShouldSerializemedal_arms() { return medal_armsSpecified; }
+    private void Resetmedal_arms() { medal_armsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _display_items_defidx = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"display_items_defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> display_items_defidx
@@ -676,14 +1191,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _featured_display_item_defidx = default(uint);
+    private uint? _featured_display_item_defidx;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"featured_display_item_defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint featured_display_item_defidx
     {
-      get { return _featured_display_item_defidx; }
+      get { return _featured_display_item_defidx?? default(uint); }
       set { _featured_display_item_defidx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool featured_display_item_defidxSpecified
+    {
+      get { return _featured_display_item_defidx != null; }
+      set { if (value == (_featured_display_item_defidx== null)) _featured_display_item_defidx = value ? this.featured_display_item_defidx : (uint?)null; }
+    }
+    private bool ShouldSerializefeatured_display_item_defidx() { return featured_display_item_defidxSpecified; }
+    private void Resetfeatured_display_item_defidx() { featured_display_item_defidxSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -695,32 +1219,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public AccountActivity() {}
     
 
-    private uint _activity = default(uint);
+    private uint? _activity;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"activity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint activity
     {
-      get { return _activity; }
+      get { return _activity?? default(uint); }
       set { _activity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activitySpecified
+    {
+      get { return _activity != null; }
+      set { if (value == (_activity== null)) _activity = value ? this.activity : (uint?)null; }
+    }
+    private bool ShouldSerializeactivity() { return activitySpecified; }
+    private void Resetactivity() { activitySpecified = false; }
+    
 
-    private uint _mode = default(uint);
+    private uint? _mode;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mode
     {
-      get { return _mode; }
+      get { return _mode?? default(uint); }
       set { _mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modeSpecified
+    {
+      get { return _mode != null; }
+      set { if (value == (_mode== null)) _mode = value ? this.mode : (uint?)null; }
+    }
+    private bool ShouldSerializemode() { return modeSpecified; }
+    private void Resetmode() { modeSpecified = false; }
+    
 
-    private uint _map = default(uint);
+    private uint? _map;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint map
     {
-      get { return _map; }
+      get { return _map?? default(uint); }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (uint?)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -732,41 +1283,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public TournamentMatchSetup() {}
     
 
-    private int _event_id = default(int);
+    private int? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(int); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private int _team_id_ct = default(int);
+    private int? _team_id_ct;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id_ct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_ct
     {
-      get { return _team_id_ct; }
+      get { return _team_id_ct?? default(int); }
       set { _team_id_ct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_ctSpecified
+    {
+      get { return _team_id_ct != null; }
+      set { if (value == (_team_id_ct== null)) _team_id_ct = value ? this.team_id_ct : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_ct() { return team_id_ctSpecified; }
+    private void Resetteam_id_ct() { team_id_ctSpecified = false; }
+    
 
-    private int _team_id_t = default(int);
+    private int? _team_id_t;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_id_t", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_t
     {
-      get { return _team_id_t; }
+      get { return _team_id_t?? default(int); }
       set { _team_id_t = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_tSpecified
+    {
+      get { return _team_id_t != null; }
+      set { if (value == (_team_id_t== null)) _team_id_t = value ? this.team_id_t : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_t() { return team_id_tSpecified; }
+    private void Resetteam_id_t() { team_id_tSpecified = false; }
+    
 
-    private int _event_stage_id = default(int);
+    private int? _event_stage_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_stage_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_stage_id
     {
-      get { return _event_stage_id; }
+      get { return _event_stage_id?? default(int); }
       set { _event_stage_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_stage_idSpecified
+    {
+      get { return _event_stage_id != null; }
+      set { if (value == (_event_stage_id== null)) _event_stage_id = value ? this.event_stage_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_stage_id() { return event_stage_idSpecified; }
+    private void Resetevent_stage_id() { event_stage_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -778,176 +1365,347 @@ namespace SteamKit2.GC.CSGO.Internal
     public ServerHltvInfo() {}
     
 
-    private uint _tv_udp_port = default(uint);
+    private uint? _tv_udp_port;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tv_udp_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_udp_port
     {
-      get { return _tv_udp_port; }
+      get { return _tv_udp_port?? default(uint); }
       set { _tv_udp_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_udp_portSpecified
+    {
+      get { return _tv_udp_port != null; }
+      set { if (value == (_tv_udp_port== null)) _tv_udp_port = value ? this.tv_udp_port : (uint?)null; }
+    }
+    private bool ShouldSerializetv_udp_port() { return tv_udp_portSpecified; }
+    private void Resettv_udp_port() { tv_udp_portSpecified = false; }
+    
 
-    private ulong _tv_watch_key = default(ulong);
+    private ulong? _tv_watch_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tv_watch_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_watch_key
     {
-      get { return _tv_watch_key; }
+      get { return _tv_watch_key?? default(ulong); }
       set { _tv_watch_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_watch_keySpecified
+    {
+      get { return _tv_watch_key != null; }
+      set { if (value == (_tv_watch_key== null)) _tv_watch_key = value ? this.tv_watch_key : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_watch_key() { return tv_watch_keySpecified; }
+    private void Resettv_watch_key() { tv_watch_keySpecified = false; }
+    
 
-    private uint _tv_slots = default(uint);
+    private uint? _tv_slots;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tv_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_slots
     {
-      get { return _tv_slots; }
+      get { return _tv_slots?? default(uint); }
       set { _tv_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_slotsSpecified
+    {
+      get { return _tv_slots != null; }
+      set { if (value == (_tv_slots== null)) _tv_slots = value ? this.tv_slots : (uint?)null; }
+    }
+    private bool ShouldSerializetv_slots() { return tv_slotsSpecified; }
+    private void Resettv_slots() { tv_slotsSpecified = false; }
+    
 
-    private uint _tv_clients = default(uint);
+    private uint? _tv_clients;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tv_clients", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_clients
     {
-      get { return _tv_clients; }
+      get { return _tv_clients?? default(uint); }
       set { _tv_clients = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_clientsSpecified
+    {
+      get { return _tv_clients != null; }
+      set { if (value == (_tv_clients== null)) _tv_clients = value ? this.tv_clients : (uint?)null; }
+    }
+    private bool ShouldSerializetv_clients() { return tv_clientsSpecified; }
+    private void Resettv_clients() { tv_clientsSpecified = false; }
+    
 
-    private uint _tv_proxies = default(uint);
+    private uint? _tv_proxies;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tv_proxies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_proxies
     {
-      get { return _tv_proxies; }
+      get { return _tv_proxies?? default(uint); }
       set { _tv_proxies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_proxiesSpecified
+    {
+      get { return _tv_proxies != null; }
+      set { if (value == (_tv_proxies== null)) _tv_proxies = value ? this.tv_proxies : (uint?)null; }
+    }
+    private bool ShouldSerializetv_proxies() { return tv_proxiesSpecified; }
+    private void Resettv_proxies() { tv_proxiesSpecified = false; }
+    
 
-    private uint _tv_time = default(uint);
+    private uint? _tv_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tv_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_time
     {
-      get { return _tv_time; }
+      get { return _tv_time?? default(uint); }
       set { _tv_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_timeSpecified
+    {
+      get { return _tv_time != null; }
+      set { if (value == (_tv_time== null)) _tv_time = value ? this.tv_time : (uint?)null; }
+    }
+    private bool ShouldSerializetv_time() { return tv_timeSpecified; }
+    private void Resettv_time() { tv_timeSpecified = false; }
+    
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private string _game_mapgroup = "";
+    private string _game_mapgroup;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"game_mapgroup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_mapgroup
     {
-      get { return _game_mapgroup; }
+      get { return _game_mapgroup?? ""; }
       set { _game_mapgroup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_mapgroupSpecified
+    {
+      get { return _game_mapgroup != null; }
+      set { if (value == (_game_mapgroup== null)) _game_mapgroup = value ? this.game_mapgroup : (string)null; }
+    }
+    private bool ShouldSerializegame_mapgroup() { return game_mapgroupSpecified; }
+    private void Resetgame_mapgroup() { game_mapgroupSpecified = false; }
+    
 
-    private string _game_map = "";
+    private string _game_map;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"game_map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_map
     {
-      get { return _game_map; }
+      get { return _game_map?? ""; }
       set { _game_map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_mapSpecified
+    {
+      get { return _game_map != null; }
+      set { if (value == (_game_map== null)) _game_map = value ? this.game_map : (string)null; }
+    }
+    private bool ShouldSerializegame_map() { return game_mapSpecified; }
+    private void Resetgame_map() { game_mapSpecified = false; }
+    
 
-    private ulong _tv_master_steamid = default(ulong);
+    private ulong? _tv_master_steamid;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"tv_master_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_master_steamid
     {
-      get { return _tv_master_steamid; }
+      get { return _tv_master_steamid?? default(ulong); }
       set { _tv_master_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_master_steamidSpecified
+    {
+      get { return _tv_master_steamid != null; }
+      set { if (value == (_tv_master_steamid== null)) _tv_master_steamid = value ? this.tv_master_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_master_steamid() { return tv_master_steamidSpecified; }
+    private void Resettv_master_steamid() { tv_master_steamidSpecified = false; }
+    
 
-    private uint _tv_local_slots = default(uint);
+    private uint? _tv_local_slots;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"tv_local_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_local_slots
     {
-      get { return _tv_local_slots; }
+      get { return _tv_local_slots?? default(uint); }
       set { _tv_local_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_local_slotsSpecified
+    {
+      get { return _tv_local_slots != null; }
+      set { if (value == (_tv_local_slots== null)) _tv_local_slots = value ? this.tv_local_slots : (uint?)null; }
+    }
+    private bool ShouldSerializetv_local_slots() { return tv_local_slotsSpecified; }
+    private void Resettv_local_slots() { tv_local_slotsSpecified = false; }
+    
 
-    private uint _tv_local_clients = default(uint);
+    private uint? _tv_local_clients;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"tv_local_clients", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_local_clients
     {
-      get { return _tv_local_clients; }
+      get { return _tv_local_clients?? default(uint); }
       set { _tv_local_clients = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_local_clientsSpecified
+    {
+      get { return _tv_local_clients != null; }
+      set { if (value == (_tv_local_clients== null)) _tv_local_clients = value ? this.tv_local_clients : (uint?)null; }
+    }
+    private bool ShouldSerializetv_local_clients() { return tv_local_clientsSpecified; }
+    private void Resettv_local_clients() { tv_local_clientsSpecified = false; }
+    
 
-    private uint _tv_local_proxies = default(uint);
+    private uint? _tv_local_proxies;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"tv_local_proxies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_local_proxies
     {
-      get { return _tv_local_proxies; }
+      get { return _tv_local_proxies?? default(uint); }
       set { _tv_local_proxies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_local_proxiesSpecified
+    {
+      get { return _tv_local_proxies != null; }
+      set { if (value == (_tv_local_proxies== null)) _tv_local_proxies = value ? this.tv_local_proxies : (uint?)null; }
+    }
+    private bool ShouldSerializetv_local_proxies() { return tv_local_proxiesSpecified; }
+    private void Resettv_local_proxies() { tv_local_proxiesSpecified = false; }
+    
 
-    private uint _tv_relay_slots = default(uint);
+    private uint? _tv_relay_slots;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"tv_relay_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_relay_slots
     {
-      get { return _tv_relay_slots; }
+      get { return _tv_relay_slots?? default(uint); }
       set { _tv_relay_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_slotsSpecified
+    {
+      get { return _tv_relay_slots != null; }
+      set { if (value == (_tv_relay_slots== null)) _tv_relay_slots = value ? this.tv_relay_slots : (uint?)null; }
+    }
+    private bool ShouldSerializetv_relay_slots() { return tv_relay_slotsSpecified; }
+    private void Resettv_relay_slots() { tv_relay_slotsSpecified = false; }
+    
 
-    private uint _tv_relay_clients = default(uint);
+    private uint? _tv_relay_clients;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"tv_relay_clients", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_relay_clients
     {
-      get { return _tv_relay_clients; }
+      get { return _tv_relay_clients?? default(uint); }
       set { _tv_relay_clients = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_clientsSpecified
+    {
+      get { return _tv_relay_clients != null; }
+      set { if (value == (_tv_relay_clients== null)) _tv_relay_clients = value ? this.tv_relay_clients : (uint?)null; }
+    }
+    private bool ShouldSerializetv_relay_clients() { return tv_relay_clientsSpecified; }
+    private void Resettv_relay_clients() { tv_relay_clientsSpecified = false; }
+    
 
-    private uint _tv_relay_proxies = default(uint);
+    private uint? _tv_relay_proxies;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"tv_relay_proxies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_relay_proxies
     {
-      get { return _tv_relay_proxies; }
+      get { return _tv_relay_proxies?? default(uint); }
       set { _tv_relay_proxies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_proxiesSpecified
+    {
+      get { return _tv_relay_proxies != null; }
+      set { if (value == (_tv_relay_proxies== null)) _tv_relay_proxies = value ? this.tv_relay_proxies : (uint?)null; }
+    }
+    private bool ShouldSerializetv_relay_proxies() { return tv_relay_proxiesSpecified; }
+    private void Resettv_relay_proxies() { tv_relay_proxiesSpecified = false; }
+    
 
-    private uint _tv_relay_address = default(uint);
+    private uint? _tv_relay_address;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"tv_relay_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_relay_address
     {
-      get { return _tv_relay_address; }
+      get { return _tv_relay_address?? default(uint); }
       set { _tv_relay_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_addressSpecified
+    {
+      get { return _tv_relay_address != null; }
+      set { if (value == (_tv_relay_address== null)) _tv_relay_address = value ? this.tv_relay_address : (uint?)null; }
+    }
+    private bool ShouldSerializetv_relay_address() { return tv_relay_addressSpecified; }
+    private void Resettv_relay_address() { tv_relay_addressSpecified = false; }
+    
 
-    private uint _tv_relay_port = default(uint);
+    private uint? _tv_relay_port;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"tv_relay_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_relay_port
     {
-      get { return _tv_relay_port; }
+      get { return _tv_relay_port?? default(uint); }
       set { _tv_relay_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_portSpecified
+    {
+      get { return _tv_relay_port != null; }
+      set { if (value == (_tv_relay_port== null)) _tv_relay_port = value ? this.tv_relay_port : (uint?)null; }
+    }
+    private bool ShouldSerializetv_relay_port() { return tv_relay_portSpecified; }
+    private void Resettv_relay_port() { tv_relay_portSpecified = false; }
+    
 
-    private ulong _tv_relay_steamid = default(ulong);
+    private ulong? _tv_relay_steamid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"tv_relay_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_relay_steamid
     {
-      get { return _tv_relay_steamid; }
+      get { return _tv_relay_steamid?? default(ulong); }
       set { _tv_relay_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_steamidSpecified
+    {
+      get { return _tv_relay_steamid != null; }
+      set { if (value == (_tv_relay_steamid== null)) _tv_relay_steamid = value ? this.tv_relay_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_relay_steamid() { return tv_relay_steamidSpecified; }
+    private void Resettv_relay_steamid() { tv_relay_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -959,59 +1717,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public IpAddressMask() {}
     
 
-    private uint _a = default(uint);
+    private uint? _a;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint a
     {
-      get { return _a; }
+      get { return _a?? default(uint); }
       set { _a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool aSpecified
+    {
+      get { return _a != null; }
+      set { if (value == (_a== null)) _a = value ? this.a : (uint?)null; }
+    }
+    private bool ShouldSerializea() { return aSpecified; }
+    private void Reseta() { aSpecified = false; }
+    
 
-    private uint _b = default(uint);
+    private uint? _b;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"b", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint b
     {
-      get { return _b; }
+      get { return _b?? default(uint); }
       set { _b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bSpecified
+    {
+      get { return _b != null; }
+      set { if (value == (_b== null)) _b = value ? this.b : (uint?)null; }
+    }
+    private bool ShouldSerializeb() { return bSpecified; }
+    private void Resetb() { bSpecified = false; }
+    
 
-    private uint _c = default(uint);
+    private uint? _c;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"c", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint c
     {
-      get { return _c; }
+      get { return _c?? default(uint); }
       set { _c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cSpecified
+    {
+      get { return _c != null; }
+      set { if (value == (_c== null)) _c = value ? this.c : (uint?)null; }
+    }
+    private bool ShouldSerializec() { return cSpecified; }
+    private void Resetc() { cSpecified = false; }
+    
 
-    private uint _d = default(uint);
+    private uint? _d;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"d", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint d
     {
-      get { return _d; }
+      get { return _d?? default(uint); }
       set { _d = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dSpecified
+    {
+      get { return _d != null; }
+      set { if (value == (_d== null)) _d = value ? this.d : (uint?)null; }
+    }
+    private bool ShouldSerialized() { return dSpecified; }
+    private void Resetd() { dSpecified = false; }
+    
 
-    private uint _bits = default(uint);
+    private uint? _bits;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"bits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bits
     {
-      get { return _bits; }
+      get { return _bits?? default(uint); }
       set { _bits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bitsSpecified
+    {
+      get { return _bits != null; }
+      set { if (value == (_bits== null)) _bits = value ? this.bits : (uint?)null; }
+    }
+    private bool ShouldSerializebits() { return bitsSpecified; }
+    private void Resetbits() { bitsSpecified = false; }
+    
 
-    private uint _token = default(uint);
+    private uint? _token;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint token
     {
-      get { return _token; }
+      get { return _token?? default(uint); }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (uint?)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1023,23 +1835,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public XpProgressData() {}
     
 
-    private uint _xp_points = default(uint);
+    private uint? _xp_points;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"xp_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp_points
     {
-      get { return _xp_points; }
+      get { return _xp_points?? default(uint); }
       set { _xp_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_pointsSpecified
+    {
+      get { return _xp_points != null; }
+      set { if (value == (_xp_points== null)) _xp_points = value ? this.xp_points : (uint?)null; }
+    }
+    private bool ShouldSerializexp_points() { return xp_pointsSpecified; }
+    private void Resetxp_points() { xp_pointsSpecified = false; }
+    
 
-    private int _xp_category = default(int);
+    private int? _xp_category;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"xp_category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int xp_category
     {
-      get { return _xp_category; }
+      get { return _xp_category?? default(int); }
       set { _xp_category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_categorySpecified
+    {
+      get { return _xp_category != null; }
+      set { if (value == (_xp_category== null)) _xp_category = value ? this.xp_category : (int?)null; }
+    }
+    private bool ShouldSerializexp_category() { return xp_categorySpecified; }
+    private void Resetxp_category() { xp_categorySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1051,32 +1881,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public MatchEndItemUpdates() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _item_attr_defidx = default(uint);
+    private uint? _item_attr_defidx;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_attr_defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_attr_defidx
     {
-      get { return _item_attr_defidx; }
+      get { return _item_attr_defidx?? default(uint); }
       set { _item_attr_defidx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_attr_defidxSpecified
+    {
+      get { return _item_attr_defidx != null; }
+      set { if (value == (_item_attr_defidx== null)) _item_attr_defidx = value ? this.item_attr_defidx : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_attr_defidx() { return item_attr_defidxSpecified; }
+    private void Resetitem_attr_defidx() { item_attr_defidxSpecified = false; }
+    
 
-    private uint _item_attr_delta_value = default(uint);
+    private uint? _item_attr_delta_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_attr_delta_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_attr_delta_value
     {
-      get { return _item_attr_delta_value; }
+      get { return _item_attr_delta_value?? default(uint); }
       set { _item_attr_delta_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_attr_delta_valueSpecified
+    {
+      get { return _item_attr_delta_value != null; }
+      set { if (value == (_item_attr_delta_value== null)) _item_attr_delta_value = value ? this.item_attr_delta_value : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_attr_delta_value() { return item_attr_delta_valueSpecified; }
+    private void Resetitem_attr_delta_value() { item_attr_delta_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1088,23 +1945,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public ScoreLeaderboardData() {}
     
 
-    private ulong _quest_id = default(ulong);
+    private ulong? _quest_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_id
     {
-      get { return _quest_id; }
+      get { return _quest_id?? default(ulong); }
       set { _quest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_idSpecified
+    {
+      get { return _quest_id != null; }
+      set { if (value == (_quest_id== null)) _quest_id = value ? this.quest_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_id() { return quest_idSpecified; }
+    private void Resetquest_id() { quest_idSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ScoreLeaderboardData.AccountEntries> _accountentries = new global::System.Collections.Generic.List<ScoreLeaderboardData.AccountEntries>();
     [global::ProtoBuf.ProtoMember(3, Name=@"accountentries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ScoreLeaderboardData.AccountEntries> accountentries
@@ -1125,23 +2000,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public Entry() {}
     
 
-    private uint _tag = default(uint);
+    private uint? _tag;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tag
     {
-      get { return _tag; }
+      get { return _tag?? default(uint); }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (uint?)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private uint _val = default(uint);
+    private uint? _val;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"val", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint val
     {
-      get { return _val; }
+      get { return _val?? default(uint); }
       set { _val = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valSpecified
+    {
+      get { return _val != null; }
+      set { if (value == (_val== null)) _val = value ? this.val : (uint?)null; }
+    }
+    private bool ShouldSerializeval() { return valSpecified; }
+    private void Resetval() { valSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1153,14 +2046,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public AccountEntries() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ScoreLeaderboardData.Entry> _entries = new global::System.Collections.Generic.List<ScoreLeaderboardData.Entry>();
     [global::ProtoBuf.ProtoMember(2, Name=@"entries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ScoreLeaderboardData.Entry> entries
@@ -1184,14 +2086,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public PlayerQuestData() {}
     
 
-    private uint _quester_account_id = default(uint);
+    private uint? _quester_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quester_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quester_account_id
     {
-      get { return _quester_account_id; }
+      get { return _quester_account_id?? default(uint); }
       set { _quester_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quester_account_idSpecified
+    {
+      get { return _quester_account_id != null; }
+      set { if (value == (_quester_account_id== null)) _quester_account_id = value ? this.quester_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializequester_account_id() { return quester_account_idSpecified; }
+    private void Resetquester_account_id() { quester_account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<PlayerQuestData.QuestItemData> _quest_item_data = new global::System.Collections.Generic.List<PlayerQuestData.QuestItemData>();
     [global::ProtoBuf.ProtoMember(2, Name=@"quest_item_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<PlayerQuestData.QuestItemData> quest_item_data
@@ -1207,23 +2118,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _time_played = default(uint);
+    private uint? _time_played;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_played
     {
-      get { return _time_played; }
+      get { return _time_played?? default(uint); }
       set { _time_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_playedSpecified
+    {
+      get { return _time_played != null; }
+      set { if (value == (_time_played== null)) _time_played = value ? this.time_played : (uint?)null; }
+    }
+    private bool ShouldSerializetime_played() { return time_playedSpecified; }
+    private void Resettime_played() { time_playedSpecified = false; }
+    
 
-    private uint _mm_game_mode = default(uint);
+    private uint? _mm_game_mode;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"mm_game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mm_game_mode
     {
-      get { return _mm_game_mode; }
+      get { return _mm_game_mode?? default(uint); }
       set { _mm_game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mm_game_modeSpecified
+    {
+      get { return _mm_game_mode != null; }
+      set { if (value == (_mm_game_mode== null)) _mm_game_mode = value ? this.mm_game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializemm_game_mode() { return mm_game_modeSpecified; }
+    private void Resetmm_game_mode() { mm_game_modeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<MatchEndItemUpdates> _item_updates = new global::System.Collections.Generic.List<MatchEndItemUpdates>();
     [global::ProtoBuf.ProtoMember(6, Name=@"item_updates", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<MatchEndItemUpdates> item_updates
@@ -1237,32 +2166,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public QuestItemData() {}
     
 
-    private ulong _quest_id = default(ulong);
+    private ulong? _quest_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_id
     {
-      get { return _quest_id; }
+      get { return _quest_id?? default(ulong); }
       set { _quest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_idSpecified
+    {
+      get { return _quest_id != null; }
+      set { if (value == (_quest_id== null)) _quest_id = value ? this.quest_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_id() { return quest_idSpecified; }
+    private void Resetquest_id() { quest_idSpecified = false; }
+    
 
-    private int _quest_normal_points_earned = default(int);
+    private int? _quest_normal_points_earned;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quest_normal_points_earned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int quest_normal_points_earned
     {
-      get { return _quest_normal_points_earned; }
+      get { return _quest_normal_points_earned?? default(int); }
       set { _quest_normal_points_earned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_normal_points_earnedSpecified
+    {
+      get { return _quest_normal_points_earned != null; }
+      set { if (value == (_quest_normal_points_earned== null)) _quest_normal_points_earned = value ? this.quest_normal_points_earned : (int?)null; }
+    }
+    private bool ShouldSerializequest_normal_points_earned() { return quest_normal_points_earnedSpecified; }
+    private void Resetquest_normal_points_earned() { quest_normal_points_earnedSpecified = false; }
+    
 
-    private int _quest_bonus_points_earned = default(int);
+    private int? _quest_bonus_points_earned;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"quest_bonus_points_earned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int quest_bonus_points_earned
     {
-      get { return _quest_bonus_points_earned; }
+      get { return _quest_bonus_points_earned?? default(int); }
       set { _quest_bonus_points_earned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_bonus_points_earnedSpecified
+    {
+      get { return _quest_bonus_points_earned != null; }
+      set { if (value == (_quest_bonus_points_earned== null)) _quest_bonus_points_earned = value ? this.quest_bonus_points_earned : (int?)null; }
+    }
+    private bool ShouldSerializequest_bonus_points_earned() { return quest_bonus_points_earnedSpecified; }
+    private void Resetquest_bonus_points_earned() { quest_bonus_points_earnedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1286,23 +2242,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private byte[] _binary_data = null;
+    private byte[] _binary_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"binary_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] binary_data
     {
-      get { return _binary_data; }
+      get { return _binary_data?? null; }
       set { _binary_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool binary_dataSpecified
+    {
+      get { return _binary_data != null; }
+      set { if (value == (_binary_data== null)) _binary_data = value ? this.binary_data : (byte[])null; }
+    }
+    private bool ShouldSerializebinary_data() { return binary_dataSpecified; }
+    private void Resetbinary_data() { binary_dataSpecified = false; }
+    
 
-    private uint _mm_game_mode = default(uint);
+    private uint? _mm_game_mode;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"mm_game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mm_game_mode
     {
-      get { return _mm_game_mode; }
+      get { return _mm_game_mode?? default(uint); }
       set { _mm_game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mm_game_modeSpecified
+    {
+      get { return _mm_game_mode != null; }
+      set { if (value == (_mm_game_mode== null)) _mm_game_mode = value ? this.mm_game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializemm_game_mode() { return mm_game_modeSpecified; }
+    private void Resetmm_game_mode() { mm_game_modeSpecified = false; }
+    
 
     private ScoreLeaderboardData _missionlbsdata = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"missionlbsdata", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1323,14 +2297,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGCOperationalStats() {}
     
 
-    private int _packetid = default(int);
+    private int? _packetid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packetid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int packetid
     {
-      get { return _packetid; }
+      get { return _packetid?? default(int); }
       set { _packetid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packetidSpecified
+    {
+      get { return _packetid != null; }
+      set { if (value == (_packetid== null)) _packetid = value ? this.packetid : (int?)null; }
+    }
+    private bool ShouldSerializepacketid() { return packetidSpecified; }
+    private void Resetpacketid() { packetidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<OperationalStatisticDescription> _namekeys = new global::System.Collections.Generic.List<OperationalStatisticDescription>();
     [global::ProtoBuf.ProtoMember(2, Name=@"namekeys", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<OperationalStatisticDescription> namekeys
@@ -1356,32 +2339,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGC2ServerConfirm() {}
     
 
-    private uint _token = default(uint);
+    private uint? _token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint token
     {
-      get { return _token; }
+      get { return _token?? default(uint); }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (uint?)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
 
-    private uint _stamp = default(uint);
+    private uint? _stamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stamp
     {
-      get { return _stamp; }
+      get { return _stamp?? default(uint); }
       set { _stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stampSpecified
+    {
+      get { return _stamp != null; }
+      set { if (value == (_stamp== null)) _stamp = value ? this.stamp : (uint?)null; }
+    }
+    private bool ShouldSerializestamp() { return stampSpecified; }
+    private void Resetstamp() { stampSpecified = false; }
+    
 
-    private ulong _exchange = default(ulong);
+    private ulong? _exchange;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"exchange", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong exchange
     {
-      get { return _exchange; }
+      get { return _exchange?? default(ulong); }
       set { _exchange = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool exchangeSpecified
+    {
+      get { return _exchange != null; }
+      set { if (value == (_exchange== null)) _exchange = value ? this.exchange : (ulong?)null; }
+    }
+    private bool ShouldSerializeexchange() { return exchangeSpecified; }
+    private void Resetexchange() { exchangeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1393,23 +2403,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_GC2ServerReservationUpdate() {}
     
 
-    private uint _viewers_external_total = default(uint);
+    private uint? _viewers_external_total;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"viewers_external_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint viewers_external_total
     {
-      get { return _viewers_external_total; }
+      get { return _viewers_external_total?? default(uint); }
       set { _viewers_external_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewers_external_totalSpecified
+    {
+      get { return _viewers_external_total != null; }
+      set { if (value == (_viewers_external_total== null)) _viewers_external_total = value ? this.viewers_external_total : (uint?)null; }
+    }
+    private bool ShouldSerializeviewers_external_total() { return viewers_external_totalSpecified; }
+    private void Resetviewers_external_total() { viewers_external_totalSpecified = false; }
+    
 
-    private uint _viewers_external_steam = default(uint);
+    private uint? _viewers_external_steam;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"viewers_external_steam", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint viewers_external_steam
     {
-      get { return _viewers_external_steam; }
+      get { return _viewers_external_steam?? default(uint); }
       set { _viewers_external_steam = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewers_external_steamSpecified
+    {
+      get { return _viewers_external_steam != null; }
+      set { if (value == (_viewers_external_steam== null)) _viewers_external_steam = value ? this.viewers_external_steam : (uint?)null; }
+    }
+    private bool ShouldSerializeviewers_external_steam() { return viewers_external_steamSpecified; }
+    private void Resetviewers_external_steam() { viewers_external_steamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1428,32 +2456,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private string _ticket_data = "";
+    private string _ticket_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ticket_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ticket_data
     {
-      get { return _ticket_data; }
+      get { return _ticket_data?? ""; }
       set { _ticket_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_dataSpecified
+    {
+      get { return _ticket_data != null; }
+      set { if (value == (_ticket_data== null)) _ticket_data = value ? this.ticket_data : (string)null; }
+    }
+    private bool ShouldSerializeticket_data() { return ticket_dataSpecified; }
+    private void Resetticket_data() { ticket_dataSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
     private TournamentMatchSetup _tournament_match = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tournament_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1474,14 +2529,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingStop() {}
     
 
-    private int _abandon = default(int);
+    private int? _abandon;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"abandon", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int abandon
     {
-      get { return _abandon; }
+      get { return _abandon?? default(int); }
       set { _abandon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abandonSpecified
+    {
+      get { return _abandon != null; }
+      set { if (value == (_abandon== null)) _abandon = value ? this.abandon : (int?)null; }
+    }
+    private bool ShouldSerializeabandon() { return abandonSpecified; }
+    private void Resetabandon() { abandonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1500,23 +2564,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private int _offset_index = default(int);
+    private int? _offset_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"offset_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int offset_index
     {
-      get { return _offset_index; }
+      get { return _offset_index?? default(int); }
       set { _offset_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offset_indexSpecified
+    {
+      get { return _offset_index != null; }
+      set { if (value == (_offset_index== null)) _offset_index = value ? this.offset_index : (int?)null; }
+    }
+    private bool ShouldSerializeoffset_index() { return offset_indexSpecified; }
+    private void Resetoffset_index() { offset_indexSpecified = false; }
+    
 
-    private int _final_batch = default(int);
+    private int? _final_batch;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"final_batch", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int final_batch
     {
-      get { return _final_batch; }
+      get { return _final_batch?? default(int); }
       set { _final_batch = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool final_batchSpecified
+    {
+      get { return _final_batch != null; }
+      set { if (value == (_final_batch== null)) _final_batch = value ? this.final_batch : (int?)null; }
+    }
+    private bool ShouldSerializefinal_batch() { return final_batchSpecified; }
+    private void Resetfinal_batch() { final_batchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1528,14 +2610,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGC2ClientUpdate() {}
     
 
-    private int _matchmaking = default(int);
+    private int? _matchmaking;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchmaking", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int matchmaking
     {
-      get { return _matchmaking; }
+      get { return _matchmaking?? default(int); }
       set { _matchmaking = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmakingSpecified
+    {
+      get { return _matchmaking != null; }
+      set { if (value == (_matchmaking== null)) _matchmaking = value ? this.matchmaking : (int?)null; }
+    }
+    private bool ShouldSerializematchmaking() { return matchmakingSpecified; }
+    private void Resetmatchmaking() { matchmakingSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _waiting_account_id_sessions = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"waiting_account_id_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> waiting_account_id_sessions
@@ -1544,14 +2635,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private string _error = "";
+    private string _error;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"error", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error
     {
-      get { return _error; }
+      get { return _error?? ""; }
       set { _error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorSpecified
+    {
+      get { return _error != null; }
+      set { if (value == (_error== null)) _error = value ? this.error : (string)null; }
+    }
+    private bool ShouldSerializeerror() { return errorSpecified; }
+    private void Reseterror() { errorSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _ongoingmatch_account_id_sessions = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"ongoingmatch_account_id_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> ongoingmatch_account_id_sessions
@@ -1632,41 +2732,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public Note() {}
     
 
-    private int _type = default(int);
+    private int? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type
     {
-      get { return _type; }
+      get { return _type?? default(int); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (int?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private int _region_id = default(int);
+    private int? _region_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"region_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int region_id
     {
-      get { return _region_id; }
+      get { return _region_id?? default(int); }
       set { _region_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_idSpecified
+    {
+      get { return _region_id != null; }
+      set { if (value == (_region_id== null)) _region_id = value ? this.region_id : (int?)null; }
+    }
+    private bool ShouldSerializeregion_id() { return region_idSpecified; }
+    private void Resetregion_id() { region_idSpecified = false; }
+    
 
-    private float _region_r = default(float);
+    private float? _region_r;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"region_r", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float region_r
     {
-      get { return _region_r; }
+      get { return _region_r?? default(float); }
       set { _region_r = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_rSpecified
+    {
+      get { return _region_r != null; }
+      set { if (value == (_region_r== null)) _region_r = value ? this.region_r : (float?)null; }
+    }
+    private bool ShouldSerializeregion_r() { return region_rSpecified; }
+    private void Resetregion_r() { region_rSpecified = false; }
+    
 
-    private float _distance = default(float);
+    private float? _distance;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"distance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float distance
     {
-      get { return _distance; }
+      get { return _distance?? default(float); }
       set { _distance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool distanceSpecified
+    {
+      get { return _distance != null; }
+      set { if (value == (_distance== null)) _distance = value ? this.distance : (float?)null; }
+    }
+    private bool ShouldSerializedistance() { return distanceSpecified; }
+    private void Resetdistance() { distanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1683,86 +2819,167 @@ namespace SteamKit2.GC.CSGO.Internal
     public CDataGCCStrike15_v2_TournamentMatchDraft() {}
     
 
-    private int _event_id = default(int);
+    private int? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(int); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private int _event_stage_id = default(int);
+    private int? _event_stage_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_stage_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_stage_id
     {
-      get { return _event_stage_id; }
+      get { return _event_stage_id?? default(int); }
       set { _event_stage_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_stage_idSpecified
+    {
+      get { return _event_stage_id != null; }
+      set { if (value == (_event_stage_id== null)) _event_stage_id = value ? this.event_stage_id : (int?)null; }
+    }
+    private bool ShouldSerializeevent_stage_id() { return event_stage_idSpecified; }
+    private void Resetevent_stage_id() { event_stage_idSpecified = false; }
+    
 
-    private int _team_id_0 = default(int);
+    private int? _team_id_0;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_id_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_0
     {
-      get { return _team_id_0; }
+      get { return _team_id_0?? default(int); }
       set { _team_id_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_0Specified
+    {
+      get { return _team_id_0 != null; }
+      set { if (value == (_team_id_0== null)) _team_id_0 = value ? this.team_id_0 : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_0() { return team_id_0Specified; }
+    private void Resetteam_id_0() { team_id_0Specified = false; }
+    
 
-    private int _team_id_1 = default(int);
+    private int? _team_id_1;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_1
     {
-      get { return _team_id_1; }
+      get { return _team_id_1?? default(int); }
       set { _team_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_1Specified
+    {
+      get { return _team_id_1 != null; }
+      set { if (value == (_team_id_1== null)) _team_id_1 = value ? this.team_id_1 : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_1() { return team_id_1Specified; }
+    private void Resetteam_id_1() { team_id_1Specified = false; }
+    
 
-    private int _maps_count = default(int);
+    private int? _maps_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"maps_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int maps_count
     {
-      get { return _maps_count; }
+      get { return _maps_count?? default(int); }
       set { _maps_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maps_countSpecified
+    {
+      get { return _maps_count != null; }
+      set { if (value == (_maps_count== null)) _maps_count = value ? this.maps_count : (int?)null; }
+    }
+    private bool ShouldSerializemaps_count() { return maps_countSpecified; }
+    private void Resetmaps_count() { maps_countSpecified = false; }
+    
 
-    private int _maps_current = default(int);
+    private int? _maps_current;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"maps_current", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int maps_current
     {
-      get { return _maps_current; }
+      get { return _maps_current?? default(int); }
       set { _maps_current = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maps_currentSpecified
+    {
+      get { return _maps_current != null; }
+      set { if (value == (_maps_current== null)) _maps_current = value ? this.maps_current : (int?)null; }
+    }
+    private bool ShouldSerializemaps_current() { return maps_currentSpecified; }
+    private void Resetmaps_current() { maps_currentSpecified = false; }
+    
 
-    private int _team_id_start = default(int);
+    private int? _team_id_start;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_id_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_start
     {
-      get { return _team_id_start; }
+      get { return _team_id_start?? default(int); }
       set { _team_id_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_startSpecified
+    {
+      get { return _team_id_start != null; }
+      set { if (value == (_team_id_start== null)) _team_id_start = value ? this.team_id_start : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_start() { return team_id_startSpecified; }
+    private void Resetteam_id_start() { team_id_startSpecified = false; }
+    
 
-    private int _team_id_veto1 = default(int);
+    private int? _team_id_veto1;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_id_veto1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_veto1
     {
-      get { return _team_id_veto1; }
+      get { return _team_id_veto1?? default(int); }
       set { _team_id_veto1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_veto1Specified
+    {
+      get { return _team_id_veto1 != null; }
+      set { if (value == (_team_id_veto1== null)) _team_id_veto1 = value ? this.team_id_veto1 : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_veto1() { return team_id_veto1Specified; }
+    private void Resetteam_id_veto1() { team_id_veto1Specified = false; }
+    
 
-    private int _team_id_pickn = default(int);
+    private int? _team_id_pickn;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"team_id_pickn", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_pickn
     {
-      get { return _team_id_pickn; }
+      get { return _team_id_pickn?? default(int); }
       set { _team_id_pickn = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_picknSpecified
+    {
+      get { return _team_id_pickn != null; }
+      set { if (value == (_team_id_pickn== null)) _team_id_pickn = value ? this.team_id_pickn : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_pickn() { return team_id_picknSpecified; }
+    private void Resetteam_id_pickn() { team_id_picknSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentMatchDraft.Entry> _drafts = new global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentMatchDraft.Entry>();
     [global::ProtoBuf.ProtoMember(10, Name=@"drafts", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentMatchDraft.Entry> drafts
@@ -1776,23 +2993,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public Entry() {}
     
 
-    private int _mapid = default(int);
+    private int? _mapid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"mapid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int mapid
     {
-      get { return _mapid; }
+      get { return _mapid?? default(int); }
       set { _mapid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapidSpecified
+    {
+      get { return _mapid != null; }
+      set { if (value == (_mapid== null)) _mapid = value ? this.mapid : (int?)null; }
+    }
+    private bool ShouldSerializemapid() { return mapidSpecified; }
+    private void Resetmapid() { mapidSpecified = false; }
+    
 
-    private int _team_id_ct = default(int);
+    private int? _team_id_ct;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id_ct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id_ct
     {
-      get { return _team_id_ct; }
+      get { return _team_id_ct?? default(int); }
       set { _team_id_ct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_id_ctSpecified
+    {
+      get { return _team_id_ct != null; }
+      set { if (value == (_team_id_ct== null)) _team_id_ct = value ? this.team_id_ct : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id_ct() { return team_id_ctSpecified; }
+    private void Resetteam_id_ct() { team_id_ctSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1809,14 +3044,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CPreMatchInfoData() {}
     
 
-    private int _predictions_pct = default(int);
+    private int? _predictions_pct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"predictions_pct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int predictions_pct
     {
-      get { return _predictions_pct; }
+      get { return _predictions_pct?? default(int); }
       set { _predictions_pct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool predictions_pctSpecified
+    {
+      get { return _predictions_pct != null; }
+      set { if (value == (_predictions_pct== null)) _predictions_pct = value ? this.predictions_pct : (int?)null; }
+    }
+    private bool ShouldSerializepredictions_pct() { return predictions_pctSpecified; }
+    private void Resetpredictions_pct() { predictions_pctSpecified = false; }
+    
 
     private CDataGCCStrike15_v2_TournamentMatchDraft _draft = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"draft", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1839,23 +3083,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public TeamStats() {}
     
 
-    private int _match_info_idxtxt = default(int);
+    private int? _match_info_idxtxt;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_info_idxtxt", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_info_idxtxt
     {
-      get { return _match_info_idxtxt; }
+      get { return _match_info_idxtxt?? default(int); }
       set { _match_info_idxtxt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_info_idxtxtSpecified
+    {
+      get { return _match_info_idxtxt != null; }
+      set { if (value == (_match_info_idxtxt== null)) _match_info_idxtxt = value ? this.match_info_idxtxt : (int?)null; }
+    }
+    private bool ShouldSerializematch_info_idxtxt() { return match_info_idxtxtSpecified; }
+    private void Resetmatch_info_idxtxt() { match_info_idxtxtSpecified = false; }
+    
 
-    private string _match_info_txt = "";
+    private string _match_info_txt;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_info_txt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string match_info_txt
     {
-      get { return _match_info_txt; }
+      get { return _match_info_txt?? ""; }
       set { _match_info_txt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_info_txtSpecified
+    {
+      get { return _match_info_txt != null; }
+      set { if (value == (_match_info_txt== null)) _match_info_txt = value ? this.match_info_txt : (string)null; }
+    }
+    private bool ShouldSerializematch_info_txt() { return match_info_txtSpecified; }
+    private void Resetmatch_info_txt() { match_info_txtSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _match_info_teams = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"match_info_teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> match_info_teams
@@ -1886,32 +3148,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<PlayerRankingInfo> _rankings = new global::System.Collections.Generic.List<PlayerRankingInfo>();
     [global::ProtoBuf.ProtoMember(5, Name=@"rankings", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<PlayerRankingInfo> rankings
@@ -1920,23 +3209,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _encryption_key = default(ulong);
+    private ulong? _encryption_key;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"encryption_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong encryption_key
     {
-      get { return _encryption_key; }
+      get { return _encryption_key?? default(ulong); }
       set { _encryption_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryption_keySpecified
+    {
+      get { return _encryption_key != null; }
+      set { if (value == (_encryption_key== null)) _encryption_key = value ? this.encryption_key : (ulong?)null; }
+    }
+    private bool ShouldSerializeencryption_key() { return encryption_keySpecified; }
+    private void Resetencryption_key() { encryption_keySpecified = false; }
+    
 
-    private ulong _encryption_key_pub = default(ulong);
+    private ulong? _encryption_key_pub;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"encryption_key_pub", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong encryption_key_pub
     {
-      get { return _encryption_key_pub; }
+      get { return _encryption_key_pub?? default(ulong); }
       set { _encryption_key_pub = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryption_key_pubSpecified
+    {
+      get { return _encryption_key_pub != null; }
+      set { if (value == (_encryption_key_pub== null)) _encryption_key_pub = value ? this.encryption_key_pub : (ulong?)null; }
+    }
+    private bool ShouldSerializeencryption_key_pub() { return encryption_key_pubSpecified; }
+    private void Resetencryption_key_pub() { encryption_key_pubSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _party_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(8, Name=@"party_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> party_ids
@@ -1952,14 +3259,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _tv_master_steamid = default(ulong);
+    private ulong? _tv_master_steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"tv_master_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_master_steamid
     {
-      get { return _tv_master_steamid; }
+      get { return _tv_master_steamid?? default(ulong); }
       set { _tv_master_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_master_steamidSpecified
+    {
+      get { return _tv_master_steamid != null; }
+      set { if (value == (_tv_master_steamid== null)) _tv_master_steamid = value ? this.tv_master_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_master_steamid() { return tv_master_steamidSpecified; }
+    private void Resettv_master_steamid() { tv_master_steamidSpecified = false; }
+    
 
     private TournamentEvent _tournament_event = null;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"tournament_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1984,14 +3300,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _tv_relay_steamid = default(ulong);
+    private ulong? _tv_relay_steamid;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"tv_relay_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_relay_steamid
     {
-      get { return _tv_relay_steamid; }
+      get { return _tv_relay_steamid?? default(ulong); }
       set { _tv_relay_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_relay_steamidSpecified
+    {
+      get { return _tv_relay_steamid != null; }
+      set { if (value == (_tv_relay_steamid== null)) _tv_relay_steamid = value ? this.tv_relay_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_relay_steamid() { return tv_relay_steamidSpecified; }
+    private void Resettv_relay_steamid() { tv_relay_steamidSpecified = false; }
+    
 
     private CPreMatchInfoData _pre_match_data = null;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"pre_match_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2012,14 +3337,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingServerReservationResponse() {}
     
 
-    private ulong _reservationid = default(ulong);
+    private ulong? _reservationid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"reservationid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reservationid
     {
-      get { return _reservationid; }
+      get { return _reservationid?? default(ulong); }
       set { _reservationid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reservationidSpecified
+    {
+      get { return _reservationid != null; }
+      set { if (value == (_reservationid== null)) _reservationid = value ? this.reservationid : (ulong?)null; }
+    }
+    private bool ShouldSerializereservationid() { return reservationidSpecified; }
+    private void Resetreservationid() { reservationidSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve _reservation = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reservation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2030,32 +3364,59 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _reservation = value; }
     }
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private ulong _gc_reservation_sent = default(ulong);
+    private ulong? _gc_reservation_sent;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"gc_reservation_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gc_reservation_sent
     {
-      get { return _gc_reservation_sent; }
+      get { return _gc_reservation_sent?? default(ulong); }
       set { _gc_reservation_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_reservation_sentSpecified
+    {
+      get { return _gc_reservation_sent != null; }
+      set { if (value == (_gc_reservation_sent== null)) _gc_reservation_sent = value ? this.gc_reservation_sent : (ulong?)null; }
+    }
+    private bool ShouldSerializegc_reservation_sent() { return gc_reservation_sentSpecified; }
+    private void Resetgc_reservation_sent() { gc_reservation_sentSpecified = false; }
+    
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
     private ServerHltvInfo _tv_info = null;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tv_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2080,50 +3441,95 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _reward_item_attr_def_idx = default(uint);
+    private uint? _reward_item_attr_def_idx;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"reward_item_attr_def_idx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_item_attr_def_idx
     {
-      get { return _reward_item_attr_def_idx; }
+      get { return _reward_item_attr_def_idx?? default(uint); }
       set { _reward_item_attr_def_idx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_item_attr_def_idxSpecified
+    {
+      get { return _reward_item_attr_def_idx != null; }
+      set { if (value == (_reward_item_attr_def_idx== null)) _reward_item_attr_def_idx = value ? this.reward_item_attr_def_idx : (uint?)null; }
+    }
+    private bool ShouldSerializereward_item_attr_def_idx() { return reward_item_attr_def_idxSpecified; }
+    private void Resetreward_item_attr_def_idx() { reward_item_attr_def_idxSpecified = false; }
+    
 
-    private uint _reward_item_attr_value = default(uint);
+    private uint? _reward_item_attr_value;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"reward_item_attr_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_item_attr_value
     {
-      get { return _reward_item_attr_value; }
+      get { return _reward_item_attr_value?? default(uint); }
       set { _reward_item_attr_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_item_attr_valueSpecified
+    {
+      get { return _reward_item_attr_value != null; }
+      set { if (value == (_reward_item_attr_value== null)) _reward_item_attr_value = value ? this.reward_item_attr_value : (uint?)null; }
+    }
+    private bool ShouldSerializereward_item_attr_value() { return reward_item_attr_valueSpecified; }
+    private void Resetreward_item_attr_value() { reward_item_attr_valueSpecified = false; }
+    
 
-    private uint _reward_item_attr_reward_idx = default(uint);
+    private uint? _reward_item_attr_reward_idx;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"reward_item_attr_reward_idx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_item_attr_reward_idx
     {
-      get { return _reward_item_attr_reward_idx; }
+      get { return _reward_item_attr_reward_idx?? default(uint); }
       set { _reward_item_attr_reward_idx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_item_attr_reward_idxSpecified
+    {
+      get { return _reward_item_attr_reward_idx != null; }
+      set { if (value == (_reward_item_attr_reward_idx== null)) _reward_item_attr_reward_idx = value ? this.reward_item_attr_reward_idx : (uint?)null; }
+    }
+    private bool ShouldSerializereward_item_attr_reward_idx() { return reward_item_attr_reward_idxSpecified; }
+    private void Resetreward_item_attr_reward_idx() { reward_item_attr_reward_idxSpecified = false; }
+    
 
-    private uint _reward_drop_list = default(uint);
+    private uint? _reward_drop_list;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"reward_drop_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_drop_list
     {
-      get { return _reward_drop_list; }
+      get { return _reward_drop_list?? default(uint); }
       set { _reward_drop_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_drop_listSpecified
+    {
+      get { return _reward_drop_list != null; }
+      set { if (value == (_reward_drop_list== null)) _reward_drop_list = value ? this.reward_drop_list : (uint?)null; }
+    }
+    private bool ShouldSerializereward_drop_list() { return reward_drop_listSpecified; }
+    private void Resetreward_drop_list() { reward_drop_listSpecified = false; }
+    
 
-    private string _tournament_tag = "";
+    private string _tournament_tag;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"tournament_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tournament_tag
     {
-      get { return _tournament_tag; }
+      get { return _tournament_tag?? ""; }
       set { _tournament_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_tagSpecified
+    {
+      get { return _tournament_tag != null; }
+      set { if (value == (_tournament_tag== null)) _tournament_tag = value ? this.tournament_tag : (string)null; }
+    }
+    private bool ShouldSerializetournament_tag() { return tournament_tagSpecified; }
+    private void Resettournament_tag() { tournament_tagSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2135,23 +3541,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve() {}
     
 
-    private ulong _serverid = default(ulong);
+    private ulong? _serverid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serverid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong serverid
     {
-      get { return _serverid; }
+      get { return _serverid?? default(ulong); }
       set { _serverid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serveridSpecified
+    {
+      get { return _serverid != null; }
+      set { if (value == (_serverid== null)) _serverid = value ? this.serverid : (ulong?)null; }
+    }
+    private bool ShouldSerializeserverid() { return serveridSpecified; }
+    private void Resetserverid() { serveridSpecified = false; }
+    
 
-    private ulong _reservationid = default(ulong);
+    private ulong? _reservationid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reservationid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reservationid
     {
-      get { return _reservationid; }
+      get { return _reservationid?? default(ulong); }
       set { _reservationid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reservationidSpecified
+    {
+      get { return _reservationid != null; }
+      set { if (value == (_reservationid== null)) _reservationid = value ? this.reservationid : (ulong?)null; }
+    }
+    private bool ShouldSerializereservationid() { return reservationidSpecified; }
+    private void Resetreservationid() { reservationidSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve _reservation = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"reservation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2162,23 +3586,41 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _reservation = value; }
     }
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private string _server_address = "";
+    private string _server_address;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"server_address", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string server_address
     {
-      get { return _server_address; }
+      get { return _server_address?? ""; }
       set { _server_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addressSpecified
+    {
+      get { return _server_address != null; }
+      set { if (value == (_server_address== null)) _server_address = value ? this.server_address : (string)null; }
+    }
+    private bool ShouldSerializeserver_address() { return server_addressSpecified; }
+    private void Resetserver_address() { server_addressSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2190,14 +3632,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingServerRoundStats() {}
     
 
-    private ulong _reservationid = default(ulong);
+    private ulong? _reservationid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"reservationid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reservationid
     {
-      get { return _reservationid; }
+      get { return _reservationid?? default(ulong); }
       set { _reservationid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reservationidSpecified
+    {
+      get { return _reservationid != null; }
+      set { if (value == (_reservationid== null)) _reservationid = value ? this.reservationid : (ulong?)null; }
+    }
+    private bool ShouldSerializereservationid() { return reservationidSpecified; }
+    private void Resetreservationid() { reservationidSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve _reservation = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reservation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2208,23 +3659,41 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _reservation = value; }
     }
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private int _round = default(int);
+    private int? _round;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int round
     {
-      get { return _round; }
+      get { return _round?? default(int); }
       set { _round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roundSpecified
+    {
+      get { return _round != null; }
+      set { if (value == (_round== null)) _round = value ? this.round : (int?)null; }
+    }
+    private bool ShouldSerializeround() { return roundSpecified; }
+    private void Resetround() { roundSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<int> _kills = new global::System.Collections.Generic.List<int>();
     [global::ProtoBuf.ProtoMember(5, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<int> kills
@@ -2261,23 +3730,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private int _round_result = default(int);
+    private int? _round_result;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"round_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int round_result
     {
-      get { return _round_result; }
+      get { return _round_result?? default(int); }
       set { _round_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool round_resultSpecified
+    {
+      get { return _round_result != null; }
+      set { if (value == (_round_result== null)) _round_result = value ? this.round_result : (int?)null; }
+    }
+    private bool ShouldSerializeround_result() { return round_resultSpecified; }
+    private void Resetround_result() { round_resultSpecified = false; }
+    
 
-    private int _match_result = default(int);
+    private int? _match_result;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"match_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_result
     {
-      get { return _match_result; }
+      get { return _match_result?? default(int); }
       set { _match_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_resultSpecified
+    {
+      get { return _match_result != null; }
+      set { if (value == (_match_result== null)) _match_result = value ? this.match_result : (int?)null; }
+    }
+    private bool ShouldSerializematch_result() { return match_resultSpecified; }
+    private void Resetmatch_result() { match_resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<int> _team_scores = new global::System.Collections.Generic.List<int>();
     [global::ProtoBuf.ProtoMember(12, Name=@"team_scores", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<int> team_scores
@@ -2295,23 +3782,41 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _confirm = value; }
     }
 
-    private int _reservation_stage = default(int);
+    private int? _reservation_stage;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"reservation_stage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int reservation_stage
     {
-      get { return _reservation_stage; }
+      get { return _reservation_stage?? default(int); }
       set { _reservation_stage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reservation_stageSpecified
+    {
+      get { return _reservation_stage != null; }
+      set { if (value == (_reservation_stage== null)) _reservation_stage = value ? this.reservation_stage : (int?)null; }
+    }
+    private bool ShouldSerializereservation_stage() { return reservation_stageSpecified; }
+    private void Resetreservation_stage() { reservation_stageSpecified = false; }
+    
 
-    private int _match_duration = default(int);
+    private int? _match_duration;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"match_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_duration
     {
-      get { return _match_duration; }
+      get { return _match_duration?? default(int); }
       set { _match_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_durationSpecified
+    {
+      get { return _match_duration != null; }
+      set { if (value == (_match_duration== null)) _match_duration = value ? this.match_duration : (int?)null; }
+    }
+    private bool ShouldSerializematch_duration() { return match_durationSpecified; }
+    private void Resetmatch_duration() { match_durationSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<int> _enemy_kills = new global::System.Collections.Generic.List<int>();
     [global::ProtoBuf.ProtoMember(16, Name=@"enemy_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<int> enemy_kills
@@ -2355,32 +3860,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _spectators_count = default(uint);
+    private uint? _spectators_count;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"spectators_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spectators_count
     {
-      get { return _spectators_count; }
+      get { return _spectators_count?? default(uint); }
       set { _spectators_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectators_countSpecified
+    {
+      get { return _spectators_count != null; }
+      set { if (value == (_spectators_count== null)) _spectators_count = value ? this.spectators_count : (uint?)null; }
+    }
+    private bool ShouldSerializespectators_count() { return spectators_countSpecified; }
+    private void Resetspectators_count() { spectators_countSpecified = false; }
+    
 
-    private uint _spectators_count_tv = default(uint);
+    private uint? _spectators_count_tv;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"spectators_count_tv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spectators_count_tv
     {
-      get { return _spectators_count_tv; }
+      get { return _spectators_count_tv?? default(uint); }
       set { _spectators_count_tv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectators_count_tvSpecified
+    {
+      get { return _spectators_count_tv != null; }
+      set { if (value == (_spectators_count_tv== null)) _spectators_count_tv = value ? this.spectators_count_tv : (uint?)null; }
+    }
+    private bool ShouldSerializespectators_count_tv() { return spectators_count_tvSpecified; }
+    private void Resetspectators_count_tv() { spectators_count_tvSpecified = false; }
+    
 
-    private uint _spectators_count_lnk = default(uint);
+    private uint? _spectators_count_lnk;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"spectators_count_lnk", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spectators_count_lnk
     {
-      get { return _spectators_count_lnk; }
+      get { return _spectators_count_lnk?? default(uint); }
       set { _spectators_count_lnk = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectators_count_lnkSpecified
+    {
+      get { return _spectators_count_lnk != null; }
+      set { if (value == (_spectators_count_lnk== null)) _spectators_count_lnk = value ? this.spectators_count_lnk : (uint?)null; }
+    }
+    private bool ShouldSerializespectators_count_lnk() { return spectators_count_lnkSpecified; }
+    private void Resetspectators_count_lnk() { spectators_count_lnkSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<int> _enemy_kills_agg = new global::System.Collections.Generic.List<int>();
     [global::ProtoBuf.ProtoMember(25, Name=@"enemy_kills_agg", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<int> enemy_kills_agg
@@ -2403,14 +3935,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public DropInfo() {}
     
 
-    private uint _account_mvp = default(uint);
+    private uint? _account_mvp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_mvp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_mvp
     {
-      get { return _account_mvp; }
+      get { return _account_mvp?? default(uint); }
       set { _account_mvp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_mvpSpecified
+    {
+      get { return _account_mvp != null; }
+      set { if (value == (_account_mvp== null)) _account_mvp = value ? this.account_mvp : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_mvp() { return account_mvpSpecified; }
+    private void Resetaccount_mvp() { account_mvpSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2445,41 +3986,77 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _confirm = value; }
     }
 
-    private ulong _rematch = default(ulong);
+    private ulong? _rematch;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rematch", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong rematch
     {
-      get { return _rematch; }
+      get { return _rematch?? default(ulong); }
       set { _rematch = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rematchSpecified
+    {
+      get { return _rematch != null; }
+      set { if (value == (_rematch== null)) _rematch = value ? this.rematch : (ulong?)null; }
+    }
+    private bool ShouldSerializerematch() { return rematchSpecified; }
+    private void Resetrematch() { rematchSpecified = false; }
+    
 
-    private uint _replay_token = default(uint);
+    private uint? _replay_token;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"replay_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_token
     {
-      get { return _replay_token; }
+      get { return _replay_token?? default(uint); }
       set { _replay_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_tokenSpecified
+    {
+      get { return _replay_token != null; }
+      set { if (value == (_replay_token== null)) _replay_token = value ? this.replay_token : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_token() { return replay_tokenSpecified; }
+    private void Resetreplay_token() { replay_tokenSpecified = false; }
+    
 
-    private uint _replay_cluster_id = default(uint);
+    private uint? _replay_cluster_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"replay_cluster_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_cluster_id
     {
-      get { return _replay_cluster_id; }
+      get { return _replay_cluster_id?? default(uint); }
       set { _replay_cluster_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_cluster_idSpecified
+    {
+      get { return _replay_cluster_id != null; }
+      set { if (value == (_replay_cluster_id== null)) _replay_cluster_id = value ? this.replay_cluster_id : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_cluster_id() { return replay_cluster_idSpecified; }
+    private void Resetreplay_cluster_id() { replay_cluster_idSpecified = false; }
+    
 
-    private bool _aborted_match = default(bool);
+    private bool? _aborted_match;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"aborted_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool aborted_match
     {
-      get { return _aborted_match; }
+      get { return _aborted_match?? default(bool); }
       set { _aborted_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool aborted_matchSpecified
+    {
+      get { return _aborted_match != null; }
+      set { if (value == (_aborted_match== null)) _aborted_match = value ? this.aborted_match : (bool?)null; }
+    }
+    private bool ShouldSerializeaborted_match() { return aborted_matchSpecified; }
+    private void Resetaborted_match() { aborted_matchSpecified = false; }
+    
 
     private CMsgGC_ServerQuestUpdateData _match_end_quest_data = null;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_end_quest_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2490,14 +4067,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _match_end_quest_data = value; }
     }
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2519,14 +4105,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGC2ClientHello() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve _ongoingmatch = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ongoingmatch", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2546,32 +4141,59 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _global_stats = value; }
     }
 
-    private uint _penalty_seconds = default(uint);
+    private uint? _penalty_seconds;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"penalty_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_seconds
     {
-      get { return _penalty_seconds; }
+      get { return _penalty_seconds?? default(uint); }
       set { _penalty_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_secondsSpecified
+    {
+      get { return _penalty_seconds != null; }
+      set { if (value == (_penalty_seconds== null)) _penalty_seconds = value ? this.penalty_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_seconds() { return penalty_secondsSpecified; }
+    private void Resetpenalty_seconds() { penalty_secondsSpecified = false; }
+    
 
-    private uint _penalty_reason = default(uint);
+    private uint? _penalty_reason;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"penalty_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_reason
     {
-      get { return _penalty_reason; }
+      get { return _penalty_reason?? default(uint); }
       set { _penalty_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_reasonSpecified
+    {
+      get { return _penalty_reason != null; }
+      set { if (value == (_penalty_reason== null)) _penalty_reason = value ? this.penalty_reason : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_reason() { return penalty_reasonSpecified; }
+    private void Resetpenalty_reason() { penalty_reasonSpecified = false; }
+    
 
-    private int _vac_banned = default(int);
+    private int? _vac_banned;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"vac_banned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int vac_banned
     {
-      get { return _vac_banned; }
+      get { return _vac_banned?? default(int); }
       set { _vac_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vac_bannedSpecified
+    {
+      get { return _vac_banned != null; }
+      set { if (value == (_vac_banned== null)) _vac_banned = value ? this.vac_banned : (int?)null; }
+    }
+    private bool ShouldSerializevac_banned() { return vac_bannedSpecified; }
+    private void Resetvac_banned() { vac_bannedSpecified = false; }
+    
 
     private PlayerRankingInfo _ranking = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"ranking", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2632,14 +4254,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _survey_vote = default(uint);
+    private uint? _survey_vote;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"survey_vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint survey_vote
     {
-      get { return _survey_vote; }
+      get { return _survey_vote?? default(uint); }
       set { _survey_vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_voteSpecified
+    {
+      get { return _survey_vote != null; }
+      set { if (value == (_survey_vote== null)) _survey_vote = value ? this.survey_vote : (uint?)null; }
+    }
+    private bool ShouldSerializesurvey_vote() { return survey_voteSpecified; }
+    private void Resetsurvey_vote() { survey_voteSpecified = false; }
+    
 
     private AccountActivity _activity = null;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"activity", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2650,32 +4281,59 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _activity = value; }
     }
 
-    private int _player_level = default(int);
+    private int? _player_level;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"player_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int player_level
     {
-      get { return _player_level; }
+      get { return _player_level?? default(int); }
       set { _player_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_levelSpecified
+    {
+      get { return _player_level != null; }
+      set { if (value == (_player_level== null)) _player_level = value ? this.player_level : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_level() { return player_levelSpecified; }
+    private void Resetplayer_level() { player_levelSpecified = false; }
+    
 
-    private int _player_cur_xp = default(int);
+    private int? _player_cur_xp;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"player_cur_xp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int player_cur_xp
     {
-      get { return _player_cur_xp; }
+      get { return _player_cur_xp?? default(int); }
       set { _player_cur_xp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_cur_xpSpecified
+    {
+      get { return _player_cur_xp != null; }
+      set { if (value == (_player_cur_xp== null)) _player_cur_xp = value ? this.player_cur_xp : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_cur_xp() { return player_cur_xpSpecified; }
+    private void Resetplayer_cur_xp() { player_cur_xpSpecified = false; }
+    
 
-    private int _player_xp_bonus_flags = default(int);
+    private int? _player_xp_bonus_flags;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"player_xp_bonus_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int player_xp_bonus_flags
     {
-      get { return _player_xp_bonus_flags; }
+      get { return _player_xp_bonus_flags?? default(int); }
       set { _player_xp_bonus_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_xp_bonus_flagsSpecified
+    {
+      get { return _player_xp_bonus_flags != null; }
+      set { if (value == (_player_xp_bonus_flags== null)) _player_xp_bonus_flags = value ? this.player_xp_bonus_flags : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_xp_bonus_flags() { return player_xp_bonus_flagsSpecified; }
+    private void Resetplayer_xp_bonus_flags() { player_xp_bonus_flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2699,23 +4357,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public Setting() {}
     
 
-    private uint _setting_type = default(uint);
+    private uint? _setting_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"setting_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint setting_type
     {
-      get { return _setting_type; }
+      get { return _setting_type?? default(uint); }
       set { _setting_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool setting_typeSpecified
+    {
+      get { return _setting_type != null; }
+      set { if (value == (_setting_type== null)) _setting_type = value ? this.setting_type : (uint?)null; }
+    }
+    private bool ShouldSerializesetting_type() { return setting_typeSpecified; }
+    private void Resetsetting_type() { setting_typeSpecified = false; }
+    
 
-    private uint _setting_value = default(uint);
+    private uint? _setting_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"setting_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint setting_value
     {
-      get { return _setting_value; }
+      get { return _setting_value?? default(uint); }
       set { _setting_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool setting_valueSpecified
+    {
+      get { return _setting_value != null; }
+      set { if (value == (_setting_value== null)) _setting_value = value ? this.setting_value : (uint?)null; }
+    }
+    private bool ShouldSerializesetting_value() { return setting_valueSpecified; }
+    private void Resetsetting_value() { setting_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2732,14 +4408,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingGC2ClientAbandon() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve _abandoned_match = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"abandoned_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2750,23 +4435,41 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _abandoned_match = value; }
     }
 
-    private uint _penalty_seconds = default(uint);
+    private uint? _penalty_seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"penalty_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_seconds
     {
-      get { return _penalty_seconds; }
+      get { return _penalty_seconds?? default(uint); }
       set { _penalty_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_secondsSpecified
+    {
+      get { return _penalty_seconds != null; }
+      set { if (value == (_penalty_seconds== null)) _penalty_seconds = value ? this.penalty_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_seconds() { return penalty_secondsSpecified; }
+    private void Resetpenalty_seconds() { penalty_secondsSpecified = false; }
+    
 
-    private uint _penalty_reason = default(uint);
+    private uint? _penalty_reason;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"penalty_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_reason
     {
-      get { return _penalty_reason; }
+      get { return _penalty_reason?? default(uint); }
       set { _penalty_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_reasonSpecified
+    {
+      get { return _penalty_reason != null; }
+      set { if (value == (_penalty_reason== null)) _penalty_reason = value ? this.penalty_reason : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_reason() { return penalty_reasonSpecified; }
+    private void Resetpenalty_reason() { penalty_reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2778,14 +4481,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingServer2GCKick() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ServerReserve _reservation = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reservation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2796,14 +4508,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _reservation = value; }
     }
 
-    private uint _reason = default(uint);
+    private uint? _reason;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reason
     {
-      get { return _reason; }
+      get { return _reason?? default(uint); }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (uint?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2822,14 +4543,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2841,14 +4571,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchmakingOperator2GCBlogUpdate() {}
     
 
-    private string _main_post_url = "";
+    private string _main_post_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"main_post_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string main_post_url
     {
-      get { return _main_post_url; }
+      get { return _main_post_url?? ""; }
       set { _main_post_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool main_post_urlSpecified
+    {
+      get { return _main_post_url != null; }
+      set { if (value == (_main_post_url== null)) _main_post_url = value ? this.main_post_url : (string)null; }
+    }
+    private bool ShouldSerializemain_post_url() { return main_post_urlSpecified; }
+    private void Resetmain_post_url() { main_post_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2860,32 +4599,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ServerNotificationForUserPenalty() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _reason = default(uint);
+    private uint? _reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reason
     {
-      get { return _reason; }
+      get { return _reason?? default(uint); }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (uint?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
 
-    private uint _seconds = default(uint);
+    private uint? _seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds
     {
-      get { return _seconds; }
+      get { return _seconds?? default(uint); }
       set { _seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secondsSpecified
+    {
+      get { return _seconds != null; }
+      set { if (value == (_seconds== null)) _seconds = value ? this.seconds : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds() { return secondsSpecified; }
+    private void Resetseconds() { secondsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2897,77 +4663,149 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientReportPlayer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _rpt_aimbot = default(uint);
+    private uint? _rpt_aimbot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rpt_aimbot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_aimbot
     {
-      get { return _rpt_aimbot; }
+      get { return _rpt_aimbot?? default(uint); }
       set { _rpt_aimbot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_aimbotSpecified
+    {
+      get { return _rpt_aimbot != null; }
+      set { if (value == (_rpt_aimbot== null)) _rpt_aimbot = value ? this.rpt_aimbot : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_aimbot() { return rpt_aimbotSpecified; }
+    private void Resetrpt_aimbot() { rpt_aimbotSpecified = false; }
+    
 
-    private uint _rpt_wallhack = default(uint);
+    private uint? _rpt_wallhack;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rpt_wallhack", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_wallhack
     {
-      get { return _rpt_wallhack; }
+      get { return _rpt_wallhack?? default(uint); }
       set { _rpt_wallhack = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_wallhackSpecified
+    {
+      get { return _rpt_wallhack != null; }
+      set { if (value == (_rpt_wallhack== null)) _rpt_wallhack = value ? this.rpt_wallhack : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_wallhack() { return rpt_wallhackSpecified; }
+    private void Resetrpt_wallhack() { rpt_wallhackSpecified = false; }
+    
 
-    private uint _rpt_speedhack = default(uint);
+    private uint? _rpt_speedhack;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rpt_speedhack", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_speedhack
     {
-      get { return _rpt_speedhack; }
+      get { return _rpt_speedhack?? default(uint); }
       set { _rpt_speedhack = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_speedhackSpecified
+    {
+      get { return _rpt_speedhack != null; }
+      set { if (value == (_rpt_speedhack== null)) _rpt_speedhack = value ? this.rpt_speedhack : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_speedhack() { return rpt_speedhackSpecified; }
+    private void Resetrpt_speedhack() { rpt_speedhackSpecified = false; }
+    
 
-    private uint _rpt_teamharm = default(uint);
+    private uint? _rpt_teamharm;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rpt_teamharm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_teamharm
     {
-      get { return _rpt_teamharm; }
+      get { return _rpt_teamharm?? default(uint); }
       set { _rpt_teamharm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_teamharmSpecified
+    {
+      get { return _rpt_teamharm != null; }
+      set { if (value == (_rpt_teamharm== null)) _rpt_teamharm = value ? this.rpt_teamharm : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_teamharm() { return rpt_teamharmSpecified; }
+    private void Resetrpt_teamharm() { rpt_teamharmSpecified = false; }
+    
 
-    private uint _rpt_textabuse = default(uint);
+    private uint? _rpt_textabuse;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rpt_textabuse", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_textabuse
     {
-      get { return _rpt_textabuse; }
+      get { return _rpt_textabuse?? default(uint); }
       set { _rpt_textabuse = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_textabuseSpecified
+    {
+      get { return _rpt_textabuse != null; }
+      set { if (value == (_rpt_textabuse== null)) _rpt_textabuse = value ? this.rpt_textabuse : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_textabuse() { return rpt_textabuseSpecified; }
+    private void Resetrpt_textabuse() { rpt_textabuseSpecified = false; }
+    
 
-    private uint _rpt_voiceabuse = default(uint);
+    private uint? _rpt_voiceabuse;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"rpt_voiceabuse", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_voiceabuse
     {
-      get { return _rpt_voiceabuse; }
+      get { return _rpt_voiceabuse?? default(uint); }
       set { _rpt_voiceabuse = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_voiceabuseSpecified
+    {
+      get { return _rpt_voiceabuse != null; }
+      set { if (value == (_rpt_voiceabuse== null)) _rpt_voiceabuse = value ? this.rpt_voiceabuse : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_voiceabuse() { return rpt_voiceabuseSpecified; }
+    private void Resetrpt_voiceabuse() { rpt_voiceabuseSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2979,23 +4817,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientCommendPlayer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
     private PlayerCommendationInfo _commendation = null;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"commendation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3006,14 +4862,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _commendation = value; }
     }
 
-    private uint _tokens = default(uint);
+    private uint? _tokens;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tokens
     {
-      get { return _tokens; }
+      get { return _tokens?? default(uint); }
       set { _tokens = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokensSpecified
+    {
+      get { return _tokens != null; }
+      set { if (value == (_tokens== null)) _tokens = value ? this.tokens : (uint?)null; }
+    }
+    private bool ShouldSerializetokens() { return tokensSpecified; }
+    private void Resettokens() { tokensSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3025,59 +4890,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientReportServer() {}
     
 
-    private uint _rpt_poorperf = default(uint);
+    private uint? _rpt_poorperf;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"rpt_poorperf", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_poorperf
     {
-      get { return _rpt_poorperf; }
+      get { return _rpt_poorperf?? default(uint); }
       set { _rpt_poorperf = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_poorperfSpecified
+    {
+      get { return _rpt_poorperf != null; }
+      set { if (value == (_rpt_poorperf== null)) _rpt_poorperf = value ? this.rpt_poorperf : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_poorperf() { return rpt_poorperfSpecified; }
+    private void Resetrpt_poorperf() { rpt_poorperfSpecified = false; }
+    
 
-    private uint _rpt_abusivemodels = default(uint);
+    private uint? _rpt_abusivemodels;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rpt_abusivemodels", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_abusivemodels
     {
-      get { return _rpt_abusivemodels; }
+      get { return _rpt_abusivemodels?? default(uint); }
       set { _rpt_abusivemodels = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_abusivemodelsSpecified
+    {
+      get { return _rpt_abusivemodels != null; }
+      set { if (value == (_rpt_abusivemodels== null)) _rpt_abusivemodels = value ? this.rpt_abusivemodels : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_abusivemodels() { return rpt_abusivemodelsSpecified; }
+    private void Resetrpt_abusivemodels() { rpt_abusivemodelsSpecified = false; }
+    
 
-    private uint _rpt_badmotd = default(uint);
+    private uint? _rpt_badmotd;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rpt_badmotd", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_badmotd
     {
-      get { return _rpt_badmotd; }
+      get { return _rpt_badmotd?? default(uint); }
       set { _rpt_badmotd = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_badmotdSpecified
+    {
+      get { return _rpt_badmotd != null; }
+      set { if (value == (_rpt_badmotd== null)) _rpt_badmotd = value ? this.rpt_badmotd : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_badmotd() { return rpt_badmotdSpecified; }
+    private void Resetrpt_badmotd() { rpt_badmotdSpecified = false; }
+    
 
-    private uint _rpt_listingabuse = default(uint);
+    private uint? _rpt_listingabuse;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rpt_listingabuse", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_listingabuse
     {
-      get { return _rpt_listingabuse; }
+      get { return _rpt_listingabuse?? default(uint); }
       set { _rpt_listingabuse = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_listingabuseSpecified
+    {
+      get { return _rpt_listingabuse != null; }
+      set { if (value == (_rpt_listingabuse== null)) _rpt_listingabuse = value ? this.rpt_listingabuse : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_listingabuse() { return rpt_listingabuseSpecified; }
+    private void Resetrpt_listingabuse() { rpt_listingabuseSpecified = false; }
+    
 
-    private uint _rpt_inventoryabuse = default(uint);
+    private uint? _rpt_inventoryabuse;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rpt_inventoryabuse", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_inventoryabuse
     {
-      get { return _rpt_inventoryabuse; }
+      get { return _rpt_inventoryabuse?? default(uint); }
       set { _rpt_inventoryabuse = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_inventoryabuseSpecified
+    {
+      get { return _rpt_inventoryabuse != null; }
+      set { if (value == (_rpt_inventoryabuse== null)) _rpt_inventoryabuse = value ? this.rpt_inventoryabuse : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_inventoryabuse() { return rpt_inventoryabuseSpecified; }
+    private void Resetrpt_inventoryabuse() { rpt_inventoryabuseSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3089,59 +5008,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientReportResponse() {}
     
 
-    private ulong _confirmation_id = default(ulong);
+    private ulong? _confirmation_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"confirmation_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong confirmation_id
     {
-      get { return _confirmation_id; }
+      get { return _confirmation_id?? default(ulong); }
       set { _confirmation_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool confirmation_idSpecified
+    {
+      get { return _confirmation_id != null; }
+      set { if (value == (_confirmation_id== null)) _confirmation_id = value ? this.confirmation_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeconfirmation_id() { return confirmation_idSpecified; }
+    private void Resetconfirmation_id() { confirmation_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _response_type = default(uint);
+    private uint? _response_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"response_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response_type
     {
-      get { return _response_type; }
+      get { return _response_type?? default(uint); }
       set { _response_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool response_typeSpecified
+    {
+      get { return _response_type != null; }
+      set { if (value == (_response_type== null)) _response_type = value ? this.response_type : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse_type() { return response_typeSpecified; }
+    private void Resetresponse_type() { response_typeSpecified = false; }
+    
 
-    private uint _response_result = default(uint);
+    private uint? _response_result;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"response_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response_result
     {
-      get { return _response_result; }
+      get { return _response_result?? default(uint); }
       set { _response_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool response_resultSpecified
+    {
+      get { return _response_result != null; }
+      set { if (value == (_response_result== null)) _response_result = value ? this.response_result : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse_result() { return response_resultSpecified; }
+    private void Resetresponse_result() { response_resultSpecified = false; }
+    
 
-    private uint _tokens = default(uint);
+    private uint? _tokens;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tokens
     {
-      get { return _tokens; }
+      get { return _tokens?? default(uint); }
       set { _tokens = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokensSpecified
+    {
+      get { return _tokens != null; }
+      set { if (value == (_tokens== null)) _tokens = value ? this.tokens : (uint?)null; }
+    }
+    private bool ShouldSerializetokens() { return tokensSpecified; }
+    private void Resettokens() { tokensSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3153,14 +5126,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientRequestWatchInfoFriends() {}
     
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids
@@ -3169,23 +5151,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _serverid = default(ulong);
+    private ulong? _serverid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"serverid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong serverid
     {
-      get { return _serverid; }
+      get { return _serverid?? default(ulong); }
       set { _serverid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serveridSpecified
+    {
+      get { return _serverid != null; }
+      set { if (value == (_serverid== null)) _serverid = value ? this.serverid : (ulong?)null; }
+    }
+    private bool ShouldSerializeserverid() { return serveridSpecified; }
+    private void Resetserverid() { serveridSpecified = false; }
+    
 
-    private ulong _matchid = default(ulong);
+    private ulong? _matchid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"matchid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong matchid
     {
-      get { return _matchid; }
+      get { return _matchid?? default(ulong); }
       set { _matchid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchidSpecified
+    {
+      get { return _matchid != null; }
+      set { if (value == (_matchid== null)) _matchid = value ? this.matchid : (ulong?)null; }
+    }
+    private bool ShouldSerializematchid() { return matchidSpecified; }
+    private void Resetmatchid() { matchidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3197,122 +5197,239 @@ namespace SteamKit2.GC.CSGO.Internal
     public WatchableMatchInfo() {}
     
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _tv_port = default(uint);
+    private uint? _tv_port;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_port
     {
-      get { return _tv_port; }
+      get { return _tv_port?? default(uint); }
       set { _tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_portSpecified
+    {
+      get { return _tv_port != null; }
+      set { if (value == (_tv_port== null)) _tv_port = value ? this.tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializetv_port() { return tv_portSpecified; }
+    private void Resettv_port() { tv_portSpecified = false; }
+    
 
-    private uint _tv_spectators = default(uint);
+    private uint? _tv_spectators;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tv_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_spectators
     {
-      get { return _tv_spectators; }
+      get { return _tv_spectators?? default(uint); }
       set { _tv_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_spectatorsSpecified
+    {
+      get { return _tv_spectators != null; }
+      set { if (value == (_tv_spectators== null)) _tv_spectators = value ? this.tv_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializetv_spectators() { return tv_spectatorsSpecified; }
+    private void Resettv_spectators() { tv_spectatorsSpecified = false; }
+    
 
-    private uint _tv_time = default(uint);
+    private uint? _tv_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tv_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tv_time
     {
-      get { return _tv_time; }
+      get { return _tv_time?? default(uint); }
       set { _tv_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_timeSpecified
+    {
+      get { return _tv_time != null; }
+      set { if (value == (_tv_time== null)) _tv_time = value ? this.tv_time : (uint?)null; }
+    }
+    private bool ShouldSerializetv_time() { return tv_timeSpecified; }
+    private void Resettv_time() { tv_timeSpecified = false; }
+    
 
-    private byte[] _tv_watch_password = null;
+    private byte[] _tv_watch_password;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tv_watch_password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] tv_watch_password
     {
-      get { return _tv_watch_password; }
+      get { return _tv_watch_password?? null; }
       set { _tv_watch_password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_watch_passwordSpecified
+    {
+      get { return _tv_watch_password != null; }
+      set { if (value == (_tv_watch_password== null)) _tv_watch_password = value ? this.tv_watch_password : (byte[])null; }
+    }
+    private bool ShouldSerializetv_watch_password() { return tv_watch_passwordSpecified; }
+    private void Resettv_watch_password() { tv_watch_passwordSpecified = false; }
+    
 
-    private ulong _cl_decryptdata_key = default(ulong);
+    private ulong? _cl_decryptdata_key;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"cl_decryptdata_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cl_decryptdata_key
     {
-      get { return _cl_decryptdata_key; }
+      get { return _cl_decryptdata_key?? default(ulong); }
       set { _cl_decryptdata_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cl_decryptdata_keySpecified
+    {
+      get { return _cl_decryptdata_key != null; }
+      set { if (value == (_cl_decryptdata_key== null)) _cl_decryptdata_key = value ? this.cl_decryptdata_key : (ulong?)null; }
+    }
+    private bool ShouldSerializecl_decryptdata_key() { return cl_decryptdata_keySpecified; }
+    private void Resetcl_decryptdata_key() { cl_decryptdata_keySpecified = false; }
+    
 
-    private ulong _cl_decryptdata_key_pub = default(ulong);
+    private ulong? _cl_decryptdata_key_pub;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cl_decryptdata_key_pub", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cl_decryptdata_key_pub
     {
-      get { return _cl_decryptdata_key_pub; }
+      get { return _cl_decryptdata_key_pub?? default(ulong); }
       set { _cl_decryptdata_key_pub = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cl_decryptdata_key_pubSpecified
+    {
+      get { return _cl_decryptdata_key_pub != null; }
+      set { if (value == (_cl_decryptdata_key_pub== null)) _cl_decryptdata_key_pub = value ? this.cl_decryptdata_key_pub : (ulong?)null; }
+    }
+    private bool ShouldSerializecl_decryptdata_key_pub() { return cl_decryptdata_key_pubSpecified; }
+    private void Resetcl_decryptdata_key_pub() { cl_decryptdata_key_pubSpecified = false; }
+    
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private string _game_mapgroup = "";
+    private string _game_mapgroup;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"game_mapgroup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_mapgroup
     {
-      get { return _game_mapgroup; }
+      get { return _game_mapgroup?? ""; }
       set { _game_mapgroup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_mapgroupSpecified
+    {
+      get { return _game_mapgroup != null; }
+      set { if (value == (_game_mapgroup== null)) _game_mapgroup = value ? this.game_mapgroup : (string)null; }
+    }
+    private bool ShouldSerializegame_mapgroup() { return game_mapgroupSpecified; }
+    private void Resetgame_mapgroup() { game_mapgroupSpecified = false; }
+    
 
-    private string _game_map = "";
+    private string _game_map;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"game_map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_map
     {
-      get { return _game_map; }
+      get { return _game_map?? ""; }
       set { _game_map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_mapSpecified
+    {
+      get { return _game_map != null; }
+      set { if (value == (_game_map== null)) _game_map = value ? this.game_map : (string)null; }
+    }
+    private bool ShouldSerializegame_map() { return game_mapSpecified; }
+    private void Resetgame_map() { game_mapSpecified = false; }
+    
 
-    private ulong _server_id = default(ulong);
+    private ulong? _server_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"server_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_id
     {
-      get { return _server_id; }
+      get { return _server_id?? default(ulong); }
       set { _server_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_idSpecified
+    {
+      get { return _server_id != null; }
+      set { if (value == (_server_id== null)) _server_id = value ? this.server_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_id() { return server_idSpecified; }
+    private void Resetserver_id() { server_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private ulong _reservation_id = default(ulong);
+    private ulong? _reservation_id;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"reservation_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reservation_id
     {
-      get { return _reservation_id; }
+      get { return _reservation_id?? default(ulong); }
       set { _reservation_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reservation_idSpecified
+    {
+      get { return _reservation_id != null; }
+      set { if (value == (_reservation_id== null)) _reservation_id = value ? this.reservation_id : (ulong?)null; }
+    }
+    private bool ShouldSerializereservation_id() { return reservation_idSpecified; }
+    private void Resetreservation_id() { reservation_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3324,41 +5441,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientRequestJoinFriendData() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _join_token = default(uint);
+    private uint? _join_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"join_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint join_token
     {
-      get { return _join_token; }
+      get { return _join_token?? default(uint); }
       set { _join_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool join_tokenSpecified
+    {
+      get { return _join_token != null; }
+      set { if (value == (_join_token== null)) _join_token = value ? this.join_token : (uint?)null; }
+    }
+    private bool ShouldSerializejoin_token() { return join_tokenSpecified; }
+    private void Resetjoin_token() { join_tokenSpecified = false; }
+    
 
-    private uint _join_ipp = default(uint);
+    private uint? _join_ipp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"join_ipp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint join_ipp
     {
-      get { return _join_ipp; }
+      get { return _join_ipp?? default(uint); }
       set { _join_ipp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool join_ippSpecified
+    {
+      get { return _join_ipp != null; }
+      set { if (value == (_join_ipp== null)) _join_ipp = value ? this.join_ipp : (uint?)null; }
+    }
+    private bool ShouldSerializejoin_ipp() { return join_ippSpecified; }
+    private void Resetjoin_ipp() { join_ippSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve _res = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"res", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3369,14 +5522,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _res = value; }
     }
 
-    private string _errormsg = "";
+    private string _errormsg;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"errormsg", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string errormsg
     {
-      get { return _errormsg; }
+      get { return _errormsg?? ""; }
       set { _errormsg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errormsgSpecified
+    {
+      get { return _errormsg != null; }
+      set { if (value == (_errormsg== null)) _errormsg = value ? this.errormsg : (string)null; }
+    }
+    private bool ShouldSerializeerrormsg() { return errormsgSpecified; }
+    private void Reseterrormsg() { errormsgSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3388,50 +5550,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientRequestJoinServerData() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _serverid = default(ulong);
+    private ulong? _serverid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"serverid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong serverid
     {
-      get { return _serverid; }
+      get { return _serverid?? default(ulong); }
       set { _serverid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serveridSpecified
+    {
+      get { return _serverid != null; }
+      set { if (value == (_serverid== null)) _serverid = value ? this.serverid : (ulong?)null; }
+    }
+    private bool ShouldSerializeserverid() { return serveridSpecified; }
+    private void Resetserverid() { serveridSpecified = false; }
+    
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
     private CMsgGCCStrike15_v2_MatchmakingGC2ClientReserve _res = null;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"res", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3452,23 +5659,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCstrike15_v2_ClientRequestNewMission() {}
     
 
-    private uint _mission_id = default(uint);
+    private uint? _mission_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"mission_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mission_id
     {
-      get { return _mission_id; }
+      get { return _mission_id?? default(uint); }
       set { _mission_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mission_idSpecified
+    {
+      get { return _mission_id != null; }
+      set { if (value == (_mission_id== null)) _mission_id = value ? this.mission_id : (uint?)null; }
+    }
+    private bool ShouldSerializemission_id() { return mission_idSpecified; }
+    private void Resetmission_id() { mission_idSpecified = false; }
+    
 
-    private uint _campaign_id = default(uint);
+    private uint? _campaign_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"campaign_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint campaign_id
     {
-      get { return _campaign_id; }
+      get { return _campaign_id?? default(uint); }
       set { _campaign_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool campaign_idSpecified
+    {
+      get { return _campaign_id != null; }
+      set { if (value == (_campaign_id== null)) _campaign_id = value ? this.campaign_id : (uint?)null; }
+    }
+    private bool ShouldSerializecampaign_id() { return campaign_idSpecified; }
+    private void Resetcampaign_id() { campaign_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3487,41 +5712,77 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _current_xp = default(uint);
+    private uint? _current_xp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"current_xp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_xp
     {
-      get { return _current_xp; }
+      get { return _current_xp?? default(uint); }
       set { _current_xp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_xpSpecified
+    {
+      get { return _current_xp != null; }
+      set { if (value == (_current_xp== null)) _current_xp = value ? this.current_xp : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_xp() { return current_xpSpecified; }
+    private void Resetcurrent_xp() { current_xpSpecified = false; }
+    
 
-    private uint _current_level = default(uint);
+    private uint? _current_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"current_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_level
     {
-      get { return _current_level; }
+      get { return _current_level?? default(uint); }
       set { _current_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_levelSpecified
+    {
+      get { return _current_level != null; }
+      set { if (value == (_current_level== null)) _current_level = value ? this.current_level : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_level() { return current_levelSpecified; }
+    private void Resetcurrent_level() { current_levelSpecified = false; }
+    
 
-    private uint _upgraded_defidx = default(uint);
+    private uint? _upgraded_defidx;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"upgraded_defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint upgraded_defidx
     {
-      get { return _upgraded_defidx; }
+      get { return _upgraded_defidx?? default(uint); }
       set { _upgraded_defidx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upgraded_defidxSpecified
+    {
+      get { return _upgraded_defidx != null; }
+      set { if (value == (_upgraded_defidx== null)) _upgraded_defidx = value ? this.upgraded_defidx : (uint?)null; }
+    }
+    private bool ShouldSerializeupgraded_defidx() { return upgraded_defidxSpecified; }
+    private void Resetupgraded_defidx() { upgraded_defidxSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3533,14 +5794,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_WatchInfoUsers() {}
     
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids
@@ -3556,14 +5826,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _extended_timeout = default(uint);
+    private uint? _extended_timeout;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"extended_timeout", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint extended_timeout
     {
-      get { return _extended_timeout; }
+      get { return _extended_timeout?? default(uint); }
       set { _extended_timeout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool extended_timeoutSpecified
+    {
+      get { return _extended_timeout != null; }
+      set { if (value == (_extended_timeout== null)) _extended_timeout = value ? this.extended_timeout : (uint?)null; }
+    }
+    private bool ShouldSerializeextended_timeout() { return extended_timeoutSpecified; }
+    private void Resetextended_timeout() { extended_timeoutSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3575,14 +5854,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientRequestPlayersProfile() {}
     
 
-    private uint _request_id__deprecated = default(uint);
+    private uint? _request_id__deprecated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id__deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id__deprecated
     {
-      get { return _request_id__deprecated; }
+      get { return _request_id__deprecated?? default(uint); }
       set { _request_id__deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_id__deprecatedSpecified
+    {
+      get { return _request_id__deprecated != null; }
+      set { if (value == (_request_id__deprecated== null)) _request_id__deprecated = value ? this.request_id__deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id__deprecated() { return request_id__deprecatedSpecified; }
+    private void Resetrequest_id__deprecated() { request_id__deprecatedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids__deprecated = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids__deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids__deprecated
@@ -3591,23 +5879,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _request_level = default(uint);
+    private uint? _request_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"request_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_level
     {
-      get { return _request_level; }
+      get { return _request_level?? default(uint); }
       set { _request_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_levelSpecified
+    {
+      get { return _request_level != null; }
+      set { if (value == (_request_level== null)) _request_level = value ? this.request_level : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_level() { return request_levelSpecified; }
+    private void Resetrequest_level() { request_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3619,14 +5925,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_PlayersProfile() {}
     
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCCStrike15_v2_MatchmakingGC2ClientHello> _account_profiles = new global::System.Collections.Generic.List<CMsgGCCStrike15_v2_MatchmakingGC2ClientHello>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_profiles", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCCStrike15_v2_MatchmakingGC2ClientHello> account_profiles
@@ -3645,77 +5960,149 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_PlayerOverwatchCaseUpdate() {}
     
 
-    private ulong _caseid = default(ulong);
+    private ulong? _caseid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"caseid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caseid
     {
-      get { return _caseid; }
+      get { return _caseid?? default(ulong); }
       set { _caseid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caseidSpecified
+    {
+      get { return _caseid != null; }
+      set { if (value == (_caseid== null)) _caseid = value ? this.caseid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaseid() { return caseidSpecified; }
+    private void Resetcaseid() { caseidSpecified = false; }
+    
 
-    private uint _suspectid = default(uint);
+    private uint? _suspectid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"suspectid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suspectid
     {
-      get { return _suspectid; }
+      get { return _suspectid?? default(uint); }
       set { _suspectid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suspectidSpecified
+    {
+      get { return _suspectid != null; }
+      set { if (value == (_suspectid== null)) _suspectid = value ? this.suspectid : (uint?)null; }
+    }
+    private bool ShouldSerializesuspectid() { return suspectidSpecified; }
+    private void Resetsuspectid() { suspectidSpecified = false; }
+    
 
-    private uint _fractionid = default(uint);
+    private uint? _fractionid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"fractionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fractionid
     {
-      get { return _fractionid; }
+      get { return _fractionid?? default(uint); }
       set { _fractionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fractionidSpecified
+    {
+      get { return _fractionid != null; }
+      set { if (value == (_fractionid== null)) _fractionid = value ? this.fractionid : (uint?)null; }
+    }
+    private bool ShouldSerializefractionid() { return fractionidSpecified; }
+    private void Resetfractionid() { fractionidSpecified = false; }
+    
 
-    private uint _rpt_aimbot = default(uint);
+    private uint? _rpt_aimbot;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rpt_aimbot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_aimbot
     {
-      get { return _rpt_aimbot; }
+      get { return _rpt_aimbot?? default(uint); }
       set { _rpt_aimbot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_aimbotSpecified
+    {
+      get { return _rpt_aimbot != null; }
+      set { if (value == (_rpt_aimbot== null)) _rpt_aimbot = value ? this.rpt_aimbot : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_aimbot() { return rpt_aimbotSpecified; }
+    private void Resetrpt_aimbot() { rpt_aimbotSpecified = false; }
+    
 
-    private uint _rpt_wallhack = default(uint);
+    private uint? _rpt_wallhack;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rpt_wallhack", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_wallhack
     {
-      get { return _rpt_wallhack; }
+      get { return _rpt_wallhack?? default(uint); }
       set { _rpt_wallhack = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_wallhackSpecified
+    {
+      get { return _rpt_wallhack != null; }
+      set { if (value == (_rpt_wallhack== null)) _rpt_wallhack = value ? this.rpt_wallhack : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_wallhack() { return rpt_wallhackSpecified; }
+    private void Resetrpt_wallhack() { rpt_wallhackSpecified = false; }
+    
 
-    private uint _rpt_speedhack = default(uint);
+    private uint? _rpt_speedhack;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"rpt_speedhack", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_speedhack
     {
-      get { return _rpt_speedhack; }
+      get { return _rpt_speedhack?? default(uint); }
       set { _rpt_speedhack = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_speedhackSpecified
+    {
+      get { return _rpt_speedhack != null; }
+      set { if (value == (_rpt_speedhack== null)) _rpt_speedhack = value ? this.rpt_speedhack : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_speedhack() { return rpt_speedhackSpecified; }
+    private void Resetrpt_speedhack() { rpt_speedhackSpecified = false; }
+    
 
-    private uint _rpt_teamharm = default(uint);
+    private uint? _rpt_teamharm;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"rpt_teamharm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rpt_teamharm
     {
-      get { return _rpt_teamharm; }
+      get { return _rpt_teamharm?? default(uint); }
       set { _rpt_teamharm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rpt_teamharmSpecified
+    {
+      get { return _rpt_teamharm != null; }
+      set { if (value == (_rpt_teamharm== null)) _rpt_teamharm = value ? this.rpt_teamharm : (uint?)null; }
+    }
+    private bool ShouldSerializerpt_teamharm() { return rpt_teamharmSpecified; }
+    private void Resetrpt_teamharm() { rpt_teamharmSpecified = false; }
+    
 
-    private uint _reason = default(uint);
+    private uint? _reason;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reason
     {
-      get { return _reason; }
+      get { return _reason?? default(uint); }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (uint?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3727,104 +6114,203 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_PlayerOverwatchCaseAssignment() {}
     
 
-    private ulong _caseid = default(ulong);
+    private ulong? _caseid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"caseid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caseid
     {
-      get { return _caseid; }
+      get { return _caseid?? default(ulong); }
       set { _caseid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caseidSpecified
+    {
+      get { return _caseid != null; }
+      set { if (value == (_caseid== null)) _caseid = value ? this.caseid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaseid() { return caseidSpecified; }
+    private void Resetcaseid() { caseidSpecified = false; }
+    
 
-    private string _caseurl = "";
+    private string _caseurl;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"caseurl", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string caseurl
     {
-      get { return _caseurl; }
+      get { return _caseurl?? ""; }
       set { _caseurl = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caseurlSpecified
+    {
+      get { return _caseurl != null; }
+      set { if (value == (_caseurl== null)) _caseurl = value ? this.caseurl : (string)null; }
+    }
+    private bool ShouldSerializecaseurl() { return caseurlSpecified; }
+    private void Resetcaseurl() { caseurlSpecified = false; }
+    
 
-    private uint _verdict = default(uint);
+    private uint? _verdict;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"verdict", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint verdict
     {
-      get { return _verdict; }
+      get { return _verdict?? default(uint); }
       set { _verdict = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool verdictSpecified
+    {
+      get { return _verdict != null; }
+      set { if (value == (_verdict== null)) _verdict = value ? this.verdict : (uint?)null; }
+    }
+    private bool ShouldSerializeverdict() { return verdictSpecified; }
+    private void Resetverdict() { verdictSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _throttleseconds = default(uint);
+    private uint? _throttleseconds;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"throttleseconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint throttleseconds
     {
-      get { return _throttleseconds; }
+      get { return _throttleseconds?? default(uint); }
       set { _throttleseconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool throttlesecondsSpecified
+    {
+      get { return _throttleseconds != null; }
+      set { if (value == (_throttleseconds== null)) _throttleseconds = value ? this.throttleseconds : (uint?)null; }
+    }
+    private bool ShouldSerializethrottleseconds() { return throttlesecondsSpecified; }
+    private void Resetthrottleseconds() { throttlesecondsSpecified = false; }
+    
 
-    private uint _suspectid = default(uint);
+    private uint? _suspectid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"suspectid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suspectid
     {
-      get { return _suspectid; }
+      get { return _suspectid?? default(uint); }
       set { _suspectid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suspectidSpecified
+    {
+      get { return _suspectid != null; }
+      set { if (value == (_suspectid== null)) _suspectid = value ? this.suspectid : (uint?)null; }
+    }
+    private bool ShouldSerializesuspectid() { return suspectidSpecified; }
+    private void Resetsuspectid() { suspectidSpecified = false; }
+    
 
-    private uint _fractionid = default(uint);
+    private uint? _fractionid;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"fractionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fractionid
     {
-      get { return _fractionid; }
+      get { return _fractionid?? default(uint); }
       set { _fractionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fractionidSpecified
+    {
+      get { return _fractionid != null; }
+      set { if (value == (_fractionid== null)) _fractionid = value ? this.fractionid : (uint?)null; }
+    }
+    private bool ShouldSerializefractionid() { return fractionidSpecified; }
+    private void Resetfractionid() { fractionidSpecified = false; }
+    
 
-    private uint _numrounds = default(uint);
+    private uint? _numrounds;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"numrounds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint numrounds
     {
-      get { return _numrounds; }
+      get { return _numrounds?? default(uint); }
       set { _numrounds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool numroundsSpecified
+    {
+      get { return _numrounds != null; }
+      set { if (value == (_numrounds== null)) _numrounds = value ? this.numrounds : (uint?)null; }
+    }
+    private bool ShouldSerializenumrounds() { return numroundsSpecified; }
+    private void Resetnumrounds() { numroundsSpecified = false; }
+    
 
-    private uint _fractionrounds = default(uint);
+    private uint? _fractionrounds;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"fractionrounds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fractionrounds
     {
-      get { return _fractionrounds; }
+      get { return _fractionrounds?? default(uint); }
       set { _fractionrounds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fractionroundsSpecified
+    {
+      get { return _fractionrounds != null; }
+      set { if (value == (_fractionrounds== null)) _fractionrounds = value ? this.fractionrounds : (uint?)null; }
+    }
+    private bool ShouldSerializefractionrounds() { return fractionroundsSpecified; }
+    private void Resetfractionrounds() { fractionroundsSpecified = false; }
+    
 
-    private int _streakconvictions = default(int);
+    private int? _streakconvictions;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"streakconvictions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int streakconvictions
     {
-      get { return _streakconvictions; }
+      get { return _streakconvictions?? default(int); }
       set { _streakconvictions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool streakconvictionsSpecified
+    {
+      get { return _streakconvictions != null; }
+      set { if (value == (_streakconvictions== null)) _streakconvictions = value ? this.streakconvictions : (int?)null; }
+    }
+    private bool ShouldSerializestreakconvictions() { return streakconvictionsSpecified; }
+    private void Resetstreakconvictions() { streakconvictionsSpecified = false; }
+    
 
-    private uint _reason = default(uint);
+    private uint? _reason;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reason
     {
-      get { return _reason; }
+      get { return _reason?? default(uint); }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (uint?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3836,23 +6322,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_PlayerOverwatchCaseStatus() {}
     
 
-    private ulong _caseid = default(ulong);
+    private ulong? _caseid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"caseid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caseid
     {
-      get { return _caseid; }
+      get { return _caseid?? default(ulong); }
       set { _caseid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caseidSpecified
+    {
+      get { return _caseid != null; }
+      set { if (value == (_caseid== null)) _caseid = value ? this.caseid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaseid() { return caseidSpecified; }
+    private void Resetcaseid() { caseidSpecified = false; }
+    
 
-    private uint _statusid = default(uint);
+    private uint? _statusid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"statusid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint statusid
     {
-      get { return _statusid; }
+      get { return _statusid?? default(uint); }
       set { _statusid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusidSpecified
+    {
+      get { return _statusid != null; }
+      set { if (value == (_statusid== null)) _statusid = value ? this.statusid : (uint?)null; }
+    }
+    private bool ShouldSerializestatusid() { return statusidSpecified; }
+    private void Resetstatusid() { statusidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3864,23 +6368,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CClientHeaderOverwatchEvidence() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private ulong _caseid = default(ulong);
+    private ulong? _caseid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"caseid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caseid
     {
-      get { return _caseid; }
+      get { return _caseid?? default(ulong); }
       set { _caseid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caseidSpecified
+    {
+      get { return _caseid != null; }
+      set { if (value == (_caseid== null)) _caseid = value ? this.caseid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaseid() { return caseidSpecified; }
+    private void Resetcaseid() { caseidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3892,32 +6414,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_GC2ClientTextMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3929,14 +6478,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Client2GCTextMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _args = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"args", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> args
@@ -3983,104 +6541,203 @@ namespace SteamKit2.GC.CSGO.Internal
     public CEconItemPreviewDataBlock() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
 
-    private uint _defindex = default(uint);
+    private uint? _defindex;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"defindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint defindex
     {
-      get { return _defindex; }
+      get { return _defindex?? default(uint); }
       set { _defindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool defindexSpecified
+    {
+      get { return _defindex != null; }
+      set { if (value == (_defindex== null)) _defindex = value ? this.defindex : (uint?)null; }
+    }
+    private bool ShouldSerializedefindex() { return defindexSpecified; }
+    private void Resetdefindex() { defindexSpecified = false; }
+    
 
-    private uint _paintindex = default(uint);
+    private uint? _paintindex;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"paintindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint paintindex
     {
-      get { return _paintindex; }
+      get { return _paintindex?? default(uint); }
       set { _paintindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool paintindexSpecified
+    {
+      get { return _paintindex != null; }
+      set { if (value == (_paintindex== null)) _paintindex = value ? this.paintindex : (uint?)null; }
+    }
+    private bool ShouldSerializepaintindex() { return paintindexSpecified; }
+    private void Resetpaintindex() { paintindexSpecified = false; }
+    
 
-    private uint _rarity = default(uint);
+    private uint? _rarity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rarity
     {
-      get { return _rarity; }
+      get { return _rarity?? default(uint); }
       set { _rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raritySpecified
+    {
+      get { return _rarity != null; }
+      set { if (value == (_rarity== null)) _rarity = value ? this.rarity : (uint?)null; }
+    }
+    private bool ShouldSerializerarity() { return raritySpecified; }
+    private void Resetrarity() { raritySpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _paintwear = default(uint);
+    private uint? _paintwear;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"paintwear", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint paintwear
     {
-      get { return _paintwear; }
+      get { return _paintwear?? default(uint); }
       set { _paintwear = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool paintwearSpecified
+    {
+      get { return _paintwear != null; }
+      set { if (value == (_paintwear== null)) _paintwear = value ? this.paintwear : (uint?)null; }
+    }
+    private bool ShouldSerializepaintwear() { return paintwearSpecified; }
+    private void Resetpaintwear() { paintwearSpecified = false; }
+    
 
-    private uint _paintseed = default(uint);
+    private uint? _paintseed;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"paintseed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint paintseed
     {
-      get { return _paintseed; }
+      get { return _paintseed?? default(uint); }
       set { _paintseed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool paintseedSpecified
+    {
+      get { return _paintseed != null; }
+      set { if (value == (_paintseed== null)) _paintseed = value ? this.paintseed : (uint?)null; }
+    }
+    private bool ShouldSerializepaintseed() { return paintseedSpecified; }
+    private void Resetpaintseed() { paintseedSpecified = false; }
+    
 
-    private uint _killeaterscoretype = default(uint);
+    private uint? _killeaterscoretype;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"killeaterscoretype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killeaterscoretype
     {
-      get { return _killeaterscoretype; }
+      get { return _killeaterscoretype?? default(uint); }
       set { _killeaterscoretype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killeaterscoretypeSpecified
+    {
+      get { return _killeaterscoretype != null; }
+      set { if (value == (_killeaterscoretype== null)) _killeaterscoretype = value ? this.killeaterscoretype : (uint?)null; }
+    }
+    private bool ShouldSerializekilleaterscoretype() { return killeaterscoretypeSpecified; }
+    private void Resetkilleaterscoretype() { killeaterscoretypeSpecified = false; }
+    
 
-    private uint _killeatervalue = default(uint);
+    private uint? _killeatervalue;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"killeatervalue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killeatervalue
     {
-      get { return _killeatervalue; }
+      get { return _killeatervalue?? default(uint); }
       set { _killeatervalue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killeatervalueSpecified
+    {
+      get { return _killeatervalue != null; }
+      set { if (value == (_killeatervalue== null)) _killeatervalue = value ? this.killeatervalue : (uint?)null; }
+    }
+    private bool ShouldSerializekilleatervalue() { return killeatervalueSpecified; }
+    private void Resetkilleatervalue() { killeatervalueSpecified = false; }
+    
 
-    private string _customname = "";
+    private string _customname;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"customname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string customname
     {
-      get { return _customname; }
+      get { return _customname?? ""; }
       set { _customname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool customnameSpecified
+    {
+      get { return _customname != null; }
+      set { if (value == (_customname== null)) _customname = value ? this.customname : (string)null; }
+    }
+    private bool ShouldSerializecustomname() { return customnameSpecified; }
+    private void Resetcustomname() { customnameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CEconItemPreviewDataBlock.Sticker> _stickers = new global::System.Collections.Generic.List<CEconItemPreviewDataBlock.Sticker>();
     [global::ProtoBuf.ProtoMember(12, Name=@"stickers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CEconItemPreviewDataBlock.Sticker> stickers
@@ -4089,91 +6746,172 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
 
-    private uint _questid = default(uint);
+    private uint? _questid;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"questid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint questid
     {
-      get { return _questid; }
+      get { return _questid?? default(uint); }
       set { _questid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool questidSpecified
+    {
+      get { return _questid != null; }
+      set { if (value == (_questid== null)) _questid = value ? this.questid : (uint?)null; }
+    }
+    private bool ShouldSerializequestid() { return questidSpecified; }
+    private void Resetquestid() { questidSpecified = false; }
+    
 
-    private uint _dropreason = default(uint);
+    private uint? _dropreason;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"dropreason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dropreason
     {
-      get { return _dropreason; }
+      get { return _dropreason?? default(uint); }
       set { _dropreason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dropreasonSpecified
+    {
+      get { return _dropreason != null; }
+      set { if (value == (_dropreason== null)) _dropreason = value ? this.dropreason : (uint?)null; }
+    }
+    private bool ShouldSerializedropreason() { return dropreasonSpecified; }
+    private void Resetdropreason() { dropreasonSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Sticker")]
   public partial class Sticker : global::ProtoBuf.IExtensible
   {
     public Sticker() {}
     
 
-    private uint _slot = default(uint);
+    private uint? _slot;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot
     {
-      get { return _slot; }
+      get { return _slot?? default(uint); }
       set { _slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slotSpecified
+    {
+      get { return _slot != null; }
+      set { if (value == (_slot== null)) _slot = value ? this.slot : (uint?)null; }
+    }
+    private bool ShouldSerializeslot() { return slotSpecified; }
+    private void Resetslot() { slotSpecified = false; }
+    
 
-    private uint _sticker_id = default(uint);
+    private uint? _sticker_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sticker_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sticker_id
     {
-      get { return _sticker_id; }
+      get { return _sticker_id?? default(uint); }
       set { _sticker_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sticker_idSpecified
+    {
+      get { return _sticker_id != null; }
+      set { if (value == (_sticker_id== null)) _sticker_id = value ? this.sticker_id : (uint?)null; }
+    }
+    private bool ShouldSerializesticker_id() { return sticker_idSpecified; }
+    private void Resetsticker_id() { sticker_idSpecified = false; }
+    
 
-    private float _wear = default(float);
+    private float? _wear;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"wear", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float wear
     {
-      get { return _wear; }
+      get { return _wear?? default(float); }
       set { _wear = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wearSpecified
+    {
+      get { return _wear != null; }
+      set { if (value == (_wear== null)) _wear = value ? this.wear : (float?)null; }
+    }
+    private bool ShouldSerializewear() { return wearSpecified; }
+    private void Resetwear() { wearSpecified = false; }
+    
 
-    private float _scale = default(float);
+    private float? _scale;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"scale", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scale
     {
-      get { return _scale; }
+      get { return _scale?? default(float); }
       set { _scale = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaleSpecified
+    {
+      get { return _scale != null; }
+      set { if (value == (_scale== null)) _scale = value ? this.scale : (float?)null; }
+    }
+    private bool ShouldSerializescale() { return scaleSpecified; }
+    private void Resetscale() { scaleSpecified = false; }
+    
 
-    private float _rotation = default(float);
+    private float? _rotation;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rotation", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float rotation
     {
-      get { return _rotation; }
+      get { return _rotation?? default(float); }
       set { _rotation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rotationSpecified
+    {
+      get { return _rotation != null; }
+      set { if (value == (_rotation== null)) _rotation = value ? this.rotation : (float?)null; }
+    }
+    private bool ShouldSerializerotation() { return rotationSpecified; }
+    private void Resetrotation() { rotationSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4228,41 +6966,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Client2GCEconPreviewDataBlockRequest() {}
     
 
-    private ulong _param_s = default(ulong);
+    private ulong? _param_s;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"param_s", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_s
     {
-      get { return _param_s; }
+      get { return _param_s?? default(ulong); }
       set { _param_s = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_sSpecified
+    {
+      get { return _param_s != null; }
+      set { if (value == (_param_s== null)) _param_s = value ? this.param_s : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_s() { return param_sSpecified; }
+    private void Resetparam_s() { param_sSpecified = false; }
+    
 
-    private ulong _param_a = default(ulong);
+    private ulong? _param_a;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"param_a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_a
     {
-      get { return _param_a; }
+      get { return _param_a?? default(ulong); }
       set { _param_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_aSpecified
+    {
+      get { return _param_a != null; }
+      set { if (value == (_param_a== null)) _param_a = value ? this.param_a : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_a() { return param_aSpecified; }
+    private void Resetparam_a() { param_aSpecified = false; }
+    
 
-    private ulong _param_d = default(ulong);
+    private ulong? _param_d;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"param_d", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_d
     {
-      get { return _param_d; }
+      get { return _param_d?? default(ulong); }
       set { _param_d = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_dSpecified
+    {
+      get { return _param_d != null; }
+      set { if (value == (_param_d== null)) _param_d = value ? this.param_d : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_d() { return param_dSpecified; }
+    private void Resetparam_d() { param_dSpecified = false; }
+    
 
-    private ulong _param_m = default(ulong);
+    private ulong? _param_m;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"param_m", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_m
     {
-      get { return _param_m; }
+      get { return _param_m?? default(ulong); }
       set { _param_m = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_mSpecified
+    {
+      get { return _param_m != null; }
+      set { if (value == (_param_m== null)) _param_m = value ? this.param_m : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_m() { return param_mSpecified; }
+    private void Resetparam_m() { param_mSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4293,23 +7067,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_TournamentMatchRewardDropsNotification() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _defindex = default(uint);
+    private uint? _defindex;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"defindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint defindex
     {
-      get { return _defindex; }
+      get { return _defindex?? default(uint); }
       set { _defindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool defindexSpecified
+    {
+      get { return _defindex != null; }
+      set { if (value == (_defindex== null)) _defindex = value ? this.defindex : (uint?)null; }
+    }
+    private bool ShouldSerializedefindex() { return defindexSpecified; }
+    private void Resetdefindex() { defindexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _accountids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"accountids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> accountids
@@ -4338,14 +7130,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchListRequestLiveGameForUser() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4357,14 +7158,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchListRequestRecentUserGames() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4376,14 +7186,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchListRequestTournamentGames() {}
     
 
-    private int _eventid = default(int);
+    private int? _eventid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eventid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int eventid
     {
-      get { return _eventid; }
+      get { return _eventid?? default(int); }
       set { _eventid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventidSpecified
+    {
+      get { return _eventid != null; }
+      set { if (value == (_eventid== null)) _eventid = value ? this.eventid : (int?)null; }
+    }
+    private bool ShouldSerializeeventid() { return eventidSpecified; }
+    private void Reseteventid() { eventidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4395,32 +7214,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchListRequestFullGameInfo() {}
     
 
-    private ulong _matchid = default(ulong);
+    private ulong? _matchid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong matchid
     {
-      get { return _matchid; }
+      get { return _matchid?? default(ulong); }
       set { _matchid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchidSpecified
+    {
+      get { return _matchid != null; }
+      set { if (value == (_matchid== null)) _matchid = value ? this.matchid : (ulong?)null; }
+    }
+    private bool ShouldSerializematchid() { return matchidSpecified; }
+    private void Resetmatchid() { matchidSpecified = false; }
+    
 
-    private ulong _outcomeid = default(ulong);
+    private ulong? _outcomeid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"outcomeid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong outcomeid
     {
-      get { return _outcomeid; }
+      get { return _outcomeid?? default(ulong); }
       set { _outcomeid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool outcomeidSpecified
+    {
+      get { return _outcomeid != null; }
+      set { if (value == (_outcomeid== null)) _outcomeid = value ? this.outcomeid : (ulong?)null; }
+    }
+    private bool ShouldSerializeoutcomeid() { return outcomeidSpecified; }
+    private void Resetoutcomeid() { outcomeidSpecified = false; }
+    
 
-    private uint _token = default(uint);
+    private uint? _token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint token
     {
-      get { return _token; }
+      get { return _token?? default(uint); }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (uint?)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4432,23 +7278,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CDataGCCStrike15_v2_MatchInfo() {}
     
 
-    private ulong _matchid = default(ulong);
+    private ulong? _matchid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong matchid
     {
-      get { return _matchid; }
+      get { return _matchid?? default(ulong); }
       set { _matchid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchidSpecified
+    {
+      get { return _matchid != null; }
+      set { if (value == (_matchid== null)) _matchid = value ? this.matchid : (ulong?)null; }
+    }
+    private bool ShouldSerializematchid() { return matchidSpecified; }
+    private void Resetmatchid() { matchidSpecified = false; }
+    
 
-    private uint _matchtime = default(uint);
+    private uint? _matchtime;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matchtime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchtime
     {
-      get { return _matchtime; }
+      get { return _matchtime?? default(uint); }
       set { _matchtime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchtimeSpecified
+    {
+      get { return _matchtime != null; }
+      set { if (value == (_matchtime== null)) _matchtime = value ? this.matchtime : (uint?)null; }
+    }
+    private bool ShouldSerializematchtime() { return matchtimeSpecified; }
+    private void Resetmatchtime() { matchtimeSpecified = false; }
+    
 
     private WatchableMatchInfo _watchablematchinfo = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"watchablematchinfo", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -4485,32 +7349,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CDataGCCStrike15_v2_TournamentGroupTeam() {}
     
 
-    private int _team_id = default(int);
+    private int? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(int); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (int?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private int _score = default(int);
+    private int? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int score
     {
-      get { return _score; }
+      get { return _score?? default(int); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (int?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private bool _correctpick = default(bool);
+    private bool? _correctpick;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"correctpick", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool correctpick
     {
-      get { return _correctpick; }
+      get { return _correctpick?? default(bool); }
       set { _correctpick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctpickSpecified
+    {
+      get { return _correctpick != null; }
+      set { if (value == (_correctpick== null)) _correctpick = value ? this.correctpick : (bool?)null; }
+    }
+    private bool ShouldSerializecorrectpick() { return correctpickSpecified; }
+    private void Resetcorrectpick() { correctpickSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4522,41 +7413,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CDataGCCStrike15_v2_TournamentGroup() {}
     
 
-    private uint _groupid = default(uint);
+    private uint? _groupid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(uint); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (uint?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _desc = "";
+    private string _desc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc
     {
-      get { return _desc; }
+      get { return _desc?? ""; }
       set { _desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descSpecified
+    {
+      get { return _desc != null; }
+      set { if (value == (_desc== null)) _desc = value ? this.desc : (string)null; }
+    }
+    private bool ShouldSerializedesc() { return descSpecified; }
+    private void Resetdesc() { descSpecified = false; }
+    
 
-    private uint _picks__deprecated = default(uint);
+    private uint? _picks__deprecated;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"picks__deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint picks__deprecated
     {
-      get { return _picks__deprecated; }
+      get { return _picks__deprecated?? default(uint); }
       set { _picks__deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool picks__deprecatedSpecified
+    {
+      get { return _picks__deprecated != null; }
+      set { if (value == (_picks__deprecated== null)) _picks__deprecated = value ? this.picks__deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializepicks__deprecated() { return picks__deprecatedSpecified; }
+    private void Resetpicks__deprecated() { picks__deprecatedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroupTeam> _teams = new global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroupTeam>();
     [global::ProtoBuf.ProtoMember(5, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroupTeam> teams
@@ -4572,32 +7499,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _picklockuntiltime = default(uint);
+    private uint? _picklockuntiltime;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"picklockuntiltime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint picklockuntiltime
     {
-      get { return _picklockuntiltime; }
+      get { return _picklockuntiltime?? default(uint); }
       set { _picklockuntiltime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool picklockuntiltimeSpecified
+    {
+      get { return _picklockuntiltime != null; }
+      set { if (value == (_picklockuntiltime== null)) _picklockuntiltime = value ? this.picklockuntiltime : (uint?)null; }
+    }
+    private bool ShouldSerializepicklockuntiltime() { return picklockuntiltimeSpecified; }
+    private void Resetpicklockuntiltime() { picklockuntiltimeSpecified = false; }
+    
 
-    private uint _pickableteams = default(uint);
+    private uint? _pickableteams;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"pickableteams", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pickableteams
     {
-      get { return _pickableteams; }
+      get { return _pickableteams?? default(uint); }
       set { _pickableteams = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickableteamsSpecified
+    {
+      get { return _pickableteams != null; }
+      set { if (value == (_pickableteams== null)) _pickableteams = value ? this.pickableteams : (uint?)null; }
+    }
+    private bool ShouldSerializepickableteams() { return pickableteamsSpecified; }
+    private void Resetpickableteams() { pickableteamsSpecified = false; }
+    
 
-    private uint _points_per_pick = default(uint);
+    private uint? _points_per_pick;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"points_per_pick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_per_pick
     {
-      get { return _points_per_pick; }
+      get { return _points_per_pick?? default(uint); }
       set { _points_per_pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_per_pickSpecified
+    {
+      get { return _points_per_pick != null; }
+      set { if (value == (_points_per_pick== null)) _points_per_pick = value ? this.points_per_pick : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_per_pick() { return points_per_pickSpecified; }
+    private void Resetpoints_per_pick() { points_per_pickSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup.Picks> _picks = new global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup.Picks>();
     [global::ProtoBuf.ProtoMember(10, Name=@"picks", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup.Picks> picks
@@ -4633,32 +7587,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CDataGCCStrike15_v2_TournamentSection() {}
     
 
-    private uint _sectionid = default(uint);
+    private uint? _sectionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sectionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sectionid
     {
-      get { return _sectionid; }
+      get { return _sectionid?? default(uint); }
       set { _sectionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sectionidSpecified
+    {
+      get { return _sectionid != null; }
+      set { if (value == (_sectionid== null)) _sectionid = value ? this.sectionid : (uint?)null; }
+    }
+    private bool ShouldSerializesectionid() { return sectionidSpecified; }
+    private void Resetsectionid() { sectionidSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _desc = "";
+    private string _desc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc
     {
-      get { return _desc; }
+      get { return _desc?? ""; }
       set { _desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descSpecified
+    {
+      get { return _desc != null; }
+      set { if (value == (_desc== null)) _desc = value ? this.desc : (string)null; }
+    }
+    private bool ShouldSerializedesc() { return descSpecified; }
+    private void Resetdesc() { descSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup> _groups = new global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup>();
     [global::ProtoBuf.ProtoMember(4, Name=@"groups", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDataGCCStrike15_v2_TournamentGroup> groups
@@ -4710,32 +7691,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_MatchList() {}
     
 
-    private uint _msgrequestid = default(uint);
+    private uint? _msgrequestid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msgrequestid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgrequestid
     {
-      get { return _msgrequestid; }
+      get { return _msgrequestid?? default(uint); }
       set { _msgrequestid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgrequestidSpecified
+    {
+      get { return _msgrequestid != null; }
+      set { if (value == (_msgrequestid== null)) _msgrequestid = value ? this.msgrequestid : (uint?)null; }
+    }
+    private bool ShouldSerializemsgrequestid() { return msgrequestidSpecified; }
+    private void Resetmsgrequestid() { msgrequestidSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _servertime = default(uint);
+    private uint? _servertime;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"servertime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint servertime
     {
-      get { return _servertime; }
+      get { return _servertime?? default(uint); }
       set { _servertime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool servertimeSpecified
+    {
+      get { return _servertime != null; }
+      set { if (value == (_servertime== null)) _servertime = value ? this.servertime : (uint?)null; }
+    }
+    private bool ShouldSerializeservertime() { return servertimeSpecified; }
+    private void Resetservertime() { servertimeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDataGCCStrike15_v2_MatchInfo> _matches = new global::System.Collections.Generic.List<CDataGCCStrike15_v2_MatchInfo>();
     [global::ProtoBuf.ProtoMember(4, Name=@"matches", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDataGCCStrike15_v2_MatchInfo> matches
@@ -4770,14 +7778,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Predictions() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Predictions.GroupMatchTeamPick> _group_match_team_picks = new global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Predictions.GroupMatchTeamPick>();
     [global::ProtoBuf.ProtoMember(2, Name=@"group_match_team_picks", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Predictions.GroupMatchTeamPick> group_match_team_picks
@@ -4791,50 +7808,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public GroupMatchTeamPick() {}
     
 
-    private int _sectionid = default(int);
+    private int? _sectionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sectionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int sectionid
     {
-      get { return _sectionid; }
+      get { return _sectionid?? default(int); }
       set { _sectionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sectionidSpecified
+    {
+      get { return _sectionid != null; }
+      set { if (value == (_sectionid== null)) _sectionid = value ? this.sectionid : (int?)null; }
+    }
+    private bool ShouldSerializesectionid() { return sectionidSpecified; }
+    private void Resetsectionid() { sectionidSpecified = false; }
+    
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
 
-    private int _index = default(int);
+    private int? _index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int index
     {
-      get { return _index; }
+      get { return _index?? default(int); }
       set { _index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool indexSpecified
+    {
+      get { return _index != null; }
+      set { if (value == (_index== null)) _index = value ? this.index : (int?)null; }
+    }
+    private bool ShouldSerializeindex() { return indexSpecified; }
+    private void Resetindex() { indexSpecified = false; }
+    
 
-    private int _teamid = default(int);
+    private int? _teamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"teamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int teamid
     {
-      get { return _teamid; }
+      get { return _teamid?? default(int); }
       set { _teamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamidSpecified
+    {
+      get { return _teamid != null; }
+      set { if (value == (_teamid== null)) _teamid = value ? this.teamid : (int?)null; }
+    }
+    private bool ShouldSerializeteamid() { return teamidSpecified; }
+    private void Resetteamid() { teamidSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4851,14 +7913,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Fantasy() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasyTeam> _teams = new global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasyTeam>();
     [global::ProtoBuf.ProtoMember(2, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasyTeam> teams
@@ -4872,32 +7943,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public FantasySlot() {}
     
 
-    private int _type = default(int);
+    private int? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type
     {
-      get { return _type; }
+      get { return _type?? default(int); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (int?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private int _pick = default(int);
+    private int? _pick;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int pick
     {
-      get { return _pick; }
+      get { return _pick?? default(int); }
       set { _pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickSpecified
+    {
+      get { return _pick != null; }
+      set { if (value == (_pick== null)) _pick = value ? this.pick : (int?)null; }
+    }
+    private bool ShouldSerializepick() { return pickSpecified; }
+    private void Resetpick() { pickSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4909,14 +8007,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public FantasyTeam() {}
     
 
-    private int _sectionid = default(int);
+    private int? _sectionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sectionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int sectionid
     {
-      get { return _sectionid; }
+      get { return _sectionid?? default(int); }
       set { _sectionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sectionidSpecified
+    {
+      get { return _sectionid != null; }
+      set { if (value == (_sectionid== null)) _sectionid = value ? this.sectionid : (int?)null; }
+    }
+    private bool ShouldSerializesectionid() { return sectionidSpecified; }
+    private void Resetsectionid() { sectionidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasySlot> _slots = new global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasySlot>();
     [global::ProtoBuf.ProtoMember(2, Name=@"slots", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCCStrike15_v2_Fantasy.FantasySlot> slots
@@ -4940,14 +8047,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CAttribute_String() {}
     
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4969,68 +8085,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgCStrike15Welcome() {}
     
 
-    private uint _store_item_hash = default(uint);
+    private uint? _store_item_hash;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"store_item_hash", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint store_item_hash
     {
-      get { return _store_item_hash; }
+      get { return _store_item_hash?? default(uint); }
       set { _store_item_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_item_hashSpecified
+    {
+      get { return _store_item_hash != null; }
+      set { if (value == (_store_item_hash== null)) _store_item_hash = value ? this.store_item_hash : (uint?)null; }
+    }
+    private bool ShouldSerializestore_item_hash() { return store_item_hashSpecified; }
+    private void Resetstore_item_hash() { store_item_hashSpecified = false; }
+    
 
-    private uint _timeplayedconsecutively = default(uint);
+    private uint? _timeplayedconsecutively;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"timeplayedconsecutively", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timeplayedconsecutively
     {
-      get { return _timeplayedconsecutively; }
+      get { return _timeplayedconsecutively?? default(uint); }
       set { _timeplayedconsecutively = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeplayedconsecutivelySpecified
+    {
+      get { return _timeplayedconsecutively != null; }
+      set { if (value == (_timeplayedconsecutively== null)) _timeplayedconsecutively = value ? this.timeplayedconsecutively : (uint?)null; }
+    }
+    private bool ShouldSerializetimeplayedconsecutively() { return timeplayedconsecutivelySpecified; }
+    private void Resettimeplayedconsecutively() { timeplayedconsecutivelySpecified = false; }
+    
 
-    private uint _time_first_played = default(uint);
+    private uint? _time_first_played;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"time_first_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_first_played
     {
-      get { return _time_first_played; }
+      get { return _time_first_played?? default(uint); }
       set { _time_first_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_first_playedSpecified
+    {
+      get { return _time_first_played != null; }
+      set { if (value == (_time_first_played== null)) _time_first_played = value ? this.time_first_played : (uint?)null; }
+    }
+    private bool ShouldSerializetime_first_played() { return time_first_playedSpecified; }
+    private void Resettime_first_played() { time_first_playedSpecified = false; }
+    
 
-    private uint _last_time_played = default(uint);
+    private uint? _last_time_played;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"last_time_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_played
     {
-      get { return _last_time_played; }
+      get { return _last_time_played?? default(uint); }
       set { _last_time_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_playedSpecified
+    {
+      get { return _last_time_played != null; }
+      set { if (value == (_last_time_played== null)) _last_time_played = value ? this.last_time_played : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_played() { return last_time_playedSpecified; }
+    private void Resetlast_time_played() { last_time_playedSpecified = false; }
+    
 
-    private uint _last_ip_address = default(uint);
+    private uint? _last_ip_address;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"last_ip_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_ip_address
     {
-      get { return _last_ip_address; }
+      get { return _last_ip_address?? default(uint); }
       set { _last_ip_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_ip_addressSpecified
+    {
+      get { return _last_ip_address != null; }
+      set { if (value == (_last_ip_address== null)) _last_ip_address = value ? this.last_ip_address : (uint?)null; }
+    }
+    private bool ShouldSerializelast_ip_address() { return last_ip_addressSpecified; }
+    private void Resetlast_ip_address() { last_ip_addressSpecified = false; }
+    
 
-    private ulong _gscookieid = default(ulong);
+    private ulong? _gscookieid;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"gscookieid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gscookieid
     {
-      get { return _gscookieid; }
+      get { return _gscookieid?? default(ulong); }
       set { _gscookieid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gscookieidSpecified
+    {
+      get { return _gscookieid != null; }
+      set { if (value == (_gscookieid== null)) _gscookieid = value ? this.gscookieid : (ulong?)null; }
+    }
+    private bool ShouldSerializegscookieid() { return gscookieidSpecified; }
+    private void Resetgscookieid() { gscookieidSpecified = false; }
+    
 
-    private ulong _uniqueid = default(ulong);
+    private ulong? _uniqueid;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"uniqueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong uniqueid
     {
-      get { return _uniqueid; }
+      get { return _uniqueid?? default(ulong); }
       set { _uniqueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool uniqueidSpecified
+    {
+      get { return _uniqueid != null; }
+      set { if (value == (_uniqueid== null)) _uniqueid = value ? this.uniqueid : (ulong?)null; }
+    }
+    private bool ShouldSerializeuniqueid() { return uniqueidSpecified; }
+    private void Resetuniqueid() { uniqueidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5042,41 +8221,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientVarValueNotificationInfo() {}
     
 
-    private string _value_name = "";
+    private string _value_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"value_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value_name
     {
-      get { return _value_name; }
+      get { return _value_name?? ""; }
       set { _value_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_nameSpecified
+    {
+      get { return _value_name != null; }
+      set { if (value == (_value_name== null)) _value_name = value ? this.value_name : (string)null; }
+    }
+    private bool ShouldSerializevalue_name() { return value_nameSpecified; }
+    private void Resetvalue_name() { value_nameSpecified = false; }
+    
 
-    private int _value_int = default(int);
+    private int? _value_int;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value_int", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int value_int
     {
-      get { return _value_int; }
+      get { return _value_int?? default(int); }
       set { _value_int = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_intSpecified
+    {
+      get { return _value_int != null; }
+      set { if (value == (_value_int== null)) _value_int = value ? this.value_int : (int?)null; }
+    }
+    private bool ShouldSerializevalue_int() { return value_intSpecified; }
+    private void Resetvalue_int() { value_intSpecified = false; }
+    
 
-    private uint _server_addr = default(uint);
+    private uint? _server_addr;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_addr
     {
-      get { return _server_addr; }
+      get { return _server_addr?? default(uint); }
       set { _server_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addrSpecified
+    {
+      get { return _server_addr != null; }
+      set { if (value == (_server_addr== null)) _server_addr = value ? this.server_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_addr() { return server_addrSpecified; }
+    private void Resetserver_addr() { server_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _choked_blocks = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(5, Name=@"choked_blocks", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> choked_blocks
@@ -5095,14 +8310,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ServerVarValueNotificationInfo() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _viewangles = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"viewangles", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> viewangles
@@ -5111,14 +8335,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5140,41 +8373,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_GiftsLeaderboardResponse() {}
     
 
-    private uint _servertime = default(uint);
+    private uint? _servertime;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"servertime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint servertime
     {
-      get { return _servertime; }
+      get { return _servertime?? default(uint); }
       set { _servertime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool servertimeSpecified
+    {
+      get { return _servertime != null; }
+      set { if (value == (_servertime== null)) _servertime = value ? this.servertime : (uint?)null; }
+    }
+    private bool ShouldSerializeservertime() { return servertimeSpecified; }
+    private void Resetservertime() { servertimeSpecified = false; }
+    
 
-    private uint _time_period_seconds = default(uint);
+    private uint? _time_period_seconds;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_period_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_period_seconds
     {
-      get { return _time_period_seconds; }
+      get { return _time_period_seconds?? default(uint); }
       set { _time_period_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_period_secondsSpecified
+    {
+      get { return _time_period_seconds != null; }
+      set { if (value == (_time_period_seconds== null)) _time_period_seconds = value ? this.time_period_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializetime_period_seconds() { return time_period_secondsSpecified; }
+    private void Resettime_period_seconds() { time_period_secondsSpecified = false; }
+    
 
-    private uint _total_gifts_given = default(uint);
+    private uint? _total_gifts_given;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_gifts_given", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_gifts_given
     {
-      get { return _total_gifts_given; }
+      get { return _total_gifts_given?? default(uint); }
       set { _total_gifts_given = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_gifts_givenSpecified
+    {
+      get { return _total_gifts_given != null; }
+      set { if (value == (_total_gifts_given== null)) _total_gifts_given = value ? this.total_gifts_given : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_gifts_given() { return total_gifts_givenSpecified; }
+    private void Resettotal_gifts_given() { total_gifts_givenSpecified = false; }
+    
 
-    private uint _total_givers = default(uint);
+    private uint? _total_givers;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"total_givers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_givers
     {
-      get { return _total_givers; }
+      get { return _total_givers?? default(uint); }
       set { _total_givers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_giversSpecified
+    {
+      get { return _total_givers != null; }
+      set { if (value == (_total_givers== null)) _total_givers = value ? this.total_givers : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_givers() { return total_giversSpecified; }
+    private void Resettotal_givers() { total_giversSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCCStrike15_v2_GiftsLeaderboardResponse.GiftLeaderboardEntry> _entries = new global::System.Collections.Generic.List<CMsgGCCStrike15_v2_GiftsLeaderboardResponse.GiftLeaderboardEntry>();
     [global::ProtoBuf.ProtoMember(5, Name=@"entries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCCStrike15_v2_GiftsLeaderboardResponse.GiftLeaderboardEntry> entries
@@ -5188,23 +8457,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public GiftLeaderboardEntry() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _gifts = default(uint);
+    private uint? _gifts;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gifts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gifts
     {
-      get { return _gifts; }
+      get { return _gifts?? default(uint); }
       set { _gifts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool giftsSpecified
+    {
+      get { return _gifts != null; }
+      set { if (value == (_gifts== null)) _gifts = value ? this.gifts : (uint?)null; }
+    }
+    private bool ShouldSerializegifts() { return giftsSpecified; }
+    private void Resetgifts() { giftsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5221,23 +8508,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientSubmitSurveyVote() {}
     
 
-    private uint _survey_id = default(uint);
+    private uint? _survey_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"survey_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint survey_id
     {
-      get { return _survey_id; }
+      get { return _survey_id?? default(uint); }
       set { _survey_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_idSpecified
+    {
+      get { return _survey_id != null; }
+      set { if (value == (_survey_id== null)) _survey_id = value ? this.survey_id : (uint?)null; }
+    }
+    private bool ShouldSerializesurvey_id() { return survey_idSpecified; }
+    private void Resetsurvey_id() { survey_idSpecified = false; }
+    
 
-    private uint _vote = default(uint);
+    private uint? _vote;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote
     {
-      get { return _vote; }
+      get { return _vote?? default(uint); }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (uint?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5249,14 +8554,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Server2GCClientValidate() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5268,77 +8582,149 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Server2GCPureServerValidationFailure() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private string _path = "";
+    private string _path;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string path
     {
-      get { return _path; }
+      get { return _path?? ""; }
       set { _path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pathSpecified
+    {
+      get { return _path != null; }
+      set { if (value == (_path== null)) _path = value ? this.path : (string)null; }
+    }
+    private bool ShouldSerializepath() { return pathSpecified; }
+    private void Resetpath() { pathSpecified = false; }
+    
 
-    private string _file = "";
+    private string _file;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file
     {
-      get { return _file; }
+      get { return _file?? ""; }
       set { _file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fileSpecified
+    {
+      get { return _file != null; }
+      set { if (value == (_file== null)) _file = value ? this.file : (string)null; }
+    }
+    private bool ShouldSerializefile() { return fileSpecified; }
+    private void Resetfile() { fileSpecified = false; }
+    
 
-    private uint _crc = default(uint);
+    private uint? _crc;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc
     {
-      get { return _crc; }
+      get { return _crc?? default(uint); }
       set { _crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crcSpecified
+    {
+      get { return _crc != null; }
+      set { if (value == (_crc== null)) _crc = value ? this.crc : (uint?)null; }
+    }
+    private bool ShouldSerializecrc() { return crcSpecified; }
+    private void Resetcrc() { crcSpecified = false; }
+    
 
-    private int _hash = default(int);
+    private int? _hash;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"hash", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int hash
     {
-      get { return _hash; }
+      get { return _hash?? default(int); }
       set { _hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hashSpecified
+    {
+      get { return _hash != null; }
+      set { if (value == (_hash== null)) _hash = value ? this.hash : (int?)null; }
+    }
+    private bool ShouldSerializehash() { return hashSpecified; }
+    private void Resethash() { hashSpecified = false; }
+    
 
-    private int _len = default(int);
+    private int? _len;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"len", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int len
     {
-      get { return _len; }
+      get { return _len?? default(int); }
       set { _len = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lenSpecified
+    {
+      get { return _len != null; }
+      set { if (value == (_len== null)) _len = value ? this.len : (int?)null; }
+    }
+    private bool ShouldSerializelen() { return lenSpecified; }
+    private void Resetlen() { lenSpecified = false; }
+    
 
-    private int _pack_number = default(int);
+    private int? _pack_number;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"pack_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int pack_number
     {
-      get { return _pack_number; }
+      get { return _pack_number?? default(int); }
       set { _pack_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pack_numberSpecified
+    {
+      get { return _pack_number != null; }
+      set { if (value == (_pack_number== null)) _pack_number = value ? this.pack_number : (int?)null; }
+    }
+    private bool ShouldSerializepack_number() { return pack_numberSpecified; }
+    private void Resetpack_number() { pack_numberSpecified = false; }
+    
 
-    private int _pack_file_id = default(int);
+    private int? _pack_file_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"pack_file_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int pack_file_id
     {
-      get { return _pack_file_id; }
+      get { return _pack_file_id?? default(int); }
       set { _pack_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pack_file_idSpecified
+    {
+      get { return _pack_file_id != null; }
+      set { if (value == (_pack_file_id== null)) _pack_file_id = value ? this.pack_file_id : (int?)null; }
+    }
+    private bool ShouldSerializepack_file_id() { return pack_file_idSpecified; }
+    private void Resetpack_file_id() { pack_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5350,32 +8736,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_GC2ClientTournamentInfo() {}
     
 
-    private uint _eventid = default(uint);
+    private uint? _eventid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eventid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eventid
     {
-      get { return _eventid; }
+      get { return _eventid?? default(uint); }
       set { _eventid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventidSpecified
+    {
+      get { return _eventid != null; }
+      set { if (value == (_eventid== null)) _eventid = value ? this.eventid : (uint?)null; }
+    }
+    private bool ShouldSerializeeventid() { return eventidSpecified; }
+    private void Reseteventid() { eventidSpecified = false; }
+    
 
-    private uint _stageid = default(uint);
+    private uint? _stageid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stageid
     {
-      get { return _stageid; }
+      get { return _stageid?? default(uint); }
       set { _stageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stageidSpecified
+    {
+      get { return _stageid != null; }
+      set { if (value == (_stageid== null)) _stageid = value ? this.stageid : (uint?)null; }
+    }
+    private bool ShouldSerializestageid() { return stageidSpecified; }
+    private void Resetstageid() { stageidSpecified = false; }
+    
 
-    private uint _game_type = default(uint);
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? default(uint); }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _teamids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"teamids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> teamids
@@ -5394,32 +8807,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconCoupon() {}
     
 
-    private uint _entryid = default(uint);
+    private uint? _entryid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"entryid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint entryid
     {
-      get { return _entryid; }
+      get { return _entryid?? default(uint); }
       set { _entryid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool entryidSpecified
+    {
+      get { return _entryid != null; }
+      set { if (value == (_entryid== null)) _entryid = value ? this.entryid : (uint?)null; }
+    }
+    private bool ShouldSerializeentryid() { return entryidSpecified; }
+    private void Resetentryid() { entryidSpecified = false; }
+    
 
-    private uint _defidx = default(uint);
+    private uint? _defidx;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint defidx
     {
-      get { return _defidx; }
+      get { return _defidx?? default(uint); }
       set { _defidx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool defidxSpecified
+    {
+      get { return _defidx != null; }
+      set { if (value == (_defidx== null)) _defidx = value ? this.defidx : (uint?)null; }
+    }
+    private bool ShouldSerializedefidx() { return defidxSpecified; }
+    private void Resetdefidx() { defidxSpecified = false; }
+    
 
-    private uint _expiration_date = default(uint);
+    private uint? _expiration_date;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expiration_date", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_date
     {
-      get { return _expiration_date; }
+      get { return _expiration_date?? default(uint); }
       set { _expiration_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_dateSpecified
+    {
+      get { return _expiration_date != null; }
+      set { if (value == (_expiration_date== null)) _expiration_date = value ? this.expiration_date : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_date() { return expiration_dateSpecified; }
+    private void Resetexpiration_date() { expiration_dateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5431,32 +8871,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOQuestProgress() {}
     
 
-    private uint _questid = default(uint);
+    private uint? _questid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"questid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint questid
     {
-      get { return _questid; }
+      get { return _questid?? default(uint); }
       set { _questid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool questidSpecified
+    {
+      get { return _questid != null; }
+      set { if (value == (_questid== null)) _questid = value ? this.questid : (uint?)null; }
+    }
+    private bool ShouldSerializequestid() { return questidSpecified; }
+    private void Resetquestid() { questidSpecified = false; }
+    
 
-    private uint _points_remaining = default(uint);
+    private uint? _points_remaining;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_remaining
     {
-      get { return _points_remaining; }
+      get { return _points_remaining?? default(uint); }
       set { _points_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_remainingSpecified
+    {
+      get { return _points_remaining != null; }
+      set { if (value == (_points_remaining== null)) _points_remaining = value ? this.points_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_remaining() { return points_remainingSpecified; }
+    private void Resetpoints_remaining() { points_remainingSpecified = false; }
+    
 
-    private uint _bonus_points = default(uint);
+    private uint? _bonus_points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bonus_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_points
     {
-      get { return _bonus_points; }
+      get { return _bonus_points?? default(uint); }
       set { _bonus_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_pointsSpecified
+    {
+      get { return _bonus_points != null; }
+      set { if (value == (_bonus_points== null)) _bonus_points = value ? this.bonus_points : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_points() { return bonus_pointsSpecified; }
+    private void Resetbonus_points() { bonus_pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5468,14 +8935,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOPersonaDataPublic() {}
     
 
-    private int _player_level = default(int);
+    private int? _player_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int player_level
     {
-      get { return _player_level; }
+      get { return _player_level?? default(int); }
       set { _player_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_levelSpecified
+    {
+      get { return _player_level != null; }
+      set { if (value == (_player_level== null)) _player_level = value ? this.player_level : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_level() { return player_levelSpecified; }
+    private void Resetplayer_level() { player_levelSpecified = false; }
+    
 
     private PlayerCommendationInfo _commendation = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"commendation", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -5486,14 +8962,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _commendation = value; }
     }
 
-    private bool _elevated_state = default(bool);
+    private bool? _elevated_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"elevated_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool elevated_state
     {
-      get { return _elevated_state; }
+      get { return _elevated_state?? default(bool); }
       set { _elevated_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool elevated_stateSpecified
+    {
+      get { return _elevated_state != null; }
+      set { if (value == (_elevated_state== null)) _elevated_state = value ? this.elevated_state : (bool?)null; }
+    }
+    private bool ShouldSerializeelevated_state() { return elevated_stateSpecified; }
+    private void Resetelevated_state() { elevated_stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5505,14 +8990,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGC_GlobalGame_Subscribe() {}
     
 
-    private ulong _ticket = default(ulong);
+    private ulong? _ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? default(ulong); }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (ulong?)null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5524,14 +9018,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGC_GlobalGame_Unsubscribe() {}
     
 
-    private int _timeleft = default(int);
+    private int? _timeleft;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timeleft", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int timeleft
     {
-      get { return _timeleft; }
+      get { return _timeleft?? default(int); }
       set { _timeleft = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeleftSpecified
+    {
+      get { return _timeleft != null; }
+      set { if (value == (_timeleft== null)) _timeleft = value ? this.timeleft : (int?)null; }
+    }
+    private bool ShouldSerializetimeleft() { return timeleftSpecified; }
+    private void Resettimeleft() { timeleftSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5543,32 +9046,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGC_GlobalGame_Play() {}
     
 
-    private ulong _ticket = default(ulong);
+    private ulong? _ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? default(ulong); }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (ulong?)null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
 
-    private uint _gametimems = default(uint);
+    private uint? _gametimems;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gametimems", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gametimems
     {
-      get { return _gametimems; }
+      get { return _gametimems?? default(uint); }
       set { _gametimems = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gametimemsSpecified
+    {
+      get { return _gametimems != null; }
+      set { if (value == (_gametimems== null)) _gametimems = value ? this.gametimems : (uint?)null; }
+    }
+    private bool ShouldSerializegametimems() { return gametimemsSpecified; }
+    private void Resetgametimems() { gametimemsSpecified = false; }
+    
 
-    private uint _msperpoint = default(uint);
+    private uint? _msperpoint;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"msperpoint", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msperpoint
     {
-      get { return _msperpoint; }
+      get { return _msperpoint?? default(uint); }
       set { _msperpoint = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msperpointSpecified
+    {
+      get { return _msperpoint != null; }
+      set { if (value == (_msperpoint== null)) _msperpoint = value ? this.msperpoint : (uint?)null; }
+    }
+    private bool ShouldSerializemsperpoint() { return msperpointSpecified; }
+    private void Resetmsperpoint() { msperpointSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5580,14 +9110,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_AcknowledgePenalty() {}
     
 
-    private int _acknowledged = default(int);
+    private int? _acknowledged;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"acknowledged", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int acknowledged
     {
-      get { return _acknowledged; }
+      get { return _acknowledged?? default(int); }
       set { _acknowledged = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acknowledgedSpecified
+    {
+      get { return _acknowledged != null; }
+      set { if (value == (_acknowledged== null)) _acknowledged = value ? this.acknowledged : (int?)null; }
+    }
+    private bool ShouldSerializeacknowledged() { return acknowledgedSpecified; }
+    private void Resetacknowledged() { acknowledgedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5609,23 +9148,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_Client2GCStreamUnlock() {}
     
 
-    private ulong _ticket = default(ulong);
+    private ulong? _ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? default(ulong); }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (ulong?)null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
 
-    private int _os = default(int);
+    private int? _os;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"os", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int os
     {
-      get { return _os; }
+      get { return _os?? default(int); }
       set { _os = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool osSpecified
+    {
+      get { return _os != null; }
+      set { if (value == (_os== null)) _os = value ? this.os : (int?)null; }
+    }
+    private bool ShouldSerializeos() { return osSpecified; }
+    private void Resetos() { osSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5637,14 +9194,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientToGCRequestElevate() {}
     
 
-    private uint _stage = default(uint);
+    private uint? _stage;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stage
     {
-      get { return _stage; }
+      get { return _stage?? default(uint); }
       set { _stage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stageSpecified
+    {
+      get { return _stage != null; }
+      set { if (value == (_stage== null)) _stage = value ? this.stage : (uint?)null; }
+    }
+    private bool ShouldSerializestage() { return stageSpecified; }
+    private void Resetstage() { stageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5656,23 +9222,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_ClientToGCChat() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5684,23 +9268,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCStrike15_v2_GCToClientChat() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgBase.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,95 +20,185 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgProtoBufHeader() {}
     
 
-    private ulong _client_steam_id = default(ulong);
+    private ulong? _client_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_steam_id
     {
-      get { return _client_steam_id; }
+      get { return _client_steam_id?? default(ulong); }
       set { _client_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_steam_idSpecified
+    {
+      get { return _client_steam_id != null; }
+      set { if (value == (_client_steam_id== null)) _client_steam_id = value ? this.client_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_steam_id() { return client_steam_idSpecified; }
+    private void Resetclient_steam_id() { client_steam_idSpecified = false; }
+    
 
-    private int _client_session_id = default(int);
+    private int? _client_session_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int client_session_id
     {
-      get { return _client_session_id; }
+      get { return _client_session_id?? default(int); }
       set { _client_session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_idSpecified
+    {
+      get { return _client_session_id != null; }
+      set { if (value == (_client_session_id== null)) _client_session_id = value ? this.client_session_id : (int?)null; }
+    }
+    private bool ShouldSerializeclient_session_id() { return client_session_idSpecified; }
+    private void Resetclient_session_id() { client_session_idSpecified = false; }
+    
 
-    private uint _source_app_id = default(uint);
+    private uint? _source_app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_app_id
     {
-      get { return _source_app_id; }
+      get { return _source_app_id?? default(uint); }
       set { _source_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_app_idSpecified
+    {
+      get { return _source_app_id != null; }
+      set { if (value == (_source_app_id== null)) _source_app_id = value ? this.source_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializesource_app_id() { return source_app_idSpecified; }
+    private void Resetsource_app_id() { source_app_idSpecified = false; }
+    
 
-    private ulong _job_id_source = (ulong)18446744073709551615;
+    private ulong? _job_id_source;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"job_id_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_source
     {
-      get { return _job_id_source; }
+      get { return _job_id_source?? (ulong)18446744073709551615; }
       set { _job_id_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_sourceSpecified
+    {
+      get { return _job_id_source != null; }
+      set { if (value == (_job_id_source== null)) _job_id_source = value ? this.job_id_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_source() { return job_id_sourceSpecified; }
+    private void Resetjob_id_source() { job_id_sourceSpecified = false; }
+    
 
-    private ulong _job_id_target = (ulong)18446744073709551615;
+    private ulong? _job_id_target;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"job_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_target
     {
-      get { return _job_id_target; }
+      get { return _job_id_target?? (ulong)18446744073709551615; }
       set { _job_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_targetSpecified
+    {
+      get { return _job_id_target != null; }
+      set { if (value == (_job_id_target== null)) _job_id_target = value ? this.job_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_target() { return job_id_targetSpecified; }
+    private void Resetjob_id_target() { job_id_targetSpecified = false; }
+    
 
-    private string _target_job_name = "";
+    private string _target_job_name;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"target_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string target_job_name
     {
-      get { return _target_job_name; }
+      get { return _target_job_name?? ""; }
       set { _target_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_job_nameSpecified
+    {
+      get { return _target_job_name != null; }
+      set { if (value == (_target_job_name== null)) _target_job_name = value ? this.target_job_name : (string)null; }
+    }
+    private bool ShouldSerializetarget_job_name() { return target_job_nameSpecified; }
+    private void Resettarget_job_name() { target_job_nameSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
 
-    private GCProtoBufMsgSrc _gc_msg_src = GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified;
+    private GCProtoBufMsgSrc? _gc_msg_src;
     [global::ProtoBuf.ProtoMember(200, IsRequired = false, Name=@"gc_msg_src", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified)]
     public GCProtoBufMsgSrc gc_msg_src
     {
-      get { return _gc_msg_src; }
+      get { return _gc_msg_src?? GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified; }
       set { _gc_msg_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_msg_srcSpecified
+    {
+      get { return _gc_msg_src != null; }
+      set { if (value == (_gc_msg_src== null)) _gc_msg_src = value ? this.gc_msg_src : (GCProtoBufMsgSrc?)null; }
+    }
+    private bool ShouldSerializegc_msg_src() { return gc_msg_srcSpecified; }
+    private void Resetgc_msg_src() { gc_msg_srcSpecified = false; }
+    
 
-    private uint _gc_dir_index_source = default(uint);
+    private uint? _gc_dir_index_source;
     [global::ProtoBuf.ProtoMember(201, IsRequired = false, Name=@"gc_dir_index_source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_dir_index_source
     {
-      get { return _gc_dir_index_source; }
+      get { return _gc_dir_index_source?? default(uint); }
       set { _gc_dir_index_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_dir_index_sourceSpecified
+    {
+      get { return _gc_dir_index_source != null; }
+      set { if (value == (_gc_dir_index_source== null)) _gc_dir_index_source = value ? this.gc_dir_index_source : (uint?)null; }
+    }
+    private bool ShouldSerializegc_dir_index_source() { return gc_dir_index_sourceSpecified; }
+    private void Resetgc_dir_index_source() { gc_dir_index_sourceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -118,50 +210,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgWebAPIKey() {}
     
 
-    private uint _status = (uint)255;
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)255)]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? (uint)255; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _account_id = (uint)0;
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? (uint)0; }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _publisher_group_id = (uint)0;
+    private uint? _publisher_group_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"publisher_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint publisher_group_id
     {
-      get { return _publisher_group_id; }
+      get { return _publisher_group_id?? (uint)0; }
       set { _publisher_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publisher_group_idSpecified
+    {
+      get { return _publisher_group_id != null; }
+      set { if (value == (_publisher_group_id== null)) _publisher_group_id = value ? this.publisher_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializepublisher_group_id() { return publisher_group_idSpecified; }
+    private void Resetpublisher_group_id() { publisher_group_idSpecified = false; }
+    
 
-    private uint _key_id = default(uint);
+    private uint? _key_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"key_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint key_id
     {
-      get { return _key_id; }
+      get { return _key_id?? default(uint); }
       set { _key_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_idSpecified
+    {
+      get { return _key_id != null; }
+      set { if (value == (_key_id== null)) _key_id = value ? this.key_id : (uint?)null; }
+    }
+    private bool ShouldSerializekey_id() { return key_idSpecified; }
+    private void Resetkey_id() { key_idSpecified = false; }
+    
 
-    private string _domain = "";
+    private string _domain;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"domain", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string domain
     {
-      get { return _domain; }
+      get { return _domain?? ""; }
       set { _domain = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool domainSpecified
+    {
+      get { return _domain != null; }
+      set { if (value == (_domain== null)) _domain = value ? this.domain : (string)null; }
+    }
+    private bool ShouldSerializedomain() { return domainSpecified; }
+    private void Resetdomain() { domainSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,32 +310,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgHttpRequest() {}
     
 
-    private uint _request_method = default(uint);
+    private uint? _request_method;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_method
     {
-      get { return _request_method; }
+      get { return _request_method?? default(uint); }
       set { _request_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_methodSpecified
+    {
+      get { return _request_method != null; }
+      set { if (value == (_request_method== null)) _request_method = value ? this.request_method : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_method() { return request_methodSpecified; }
+    private void Resetrequest_method() { request_methodSpecified = false; }
+    
 
-    private string _hostname = "";
+    private string _hostname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hostname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string hostname
     {
-      get { return _hostname; }
+      get { return _hostname?? ""; }
       set { _hostname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hostnameSpecified
+    {
+      get { return _hostname != null; }
+      set { if (value == (_hostname== null)) _hostname = value ? this.hostname : (string)null; }
+    }
+    private bool ShouldSerializehostname() { return hostnameSpecified; }
+    private void Resethostname() { hostnameSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader>();
     [global::ProtoBuf.ProtoMember(4, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> headers
@@ -221,46 +385,82 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
 
-    private uint _absolute_timeout = default(uint);
+    private uint? _absolute_timeout;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"absolute_timeout", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint absolute_timeout
     {
-      get { return _absolute_timeout; }
+      get { return _absolute_timeout?? default(uint); }
       set { _absolute_timeout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool absolute_timeoutSpecified
+    {
+      get { return _absolute_timeout != null; }
+      set { if (value == (_absolute_timeout== null)) _absolute_timeout = value ? this.absolute_timeout : (uint?)null; }
+    }
+    private bool ShouldSerializeabsolute_timeout() { return absolute_timeoutSpecified; }
+    private void Resetabsolute_timeout() { absolute_timeoutSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"RequestHeader")]
   public partial class RequestHeader : global::ProtoBuf.IExtensible
   {
     public RequestHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -272,23 +472,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public QueryParam() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -305,41 +523,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgWebAPIRequest() {}
     
 
-    private string _UNUSED_job_name = "";
+    private string _UNUSED_job_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"UNUSED_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string UNUSED_job_name
     {
-      get { return _UNUSED_job_name; }
+      get { return _UNUSED_job_name?? ""; }
       set { _UNUSED_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool UNUSED_job_nameSpecified
+    {
+      get { return _UNUSED_job_name != null; }
+      set { if (value == (_UNUSED_job_name== null)) _UNUSED_job_name = value ? this.UNUSED_job_name : (string)null; }
+    }
+    private bool ShouldSerializeUNUSED_job_name() { return UNUSED_job_nameSpecified; }
+    private void ResetUNUSED_job_name() { UNUSED_job_nameSpecified = false; }
+    
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgWebAPIKey _api_key = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"api_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -359,14 +613,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _request = value; }
     }
 
-    private uint _routing_app_id = default(uint);
+    private uint? _routing_app_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"routing_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint routing_app_id
     {
-      get { return _routing_app_id; }
+      get { return _routing_app_id?? default(uint); }
       set { _routing_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_app_idSpecified
+    {
+      get { return _routing_app_id != null; }
+      set { if (value == (_routing_app_id== null)) _routing_app_id = value ? this.routing_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializerouting_app_id() { return routing_app_idSpecified; }
+    private void Resetrouting_app_id() { routing_app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -378,14 +641,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgHttpResponse() {}
     
 
-    private uint _status_code = default(uint);
+    private uint? _status_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_code
     {
-      get { return _status_code; }
+      get { return _status_code?? default(uint); }
       set { _status_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_codeSpecified
+    {
+      get { return _status_code != null; }
+      set { if (value == (_status_code== null)) _status_code = value ? this.status_code : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_code() { return status_codeSpecified; }
+    private void Resetstatus_code() { status_codeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader>();
     [global::ProtoBuf.ProtoMember(2, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> headers
@@ -394,37 +666,64 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ResponseHeader")]
   public partial class ResponseHeader : global::ProtoBuf.IExtensible
   {
     public ResponseHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -441,23 +740,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMFindAccounts() {}
     
 
-    private uint _search_type = default(uint);
+    private uint? _search_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_type
     {
-      get { return _search_type; }
+      get { return _search_type?? default(uint); }
       set { _search_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_typeSpecified
+    {
+      get { return _search_type != null; }
+      set { if (value == (_search_type== null)) _search_type = value ? this.search_type : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_type() { return search_typeSpecified; }
+    private void Resetsearch_type() { search_typeSpecified = false; }
+    
 
-    private string _search_string = "";
+    private string _search_string;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"search_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_string
     {
-      get { return _search_string; }
+      get { return _search_string?? ""; }
       set { _search_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_stringSpecified
+    {
+      get { return _search_string != null; }
+      set { if (value == (_search_string== null)) _search_string = value ? this.search_string : (string)null; }
+    }
+    private bool ShouldSerializesearch_string() { return search_stringSpecified; }
+    private void Resetsearch_string() { search_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -486,68 +803,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgNotifyWatchdog() {}
     
 
-    private uint _source = default(uint);
+    private uint? _source;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source
     {
-      get { return _source; }
+      get { return _source?? default(uint); }
       set { _source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sourceSpecified
+    {
+      get { return _source != null; }
+      set { if (value == (_source== null)) _source = value ? this.source : (uint?)null; }
+    }
+    private bool ShouldSerializesource() { return sourceSpecified; }
+    private void Resetsource() { sourceSpecified = false; }
+    
 
-    private uint _alert_type = default(uint);
+    private uint? _alert_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"alert_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint alert_type
     {
-      get { return _alert_type; }
+      get { return _alert_type?? default(uint); }
       set { _alert_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool alert_typeSpecified
+    {
+      get { return _alert_type != null; }
+      set { if (value == (_alert_type== null)) _alert_type = value ? this.alert_type : (uint?)null; }
+    }
+    private bool ShouldSerializealert_type() { return alert_typeSpecified; }
+    private void Resetalert_type() { alert_typeSpecified = false; }
+    
 
-    private uint _alert_destination = default(uint);
+    private uint? _alert_destination;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"alert_destination", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint alert_destination
     {
-      get { return _alert_destination; }
+      get { return _alert_destination?? default(uint); }
       set { _alert_destination = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool alert_destinationSpecified
+    {
+      get { return _alert_destination != null; }
+      set { if (value == (_alert_destination== null)) _alert_destination = value ? this.alert_destination : (uint?)null; }
+    }
+    private bool ShouldSerializealert_destination() { return alert_destinationSpecified; }
+    private void Resetalert_destination() { alert_destinationSpecified = false; }
+    
 
-    private bool _critical = default(bool);
+    private bool? _critical;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"critical", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool critical
     {
-      get { return _critical; }
+      get { return _critical?? default(bool); }
       set { _critical = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool criticalSpecified
+    {
+      get { return _critical != null; }
+      set { if (value == (_critical== null)) _critical = value ? this.critical : (bool?)null; }
+    }
+    private bool ShouldSerializecritical() { return criticalSpecified; }
+    private void Resetcritical() { criticalSpecified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -559,14 +939,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMGetLicenses() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -578,32 +967,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgPackageLicense() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -622,14 +1038,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -641,23 +1066,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMGetUserGameStats() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _stats = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> stats
@@ -676,32 +1119,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMGetUserGameStatsResponse() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> _stats = new global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats>();
     [global::ProtoBuf.ProtoMember(4, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> stats
@@ -722,23 +1192,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -750,32 +1238,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public Achievement_Blocks() {}
     
 
-    private uint _achievement_id = default(uint);
+    private uint? _achievement_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"achievement_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_id
     {
-      get { return _achievement_id; }
+      get { return _achievement_id?? default(uint); }
       set { _achievement_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_idSpecified
+    {
+      get { return _achievement_id != null; }
+      set { if (value == (_achievement_id== null)) _achievement_id = value ? this.achievement_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_id() { return achievement_idSpecified; }
+    private void Resetachievement_id() { achievement_idSpecified = false; }
+    
 
-    private uint _achievement_bit_id = default(uint);
+    private uint? _achievement_bit_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"achievement_bit_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_bit_id
     {
-      get { return _achievement_bit_id; }
+      get { return _achievement_bit_id?? default(uint); }
       set { _achievement_bit_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_bit_idSpecified
+    {
+      get { return _achievement_bit_id != null; }
+      set { if (value == (_achievement_bit_id== null)) _achievement_bit_id = value ? this.achievement_bit_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_bit_id() { return achievement_bit_idSpecified; }
+    private void Resetachievement_bit_id() { achievement_bit_idSpecified = false; }
+    
 
-    private uint _unlock_time = default(uint);
+    private uint? _unlock_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"unlock_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unlock_time
     {
-      get { return _unlock_time; }
+      get { return _unlock_time?? default(uint); }
       set { _unlock_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unlock_timeSpecified
+    {
+      get { return _unlock_time != null; }
+      set { if (value == (_unlock_time== null)) _unlock_time = value ? this.unlock_time : (uint?)null; }
+    }
+    private bool ShouldSerializeunlock_time() { return unlock_timeSpecified; }
+    private void Resetunlock_time() { unlock_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -792,23 +1307,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGetCommandList() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _command_prefix = "";
+    private string _command_prefix;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"command_prefix", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_prefix
     {
-      get { return _command_prefix; }
+      get { return _command_prefix?? ""; }
       set { _command_prefix = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_prefixSpecified
+    {
+      get { return _command_prefix != null; }
+      set { if (value == (_command_prefix== null)) _command_prefix = value ? this.command_prefix : (string)null; }
+    }
+    private bool ShouldSerializecommand_prefix() { return command_prefixSpecified; }
+    private void Resetcommand_prefix() { command_prefixSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -866,23 +1399,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public ValueTag() {}
     
 
-    private bool _found = default(bool);
+    private bool? _found;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"found", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found
     {
-      get { return _found; }
+      get { return _found?? default(bool); }
       set { _found = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool foundSpecified
+    {
+      get { return _found != null; }
+      set { if (value == (_found== null)) _found = value ? this.found : (bool?)null; }
+    }
+    private bool ShouldSerializefound() { return foundSpecified; }
+    private void Resetfound() { foundSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -911,23 +1462,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public KeyPair() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -971,131 +1540,257 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCMsgMemCachedStatsResponse() {}
     
 
-    private ulong _curr_connections = default(ulong);
+    private ulong? _curr_connections;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"curr_connections", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_connections
     {
-      get { return _curr_connections; }
+      get { return _curr_connections?? default(ulong); }
       set { _curr_connections = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_connectionsSpecified
+    {
+      get { return _curr_connections != null; }
+      set { if (value == (_curr_connections== null)) _curr_connections = value ? this.curr_connections : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_connections() { return curr_connectionsSpecified; }
+    private void Resetcurr_connections() { curr_connectionsSpecified = false; }
+    
 
-    private ulong _cmd_get = default(ulong);
+    private ulong? _cmd_get;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cmd_get", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_get
     {
-      get { return _cmd_get; }
+      get { return _cmd_get?? default(ulong); }
       set { _cmd_get = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_getSpecified
+    {
+      get { return _cmd_get != null; }
+      set { if (value == (_cmd_get== null)) _cmd_get = value ? this.cmd_get : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_get() { return cmd_getSpecified; }
+    private void Resetcmd_get() { cmd_getSpecified = false; }
+    
 
-    private ulong _cmd_set = default(ulong);
+    private ulong? _cmd_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cmd_set", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_set
     {
-      get { return _cmd_set; }
+      get { return _cmd_set?? default(ulong); }
       set { _cmd_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_setSpecified
+    {
+      get { return _cmd_set != null; }
+      set { if (value == (_cmd_set== null)) _cmd_set = value ? this.cmd_set : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_set() { return cmd_setSpecified; }
+    private void Resetcmd_set() { cmd_setSpecified = false; }
+    
 
-    private ulong _cmd_flush = default(ulong);
+    private ulong? _cmd_flush;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cmd_flush", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_flush
     {
-      get { return _cmd_flush; }
+      get { return _cmd_flush?? default(ulong); }
       set { _cmd_flush = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_flushSpecified
+    {
+      get { return _cmd_flush != null; }
+      set { if (value == (_cmd_flush== null)) _cmd_flush = value ? this.cmd_flush : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_flush() { return cmd_flushSpecified; }
+    private void Resetcmd_flush() { cmd_flushSpecified = false; }
+    
 
-    private ulong _get_hits = default(ulong);
+    private ulong? _get_hits;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"get_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_hits
     {
-      get { return _get_hits; }
+      get { return _get_hits?? default(ulong); }
       set { _get_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_hitsSpecified
+    {
+      get { return _get_hits != null; }
+      set { if (value == (_get_hits== null)) _get_hits = value ? this.get_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_hits() { return get_hitsSpecified; }
+    private void Resetget_hits() { get_hitsSpecified = false; }
+    
 
-    private ulong _get_misses = default(ulong);
+    private ulong? _get_misses;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"get_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_misses
     {
-      get { return _get_misses; }
+      get { return _get_misses?? default(ulong); }
       set { _get_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_missesSpecified
+    {
+      get { return _get_misses != null; }
+      set { if (value == (_get_misses== null)) _get_misses = value ? this.get_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_misses() { return get_missesSpecified; }
+    private void Resetget_misses() { get_missesSpecified = false; }
+    
 
-    private ulong _delete_hits = default(ulong);
+    private ulong? _delete_hits;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"delete_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_hits
     {
-      get { return _delete_hits; }
+      get { return _delete_hits?? default(ulong); }
       set { _delete_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_hitsSpecified
+    {
+      get { return _delete_hits != null; }
+      set { if (value == (_delete_hits== null)) _delete_hits = value ? this.delete_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_hits() { return delete_hitsSpecified; }
+    private void Resetdelete_hits() { delete_hitsSpecified = false; }
+    
 
-    private ulong _delete_misses = default(ulong);
+    private ulong? _delete_misses;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"delete_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_misses
     {
-      get { return _delete_misses; }
+      get { return _delete_misses?? default(ulong); }
       set { _delete_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_missesSpecified
+    {
+      get { return _delete_misses != null; }
+      set { if (value == (_delete_misses== null)) _delete_misses = value ? this.delete_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_misses() { return delete_missesSpecified; }
+    private void Resetdelete_misses() { delete_missesSpecified = false; }
+    
 
-    private ulong _bytes_read = default(ulong);
+    private ulong? _bytes_read;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"bytes_read", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_read
     {
-      get { return _bytes_read; }
+      get { return _bytes_read?? default(ulong); }
       set { _bytes_read = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_readSpecified
+    {
+      get { return _bytes_read != null; }
+      set { if (value == (_bytes_read== null)) _bytes_read = value ? this.bytes_read : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_read() { return bytes_readSpecified; }
+    private void Resetbytes_read() { bytes_readSpecified = false; }
+    
 
-    private ulong _bytes_written = default(ulong);
+    private ulong? _bytes_written;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"bytes_written", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_written
     {
-      get { return _bytes_written; }
+      get { return _bytes_written?? default(ulong); }
       set { _bytes_written = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_writtenSpecified
+    {
+      get { return _bytes_written != null; }
+      set { if (value == (_bytes_written== null)) _bytes_written = value ? this.bytes_written : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_written() { return bytes_writtenSpecified; }
+    private void Resetbytes_written() { bytes_writtenSpecified = false; }
+    
 
-    private ulong _limit_maxbytes = default(ulong);
+    private ulong? _limit_maxbytes;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"limit_maxbytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong limit_maxbytes
     {
-      get { return _limit_maxbytes; }
+      get { return _limit_maxbytes?? default(ulong); }
       set { _limit_maxbytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool limit_maxbytesSpecified
+    {
+      get { return _limit_maxbytes != null; }
+      set { if (value == (_limit_maxbytes== null)) _limit_maxbytes = value ? this.limit_maxbytes : (ulong?)null; }
+    }
+    private bool ShouldSerializelimit_maxbytes() { return limit_maxbytesSpecified; }
+    private void Resetlimit_maxbytes() { limit_maxbytesSpecified = false; }
+    
 
-    private ulong _curr_items = default(ulong);
+    private ulong? _curr_items;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"curr_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_items
     {
-      get { return _curr_items; }
+      get { return _curr_items?? default(ulong); }
       set { _curr_items = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_itemsSpecified
+    {
+      get { return _curr_items != null; }
+      set { if (value == (_curr_items== null)) _curr_items = value ? this.curr_items : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_items() { return curr_itemsSpecified; }
+    private void Resetcurr_items() { curr_itemsSpecified = false; }
+    
 
-    private ulong _evictions = default(ulong);
+    private ulong? _evictions;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"evictions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong evictions
     {
-      get { return _evictions; }
+      get { return _evictions?? default(ulong); }
       set { _evictions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool evictionsSpecified
+    {
+      get { return _evictions != null; }
+      set { if (value == (_evictions== null)) _evictions = value ? this.evictions : (ulong?)null; }
+    }
+    private bool ShouldSerializeevictions() { return evictionsSpecified; }
+    private void Resetevictions() { evictionsSpecified = false; }
+    
 
-    private ulong _bytes = default(ulong);
+    private ulong? _bytes;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes
     {
-      get { return _bytes; }
+      get { return _bytes?? default(ulong); }
       set { _bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytesSpecified
+    {
+      get { return _bytes != null; }
+      set { if (value == (_bytes== null)) _bytes = value ? this.bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes() { return bytesSpecified; }
+    private void Resetbytes() { bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1107,14 +1802,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCMsgSQLStats() {}
     
 
-    private uint _schema_catalog = default(uint);
+    private uint? _schema_catalog;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"schema_catalog", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint schema_catalog
     {
-      get { return _schema_catalog; }
+      get { return _schema_catalog?? default(uint); }
       set { _schema_catalog = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_catalogSpecified
+    {
+      get { return _schema_catalog != null; }
+      set { if (value == (_schema_catalog== null)) _schema_catalog = value ? this.schema_catalog : (uint?)null; }
+    }
+    private bool ShouldSerializeschema_catalog() { return schema_catalogSpecified; }
+    private void Resetschema_catalog() { schema_catalogSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1126,86 +1830,167 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCMsgSQLStatsResponse() {}
     
 
-    private uint _threads = default(uint);
+    private uint? _threads;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"threads", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads
     {
-      get { return _threads; }
+      get { return _threads?? default(uint); }
       set { _threads = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threadsSpecified
+    {
+      get { return _threads != null; }
+      set { if (value == (_threads== null)) _threads = value ? this.threads : (uint?)null; }
+    }
+    private bool ShouldSerializethreads() { return threadsSpecified; }
+    private void Resetthreads() { threadsSpecified = false; }
+    
 
-    private uint _threads_connected = default(uint);
+    private uint? _threads_connected;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"threads_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_connected
     {
-      get { return _threads_connected; }
+      get { return _threads_connected?? default(uint); }
       set { _threads_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_connectedSpecified
+    {
+      get { return _threads_connected != null; }
+      set { if (value == (_threads_connected== null)) _threads_connected = value ? this.threads_connected : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_connected() { return threads_connectedSpecified; }
+    private void Resetthreads_connected() { threads_connectedSpecified = false; }
+    
 
-    private uint _threads_active = default(uint);
+    private uint? _threads_active;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"threads_active", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_active
     {
-      get { return _threads_active; }
+      get { return _threads_active?? default(uint); }
       set { _threads_active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_activeSpecified
+    {
+      get { return _threads_active != null; }
+      set { if (value == (_threads_active== null)) _threads_active = value ? this.threads_active : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_active() { return threads_activeSpecified; }
+    private void Resetthreads_active() { threads_activeSpecified = false; }
+    
 
-    private uint _operations_submitted = default(uint);
+    private uint? _operations_submitted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"operations_submitted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_submitted
     {
-      get { return _operations_submitted; }
+      get { return _operations_submitted?? default(uint); }
       set { _operations_submitted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_submittedSpecified
+    {
+      get { return _operations_submitted != null; }
+      set { if (value == (_operations_submitted== null)) _operations_submitted = value ? this.operations_submitted : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_submitted() { return operations_submittedSpecified; }
+    private void Resetoperations_submitted() { operations_submittedSpecified = false; }
+    
 
-    private uint _prepared_statements_executed = default(uint);
+    private uint? _prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prepared_statements_executed
     {
-      get { return _prepared_statements_executed; }
+      get { return _prepared_statements_executed?? default(uint); }
       set { _prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prepared_statements_executedSpecified
+    {
+      get { return _prepared_statements_executed != null; }
+      set { if (value == (_prepared_statements_executed== null)) _prepared_statements_executed = value ? this.prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializeprepared_statements_executed() { return prepared_statements_executedSpecified; }
+    private void Resetprepared_statements_executed() { prepared_statements_executedSpecified = false; }
+    
 
-    private uint _non_prepared_statements_executed = default(uint);
+    private uint? _non_prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"non_prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint non_prepared_statements_executed
     {
-      get { return _non_prepared_statements_executed; }
+      get { return _non_prepared_statements_executed?? default(uint); }
       set { _non_prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool non_prepared_statements_executedSpecified
+    {
+      get { return _non_prepared_statements_executed != null; }
+      set { if (value == (_non_prepared_statements_executed== null)) _non_prepared_statements_executed = value ? this.non_prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializenon_prepared_statements_executed() { return non_prepared_statements_executedSpecified; }
+    private void Resetnon_prepared_statements_executed() { non_prepared_statements_executedSpecified = false; }
+    
 
-    private uint _deadlock_retries = default(uint);
+    private uint? _deadlock_retries;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deadlock_retries", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deadlock_retries
     {
-      get { return _deadlock_retries; }
+      get { return _deadlock_retries?? default(uint); }
       set { _deadlock_retries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deadlock_retriesSpecified
+    {
+      get { return _deadlock_retries != null; }
+      set { if (value == (_deadlock_retries== null)) _deadlock_retries = value ? this.deadlock_retries : (uint?)null; }
+    }
+    private bool ShouldSerializedeadlock_retries() { return deadlock_retriesSpecified; }
+    private void Resetdeadlock_retries() { deadlock_retriesSpecified = false; }
+    
 
-    private uint _operations_timed_out_in_queue = default(uint);
+    private uint? _operations_timed_out_in_queue;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"operations_timed_out_in_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_timed_out_in_queue
     {
-      get { return _operations_timed_out_in_queue; }
+      get { return _operations_timed_out_in_queue?? default(uint); }
       set { _operations_timed_out_in_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_timed_out_in_queueSpecified
+    {
+      get { return _operations_timed_out_in_queue != null; }
+      set { if (value == (_operations_timed_out_in_queue== null)) _operations_timed_out_in_queue = value ? this.operations_timed_out_in_queue : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_timed_out_in_queue() { return operations_timed_out_in_queueSpecified; }
+    private void Resetoperations_timed_out_in_queue() { operations_timed_out_in_queueSpecified = false; }
+    
 
-    private uint _errors = default(uint);
+    private uint? _errors;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"errors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint errors
     {
-      get { return _errors; }
+      get { return _errors?? default(uint); }
       set { _errors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorsSpecified
+    {
+      get { return _errors != null; }
+      set { if (value == (_errors== null)) _errors = value ? this.errors : (uint?)null; }
+    }
+    private bool ShouldSerializeerrors() { return errorsSpecified; }
+    private void Reseterrors() { errorsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1217,41 +2002,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMAddFreeLicense() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip_public = default(uint);
+    private uint? _ip_public;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip_public", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip_public
     {
-      get { return _ip_public; }
+      get { return _ip_public?? default(uint); }
       set { _ip_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_publicSpecified
+    {
+      get { return _ip_public != null; }
+      set { if (value == (_ip_public== null)) _ip_public = value ? this.ip_public : (uint?)null; }
+    }
+    private bool ShouldSerializeip_public() { return ip_publicSpecified; }
+    private void Resetip_public() { ip_publicSpecified = false; }
+    
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private string _store_country_code = "";
+    private string _store_country_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"store_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string store_country_code
     {
-      get { return _store_country_code; }
+      get { return _store_country_code?? ""; }
       set { _store_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_country_codeSpecified
+    {
+      get { return _store_country_code != null; }
+      set { if (value == (_store_country_code== null)) _store_country_code = value ? this.store_country_code : (string)null; }
+    }
+    private bool ShouldSerializestore_country_code() { return store_country_codeSpecified; }
+    private void Resetstore_country_code() { store_country_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1263,32 +2084,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMAddFreeLicenseResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _purchase_result_detail = default(int);
+    private int? _purchase_result_detail;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"purchase_result_detail", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int purchase_result_detail
     {
-      get { return _purchase_result_detail; }
+      get { return _purchase_result_detail?? default(int); }
       set { _purchase_result_detail = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_result_detailSpecified
+    {
+      get { return _purchase_result_detail != null; }
+      set { if (value == (_purchase_result_detail== null)) _purchase_result_detail = value ? this.purchase_result_detail : (int?)null; }
+    }
+    private bool ShouldSerializepurchase_result_detail() { return purchase_result_detailSpecified; }
+    private void Resetpurchase_result_detail() { purchase_result_detailSpecified = false; }
+    
 
-    private ulong _transid = default(ulong);
+    private ulong? _transid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"transid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong transid
     {
-      get { return _transid; }
+      get { return _transid?? default(ulong); }
       set { _transid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transidSpecified
+    {
+      get { return _transid != null; }
+      set { if (value == (_transid== null)) _transid = value ? this.transid : (ulong?)null; }
+    }
+    private bool ShouldSerializetransid() { return transidSpecified; }
+    private void Resettransid() { transidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1317,59 +2165,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public CIPLocationInfo() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private float _latitude = default(float);
+    private float? _latitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float latitude
     {
-      get { return _latitude; }
+      get { return _latitude?? default(float); }
       set { _latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latitudeSpecified
+    {
+      get { return _latitude != null; }
+      set { if (value == (_latitude== null)) _latitude = value ? this.latitude : (float?)null; }
+    }
+    private bool ShouldSerializelatitude() { return latitudeSpecified; }
+    private void Resetlatitude() { latitudeSpecified = false; }
+    
 
-    private float _longitude = default(float);
+    private float? _longitude;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float longitude
     {
-      get { return _longitude; }
+      get { return _longitude?? default(float); }
       set { _longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool longitudeSpecified
+    {
+      get { return _longitude != null; }
+      set { if (value == (_longitude== null)) _longitude = value ? this.longitude : (float?)null; }
+    }
+    private bool ShouldSerializelongitude() { return longitudeSpecified; }
+    private void Resetlongitude() { longitudeSpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private string _state = "";
+    private string _state;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string state
     {
-      get { return _state; }
+      get { return _state?? ""; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (string)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _city = "";
+    private string _city;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"city", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string city
     {
-      get { return _city; }
+      get { return _city?? ""; }
       set { _city = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool citySpecified
+    {
+      get { return _city != null; }
+      set { if (value == (_city== null)) _city = value ? this.city : (string)null; }
+    }
+    private bool ShouldSerializecity() { return citySpecified; }
+    private void Resetcity() { citySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1398,23 +2300,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCMsgSystemStatsSchema() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _schema_kv = null;
+    private byte[] _schema_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"schema_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] schema_kv
     {
-      get { return _schema_kv; }
+      get { return _schema_kv?? null; }
       set { _schema_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_kvSpecified
+    {
+      get { return _schema_kv != null; }
+      set { if (value == (_schema_kv== null)) _schema_kv = value ? this.schema_kv : (byte[])null; }
+    }
+    private bool ShouldSerializeschema_kv() { return schema_kvSpecified; }
+    private void Resetschema_kv() { schema_kvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1436,122 +2356,239 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCMsgGetSystemStatsResponse() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _stats_kv = null;
+    private byte[] _stats_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stats_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] stats_kv
     {
-      get { return _stats_kv; }
+      get { return _stats_kv?? null; }
       set { _stats_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_kvSpecified
+    {
+      get { return _stats_kv != null; }
+      set { if (value == (_stats_kv== null)) _stats_kv = value ? this.stats_kv : (byte[])null; }
+    }
+    private bool ShouldSerializestats_kv() { return stats_kvSpecified; }
+    private void Resetstats_kv() { stats_kvSpecified = false; }
+    
 
-    private uint _active_jobs = default(uint);
+    private uint? _active_jobs;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"active_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_jobs
     {
-      get { return _active_jobs; }
+      get { return _active_jobs?? default(uint); }
       set { _active_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_jobsSpecified
+    {
+      get { return _active_jobs != null; }
+      set { if (value == (_active_jobs== null)) _active_jobs = value ? this.active_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_jobs() { return active_jobsSpecified; }
+    private void Resetactive_jobs() { active_jobsSpecified = false; }
+    
 
-    private uint _yielding_jobs = default(uint);
+    private uint? _yielding_jobs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"yielding_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint yielding_jobs
     {
-      get { return _yielding_jobs; }
+      get { return _yielding_jobs?? default(uint); }
       set { _yielding_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool yielding_jobsSpecified
+    {
+      get { return _yielding_jobs != null; }
+      set { if (value == (_yielding_jobs== null)) _yielding_jobs = value ? this.yielding_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeyielding_jobs() { return yielding_jobsSpecified; }
+    private void Resetyielding_jobs() { yielding_jobsSpecified = false; }
+    
 
-    private uint _user_sessions = default(uint);
+    private uint? _user_sessions;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"user_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_sessions
     {
-      get { return _user_sessions; }
+      get { return _user_sessions?? default(uint); }
       set { _user_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_sessionsSpecified
+    {
+      get { return _user_sessions != null; }
+      set { if (value == (_user_sessions== null)) _user_sessions = value ? this.user_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_sessions() { return user_sessionsSpecified; }
+    private void Resetuser_sessions() { user_sessionsSpecified = false; }
+    
 
-    private uint _game_server_sessions = default(uint);
+    private uint? _game_server_sessions;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_server_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_sessions
     {
-      get { return _game_server_sessions; }
+      get { return _game_server_sessions?? default(uint); }
       set { _game_server_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_sessionsSpecified
+    {
+      get { return _game_server_sessions != null; }
+      set { if (value == (_game_server_sessions== null)) _game_server_sessions = value ? this.game_server_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_sessions() { return game_server_sessionsSpecified; }
+    private void Resetgame_server_sessions() { game_server_sessionsSpecified = false; }
+    
 
-    private uint _socaches = default(uint);
+    private uint? _socaches;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"socaches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches
     {
-      get { return _socaches; }
+      get { return _socaches?? default(uint); }
       set { _socaches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socachesSpecified
+    {
+      get { return _socaches != null; }
+      set { if (value == (_socaches== null)) _socaches = value ? this.socaches : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches() { return socachesSpecified; }
+    private void Resetsocaches() { socachesSpecified = false; }
+    
 
-    private uint _socaches_to_unload = default(uint);
+    private uint? _socaches_to_unload;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"socaches_to_unload", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_to_unload
     {
-      get { return _socaches_to_unload; }
+      get { return _socaches_to_unload?? default(uint); }
       set { _socaches_to_unload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_to_unloadSpecified
+    {
+      get { return _socaches_to_unload != null; }
+      set { if (value == (_socaches_to_unload== null)) _socaches_to_unload = value ? this.socaches_to_unload : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_to_unload() { return socaches_to_unloadSpecified; }
+    private void Resetsocaches_to_unload() { socaches_to_unloadSpecified = false; }
+    
 
-    private uint _socaches_loading = default(uint);
+    private uint? _socaches_loading;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"socaches_loading", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_loading
     {
-      get { return _socaches_loading; }
+      get { return _socaches_loading?? default(uint); }
       set { _socaches_loading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_loadingSpecified
+    {
+      get { return _socaches_loading != null; }
+      set { if (value == (_socaches_loading== null)) _socaches_loading = value ? this.socaches_loading : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_loading() { return socaches_loadingSpecified; }
+    private void Resetsocaches_loading() { socaches_loadingSpecified = false; }
+    
 
-    private uint _writeback_queue = default(uint);
+    private uint? _writeback_queue;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"writeback_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint writeback_queue
     {
-      get { return _writeback_queue; }
+      get { return _writeback_queue?? default(uint); }
       set { _writeback_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool writeback_queueSpecified
+    {
+      get { return _writeback_queue != null; }
+      set { if (value == (_writeback_queue== null)) _writeback_queue = value ? this.writeback_queue : (uint?)null; }
+    }
+    private bool ShouldSerializewriteback_queue() { return writeback_queueSpecified; }
+    private void Resetwriteback_queue() { writeback_queueSpecified = false; }
+    
 
-    private uint _steamid_locks = default(uint);
+    private uint? _steamid_locks;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"steamid_locks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamid_locks
     {
-      get { return _steamid_locks; }
+      get { return _steamid_locks?? default(uint); }
       set { _steamid_locks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_locksSpecified
+    {
+      get { return _steamid_locks != null; }
+      set { if (value == (_steamid_locks== null)) _steamid_locks = value ? this.steamid_locks : (uint?)null; }
+    }
+    private bool ShouldSerializesteamid_locks() { return steamid_locksSpecified; }
+    private void Resetsteamid_locks() { steamid_locksSpecified = false; }
+    
 
-    private uint _logon_queue = default(uint);
+    private uint? _logon_queue;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"logon_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_queue
     {
-      get { return _logon_queue; }
+      get { return _logon_queue?? default(uint); }
       set { _logon_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_queueSpecified
+    {
+      get { return _logon_queue != null; }
+      set { if (value == (_logon_queue== null)) _logon_queue = value ? this.logon_queue : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_queue() { return logon_queueSpecified; }
+    private void Resetlogon_queue() { logon_queueSpecified = false; }
+    
 
-    private uint _logon_jobs = default(uint);
+    private uint? _logon_jobs;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"logon_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_jobs
     {
-      get { return _logon_jobs; }
+      get { return _logon_jobs?? default(uint); }
       set { _logon_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_jobsSpecified
+    {
+      get { return _logon_jobs != null; }
+      set { if (value == (_logon_jobs== null)) _logon_jobs = value ? this.logon_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_jobs() { return logon_jobsSpecified; }
+    private void Resetlogon_jobs() { logon_jobsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1563,32 +2600,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMSendEmail() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private uint _email_format = default(uint);
+    private uint? _email_format;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(uint); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> _persona_name_tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken>();
     [global::ProtoBuf.ProtoMember(5, Name=@"persona_name_tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> persona_name_tokens
@@ -1597,14 +2661,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _source_gc = default(uint);
+    private uint? _source_gc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"source_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_gc
     {
-      get { return _source_gc; }
+      get { return _source_gc?? default(uint); }
       set { _source_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_gcSpecified
+    {
+      get { return _source_gc != null; }
+      set { if (value == (_source_gc== null)) _source_gc = value ? this.source_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesource_gc() { return source_gcSpecified; }
+    private void Resetsource_gc() { source_gcSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> _tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken>();
     [global::ProtoBuf.ProtoMember(7, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> tokens
@@ -1618,23 +2691,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public ReplacementToken() {}
     
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
 
-    private string _token_value = "";
+    private string _token_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_value
     {
-      get { return _token_value; }
+      get { return _token_value?? ""; }
       set { _token_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_valueSpecified
+    {
+      get { return _token_value != null; }
+      set { if (value == (_token_value== null)) _token_value = value ? this.token_value : (string)null; }
+    }
+    private bool ShouldSerializetoken_value() { return token_valueSpecified; }
+    private void Resettoken_value() { token_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1646,23 +2737,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public PersonaNameReplacementToken() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1679,14 +2788,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMSendEmailResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1698,41 +2816,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGetEmailTemplate() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private int _email_lang = default(int);
+    private int? _email_lang;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_lang", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_lang
     {
-      get { return _email_lang; }
+      get { return _email_lang?? default(int); }
       set { _email_lang = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_langSpecified
+    {
+      get { return _email_lang != null; }
+      set { if (value == (_email_lang== null)) _email_lang = value ? this.email_lang : (int?)null; }
+    }
+    private bool ShouldSerializeemail_lang() { return email_langSpecified; }
+    private void Resetemail_lang() { email_langSpecified = false; }
+    
 
-    private int _email_format = default(int);
+    private int? _email_format;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(int); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (int?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1744,32 +2898,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGetEmailTemplateResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _template_exists = default(bool);
+    private bool? _template_exists;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"template_exists", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool template_exists
     {
-      get { return _template_exists; }
+      get { return _template_exists?? default(bool); }
       set { _template_exists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool template_existsSpecified
+    {
+      get { return _template_exists != null; }
+      set { if (value == (_template_exists== null)) _template_exists = value ? this.template_exists : (bool?)null; }
+    }
+    private bool ShouldSerializetemplate_exists() { return template_existsSpecified; }
+    private void Resettemplate_exists() { template_existsSpecified = false; }
+    
 
-    private string _template = "";
+    private string _template;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"template", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string template
     {
-      get { return _template; }
+      get { return _template?? ""; }
       set { _template = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool templateSpecified
+    {
+      get { return _template != null; }
+      set { if (value == (_template== null)) _template = value ? this.template : (string)null; }
+    }
+    private bool ShouldSerializetemplate() { return templateSpecified; }
+    private void Resettemplate() { templateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1781,50 +2962,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMGrantGuestPasses2() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private int _passes_to_grant = default(int);
+    private int? _passes_to_grant;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"passes_to_grant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int passes_to_grant
     {
-      get { return _passes_to_grant; }
+      get { return _passes_to_grant?? default(int); }
       set { _passes_to_grant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_to_grantSpecified
+    {
+      get { return _passes_to_grant != null; }
+      set { if (value == (_passes_to_grant== null)) _passes_to_grant = value ? this.passes_to_grant : (int?)null; }
+    }
+    private bool ShouldSerializepasses_to_grant() { return passes_to_grantSpecified; }
+    private void Resetpasses_to_grant() { passes_to_grantSpecified = false; }
+    
 
-    private int _days_to_expiration = default(int);
+    private int? _days_to_expiration;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"days_to_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int days_to_expiration
     {
-      get { return _days_to_expiration; }
+      get { return _days_to_expiration?? default(int); }
       set { _days_to_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool days_to_expirationSpecified
+    {
+      get { return _days_to_expiration != null; }
+      set { if (value == (_days_to_expiration== null)) _days_to_expiration = value ? this.days_to_expiration : (int?)null; }
+    }
+    private bool ShouldSerializedays_to_expiration() { return days_to_expirationSpecified; }
+    private void Resetdays_to_expiration() { days_to_expirationSpecified = false; }
+    
 
-    private int _action = default(int);
+    private int? _action;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int action
     {
-      get { return _action; }
+      get { return _action?? default(int); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (int?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1836,23 +3062,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAMGrantGuestPasses2Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _passes_granted = (int)0;
+    private int? _passes_granted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"passes_granted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int passes_granted
     {
-      get { return _passes_granted; }
+      get { return _passes_granted?? (int)0; }
       set { _passes_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_grantedSpecified
+    {
+      get { return _passes_granted != null; }
+      set { if (value == (_passes_granted== null)) _passes_granted = value ? this.passes_granted : (int?)null; }
+    }
+    private bool ShouldSerializepasses_granted() { return passes_grantedSpecified; }
+    private void Resetpasses_granted() { passes_grantedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1864,23 +3108,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCSystemMsg_GetAccountDetails() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1892,284 +3154,563 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCSystemMsg_GetAccountDetails_Response() {}
     
 
-    private uint _eresult_deprecated = (uint)2;
+    private uint? _eresult_deprecated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult_deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult_deprecated
     {
-      get { return _eresult_deprecated; }
+      get { return _eresult_deprecated?? (uint)2; }
       set { _eresult_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_deprecatedSpecified
+    {
+      get { return _eresult_deprecated != null; }
+      set { if (value == (_eresult_deprecated== null)) _eresult_deprecated = value ? this.eresult_deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult_deprecated() { return eresult_deprecatedSpecified; }
+    private void Reseteresult_deprecated() { eresult_deprecatedSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private bool _is_profile_public = default(bool);
+    private bool? _is_profile_public;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_profile_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_profile_public
     {
-      get { return _is_profile_public; }
+      get { return _is_profile_public?? default(bool); }
       set { _is_profile_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_profile_publicSpecified
+    {
+      get { return _is_profile_public != null; }
+      set { if (value == (_is_profile_public== null)) _is_profile_public = value ? this.is_profile_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_profile_public() { return is_profile_publicSpecified; }
+    private void Resetis_profile_public() { is_profile_publicSpecified = false; }
+    
 
-    private bool _is_inventory_public = default(bool);
+    private bool? _is_inventory_public;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_inventory_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_inventory_public
     {
-      get { return _is_inventory_public; }
+      get { return _is_inventory_public?? default(bool); }
       set { _is_inventory_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_inventory_publicSpecified
+    {
+      get { return _is_inventory_public != null; }
+      set { if (value == (_is_inventory_public== null)) _is_inventory_public = value ? this.is_inventory_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_inventory_public() { return is_inventory_publicSpecified; }
+    private void Resetis_inventory_public() { is_inventory_publicSpecified = false; }
+    
 
-    private bool _is_vac_banned = default(bool);
+    private bool? _is_vac_banned;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_vac_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_vac_banned
     {
-      get { return _is_vac_banned; }
+      get { return _is_vac_banned?? default(bool); }
       set { _is_vac_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_vac_bannedSpecified
+    {
+      get { return _is_vac_banned != null; }
+      set { if (value == (_is_vac_banned== null)) _is_vac_banned = value ? this.is_vac_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_vac_banned() { return is_vac_bannedSpecified; }
+    private void Resetis_vac_banned() { is_vac_bannedSpecified = false; }
+    
 
-    private bool _is_cyber_cafe = default(bool);
+    private bool? _is_cyber_cafe;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_cyber_cafe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_cyber_cafe
     {
-      get { return _is_cyber_cafe; }
+      get { return _is_cyber_cafe?? default(bool); }
       set { _is_cyber_cafe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_cyber_cafeSpecified
+    {
+      get { return _is_cyber_cafe != null; }
+      set { if (value == (_is_cyber_cafe== null)) _is_cyber_cafe = value ? this.is_cyber_cafe : (bool?)null; }
+    }
+    private bool ShouldSerializeis_cyber_cafe() { return is_cyber_cafeSpecified; }
+    private void Resetis_cyber_cafe() { is_cyber_cafeSpecified = false; }
+    
 
-    private bool _is_school_account = default(bool);
+    private bool? _is_school_account;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_school_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_school_account
     {
-      get { return _is_school_account; }
+      get { return _is_school_account?? default(bool); }
       set { _is_school_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_school_accountSpecified
+    {
+      get { return _is_school_account != null; }
+      set { if (value == (_is_school_account== null)) _is_school_account = value ? this.is_school_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_school_account() { return is_school_accountSpecified; }
+    private void Resetis_school_account() { is_school_accountSpecified = false; }
+    
 
-    private bool _is_limited = default(bool);
+    private bool? _is_limited;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_limited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_limited
     {
-      get { return _is_limited; }
+      get { return _is_limited?? default(bool); }
       set { _is_limited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_limitedSpecified
+    {
+      get { return _is_limited != null; }
+      set { if (value == (_is_limited== null)) _is_limited = value ? this.is_limited : (bool?)null; }
+    }
+    private bool ShouldSerializeis_limited() { return is_limitedSpecified; }
+    private void Resetis_limited() { is_limitedSpecified = false; }
+    
 
-    private bool _is_subscribed = default(bool);
+    private bool? _is_subscribed;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_subscribed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_subscribed
     {
-      get { return _is_subscribed; }
+      get { return _is_subscribed?? default(bool); }
       set { _is_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_subscribedSpecified
+    {
+      get { return _is_subscribed != null; }
+      set { if (value == (_is_subscribed== null)) _is_subscribed = value ? this.is_subscribed : (bool?)null; }
+    }
+    private bool ShouldSerializeis_subscribed() { return is_subscribedSpecified; }
+    private void Resetis_subscribed() { is_subscribedSpecified = false; }
+    
 
-    private uint _package = default(uint);
+    private uint? _package;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"package", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package
     {
-      get { return _package; }
+      get { return _package?? default(uint); }
       set { _package = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageSpecified
+    {
+      get { return _package != null; }
+      set { if (value == (_package== null)) _package = value ? this.package : (uint?)null; }
+    }
+    private bool ShouldSerializepackage() { return packageSpecified; }
+    private void Resetpackage() { packageSpecified = false; }
+    
 
-    private bool _is_free_trial_account = default(bool);
+    private bool? _is_free_trial_account;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"is_free_trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_free_trial_account
     {
-      get { return _is_free_trial_account; }
+      get { return _is_free_trial_account?? default(bool); }
       set { _is_free_trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_free_trial_accountSpecified
+    {
+      get { return _is_free_trial_account != null; }
+      set { if (value == (_is_free_trial_account== null)) _is_free_trial_account = value ? this.is_free_trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_free_trial_account() { return is_free_trial_accountSpecified; }
+    private void Resetis_free_trial_account() { is_free_trial_accountSpecified = false; }
+    
 
-    private uint _free_trial_expiration = default(uint);
+    private uint? _free_trial_expiration;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"free_trial_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint free_trial_expiration
     {
-      get { return _free_trial_expiration; }
+      get { return _free_trial_expiration?? default(uint); }
       set { _free_trial_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool free_trial_expirationSpecified
+    {
+      get { return _free_trial_expiration != null; }
+      set { if (value == (_free_trial_expiration== null)) _free_trial_expiration = value ? this.free_trial_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializefree_trial_expiration() { return free_trial_expirationSpecified; }
+    private void Resetfree_trial_expiration() { free_trial_expirationSpecified = false; }
+    
 
-    private bool _is_low_violence = default(bool);
+    private bool? _is_low_violence;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"is_low_violence", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_low_violence
     {
-      get { return _is_low_violence; }
+      get { return _is_low_violence?? default(bool); }
       set { _is_low_violence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_low_violenceSpecified
+    {
+      get { return _is_low_violence != null; }
+      set { if (value == (_is_low_violence== null)) _is_low_violence = value ? this.is_low_violence : (bool?)null; }
+    }
+    private bool ShouldSerializeis_low_violence() { return is_low_violenceSpecified; }
+    private void Resetis_low_violence() { is_low_violenceSpecified = false; }
+    
 
-    private bool _is_account_locked_down = default(bool);
+    private bool? _is_account_locked_down;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"is_account_locked_down", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_account_locked_down
     {
-      get { return _is_account_locked_down; }
+      get { return _is_account_locked_down?? default(bool); }
       set { _is_account_locked_down = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_account_locked_downSpecified
+    {
+      get { return _is_account_locked_down != null; }
+      set { if (value == (_is_account_locked_down== null)) _is_account_locked_down = value ? this.is_account_locked_down : (bool?)null; }
+    }
+    private bool ShouldSerializeis_account_locked_down() { return is_account_locked_downSpecified; }
+    private void Resetis_account_locked_down() { is_account_locked_downSpecified = false; }
+    
 
-    private bool _is_community_banned = default(bool);
+    private bool? _is_community_banned;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"is_community_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_community_banned
     {
-      get { return _is_community_banned; }
+      get { return _is_community_banned?? default(bool); }
       set { _is_community_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_community_bannedSpecified
+    {
+      get { return _is_community_banned != null; }
+      set { if (value == (_is_community_banned== null)) _is_community_banned = value ? this.is_community_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_community_banned() { return is_community_bannedSpecified; }
+    private void Resetis_community_banned() { is_community_bannedSpecified = false; }
+    
 
-    private bool _is_trade_banned = default(bool);
+    private bool? _is_trade_banned;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"is_trade_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_trade_banned
     {
-      get { return _is_trade_banned; }
+      get { return _is_trade_banned?? default(bool); }
       set { _is_trade_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_trade_bannedSpecified
+    {
+      get { return _is_trade_banned != null; }
+      set { if (value == (_is_trade_banned== null)) _is_trade_banned = value ? this.is_trade_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_trade_banned() { return is_trade_bannedSpecified; }
+    private void Resetis_trade_banned() { is_trade_bannedSpecified = false; }
+    
 
-    private uint _trade_ban_expiration = default(uint);
+    private uint? _trade_ban_expiration;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"trade_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_expiration
     {
-      get { return _trade_ban_expiration; }
+      get { return _trade_ban_expiration?? default(uint); }
       set { _trade_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_expirationSpecified
+    {
+      get { return _trade_ban_expiration != null; }
+      set { if (value == (_trade_ban_expiration== null)) _trade_ban_expiration = value ? this.trade_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_expiration() { return trade_ban_expirationSpecified; }
+    private void Resettrade_ban_expiration() { trade_ban_expirationSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _suspension_end_time = default(uint);
+    private uint? _suspension_end_time;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"suspension_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suspension_end_time
     {
-      get { return _suspension_end_time; }
+      get { return _suspension_end_time?? default(uint); }
       set { _suspension_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suspension_end_timeSpecified
+    {
+      get { return _suspension_end_time != null; }
+      set { if (value == (_suspension_end_time== null)) _suspension_end_time = value ? this.suspension_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializesuspension_end_time() { return suspension_end_timeSpecified; }
+    private void Resetsuspension_end_time() { suspension_end_timeSpecified = false; }
+    
 
-    private string _currency = "";
+    private string _currency;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string currency
     {
-      get { return _currency; }
+      get { return _currency?? ""; }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (string)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private uint _steam_level = default(uint);
+    private uint? _steam_level;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"steam_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steam_level
     {
-      get { return _steam_level; }
+      get { return _steam_level?? default(uint); }
       set { _steam_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_levelSpecified
+    {
+      get { return _steam_level != null; }
+      set { if (value == (_steam_level== null)) _steam_level = value ? this.steam_level : (uint?)null; }
+    }
+    private bool ShouldSerializesteam_level() { return steam_levelSpecified; }
+    private void Resetsteam_level() { steam_levelSpecified = false; }
+    
 
-    private uint _friend_count = default(uint);
+    private uint? _friend_count;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"friend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friend_count
     {
-      get { return _friend_count; }
+      get { return _friend_count?? default(uint); }
       set { _friend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_countSpecified
+    {
+      get { return _friend_count != null; }
+      set { if (value == (_friend_count== null)) _friend_count = value ? this.friend_count : (uint?)null; }
+    }
+    private bool ShouldSerializefriend_count() { return friend_countSpecified; }
+    private void Resetfriend_count() { friend_countSpecified = false; }
+    
 
-    private uint _account_creation_time = default(uint);
+    private uint? _account_creation_time;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"account_creation_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_creation_time
     {
-      get { return _account_creation_time; }
+      get { return _account_creation_time?? default(uint); }
       set { _account_creation_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_creation_timeSpecified
+    {
+      get { return _account_creation_time != null; }
+      set { if (value == (_account_creation_time== null)) _account_creation_time = value ? this.account_creation_time : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_creation_time() { return account_creation_timeSpecified; }
+    private void Resetaccount_creation_time() { account_creation_timeSpecified = false; }
+    
 
-    private bool _is_steamguard_enabled = default(bool);
+    private bool? _is_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"is_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_steamguard_enabled
     {
-      get { return _is_steamguard_enabled; }
+      get { return _is_steamguard_enabled?? default(bool); }
       set { _is_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_steamguard_enabledSpecified
+    {
+      get { return _is_steamguard_enabled != null; }
+      set { if (value == (_is_steamguard_enabled== null)) _is_steamguard_enabled = value ? this.is_steamguard_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_steamguard_enabled() { return is_steamguard_enabledSpecified; }
+    private void Resetis_steamguard_enabled() { is_steamguard_enabledSpecified = false; }
+    
 
-    private bool _is_phone_verified = default(bool);
+    private bool? _is_phone_verified;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"is_phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_verified
     {
-      get { return _is_phone_verified; }
+      get { return _is_phone_verified?? default(bool); }
       set { _is_phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_verifiedSpecified
+    {
+      get { return _is_phone_verified != null; }
+      set { if (value == (_is_phone_verified== null)) _is_phone_verified = value ? this.is_phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_verified() { return is_phone_verifiedSpecified; }
+    private void Resetis_phone_verified() { is_phone_verifiedSpecified = false; }
+    
 
-    private bool _is_two_factor_auth_enabled = default(bool);
+    private bool? _is_two_factor_auth_enabled;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"is_two_factor_auth_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_two_factor_auth_enabled
     {
-      get { return _is_two_factor_auth_enabled; }
+      get { return _is_two_factor_auth_enabled?? default(bool); }
       set { _is_two_factor_auth_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_two_factor_auth_enabledSpecified
+    {
+      get { return _is_two_factor_auth_enabled != null; }
+      set { if (value == (_is_two_factor_auth_enabled== null)) _is_two_factor_auth_enabled = value ? this.is_two_factor_auth_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_two_factor_auth_enabled() { return is_two_factor_auth_enabledSpecified; }
+    private void Resetis_two_factor_auth_enabled() { is_two_factor_auth_enabledSpecified = false; }
+    
 
-    private uint _two_factor_enabled_time = default(uint);
+    private uint? _two_factor_enabled_time;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"two_factor_enabled_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint two_factor_enabled_time
     {
-      get { return _two_factor_enabled_time; }
+      get { return _two_factor_enabled_time?? default(uint); }
       set { _two_factor_enabled_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool two_factor_enabled_timeSpecified
+    {
+      get { return _two_factor_enabled_time != null; }
+      set { if (value == (_two_factor_enabled_time== null)) _two_factor_enabled_time = value ? this.two_factor_enabled_time : (uint?)null; }
+    }
+    private bool ShouldSerializetwo_factor_enabled_time() { return two_factor_enabled_timeSpecified; }
+    private void Resettwo_factor_enabled_time() { two_factor_enabled_timeSpecified = false; }
+    
 
-    private uint _phone_verification_time = default(uint);
+    private uint? _phone_verification_time;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"phone_verification_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phone_verification_time
     {
-      get { return _phone_verification_time; }
+      get { return _phone_verification_time?? default(uint); }
       set { _phone_verification_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_verification_timeSpecified
+    {
+      get { return _phone_verification_time != null; }
+      set { if (value == (_phone_verification_time== null)) _phone_verification_time = value ? this.phone_verification_time : (uint?)null; }
+    }
+    private bool ShouldSerializephone_verification_time() { return phone_verification_timeSpecified; }
+    private void Resetphone_verification_time() { phone_verification_timeSpecified = false; }
+    
 
-    private ulong _phone_id = default(ulong);
+    private ulong? _phone_id;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"phone_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong phone_id
     {
-      get { return _phone_id; }
+      get { return _phone_id?? default(ulong); }
       set { _phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_idSpecified
+    {
+      get { return _phone_id != null; }
+      set { if (value == (_phone_id== null)) _phone_id = value ? this.phone_id : (ulong?)null; }
+    }
+    private bool ShouldSerializephone_id() { return phone_idSpecified; }
+    private void Resetphone_id() { phone_idSpecified = false; }
+    
 
-    private bool _is_phone_identifying = default(bool);
+    private bool? _is_phone_identifying;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"is_phone_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_identifying
     {
-      get { return _is_phone_identifying; }
+      get { return _is_phone_identifying?? default(bool); }
       set { _is_phone_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_identifyingSpecified
+    {
+      get { return _is_phone_identifying != null; }
+      set { if (value == (_is_phone_identifying== null)) _is_phone_identifying = value ? this.is_phone_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_identifying() { return is_phone_identifyingSpecified; }
+    private void Resetis_phone_identifying() { is_phone_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2217,23 +3758,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public PersonaName() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2250,23 +3809,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCheckFriendship() {}
     
 
-    private ulong _steamid_left = default(ulong);
+    private ulong? _steamid_left;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_left", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_left
     {
-      get { return _steamid_left; }
+      get { return _steamid_left?? default(ulong); }
       set { _steamid_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_leftSpecified
+    {
+      get { return _steamid_left != null; }
+      set { if (value == (_steamid_left== null)) _steamid_left = value ? this.steamid_left : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_left() { return steamid_leftSpecified; }
+    private void Resetsteamid_left() { steamid_leftSpecified = false; }
+    
 
-    private ulong _steamid_right = default(ulong);
+    private ulong? _steamid_right;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_right", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_right
     {
-      get { return _steamid_right; }
+      get { return _steamid_right?? default(ulong); }
       set { _steamid_right = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_rightSpecified
+    {
+      get { return _steamid_right != null; }
+      set { if (value == (_steamid_right== null)) _steamid_right = value ? this.steamid_right : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_right() { return steamid_rightSpecified; }
+    private void Resetsteamid_right() { steamid_rightSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2278,23 +3855,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCheckFriendship_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private bool _found_friendship = default(bool);
+    private bool? _found_friendship;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"found_friendship", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found_friendship
     {
-      get { return _found_friendship; }
+      get { return _found_friendship?? default(bool); }
       set { _found_friendship = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool found_friendshipSpecified
+    {
+      get { return _found_friendship != null; }
+      set { if (value == (_found_friendship== null)) _found_friendship = value ? this.found_friendship : (bool?)null; }
+    }
+    private bool ShouldSerializefound_friendship() { return found_friendshipSpecified; }
+    private void Resetfound_friendship() { found_friendshipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2306,14 +3901,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMsgMasterSetDirectory() {}
     
 
-    private uint _master_dir_index = default(uint);
+    private uint? _master_dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"master_dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint master_dir_index
     {
-      get { return _master_dir_index; }
+      get { return _master_dir_index?? default(uint); }
       set { _master_dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool master_dir_indexSpecified
+    {
+      get { return _master_dir_index != null; }
+      set { if (value == (_master_dir_index== null)) _master_dir_index = value ? this.master_dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializemaster_dir_index() { return master_dir_indexSpecified; }
+    private void Resetmaster_dir_index() { master_dir_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> _dir = new global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC>();
     [global::ProtoBuf.ProtoMember(2, Name=@"dir", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> dir
@@ -2327,50 +3931,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public SubGC() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _box = "";
+    private string _box;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"box", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string box
     {
-      get { return _box; }
+      get { return _box?? ""; }
       set { _box = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boxSpecified
+    {
+      get { return _box != null; }
+      set { if (value == (_box== null)) _box = value ? this.box : (string)null; }
+    }
+    private bool ShouldSerializebox() { return boxSpecified; }
+    private void Resetbox() { boxSpecified = false; }
+    
 
-    private string _command_line = "";
+    private string _command_line;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"command_line", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_line
     {
-      get { return _command_line; }
+      get { return _command_line?? ""; }
       set { _command_line = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_lineSpecified
+    {
+      get { return _command_line != null; }
+      set { if (value == (_command_line== null)) _command_line = value ? this.command_line : (string)null; }
+    }
+    private bool ShouldSerializecommand_line() { return command_lineSpecified; }
+    private void Resetcommand_line() { command_lineSpecified = false; }
+    
 
-    private string _gc_binary = "";
+    private string _gc_binary;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gc_binary", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gc_binary
     {
-      get { return _gc_binary; }
+      get { return _gc_binary?? ""; }
       set { _gc_binary = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_binarySpecified
+    {
+      get { return _gc_binary != null; }
+      set { if (value == (_gc_binary== null)) _gc_binary = value ? this.gc_binary : (string)null; }
+    }
+    private bool ShouldSerializegc_binary() { return gc_binarySpecified; }
+    private void Resetgc_binary() { gc_binarySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2387,14 +4036,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMsgMasterSetDirectory_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2406,14 +4064,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMsgWebAPIJobRequestForwardResponse() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2425,14 +4092,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCSystemMsg_GetPurchaseTrust_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2444,41 +4120,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCSystemMsg_GetPurchaseTrust_Response() {}
     
 
-    private bool _has_prior_purchase_history = default(bool);
+    private bool? _has_prior_purchase_history;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_prior_purchase_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_prior_purchase_history
     {
-      get { return _has_prior_purchase_history; }
+      get { return _has_prior_purchase_history?? default(bool); }
       set { _has_prior_purchase_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_prior_purchase_historySpecified
+    {
+      get { return _has_prior_purchase_history != null; }
+      set { if (value == (_has_prior_purchase_history== null)) _has_prior_purchase_history = value ? this.has_prior_purchase_history : (bool?)null; }
+    }
+    private bool ShouldSerializehas_prior_purchase_history() { return has_prior_purchase_historySpecified; }
+    private void Resethas_prior_purchase_history() { has_prior_purchase_historySpecified = false; }
+    
 
-    private bool _has_no_recent_password_resets = default(bool);
+    private bool? _has_no_recent_password_resets;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"has_no_recent_password_resets", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_no_recent_password_resets
     {
-      get { return _has_no_recent_password_resets; }
+      get { return _has_no_recent_password_resets?? default(bool); }
       set { _has_no_recent_password_resets = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_no_recent_password_resetsSpecified
+    {
+      get { return _has_no_recent_password_resets != null; }
+      set { if (value == (_has_no_recent_password_resets== null)) _has_no_recent_password_resets = value ? this.has_no_recent_password_resets : (bool?)null; }
+    }
+    private bool ShouldSerializehas_no_recent_password_resets() { return has_no_recent_password_resetsSpecified; }
+    private void Resethas_no_recent_password_resets() { has_no_recent_password_resetsSpecified = false; }
+    
 
-    private bool _is_wallet_cash_trusted = default(bool);
+    private bool? _is_wallet_cash_trusted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_wallet_cash_trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_wallet_cash_trusted
     {
-      get { return _is_wallet_cash_trusted; }
+      get { return _is_wallet_cash_trusted?? default(bool); }
       set { _is_wallet_cash_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_wallet_cash_trustedSpecified
+    {
+      get { return _is_wallet_cash_trusted != null; }
+      set { if (value == (_is_wallet_cash_trusted== null)) _is_wallet_cash_trusted = value ? this.is_wallet_cash_trusted : (bool?)null; }
+    }
+    private bool ShouldSerializeis_wallet_cash_trusted() { return is_wallet_cash_trustedSpecified; }
+    private void Resetis_wallet_cash_trusted() { is_wallet_cash_trustedSpecified = false; }
+    
 
-    private uint _time_all_trusted = default(uint);
+    private uint? _time_all_trusted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_all_trusted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_all_trusted
     {
-      get { return _time_all_trusted; }
+      get { return _time_all_trusted?? default(uint); }
       set { _time_all_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_all_trustedSpecified
+    {
+      get { return _time_all_trusted != null; }
+      set { if (value == (_time_all_trusted== null)) _time_all_trusted = value ? this.time_all_trusted : (uint?)null; }
+    }
+    private bool ShouldSerializetime_all_trusted() { return time_all_trustedSpecified; }
+    private void Resettime_all_trusted() { time_all_trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2490,50 +4202,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCHAccountVacStatusChange() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _rtime_vacban_starts = default(uint);
+    private uint? _rtime_vacban_starts;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rtime_vacban_starts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime_vacban_starts
     {
-      get { return _rtime_vacban_starts; }
+      get { return _rtime_vacban_starts?? default(uint); }
       set { _rtime_vacban_starts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_vacban_startsSpecified
+    {
+      get { return _rtime_vacban_starts != null; }
+      set { if (value == (_rtime_vacban_starts== null)) _rtime_vacban_starts = value ? this.rtime_vacban_starts : (uint?)null; }
+    }
+    private bool ShouldSerializertime_vacban_starts() { return rtime_vacban_startsSpecified; }
+    private void Resetrtime_vacban_starts() { rtime_vacban_startsSpecified = false; }
+    
 
-    private bool _is_banned_now = default(bool);
+    private bool? _is_banned_now;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_banned_now", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_now
     {
-      get { return _is_banned_now; }
+      get { return _is_banned_now?? default(bool); }
       set { _is_banned_now = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_nowSpecified
+    {
+      get { return _is_banned_now != null; }
+      set { if (value == (_is_banned_now== null)) _is_banned_now = value ? this.is_banned_now : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_now() { return is_banned_nowSpecified; }
+    private void Resetis_banned_now() { is_banned_nowSpecified = false; }
+    
 
-    private bool _is_banned_future = default(bool);
+    private bool? _is_banned_future;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_banned_future", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_future
     {
-      get { return _is_banned_future; }
+      get { return _is_banned_future?? default(bool); }
       set { _is_banned_future = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_futureSpecified
+    {
+      get { return _is_banned_future != null; }
+      set { if (value == (_is_banned_future== null)) _is_banned_future = value ? this.is_banned_future : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_future() { return is_banned_futureSpecified; }
+    private void Resetis_banned_future() { is_banned_futureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2545,14 +4302,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGetPartnerAccountLink() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2564,23 +4330,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGetPartnerAccountLink_Response() {}
     
 
-    private uint _pwid = default(uint);
+    private uint? _pwid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"pwid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pwid
     {
-      get { return _pwid; }
+      get { return _pwid?? default(uint); }
       set { _pwid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pwidSpecified
+    {
+      get { return _pwid != null; }
+      set { if (value == (_pwid== null)) _pwid = value ? this.pwid : (uint?)null; }
+    }
+    private bool ShouldSerializepwid() { return pwidSpecified; }
+    private void Resetpwid() { pwidSpecified = false; }
+    
 
-    private uint _nexonid = default(uint);
+    private uint? _nexonid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"nexonid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint nexonid
     {
-      get { return _nexonid; }
+      get { return _nexonid?? default(uint); }
       set { _nexonid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nexonidSpecified
+    {
+      get { return _nexonid != null; }
+      set { if (value == (_nexonid== null)) _nexonid = value ? this.nexonid : (uint?)null; }
+    }
+    private bool ShouldSerializenexonid() { return nexonidSpecified; }
+    private void Resetnexonid() { nexonidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2599,41 +4383,77 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private CMsgGCRoutingInfo.RoutingMethod _method = CMsgGCRoutingInfo.RoutingMethod.RANDOM;
+    private CMsgGCRoutingInfo.RoutingMethod? _method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.RANDOM)]
     public CMsgGCRoutingInfo.RoutingMethod method
     {
-      get { return _method; }
+      get { return _method?? CMsgGCRoutingInfo.RoutingMethod.RANDOM; }
       set { _method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool methodSpecified
+    {
+      get { return _method != null; }
+      set { if (value == (_method== null)) _method = value ? this.method : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializemethod() { return methodSpecified; }
+    private void Resetmethod() { methodSpecified = false; }
+    
 
-    private CMsgGCRoutingInfo.RoutingMethod _fallback = CMsgGCRoutingInfo.RoutingMethod.DISCARD;
+    private CMsgGCRoutingInfo.RoutingMethod? _fallback;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fallback", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.DISCARD)]
     public CMsgGCRoutingInfo.RoutingMethod fallback
     {
-      get { return _fallback; }
+      get { return _fallback?? CMsgGCRoutingInfo.RoutingMethod.DISCARD; }
       set { _fallback = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fallbackSpecified
+    {
+      get { return _fallback != null; }
+      set { if (value == (_fallback== null)) _fallback = value ? this.fallback : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializefallback() { return fallbackSpecified; }
+    private void Resetfallback() { fallbackSpecified = false; }
+    
 
-    private uint _protobuf_field = default(uint);
+    private uint? _protobuf_field;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"protobuf_field", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protobuf_field
     {
-      get { return _protobuf_field; }
+      get { return _protobuf_field?? default(uint); }
       set { _protobuf_field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protobuf_fieldSpecified
+    {
+      get { return _protobuf_field != null; }
+      set { if (value == (_protobuf_field== null)) _protobuf_field = value ? this.protobuf_field : (uint?)null; }
+    }
+    private bool ShouldSerializeprotobuf_field() { return protobuf_fieldSpecified; }
+    private void Resetprotobuf_field() { protobuf_fieldSpecified = false; }
+    
 
-    private string _webapi_param = "";
+    private string _webapi_param;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"webapi_param", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webapi_param
     {
-      get { return _webapi_param; }
+      get { return _webapi_param?? ""; }
       set { _webapi_param = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_paramSpecified
+    {
+      get { return _webapi_param != null; }
+      set { if (value == (_webapi_param== null)) _webapi_param = value ? this.webapi_param : (string)null; }
+    }
+    private bool ShouldSerializewebapi_param() { return webapi_paramSpecified; }
+    private void Resetwebapi_param() { webapi_paramSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"RoutingMethod", EnumPassthru=true)]
     public enum RoutingMethod
     {
@@ -2677,23 +4497,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public Entry() {}
     
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2731,14 +4569,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public Entry() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2764,14 +4611,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMsgMasterSetWebAPIRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2783,14 +4639,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMsgMasterSetClientMsgRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2867,77 +4732,149 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCHUpdateSession() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private bool _online = default(bool);
+    private bool? _online;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"online", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool online
     {
-      get { return _online; }
+      get { return _online?? default(bool); }
       set { _online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onlineSpecified
+    {
+      get { return _online != null; }
+      set { if (value == (_online== null)) _online = value ? this.online : (bool?)null; }
+    }
+    private bool ShouldSerializeonline() { return onlineSpecified; }
+    private void Resetonline() { onlineSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private uint _server_addr = default(uint);
+    private uint? _server_addr;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_addr
     {
-      get { return _server_addr; }
+      get { return _server_addr?? default(uint); }
       set { _server_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addrSpecified
+    {
+      get { return _server_addr != null; }
+      set { if (value == (_server_addr== null)) _server_addr = value ? this.server_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_addr() { return server_addrSpecified; }
+    private void Resetserver_addr() { server_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _os_type = default(uint);
+    private uint? _os_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint os_type
     {
-      get { return _os_type; }
+      get { return _os_type?? default(uint); }
       set { _os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_typeSpecified
+    {
+      get { return _os_type != null; }
+      set { if (value == (_os_type== null)) _os_type = value ? this.os_type : (uint?)null; }
+    }
+    private bool ShouldSerializeos_type() { return os_typeSpecified; }
+    private void Resetos_type() { os_typeSpecified = false; }
+    
 
-    private uint _client_addr = default(uint);
+    private uint? _client_addr;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"client_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_addr
     {
-      get { return _client_addr; }
+      get { return _client_addr?? default(uint); }
       set { _client_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_addrSpecified
+    {
+      get { return _client_addr != null; }
+      set { if (value == (_client_addr== null)) _client_addr = value ? this.client_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_addr() { return client_addrSpecified; }
+    private void Resetclient_addr() { client_addrSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> _extra_fields = new global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField>();
     [global::ProtoBuf.ProtoMember(9, Name=@"extra_fields", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> extra_fields
@@ -2951,23 +4888,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public ExtraField() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2984,23 +4939,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgNotificationOfSuspiciousActivity() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
     private CMsgNotificationOfSuspiciousActivity.MultipleGameInstances _multiple_instances = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"multiple_instances", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3016,14 +4989,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public MultipleGameInstances() {}
     
 
-    private uint _app_instance_count = default(uint);
+    private uint? _app_instance_count;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_instance_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_instance_count
     {
-      get { return _app_instance_count; }
+      get { return _app_instance_count?? default(uint); }
       set { _app_instance_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_instance_countSpecified
+    {
+      get { return _app_instance_count != null; }
+      set { if (value == (_app_instance_count== null)) _app_instance_count = value ? this.app_instance_count : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_instance_count() { return app_instance_countSpecified; }
+    private void Resetapp_instance_count() { app_instance_countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _other_steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"other_steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> other_steamids

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: base_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCStorePurchaseInit_LineItem() {}
     
 
-    private uint _item_def_id = default(uint);
+    private uint? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(uint); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _cost_in_local_currency = default(uint);
+    private uint? _cost_in_local_currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cost_in_local_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cost_in_local_currency
     {
-      get { return _cost_in_local_currency; }
+      get { return _cost_in_local_currency?? default(uint); }
       set { _cost_in_local_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cost_in_local_currencySpecified
+    {
+      get { return _cost_in_local_currency != null; }
+      set { if (value == (_cost_in_local_currency== null)) _cost_in_local_currency = value ? this.cost_in_local_currency : (uint?)null; }
+    }
+    private bool ShouldSerializecost_in_local_currency() { return cost_in_local_currencySpecified; }
+    private void Resetcost_in_local_currency() { cost_in_local_currencySpecified = false; }
+    
 
-    private uint _purchase_type = default(uint);
+    private uint? _purchase_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"purchase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint purchase_type
     {
-      get { return _purchase_type; }
+      get { return _purchase_type?? default(uint); }
       set { _purchase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_typeSpecified
+    {
+      get { return _purchase_type != null; }
+      set { if (value == (_purchase_type== null)) _purchase_type = value ? this.purchase_type : (uint?)null; }
+    }
+    private bool ShouldSerializepurchase_type() { return purchase_typeSpecified; }
+    private void Resetpurchase_type() { purchase_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -64,32 +102,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseInit() {}
     
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> _line_items = new global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem>();
     [global::ProtoBuf.ProtoMember(4, Name=@"line_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> line_items
@@ -108,23 +173,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseInitResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -136,32 +219,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOPartyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,32 +283,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOLobbyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -210,14 +347,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSystemBroadcast() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -229,32 +375,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgInviteToParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _team_invite = default(uint);
+    private uint? _team_invite;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_invite", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_invite
     {
-      get { return _team_invite; }
+      get { return _team_invite?? default(uint); }
       set { _team_invite = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_inviteSpecified
+    {
+      get { return _team_invite != null; }
+      set { if (value == (_team_invite== null)) _team_invite = value ? this.team_invite : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_invite() { return team_inviteSpecified; }
+    private void Resetteam_invite() { team_inviteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -266,23 +439,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgInvitationCreated() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -294,41 +485,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgPartyInviteResponse() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private bool _accept = default(bool);
+    private bool? _accept;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accept", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept
     {
-      get { return _accept; }
+      get { return _accept?? default(bool); }
       set { _accept = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptSpecified
+    {
+      get { return _accept != null; }
+      set { if (value == (_accept== null)) _accept = value ? this.accept : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept() { return acceptSpecified; }
+    private void Resetaccept() { acceptSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _team_invite = default(uint);
+    private uint? _team_invite;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_invite", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_invite
     {
-      get { return _team_invite; }
+      get { return _team_invite?? default(uint); }
       set { _team_invite = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_inviteSpecified
+    {
+      get { return _team_invite != null; }
+      set { if (value == (_team_invite== null)) _team_invite = value ? this.team_invite : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_invite() { return team_inviteSpecified; }
+    private void Resetteam_invite() { team_inviteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -340,14 +567,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgKickFromParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -379,14 +615,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgLANServerAvailable() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -398,50 +643,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconGameAccountClient() {}
     
 
-    private uint _additional_backpack_slots = (uint)0;
+    private uint? _additional_backpack_slots;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"additional_backpack_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint additional_backpack_slots
     {
-      get { return _additional_backpack_slots; }
+      get { return _additional_backpack_slots?? (uint)0; }
       set { _additional_backpack_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool additional_backpack_slotsSpecified
+    {
+      get { return _additional_backpack_slots != null; }
+      set { if (value == (_additional_backpack_slots== null)) _additional_backpack_slots = value ? this.additional_backpack_slots : (uint?)null; }
+    }
+    private bool ShouldSerializeadditional_backpack_slots() { return additional_backpack_slotsSpecified; }
+    private void Resetadditional_backpack_slots() { additional_backpack_slotsSpecified = false; }
+    
 
-    private uint _bonus_xp_timestamp_refresh = default(uint);
+    private uint? _bonus_xp_timestamp_refresh;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"bonus_xp_timestamp_refresh", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_xp_timestamp_refresh
     {
-      get { return _bonus_xp_timestamp_refresh; }
+      get { return _bonus_xp_timestamp_refresh?? default(uint); }
       set { _bonus_xp_timestamp_refresh = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_xp_timestamp_refreshSpecified
+    {
+      get { return _bonus_xp_timestamp_refresh != null; }
+      set { if (value == (_bonus_xp_timestamp_refresh== null)) _bonus_xp_timestamp_refresh = value ? this.bonus_xp_timestamp_refresh : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_xp_timestamp_refresh() { return bonus_xp_timestamp_refreshSpecified; }
+    private void Resetbonus_xp_timestamp_refresh() { bonus_xp_timestamp_refreshSpecified = false; }
+    
 
-    private uint _bonus_xp_usedflags = default(uint);
+    private uint? _bonus_xp_usedflags;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"bonus_xp_usedflags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_xp_usedflags
     {
-      get { return _bonus_xp_usedflags; }
+      get { return _bonus_xp_usedflags?? default(uint); }
       set { _bonus_xp_usedflags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_xp_usedflagsSpecified
+    {
+      get { return _bonus_xp_usedflags != null; }
+      set { if (value == (_bonus_xp_usedflags== null)) _bonus_xp_usedflags = value ? this.bonus_xp_usedflags : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_xp_usedflags() { return bonus_xp_usedflagsSpecified; }
+    private void Resetbonus_xp_usedflags() { bonus_xp_usedflagsSpecified = false; }
+    
 
-    private uint _elevated_state = default(uint);
+    private uint? _elevated_state;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"elevated_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint elevated_state
     {
-      get { return _elevated_state; }
+      get { return _elevated_state?? default(uint); }
       set { _elevated_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool elevated_stateSpecified
+    {
+      get { return _elevated_state != null; }
+      set { if (value == (_elevated_state== null)) _elevated_state = value ? this.elevated_state : (uint?)null; }
+    }
+    private bool ShouldSerializeelevated_state() { return elevated_stateSpecified; }
+    private void Resetelevated_state() { elevated_stateSpecified = false; }
+    
 
-    private uint _elevated_timestamp = default(uint);
+    private uint? _elevated_timestamp;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"elevated_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint elevated_timestamp
     {
-      get { return _elevated_timestamp; }
+      get { return _elevated_timestamp?? default(uint); }
       set { _elevated_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool elevated_timestampSpecified
+    {
+      get { return _elevated_timestamp != null; }
+      set { if (value == (_elevated_timestamp== null)) _elevated_timestamp = value ? this.elevated_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializeelevated_timestamp() { return elevated_timestampSpecified; }
+    private void Resetelevated_timestamp() { elevated_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -453,50 +743,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOItemCriteriaCondition() {}
     
 
-    private int _op = default(int);
+    private int? _op;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"op", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int op
     {
-      get { return _op; }
+      get { return _op?? default(int); }
       set { _op = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opSpecified
+    {
+      get { return _op != null; }
+      set { if (value == (_op== null)) _op = value ? this.op : (int?)null; }
+    }
+    private bool ShouldSerializeop() { return opSpecified; }
+    private void Resetop() { opSpecified = false; }
+    
 
-    private string _field = "";
+    private string _field;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"field", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string field
     {
-      get { return _field; }
+      get { return _field?? ""; }
       set { _field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fieldSpecified
+    {
+      get { return _field != null; }
+      set { if (value == (_field== null)) _field = value ? this.field : (string)null; }
+    }
+    private bool ShouldSerializefield() { return fieldSpecified; }
+    private void Resetfield() { fieldSpecified = false; }
+    
 
-    private bool _required = default(bool);
+    private bool? _required;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"required", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool required
     {
-      get { return _required; }
+      get { return _required?? default(bool); }
       set { _required = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requiredSpecified
+    {
+      get { return _required != null; }
+      set { if (value == (_required== null)) _required = value ? this.required : (bool?)null; }
+    }
+    private bool ShouldSerializerequired() { return requiredSpecified; }
+    private void Resetrequired() { requiredSpecified = false; }
+    
 
-    private float _float_value = default(float);
+    private float? _float_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"float_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float float_value
     {
-      get { return _float_value; }
+      get { return _float_value?? default(float); }
       set { _float_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool float_valueSpecified
+    {
+      get { return _float_value != null; }
+      set { if (value == (_float_value== null)) _float_value = value ? this.float_value : (float?)null; }
+    }
+    private bool ShouldSerializefloat_value() { return float_valueSpecified; }
+    private void Resetfloat_value() { float_valueSpecified = false; }
+    
 
-    private string _string_value = "";
+    private string _string_value;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"string_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string string_value
     {
-      get { return _string_value; }
+      get { return _string_value?? ""; }
       set { _string_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool string_valueSpecified
+    {
+      get { return _string_value != null; }
+      set { if (value == (_string_value== null)) _string_value = value ? this.string_value : (string)null; }
+    }
+    private bool ShouldSerializestring_value() { return string_valueSpecified; }
+    private void Resetstring_value() { string_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -508,68 +843,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOItemCriteria() {}
     
 
-    private uint _item_level = default(uint);
+    private uint? _item_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_level
     {
-      get { return _item_level; }
+      get { return _item_level?? default(uint); }
       set { _item_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_levelSpecified
+    {
+      get { return _item_level != null; }
+      set { if (value == (_item_level== null)) _item_level = value ? this.item_level : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_level() { return item_levelSpecified; }
+    private void Resetitem_level() { item_levelSpecified = false; }
+    
 
-    private int _item_quality = default(int);
+    private int? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(int); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (int?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private bool _item_level_set = default(bool);
+    private bool? _item_level_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_level_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_level_set
     {
-      get { return _item_level_set; }
+      get { return _item_level_set?? default(bool); }
       set { _item_level_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_level_setSpecified
+    {
+      get { return _item_level_set != null; }
+      set { if (value == (_item_level_set== null)) _item_level_set = value ? this.item_level_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_level_set() { return item_level_setSpecified; }
+    private void Resetitem_level_set() { item_level_setSpecified = false; }
+    
 
-    private bool _item_quality_set = default(bool);
+    private bool? _item_quality_set;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"item_quality_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_quality_set
     {
-      get { return _item_quality_set; }
+      get { return _item_quality_set?? default(bool); }
       set { _item_quality_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_quality_setSpecified
+    {
+      get { return _item_quality_set != null; }
+      set { if (value == (_item_quality_set== null)) _item_quality_set = value ? this.item_quality_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_quality_set() { return item_quality_setSpecified; }
+    private void Resetitem_quality_set() { item_quality_setSpecified = false; }
+    
 
-    private uint _initial_inventory = default(uint);
+    private uint? _initial_inventory;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initial_inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_inventory
     {
-      get { return _initial_inventory; }
+      get { return _initial_inventory?? default(uint); }
       set { _initial_inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_inventorySpecified
+    {
+      get { return _initial_inventory != null; }
+      set { if (value == (_initial_inventory== null)) _initial_inventory = value ? this.initial_inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_inventory() { return initial_inventorySpecified; }
+    private void Resetinitial_inventory() { initial_inventorySpecified = false; }
+    
 
-    private uint _initial_quantity = default(uint);
+    private uint? _initial_quantity;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"initial_quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_quantity
     {
-      get { return _initial_quantity; }
+      get { return _initial_quantity?? default(uint); }
       set { _initial_quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_quantitySpecified
+    {
+      get { return _initial_quantity != null; }
+      set { if (value == (_initial_quantity== null)) _initial_quantity = value ? this.initial_quantity : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_quantity() { return initial_quantitySpecified; }
+    private void Resetinitial_quantity() { initial_quantitySpecified = false; }
+    
 
-    private bool _ignore_enabled_flag = default(bool);
+    private bool? _ignore_enabled_flag;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"ignore_enabled_flag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ignore_enabled_flag
     {
-      get { return _ignore_enabled_flag; }
+      get { return _ignore_enabled_flag?? default(bool); }
       set { _ignore_enabled_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ignore_enabled_flagSpecified
+    {
+      get { return _ignore_enabled_flag != null; }
+      set { if (value == (_ignore_enabled_flag== null)) _ignore_enabled_flag = value ? this.ignore_enabled_flag : (bool?)null; }
+    }
+    private bool ShouldSerializeignore_enabled_flag() { return ignore_enabled_flagSpecified; }
+    private void Resetignore_enabled_flag() { ignore_enabled_flagSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteriaCondition> _conditions = new global::System.Collections.Generic.List<CSOItemCriteriaCondition>();
     [global::ProtoBuf.ProtoMember(9, Name=@"conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteriaCondition> conditions
@@ -578,32 +976,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private int _item_rarity = default(int);
+    private int? _item_rarity;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"item_rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_rarity
     {
-      get { return _item_rarity; }
+      get { return _item_rarity?? default(int); }
       set { _item_rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_raritySpecified
+    {
+      get { return _item_rarity != null; }
+      set { if (value == (_item_rarity== null)) _item_rarity = value ? this.item_rarity : (int?)null; }
+    }
+    private bool ShouldSerializeitem_rarity() { return item_raritySpecified; }
+    private void Resetitem_rarity() { item_raritySpecified = false; }
+    
 
-    private bool _item_rarity_set = default(bool);
+    private bool? _item_rarity_set;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"item_rarity_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_rarity_set
     {
-      get { return _item_rarity_set; }
+      get { return _item_rarity_set?? default(bool); }
       set { _item_rarity_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_rarity_setSpecified
+    {
+      get { return _item_rarity_set != null; }
+      set { if (value == (_item_rarity_set== null)) _item_rarity_set = value ? this.item_rarity_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_rarity_set() { return item_rarity_setSpecified; }
+    private void Resetitem_rarity_set() { item_rarity_setSpecified = false; }
+    
 
-    private bool _recent_only = default(bool);
+    private bool? _recent_only;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"recent_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool recent_only
     {
-      get { return _recent_only; }
+      get { return _recent_only?? default(bool); }
       set { _recent_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recent_onlySpecified
+    {
+      get { return _recent_only != null; }
+      set { if (value == (_recent_only== null)) _recent_only = value ? this.recent_only : (bool?)null; }
+    }
+    private bool ShouldSerializerecent_only() { return recent_onlySpecified; }
+    private void Resetrecent_only() { recent_onlySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -615,149 +1040,293 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOItemRecipe() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _n_a = "";
+    private string _n_a;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"n_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string n_a
     {
-      get { return _n_a; }
+      get { return _n_a?? ""; }
       set { _n_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool n_aSpecified
+    {
+      get { return _n_a != null; }
+      set { if (value == (_n_a== null)) _n_a = value ? this.n_a : (string)null; }
+    }
+    private bool ShouldSerializen_a() { return n_aSpecified; }
+    private void Resetn_a() { n_aSpecified = false; }
+    
 
-    private string _desc_inputs = "";
+    private string _desc_inputs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"desc_inputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_inputs
     {
-      get { return _desc_inputs; }
+      get { return _desc_inputs?? ""; }
       set { _desc_inputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_inputsSpecified
+    {
+      get { return _desc_inputs != null; }
+      set { if (value == (_desc_inputs== null)) _desc_inputs = value ? this.desc_inputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_inputs() { return desc_inputsSpecified; }
+    private void Resetdesc_inputs() { desc_inputsSpecified = false; }
+    
 
-    private string _desc_outputs = "";
+    private string _desc_outputs;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"desc_outputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_outputs
     {
-      get { return _desc_outputs; }
+      get { return _desc_outputs?? ""; }
       set { _desc_outputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_outputsSpecified
+    {
+      get { return _desc_outputs != null; }
+      set { if (value == (_desc_outputs== null)) _desc_outputs = value ? this.desc_outputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_outputs() { return desc_outputsSpecified; }
+    private void Resetdesc_outputs() { desc_outputsSpecified = false; }
+    
 
-    private string _di_a = "";
+    private string _di_a;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"di_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_a
     {
-      get { return _di_a; }
+      get { return _di_a?? ""; }
       set { _di_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_aSpecified
+    {
+      get { return _di_a != null; }
+      set { if (value == (_di_a== null)) _di_a = value ? this.di_a : (string)null; }
+    }
+    private bool ShouldSerializedi_a() { return di_aSpecified; }
+    private void Resetdi_a() { di_aSpecified = false; }
+    
 
-    private string _di_b = "";
+    private string _di_b;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"di_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_b
     {
-      get { return _di_b; }
+      get { return _di_b?? ""; }
       set { _di_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_bSpecified
+    {
+      get { return _di_b != null; }
+      set { if (value == (_di_b== null)) _di_b = value ? this.di_b : (string)null; }
+    }
+    private bool ShouldSerializedi_b() { return di_bSpecified; }
+    private void Resetdi_b() { di_bSpecified = false; }
+    
 
-    private string _di_c = "";
+    private string _di_c;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"di_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_c
     {
-      get { return _di_c; }
+      get { return _di_c?? ""; }
       set { _di_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_cSpecified
+    {
+      get { return _di_c != null; }
+      set { if (value == (_di_c== null)) _di_c = value ? this.di_c : (string)null; }
+    }
+    private bool ShouldSerializedi_c() { return di_cSpecified; }
+    private void Resetdi_c() { di_cSpecified = false; }
+    
 
-    private string _do_a = "";
+    private string _do_a;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"do_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_a
     {
-      get { return _do_a; }
+      get { return _do_a?? ""; }
       set { _do_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_aSpecified
+    {
+      get { return _do_a != null; }
+      set { if (value == (_do_a== null)) _do_a = value ? this.do_a : (string)null; }
+    }
+    private bool ShouldSerializedo_a() { return do_aSpecified; }
+    private void Resetdo_a() { do_aSpecified = false; }
+    
 
-    private string _do_b = "";
+    private string _do_b;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"do_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_b
     {
-      get { return _do_b; }
+      get { return _do_b?? ""; }
       set { _do_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_bSpecified
+    {
+      get { return _do_b != null; }
+      set { if (value == (_do_b== null)) _do_b = value ? this.do_b : (string)null; }
+    }
+    private bool ShouldSerializedo_b() { return do_bSpecified; }
+    private void Resetdo_b() { do_bSpecified = false; }
+    
 
-    private string _do_c = "";
+    private string _do_c;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"do_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_c
     {
-      get { return _do_c; }
+      get { return _do_c?? ""; }
       set { _do_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_cSpecified
+    {
+      get { return _do_c != null; }
+      set { if (value == (_do_c== null)) _do_c = value ? this.do_c : (string)null; }
+    }
+    private bool ShouldSerializedo_c() { return do_cSpecified; }
+    private void Resetdo_c() { do_cSpecified = false; }
+    
 
-    private bool _requires_all_same_class = default(bool);
+    private bool? _requires_all_same_class;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"requires_all_same_class", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_class
     {
-      get { return _requires_all_same_class; }
+      get { return _requires_all_same_class?? default(bool); }
       set { _requires_all_same_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_classSpecified
+    {
+      get { return _requires_all_same_class != null; }
+      set { if (value == (_requires_all_same_class== null)) _requires_all_same_class = value ? this.requires_all_same_class : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_class() { return requires_all_same_classSpecified; }
+    private void Resetrequires_all_same_class() { requires_all_same_classSpecified = false; }
+    
 
-    private bool _requires_all_same_slot = default(bool);
+    private bool? _requires_all_same_slot;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"requires_all_same_slot", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_slot
     {
-      get { return _requires_all_same_slot; }
+      get { return _requires_all_same_slot?? default(bool); }
       set { _requires_all_same_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_slotSpecified
+    {
+      get { return _requires_all_same_slot != null; }
+      set { if (value == (_requires_all_same_slot== null)) _requires_all_same_slot = value ? this.requires_all_same_slot : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_slot() { return requires_all_same_slotSpecified; }
+    private void Resetrequires_all_same_slot() { requires_all_same_slotSpecified = false; }
+    
 
-    private int _class_usage_for_output = default(int);
+    private int? _class_usage_for_output;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"class_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int class_usage_for_output
     {
-      get { return _class_usage_for_output; }
+      get { return _class_usage_for_output?? default(int); }
       set { _class_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_usage_for_outputSpecified
+    {
+      get { return _class_usage_for_output != null; }
+      set { if (value == (_class_usage_for_output== null)) _class_usage_for_output = value ? this.class_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeclass_usage_for_output() { return class_usage_for_outputSpecified; }
+    private void Resetclass_usage_for_output() { class_usage_for_outputSpecified = false; }
+    
 
-    private int _slot_usage_for_output = default(int);
+    private int? _slot_usage_for_output;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"slot_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int slot_usage_for_output
     {
-      get { return _slot_usage_for_output; }
+      get { return _slot_usage_for_output?? default(int); }
       set { _slot_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_usage_for_outputSpecified
+    {
+      get { return _slot_usage_for_output != null; }
+      set { if (value == (_slot_usage_for_output== null)) _slot_usage_for_output = value ? this.slot_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeslot_usage_for_output() { return slot_usage_for_outputSpecified; }
+    private void Resetslot_usage_for_output() { slot_usage_for_outputSpecified = false; }
+    
 
-    private int _set_for_output = default(int);
+    private int? _set_for_output;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"set_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int set_for_output
     {
-      get { return _set_for_output; }
+      get { return _set_for_output?? default(int); }
       set { _set_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool set_for_outputSpecified
+    {
+      get { return _set_for_output != null; }
+      set { if (value == (_set_for_output== null)) _set_for_output = value ? this.set_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeset_for_output() { return set_for_outputSpecified; }
+    private void Resetset_for_output() { set_for_outputSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteria> _input_items_criteria = new global::System.Collections.Generic.List<CSOItemCriteria>();
     [global::ProtoBuf.ProtoMember(20, Name=@"input_items_criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteria> input_items_criteria
@@ -790,14 +1359,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgDevNewItemRequest() {}
     
 
-    private ulong _receiver = default(ulong);
+    private ulong? _receiver;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"receiver", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong receiver
     {
-      get { return _receiver; }
+      get { return _receiver?? default(ulong); }
       set { _receiver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiverSpecified
+    {
+      get { return _receiver != null; }
+      set { if (value == (_receiver== null)) _receiver = value ? this.receiver : (ulong?)null; }
+    }
+    private bool ShouldSerializereceiver() { return receiverSpecified; }
+    private void Resetreceiver() { receiverSpecified = false; }
+    
 
     private CSOItemCriteria _criteria = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -818,50 +1396,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgIncrementKillCountAttribute() {}
     
 
-    private uint _killer_account_id = default(uint);
+    private uint? _killer_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_account_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_account_id
     {
-      get { return _killer_account_id; }
+      get { return _killer_account_id?? default(uint); }
       set { _killer_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_account_idSpecified
+    {
+      get { return _killer_account_id != null; }
+      set { if (value == (_killer_account_id== null)) _killer_account_id = value ? this.killer_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_account_id() { return killer_account_idSpecified; }
+    private void Resetkiller_account_id() { killer_account_idSpecified = false; }
+    
 
-    private uint _victim_account_id = default(uint);
+    private uint? _victim_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"victim_account_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint victim_account_id
     {
-      get { return _victim_account_id; }
+      get { return _victim_account_id?? default(uint); }
       set { _victim_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victim_account_idSpecified
+    {
+      get { return _victim_account_id != null; }
+      set { if (value == (_victim_account_id== null)) _victim_account_id = value ? this.victim_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializevictim_account_id() { return victim_account_idSpecified; }
+    private void Resetvictim_account_id() { victim_account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private uint _amount = default(uint);
+    private uint? _amount;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint amount
     {
-      get { return _amount; }
+      get { return _amount?? default(uint); }
       set { _amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool amountSpecified
+    {
+      get { return _amount != null; }
+      set { if (value == (_amount== null)) _amount = value ? this.amount : (uint?)null; }
+    }
+    private bool ShouldSerializeamount() { return amountSpecified; }
+    private void Resetamount() { amountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -873,50 +1496,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplySticker() {}
     
 
-    private ulong _sticker_item_id = default(ulong);
+    private ulong? _sticker_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sticker_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sticker_item_id
     {
-      get { return _sticker_item_id; }
+      get { return _sticker_item_id?? default(ulong); }
       set { _sticker_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sticker_item_idSpecified
+    {
+      get { return _sticker_item_id != null; }
+      set { if (value == (_sticker_item_id== null)) _sticker_item_id = value ? this.sticker_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesticker_item_id() { return sticker_item_idSpecified; }
+    private void Resetsticker_item_id() { sticker_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
 
-    private uint _sticker_slot = default(uint);
+    private uint? _sticker_slot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sticker_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sticker_slot
     {
-      get { return _sticker_slot; }
+      get { return _sticker_slot?? default(uint); }
       set { _sticker_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sticker_slotSpecified
+    {
+      get { return _sticker_slot != null; }
+      set { if (value == (_sticker_slot== null)) _sticker_slot = value ? this.sticker_slot : (uint?)null; }
+    }
+    private bool ShouldSerializesticker_slot() { return sticker_slotSpecified; }
+    private void Resetsticker_slot() { sticker_slotSpecified = false; }
+    
 
-    private uint _baseitem_defidx = default(uint);
+    private uint? _baseitem_defidx;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"baseitem_defidx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint baseitem_defidx
     {
-      get { return _baseitem_defidx; }
+      get { return _baseitem_defidx?? default(uint); }
       set { _baseitem_defidx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool baseitem_defidxSpecified
+    {
+      get { return _baseitem_defidx != null; }
+      set { if (value == (_baseitem_defidx== null)) _baseitem_defidx = value ? this.baseitem_defidx : (uint?)null; }
+    }
+    private bool ShouldSerializebaseitem_defidx() { return baseitem_defidxSpecified; }
+    private void Resetbaseitem_defidx() { baseitem_defidxSpecified = false; }
+    
 
-    private float _sticker_wear = default(float);
+    private float? _sticker_wear;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sticker_wear", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float sticker_wear
     {
-      get { return _sticker_wear; }
+      get { return _sticker_wear?? default(float); }
       set { _sticker_wear = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sticker_wearSpecified
+    {
+      get { return _sticker_wear != null; }
+      set { if (value == (_sticker_wear== null)) _sticker_wear = value ? this.sticker_wear : (float?)null; }
+    }
+    private bool ShouldSerializesticker_wear() { return sticker_wearSpecified; }
+    private void Resetsticker_wear() { sticker_wearSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -928,32 +1596,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplyStatTrakSwap() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private ulong _item_1_item_id = default(ulong);
+    private ulong? _item_1_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_1_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_1_item_id
     {
-      get { return _item_1_item_id; }
+      get { return _item_1_item_id?? default(ulong); }
       set { _item_1_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_1_item_idSpecified
+    {
+      get { return _item_1_item_id != null; }
+      set { if (value == (_item_1_item_id== null)) _item_1_item_id = value ? this.item_1_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_1_item_id() { return item_1_item_idSpecified; }
+    private void Resetitem_1_item_id() { item_1_item_idSpecified = false; }
+    
 
-    private ulong _item_2_item_id = default(ulong);
+    private ulong? _item_2_item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_2_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_2_item_id
     {
-      get { return _item_2_item_id; }
+      get { return _item_2_item_id?? default(ulong); }
       set { _item_2_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_2_item_idSpecified
+    {
+      get { return _item_2_item_id != null; }
+      set { if (value == (_item_2_item_id== null)) _item_2_item_id = value ? this.item_2_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_2_item_id() { return item_2_item_idSpecified; }
+    private void Resetitem_2_item_id() { item_2_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -965,23 +1660,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplyStrangePart() {}
     
 
-    private ulong _strange_part_item_id = default(ulong);
+    private ulong? _strange_part_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"strange_part_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong strange_part_item_id
     {
-      get { return _strange_part_item_id; }
+      get { return _strange_part_item_id?? default(ulong); }
       set { _strange_part_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_part_item_idSpecified
+    {
+      get { return _strange_part_item_id != null; }
+      set { if (value == (_strange_part_item_id== null)) _strange_part_item_id = value ? this.strange_part_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestrange_part_item_id() { return strange_part_item_idSpecified; }
+    private void Resetstrange_part_item_id() { strange_part_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -993,23 +1706,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplyPennantUpgrade() {}
     
 
-    private ulong _upgrade_item_id = default(ulong);
+    private ulong? _upgrade_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upgrade_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upgrade_item_id
     {
-      get { return _upgrade_item_id; }
+      get { return _upgrade_item_id?? default(ulong); }
       set { _upgrade_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upgrade_item_idSpecified
+    {
+      get { return _upgrade_item_id != null; }
+      set { if (value == (_upgrade_item_id== null)) _upgrade_item_id = value ? this.upgrade_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeupgrade_item_id() { return upgrade_item_idSpecified; }
+    private void Resetupgrade_item_id() { upgrade_item_idSpecified = false; }
+    
 
-    private ulong _pennant_item_id = default(ulong);
+    private ulong? _pennant_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pennant_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pennant_item_id
     {
-      get { return _pennant_item_id; }
+      get { return _pennant_item_id?? default(ulong); }
       set { _pennant_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pennant_item_idSpecified
+    {
+      get { return _pennant_item_id != null; }
+      set { if (value == (_pennant_item_id== null)) _pennant_item_id = value ? this.pennant_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepennant_item_id() { return pennant_item_idSpecified; }
+    private void Resetpennant_item_id() { pennant_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1021,23 +1752,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplyEggEssence() {}
     
 
-    private ulong _essence_item_id = default(ulong);
+    private ulong? _essence_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"essence_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong essence_item_id
     {
-      get { return _essence_item_id; }
+      get { return _essence_item_id?? default(ulong); }
       set { _essence_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool essence_item_idSpecified
+    {
+      get { return _essence_item_id != null; }
+      set { if (value == (_essence_item_id== null)) _essence_item_id = value ? this.essence_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeessence_item_id() { return essence_item_idSpecified; }
+    private void Resetessence_item_id() { essence_item_idSpecified = false; }
+    
 
-    private ulong _egg_item_id = default(ulong);
+    private ulong? _egg_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"egg_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong egg_item_id
     {
-      get { return _egg_item_id; }
+      get { return _egg_item_id?? default(ulong); }
       set { _egg_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool egg_item_idSpecified
+    {
+      get { return _egg_item_id != null; }
+      set { if (value == (_egg_item_id== null)) _egg_item_id = value ? this.egg_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeegg_item_id() { return egg_item_idSpecified; }
+    private void Resetegg_item_id() { egg_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1049,32 +1798,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItemAttribute() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private byte[] _value_bytes = null;
+    private byte[] _value_bytes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"value_bytes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value_bytes
     {
-      get { return _value_bytes; }
+      get { return _value_bytes?? null; }
       set { _value_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_bytesSpecified
+    {
+      get { return _value_bytes != null; }
+      set { if (value == (_value_bytes== null)) _value_bytes = value ? this.value_bytes : (byte[])null; }
+    }
+    private bool ShouldSerializevalue_bytes() { return value_bytesSpecified; }
+    private void Resetvalue_bytes() { value_bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1086,23 +1862,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItemEquipped() {}
     
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1114,104 +1908,203 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItem() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _flags = (uint)0;
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? (uint)0; }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
 
-    private string _custom_name = "";
+    private string _custom_name;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"custom_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_name
     {
-      get { return _custom_name; }
+      get { return _custom_name?? ""; }
       set { _custom_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_nameSpecified
+    {
+      get { return _custom_name != null; }
+      set { if (value == (_custom_name== null)) _custom_name = value ? this.custom_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_name() { return custom_nameSpecified; }
+    private void Resetcustom_name() { custom_nameSpecified = false; }
+    
 
-    private string _custom_desc = "";
+    private string _custom_desc;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"custom_desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_desc
     {
-      get { return _custom_desc; }
+      get { return _custom_desc?? ""; }
       set { _custom_desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_descSpecified
+    {
+      get { return _custom_desc != null; }
+      set { if (value == (_custom_desc== null)) _custom_desc = value ? this.custom_desc : (string)null; }
+    }
+    private bool ShouldSerializecustom_desc() { return custom_descSpecified; }
+    private void Resetcustom_desc() { custom_descSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemAttribute> _attribute = new global::System.Collections.Generic.List<CSOEconItemAttribute>();
     [global::ProtoBuf.ProtoMember(12, Name=@"attribute", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemAttribute> attribute
@@ -1229,32 +2122,59 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _interior_item = value; }
     }
 
-    private bool _in_use = (bool)false;
+    private bool? _in_use;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"in_use", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool in_use
     {
-      get { return _in_use; }
+      get { return _in_use?? (bool)false; }
       set { _in_use = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_useSpecified
+    {
+      get { return _in_use != null; }
+      set { if (value == (_in_use== null)) _in_use = value ? this.in_use : (bool?)null; }
+    }
+    private bool ShouldSerializein_use() { return in_useSpecified; }
+    private void Resetin_use() { in_useSpecified = false; }
+    
 
-    private uint _style = (uint)0;
+    private uint? _style;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"style", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint style
     {
-      get { return _style; }
+      get { return _style?? (uint)0; }
       set { _style = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool styleSpecified
+    {
+      get { return _style != null; }
+      set { if (value == (_style== null)) _style = value ? this.style : (uint?)null; }
+    }
+    private bool ShouldSerializestyle() { return styleSpecified; }
+    private void Resetstyle() { styleSpecified = false; }
+    
 
-    private ulong _original_id = (ulong)0;
+    private ulong? _original_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"original_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong original_id
     {
-      get { return _original_id; }
+      get { return _original_id?? (ulong)0; }
       set { _original_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_idSpecified
+    {
+      get { return _original_id != null; }
+      set { if (value == (_original_id== null)) _original_id = value ? this.original_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeoriginal_id() { return original_idSpecified; }
+    private void Resetoriginal_id() { original_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemEquipped> _equipped_state = new global::System.Collections.Generic.List<CSOEconItemEquipped>();
     [global::ProtoBuf.ProtoMember(18, Name=@"equipped_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemEquipped> equipped_state
@@ -1263,14 +2183,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _rarity = default(uint);
+    private uint? _rarity;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rarity
     {
-      get { return _rarity; }
+      get { return _rarity?? default(uint); }
       set { _rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raritySpecified
+    {
+      get { return _rarity != null; }
+      set { if (value == (_rarity== null)) _rarity = value ? this.rarity : (uint?)null; }
+    }
+    private bool ShouldSerializerarity() { return raritySpecified; }
+    private void Resetrarity() { raritySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1282,41 +2211,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAdjustItemEquippedState() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
 
-    private bool _swap = default(bool);
+    private bool? _swap;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"swap", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool swap
     {
-      get { return _swap; }
+      get { return _swap?? default(bool); }
       set { _swap = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool swapSpecified
+    {
+      get { return _swap != null; }
+      set { if (value == (_swap== null)) _swap = value ? this.swap : (bool?)null; }
+    }
+    private bool ShouldSerializeswap() { return swapSpecified; }
+    private void Resetswap() { swapSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1328,14 +2293,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSortItems() {}
     
 
-    private uint _sort_type = default(uint);
+    private uint? _sort_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sort_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_type
     {
-      get { return _sort_type; }
+      get { return _sort_type?? default(uint); }
       set { _sort_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_typeSpecified
+    {
+      get { return _sort_type != null; }
+      set { if (value == (_sort_type== null)) _sort_type = value ? this.sort_type : (uint?)null; }
+    }
+    private bool ShouldSerializesort_type() { return sort_typeSpecified; }
+    private void Resetsort_type() { sort_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1347,41 +2321,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconClaimCode() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _code_type = default(uint);
+    private uint? _code_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"code_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint code_type
     {
-      get { return _code_type; }
+      get { return _code_type?? default(uint); }
       set { _code_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool code_typeSpecified
+    {
+      get { return _code_type != null; }
+      set { if (value == (_code_type== null)) _code_type = value ? this.code_type : (uint?)null; }
+    }
+    private bool ShouldSerializecode_type() { return code_typeSpecified; }
+    private void Resetcode_type() { code_typeSpecified = false; }
+    
 
-    private uint _time_acquired = default(uint);
+    private uint? _time_acquired;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_acquired", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_acquired
     {
-      get { return _time_acquired; }
+      get { return _time_acquired?? default(uint); }
       set { _time_acquired = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_acquiredSpecified
+    {
+      get { return _time_acquired != null; }
+      set { if (value == (_time_acquired== null)) _time_acquired = value ? this.time_acquired : (uint?)null; }
+    }
+    private bool ShouldSerializetime_acquired() { return time_acquiredSpecified; }
+    private void Resettime_acquired() { time_acquiredSpecified = false; }
+    
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1393,23 +2403,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgStoreGetUserData() {}
     
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1421,50 +2449,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgStoreGetUserDataResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private int _currency_deprecated = default(int);
+    private int? _currency_deprecated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency_deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency_deprecated
     {
-      get { return _currency_deprecated; }
+      get { return _currency_deprecated?? default(int); }
       set { _currency_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currency_deprecatedSpecified
+    {
+      get { return _currency_deprecated != null; }
+      set { if (value == (_currency_deprecated== null)) _currency_deprecated = value ? this.currency_deprecated : (int?)null; }
+    }
+    private bool ShouldSerializecurrency_deprecated() { return currency_deprecatedSpecified; }
+    private void Resetcurrency_deprecated() { currency_deprecatedSpecified = false; }
+    
 
-    private string _country_deprecated = "";
+    private string _country_deprecated;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country_deprecated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_deprecated
     {
-      get { return _country_deprecated; }
+      get { return _country_deprecated?? ""; }
       set { _country_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_deprecatedSpecified
+    {
+      get { return _country_deprecated != null; }
+      set { if (value == (_country_deprecated== null)) _country_deprecated = value ? this.country_deprecated : (string)null; }
+    }
+    private bool ShouldSerializecountry_deprecated() { return country_deprecatedSpecified; }
+    private void Resetcountry_deprecated() { country_deprecatedSpecified = false; }
+    
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
 
-    private byte[] _price_sheet = null;
+    private byte[] _price_sheet;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"price_sheet", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] price_sheet
     {
-      get { return _price_sheet; }
+      get { return _price_sheet?? null; }
       set { _price_sheet = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheetSpecified
+    {
+      get { return _price_sheet != null; }
+      set { if (value == (_price_sheet== null)) _price_sheet = value ? this.price_sheet : (byte[])null; }
+    }
+    private bool ShouldSerializeprice_sheet() { return price_sheetSpecified; }
+    private void Resetprice_sheet() { price_sheetSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1476,41 +2549,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgUpdateItemSchema() {}
     
 
-    private byte[] _items_game = null;
+    private byte[] _items_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"items_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] items_game
     {
-      get { return _items_game; }
+      get { return _items_game?? null; }
       set { _items_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_gameSpecified
+    {
+      get { return _items_game != null; }
+      set { if (value == (_items_game== null)) _items_game = value ? this.items_game : (byte[])null; }
+    }
+    private bool ShouldSerializeitems_game() { return items_gameSpecified; }
+    private void Resetitems_game() { items_gameSpecified = false; }
+    
 
-    private uint _item_schema_version = default(uint);
+    private uint? _item_schema_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_schema_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_schema_version
     {
-      get { return _item_schema_version; }
+      get { return _item_schema_version?? default(uint); }
       set { _item_schema_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_schema_versionSpecified
+    {
+      get { return _item_schema_version != null; }
+      set { if (value == (_item_schema_version== null)) _item_schema_version = value ? this.item_schema_version : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_schema_version() { return item_schema_versionSpecified; }
+    private void Resetitem_schema_version() { item_schema_versionSpecified = false; }
+    
 
-    private string _items_game_url_DEPRECATED2013 = "";
+    private string _items_game_url_DEPRECATED2013;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"items_game_url_DEPRECATED2013", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string items_game_url_DEPRECATED2013
     {
-      get { return _items_game_url_DEPRECATED2013; }
+      get { return _items_game_url_DEPRECATED2013?? ""; }
       set { _items_game_url_DEPRECATED2013 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_game_url_DEPRECATED2013Specified
+    {
+      get { return _items_game_url_DEPRECATED2013 != null; }
+      set { if (value == (_items_game_url_DEPRECATED2013== null)) _items_game_url_DEPRECATED2013 = value ? this.items_game_url_DEPRECATED2013 : (string)null; }
+    }
+    private bool ShouldSerializeitems_game_url_DEPRECATED2013() { return items_game_url_DEPRECATED2013Specified; }
+    private void Resetitems_game_url_DEPRECATED2013() { items_game_url_DEPRECATED2013Specified = false; }
+    
 
-    private string _items_game_url = "";
+    private string _items_game_url;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"items_game_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string items_game_url
     {
-      get { return _items_game_url; }
+      get { return _items_game_url?? ""; }
       set { _items_game_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_game_urlSpecified
+    {
+      get { return _items_game_url != null; }
+      set { if (value == (_items_game_url== null)) _items_game_url = value ? this.items_game_url : (string)null; }
+    }
+    private bool ShouldSerializeitems_game_url() { return items_game_urlSpecified; }
+    private void Resetitems_game_url() { items_game_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1522,14 +2631,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCError() {}
     
 
-    private string _error_text = "";
+    private string _error_text;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"error_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_text
     {
-      get { return _error_text; }
+      get { return _error_text?? ""; }
       set { _error_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_textSpecified
+    {
+      get { return _error_text != null; }
+      set { if (value == (_error_text== null)) _error_text = value ? this.error_text : (string)null; }
+    }
+    private bool ShouldSerializeerror_text() { return error_textSpecified; }
+    private void Reseterror_text() { error_textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1551,23 +2669,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgConVarValue() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1596,23 +2732,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgUseItem() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _gift__potential_targets = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"gift__potential_targets", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> gift__potential_targets
@@ -1621,23 +2775,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _duel__class_lock = default(uint);
+    private uint? _duel__class_lock;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"duel__class_lock", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel__class_lock
     {
-      get { return _duel__class_lock; }
+      get { return _duel__class_lock?? default(uint); }
       set { _duel__class_lock = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel__class_lockSpecified
+    {
+      get { return _duel__class_lock != null; }
+      set { if (value == (_duel__class_lock== null)) _duel__class_lock = value ? this.duel__class_lock : (uint?)null; }
+    }
+    private bool ShouldSerializeduel__class_lock() { return duel__class_lockSpecified; }
+    private void Resetduel__class_lock() { duel__class_lockSpecified = false; }
+    
 
-    private ulong _initiator_steam_id = default(ulong);
+    private ulong? _initiator_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initiator_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong initiator_steam_id
     {
-      get { return _initiator_steam_id; }
+      get { return _initiator_steam_id?? default(ulong); }
       set { _initiator_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiator_steam_idSpecified
+    {
+      get { return _initiator_steam_id != null; }
+      set { if (value == (_initiator_steam_id== null)) _initiator_steam_id = value ? this.initiator_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeinitiator_steam_id() { return initiator_steam_idSpecified; }
+    private void Resetinitiator_steam_id() { initiator_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1649,32 +2821,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgReplayUploadedToYouTube() {}
     
 
-    private string _youtube_url = "";
+    private string _youtube_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"youtube_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_url
     {
-      get { return _youtube_url; }
+      get { return _youtube_url?? ""; }
       set { _youtube_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_urlSpecified
+    {
+      get { return _youtube_url != null; }
+      set { if (value == (_youtube_url== null)) _youtube_url = value ? this.youtube_url : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_url() { return youtube_urlSpecified; }
+    private void Resetyoutube_url() { youtube_urlSpecified = false; }
+    
 
-    private string _youtube_account_name = "";
+    private string _youtube_account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"youtube_account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_account_name
     {
-      get { return _youtube_account_name; }
+      get { return _youtube_account_name?? ""; }
       set { _youtube_account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_account_nameSpecified
+    {
+      get { return _youtube_account_name != null; }
+      set { if (value == (_youtube_account_name== null)) _youtube_account_name = value ? this.youtube_account_name : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_account_name() { return youtube_account_nameSpecified; }
+    private void Resetyoutube_account_name() { youtube_account_nameSpecified = false; }
+    
 
-    private ulong _session_id = default(ulong);
+    private ulong? _session_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong session_id
     {
-      get { return _session_id; }
+      get { return _session_id?? default(ulong); }
       set { _session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool session_idSpecified
+    {
+      get { return _session_id != null; }
+      set { if (value == (_session_id== null)) _session_id = value ? this.session_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesession_id() { return session_idSpecified; }
+    private void Resetsession_id() { session_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1686,14 +2885,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgConsumableExhausted() {}
     
 
-    private int _item_def_id = default(int);
+    private int? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(int); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (int?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1705,68 +2913,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgItemAcknowledged__DEPRECATED() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _rarity = default(uint);
+    private uint? _rarity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rarity
     {
-      get { return _rarity; }
+      get { return _rarity?? default(uint); }
       set { _rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raritySpecified
+    {
+      get { return _rarity != null; }
+      set { if (value == (_rarity== null)) _rarity = value ? this.rarity : (uint?)null; }
+    }
+    private bool ShouldSerializerarity() { return raritySpecified; }
+    private void Resetrarity() { raritySpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1790,32 +3061,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public ItemPosition() {}
     
 
-    private uint _legacy_item_id = default(uint);
+    private uint? _legacy_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"legacy_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint legacy_item_id
     {
-      get { return _legacy_item_id; }
+      get { return _legacy_item_id?? default(uint); }
       set { _legacy_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_item_idSpecified
+    {
+      get { return _legacy_item_id != null; }
+      set { if (value == (_legacy_item_id== null)) _legacy_item_id = value ? this.legacy_item_id : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_item_id() { return legacy_item_idSpecified; }
+    private void Resetlegacy_item_id() { legacy_item_idSpecified = false; }
+    
 
-    private uint _position = default(uint);
+    private uint? _position;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint position
     {
-      get { return _position; }
+      get { return _position?? default(uint); }
       set { _position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool positionSpecified
+    {
+      get { return _position != null; }
+      set { if (value == (_position== null)) _position = value ? this.position : (uint?)null; }
+    }
+    private bool ShouldSerializeposition() { return positionSpecified; }
+    private void Resetposition() { positionSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1832,68 +3130,131 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCReportAbuse() {}
     
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private ulong _gid = default(ulong);
+    private ulong? _gid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gid
     {
-      get { return _gid; }
+      get { return _gid?? default(ulong); }
       set { _gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gidSpecified
+    {
+      get { return _gid != null; }
+      set { if (value == (_gid== null)) _gid = value ? this.gid : (ulong?)null; }
+    }
+    private bool ShouldSerializegid() { return gidSpecified; }
+    private void Resetgid() { gidSpecified = false; }
+    
 
-    private uint _abuse_type = default(uint);
+    private uint? _abuse_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"abuse_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint abuse_type
     {
-      get { return _abuse_type; }
+      get { return _abuse_type?? default(uint); }
       set { _abuse_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abuse_typeSpecified
+    {
+      get { return _abuse_type != null; }
+      set { if (value == (_abuse_type== null)) _abuse_type = value ? this.abuse_type : (uint?)null; }
+    }
+    private bool ShouldSerializeabuse_type() { return abuse_typeSpecified; }
+    private void Resetabuse_type() { abuse_typeSpecified = false; }
+    
 
-    private uint _content_type = default(uint);
+    private uint? _content_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"content_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint content_type
     {
-      get { return _content_type; }
+      get { return _content_type?? default(uint); }
       set { _content_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool content_typeSpecified
+    {
+      get { return _content_type != null; }
+      set { if (value == (_content_type== null)) _content_type = value ? this.content_type : (uint?)null; }
+    }
+    private bool ShouldSerializecontent_type() { return content_typeSpecified; }
+    private void Resetcontent_type() { content_typeSpecified = false; }
+    
 
-    private uint _target_game_server_ip = default(uint);
+    private uint? _target_game_server_ip;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"target_game_server_ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_game_server_ip
     {
-      get { return _target_game_server_ip; }
+      get { return _target_game_server_ip?? default(uint); }
       set { _target_game_server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_game_server_ipSpecified
+    {
+      get { return _target_game_server_ip != null; }
+      set { if (value == (_target_game_server_ip== null)) _target_game_server_ip = value ? this.target_game_server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_game_server_ip() { return target_game_server_ipSpecified; }
+    private void Resettarget_game_server_ip() { target_game_server_ipSpecified = false; }
+    
 
-    private uint _target_game_server_port = default(uint);
+    private uint? _target_game_server_port;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"target_game_server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_game_server_port
     {
-      get { return _target_game_server_port; }
+      get { return _target_game_server_port?? default(uint); }
       set { _target_game_server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_game_server_portSpecified
+    {
+      get { return _target_game_server_port != null; }
+      set { if (value == (_target_game_server_port== null)) _target_game_server_port = value ? this.target_game_server_port : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_game_server_port() { return target_game_server_portSpecified; }
+    private void Resettarget_game_server_port() { target_game_server_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1905,32 +3266,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCReportAbuseResponse() {}
     
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1942,32 +3330,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCNameItemNotification() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private string _item_name_custom = "";
+    private string _item_name_custom;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_name_custom", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_name_custom
     {
-      get { return _item_name_custom; }
+      get { return _item_name_custom?? ""; }
       set { _item_name_custom = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_name_customSpecified
+    {
+      get { return _item_name_custom != null; }
+      set { if (value == (_item_name_custom== null)) _item_name_custom = value ? this.item_name_custom : (string)null; }
+    }
+    private bool ShouldSerializeitem_name_custom() { return item_name_customSpecified; }
+    private void Resetitem_name_custom() { item_name_customSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1979,23 +3394,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCClientDisplayNotification() {}
     
 
-    private string _notification_title_localization_key = "";
+    private string _notification_title_localization_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"notification_title_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_title_localization_key
     {
-      get { return _notification_title_localization_key; }
+      get { return _notification_title_localization_key?? ""; }
       set { _notification_title_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_title_localization_keySpecified
+    {
+      get { return _notification_title_localization_key != null; }
+      set { if (value == (_notification_title_localization_key== null)) _notification_title_localization_key = value ? this.notification_title_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_title_localization_key() { return notification_title_localization_keySpecified; }
+    private void Resetnotification_title_localization_key() { notification_title_localization_keySpecified = false; }
+    
 
-    private string _notification_body_localization_key = "";
+    private string _notification_body_localization_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"notification_body_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_body_localization_key
     {
-      get { return _notification_body_localization_key; }
+      get { return _notification_body_localization_key?? ""; }
       set { _notification_body_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_body_localization_keySpecified
+    {
+      get { return _notification_body_localization_key != null; }
+      set { if (value == (_notification_body_localization_key== null)) _notification_body_localization_key = value ? this.notification_body_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_body_localization_key() { return notification_body_localization_keySpecified; }
+    private void Resetnotification_body_localization_key() { notification_body_localization_keySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _body_substring_keys = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"body_substring_keys", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> body_substring_keys
@@ -2021,14 +3454,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCShowItemsPickedUp() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2040,41 +3482,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCIncrementKillCountResponse() {}
     
 
-    private uint _killer_account_id = default(uint);
+    private uint? _killer_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_account_id
     {
-      get { return _killer_account_id; }
+      get { return _killer_account_id?? default(uint); }
       set { _killer_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_account_idSpecified
+    {
+      get { return _killer_account_id != null; }
+      set { if (value == (_killer_account_id== null)) _killer_account_id = value ? this.killer_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_account_id() { return killer_account_idSpecified; }
+    private void Resetkiller_account_id() { killer_account_idSpecified = false; }
+    
 
-    private uint _num_kills = default(uint);
+    private uint? _num_kills;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_kills
     {
-      get { return _num_kills; }
+      get { return _num_kills?? default(uint); }
       set { _num_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_killsSpecified
+    {
+      get { return _num_kills != null; }
+      set { if (value == (_num_kills== null)) _num_kills = value ? this.num_kills : (uint?)null; }
+    }
+    private bool ShouldSerializenum_kills() { return num_killsSpecified; }
+    private void Resetnum_kills() { num_killsSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _level_type = default(uint);
+    private uint? _level_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"level_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level_type
     {
-      get { return _level_type; }
+      get { return _level_type?? default(uint); }
       set { _level_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_typeSpecified
+    {
+      get { return _level_type != null; }
+      set { if (value == (_level_type== null)) _level_type = value ? this.level_type : (uint?)null; }
+    }
+    private bool ShouldSerializelevel_type() { return level_typeSpecified; }
+    private void Resetlevel_type() { level_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2086,59 +3564,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItemDropRateBonus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _expiration_date = default(uint);
+    private uint? _expiration_date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"expiration_date", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_date
     {
-      get { return _expiration_date; }
+      get { return _expiration_date?? default(uint); }
       set { _expiration_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_dateSpecified
+    {
+      get { return _expiration_date != null; }
+      set { if (value == (_expiration_date== null)) _expiration_date = value ? this.expiration_date : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_date() { return expiration_dateSpecified; }
+    private void Resetexpiration_date() { expiration_dateSpecified = false; }
+    
 
-    private float _bonus = default(float);
+    private float? _bonus;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bonus", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float bonus
     {
-      get { return _bonus; }
+      get { return _bonus?? default(float); }
       set { _bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonusSpecified
+    {
+      get { return _bonus != null; }
+      set { if (value == (_bonus== null)) _bonus = value ? this.bonus : (float?)null; }
+    }
+    private bool ShouldSerializebonus() { return bonusSpecified; }
+    private void Resetbonus() { bonusSpecified = false; }
+    
 
-    private uint _bonus_count = default(uint);
+    private uint? _bonus_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bonus_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_count
     {
-      get { return _bonus_count; }
+      get { return _bonus_count?? default(uint); }
       set { _bonus_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_countSpecified
+    {
+      get { return _bonus_count != null; }
+      set { if (value == (_bonus_count== null)) _bonus_count = value ? this.bonus_count : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_count() { return bonus_countSpecified; }
+    private void Resetbonus_count() { bonus_countSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2150,41 +3682,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItemLeagueViewPass() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _admin = default(uint);
+    private uint? _admin;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"admin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint admin
     {
-      get { return _admin; }
+      get { return _admin?? default(uint); }
       set { _admin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool adminSpecified
+    {
+      get { return _admin != null; }
+      set { if (value == (_admin== null)) _admin = value ? this.admin : (uint?)null; }
+    }
+    private bool ShouldSerializeadmin() { return adminSpecified; }
+    private void Resetadmin() { adminSpecified = false; }
+    
 
-    private uint _itemindex = default(uint);
+    private uint? _itemindex;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"itemindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint itemindex
     {
-      get { return _itemindex; }
+      get { return _itemindex?? default(uint); }
       set { _itemindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemindexSpecified
+    {
+      get { return _itemindex != null; }
+      set { if (value == (_itemindex== null)) _itemindex = value ? this.itemindex : (uint?)null; }
+    }
+    private bool ShouldSerializeitemindex() { return itemindexSpecified; }
+    private void Resetitemindex() { itemindexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2196,32 +3764,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconItemEventTicket() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2233,14 +3828,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCItemPreviewItemBoughtNotification() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2252,14 +3856,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseCancel() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2271,14 +3884,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseCancelResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2290,14 +3912,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseFinalize() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2309,14 +3940,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCStorePurchaseFinalizeResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -2335,23 +3975,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCBannedWordListRequest() {}
     
 
-    private uint _ban_list_group_id = default(uint);
+    private uint? _ban_list_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ban_list_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ban_list_group_id
     {
-      get { return _ban_list_group_id; }
+      get { return _ban_list_group_id?? default(uint); }
       set { _ban_list_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_list_group_idSpecified
+    {
+      get { return _ban_list_group_id != null; }
+      set { if (value == (_ban_list_group_id== null)) _ban_list_group_id = value ? this.ban_list_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializeban_list_group_id() { return ban_list_group_idSpecified; }
+    private void Resetban_list_group_id() { ban_list_group_idSpecified = false; }
+    
 
-    private uint _word_id = default(uint);
+    private uint? _word_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint word_id
     {
-      get { return _word_id; }
+      get { return _word_id?? default(uint); }
       set { _word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_idSpecified
+    {
+      get { return _word_id != null; }
+      set { if (value == (_word_id== null)) _word_id = value ? this.word_id : (uint?)null; }
+    }
+    private bool ShouldSerializeword_id() { return word_idSpecified; }
+    private void Resetword_id() { word_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2373,41 +4031,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCRequestAnnouncementsResponse() {}
     
 
-    private string _announcement_title = "";
+    private string _announcement_title;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"announcement_title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string announcement_title
     {
-      get { return _announcement_title; }
+      get { return _announcement_title?? ""; }
       set { _announcement_title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool announcement_titleSpecified
+    {
+      get { return _announcement_title != null; }
+      set { if (value == (_announcement_title== null)) _announcement_title = value ? this.announcement_title : (string)null; }
+    }
+    private bool ShouldSerializeannouncement_title() { return announcement_titleSpecified; }
+    private void Resetannouncement_title() { announcement_titleSpecified = false; }
+    
 
-    private string _announcement = "";
+    private string _announcement;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"announcement", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string announcement
     {
-      get { return _announcement; }
+      get { return _announcement?? ""; }
       set { _announcement = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool announcementSpecified
+    {
+      get { return _announcement != null; }
+      set { if (value == (_announcement== null)) _announcement = value ? this.announcement : (string)null; }
+    }
+    private bool ShouldSerializeannouncement() { return announcementSpecified; }
+    private void Resetannouncement() { announcementSpecified = false; }
+    
 
-    private string _nextmatch_title = "";
+    private string _nextmatch_title;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"nextmatch_title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string nextmatch_title
     {
-      get { return _nextmatch_title; }
+      get { return _nextmatch_title?? ""; }
       set { _nextmatch_title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nextmatch_titleSpecified
+    {
+      get { return _nextmatch_title != null; }
+      set { if (value == (_nextmatch_title== null)) _nextmatch_title = value ? this.nextmatch_title : (string)null; }
+    }
+    private bool ShouldSerializenextmatch_title() { return nextmatch_titleSpecified; }
+    private void Resetnextmatch_title() { nextmatch_titleSpecified = false; }
+    
 
-    private string _nextmatch = "";
+    private string _nextmatch;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"nextmatch", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string nextmatch
     {
-      get { return _nextmatch; }
+      get { return _nextmatch?? ""; }
       set { _nextmatch = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nextmatchSpecified
+    {
+      get { return _nextmatch != null; }
+      set { if (value == (_nextmatch== null)) _nextmatch = value ? this.nextmatch : (string)null; }
+    }
+    private bool ShouldSerializenextmatch() { return nextmatchSpecified; }
+    private void Resetnextmatch() { nextmatchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2419,32 +4113,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCBannedWord() {}
     
 
-    private uint _word_id = default(uint);
+    private uint? _word_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint word_id
     {
-      get { return _word_id; }
+      get { return _word_id?? default(uint); }
       set { _word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_idSpecified
+    {
+      get { return _word_id != null; }
+      set { if (value == (_word_id== null)) _word_id = value ? this.word_id : (uint?)null; }
+    }
+    private bool ShouldSerializeword_id() { return word_idSpecified; }
+    private void Resetword_id() { word_idSpecified = false; }
+    
 
-    private GC_BannedWordType _word_type = GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD;
+    private GC_BannedWordType? _word_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"word_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD)]
     public GC_BannedWordType word_type
     {
-      get { return _word_type; }
+      get { return _word_type?? GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD; }
       set { _word_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_typeSpecified
+    {
+      get { return _word_type != null; }
+      set { if (value == (_word_type== null)) _word_type = value ? this.word_type : (GC_BannedWordType?)null; }
+    }
+    private bool ShouldSerializeword_type() { return word_typeSpecified; }
+    private void Resetword_type() { word_typeSpecified = false; }
+    
 
-    private string _word = "";
+    private string _word;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"word", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string word
     {
-      get { return _word; }
+      get { return _word?? ""; }
       set { _word = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wordSpecified
+    {
+      get { return _word != null; }
+      set { if (value == (_word== null)) _word = value ? this.word : (string)null; }
+    }
+    private bool ShouldSerializeword() { return wordSpecified; }
+    private void Resetword() { wordSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2456,14 +4177,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCBannedWordListResponse() {}
     
 
-    private uint _ban_list_group_id = default(uint);
+    private uint? _ban_list_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ban_list_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ban_list_group_id
     {
-      get { return _ban_list_group_id; }
+      get { return _ban_list_group_id?? default(uint); }
       set { _ban_list_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_list_group_idSpecified
+    {
+      get { return _ban_list_group_id != null; }
+      set { if (value == (_ban_list_group_id== null)) _ban_list_group_id = value ? this.ban_list_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializeban_list_group_id() { return ban_list_group_idSpecified; }
+    private void Resetban_list_group_id() { ban_list_group_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCBannedWord> _word_list = new global::System.Collections.Generic.List<CMsgGCBannedWord>();
     [global::ProtoBuf.ProtoMember(2, Name=@"word_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCBannedWord> word_list
@@ -2501,14 +4231,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCBannedWordListUpdated() {}
     
 
-    private uint _group_id = default(uint);
+    private uint? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(uint); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (uint?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2520,41 +4259,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CSOEconDefaultEquippedDefinitionInstanceClient() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _item_definition = default(uint);
+    private uint? _item_definition;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_definition", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_definition
     {
-      get { return _item_definition; }
+      get { return _item_definition?? default(uint); }
       set { _item_definition = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_definitionSpecified
+    {
+      get { return _item_definition != null; }
+      set { if (value == (_item_definition== null)) _item_definition = value ? this.item_definition : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_definition() { return item_definitionSpecified; }
+    private void Resetitem_definition() { item_definitionSpecified = false; }
+    
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2566,23 +4341,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCDirtySDOCache() {}
     
 
-    private uint _sdo_type = default(uint);
+    private uint? _sdo_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sdo_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sdo_type
     {
-      get { return _sdo_type; }
+      get { return _sdo_type?? default(uint); }
       set { _sdo_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sdo_typeSpecified
+    {
+      get { return _sdo_type != null; }
+      set { if (value == (_sdo_type== null)) _sdo_type = value ? this.sdo_type : (uint?)null; }
+    }
+    private bool ShouldSerializesdo_type() { return sdo_typeSpecified; }
+    private void Resetsdo_type() { sdo_typeSpecified = false; }
+    
 
-    private ulong _key_uint64 = default(ulong);
+    private ulong? _key_uint64;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"key_uint64", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong key_uint64
     {
-      get { return _key_uint64; }
+      get { return _key_uint64?? default(ulong); }
       set { _key_uint64 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_uint64Specified
+    {
+      get { return _key_uint64 != null; }
+      set { if (value == (_key_uint64== null)) _key_uint64 = value ? this.key_uint64 : (ulong?)null; }
+    }
+    private bool ShouldSerializekey_uint64() { return key_uint64Specified; }
+    private void Resetkey_uint64() { key_uint64Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2594,14 +4387,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCDirtyMultipleSDOCache() {}
     
 
-    private uint _sdo_type = default(uint);
+    private uint? _sdo_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sdo_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sdo_type
     {
-      get { return _sdo_type; }
+      get { return _sdo_type?? default(uint); }
       set { _sdo_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sdo_typeSpecified
+    {
+      get { return _sdo_type != null; }
+      set { if (value == (_sdo_type== null)) _sdo_type = value ? this.sdo_type : (uint?)null; }
+    }
+    private bool ShouldSerializesdo_type() { return sdo_typeSpecified; }
+    private void Resetsdo_type() { sdo_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _key_uint64 = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"key_uint64", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> key_uint64
@@ -2620,23 +4422,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCCollectItem() {}
     
 
-    private ulong _collection_item_id = default(ulong);
+    private ulong? _collection_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"collection_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong collection_item_id
     {
-      get { return _collection_item_id; }
+      get { return _collection_item_id?? default(ulong); }
       set { _collection_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool collection_item_idSpecified
+    {
+      get { return _collection_item_id != null; }
+      set { if (value == (_collection_item_id== null)) _collection_item_id = value ? this.collection_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecollection_item_id() { return collection_item_idSpecified; }
+    private void Resetcollection_item_id() { collection_item_idSpecified = false; }
+    
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2658,14 +4478,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCUpdateSQLKeyValue() {}
     
 
-    private string _key_name = "";
+    private string _key_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key_name
     {
-      get { return _key_name; }
+      get { return _key_name?? ""; }
       set { _key_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_nameSpecified
+    {
+      get { return _key_name != null; }
+      set { if (value == (_key_name== null)) _key_name = value ? this.key_name : (string)null; }
+    }
+    private bool ShouldSerializekey_name() { return key_nameSpecified; }
+    private void Resetkey_name() { key_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2677,14 +4506,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCIsTrustedServer() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2696,14 +4534,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCIsTrustedServerResponse() {}
     
 
-    private bool _is_trusted = default(bool);
+    private bool? _is_trusted;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_trusted
     {
-      get { return _is_trusted; }
+      get { return _is_trusted?? default(bool); }
       set { _is_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_trustedSpecified
+    {
+      get { return _is_trusted != null; }
+      set { if (value == (_is_trusted== null)) _is_trusted = value ? this.is_trusted : (bool?)null; }
+    }
+    private bool ShouldSerializeis_trusted() { return is_trustedSpecified; }
+    private void Resetis_trusted() { is_trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2715,14 +4562,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCBroadcastConsoleCommand() {}
     
 
-    private string _con_command = "";
+    private string _con_command;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"con_command", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string con_command
     {
-      get { return _con_command; }
+      get { return _con_command?? ""; }
       set { _con_command = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool con_commandSpecified
+    {
+      get { return _con_command != null; }
+      set { if (value == (_con_command== null)) _con_command = value ? this.con_command : (string)null; }
+    }
+    private bool ShouldSerializecon_command() { return con_commandSpecified; }
+    private void Resetcon_command() { con_commandSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2734,14 +4590,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCServerVersionUpdated() {}
     
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2753,14 +4618,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCClientVersionUpdated() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2782,32 +4656,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCToGCRequestPassportItemGrant() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private int _reward_flag = default(int);
+    private int? _reward_flag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"reward_flag", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int reward_flag
     {
-      get { return _reward_flag; }
+      get { return _reward_flag?? default(int); }
       set { _reward_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_flagSpecified
+    {
+      get { return _reward_flag != null; }
+      set { if (value == (_reward_flag== null)) _reward_flag = value ? this.reward_flag : (int?)null; }
+    }
+    private bool ShouldSerializereward_flag() { return reward_flagSpecified; }
+    private void Resetreward_flag() { reward_flagSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2819,167 +4720,329 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGameServerInfo() {}
     
 
-    private uint _server_public_ip_addr = default(uint);
+    private uint? _server_public_ip_addr;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_public_ip_addr", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_public_ip_addr
     {
-      get { return _server_public_ip_addr; }
+      get { return _server_public_ip_addr?? default(uint); }
       set { _server_public_ip_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_public_ip_addrSpecified
+    {
+      get { return _server_public_ip_addr != null; }
+      set { if (value == (_server_public_ip_addr== null)) _server_public_ip_addr = value ? this.server_public_ip_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_public_ip_addr() { return server_public_ip_addrSpecified; }
+    private void Resetserver_public_ip_addr() { server_public_ip_addrSpecified = false; }
+    
 
-    private uint _server_private_ip_addr = default(uint);
+    private uint? _server_private_ip_addr;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_private_ip_addr", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_private_ip_addr
     {
-      get { return _server_private_ip_addr; }
+      get { return _server_private_ip_addr?? default(uint); }
       set { _server_private_ip_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_private_ip_addrSpecified
+    {
+      get { return _server_private_ip_addr != null; }
+      set { if (value == (_server_private_ip_addr== null)) _server_private_ip_addr = value ? this.server_private_ip_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_private_ip_addr() { return server_private_ip_addrSpecified; }
+    private void Resetserver_private_ip_addr() { server_private_ip_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _server_tv_port = default(uint);
+    private uint? _server_tv_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_tv_port
     {
-      get { return _server_tv_port; }
+      get { return _server_tv_port?? default(uint); }
       set { _server_tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_tv_portSpecified
+    {
+      get { return _server_tv_port != null; }
+      set { if (value == (_server_tv_port== null)) _server_tv_port = value ? this.server_tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_tv_port() { return server_tv_portSpecified; }
+    private void Resetserver_tv_port() { server_tv_portSpecified = false; }
+    
 
-    private string _server_key = "";
+    private string _server_key;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string server_key
     {
-      get { return _server_key; }
+      get { return _server_key?? ""; }
       set { _server_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_keySpecified
+    {
+      get { return _server_key != null; }
+      set { if (value == (_server_key== null)) _server_key = value ? this.server_key : (string)null; }
+    }
+    private bool ShouldSerializeserver_key() { return server_keySpecified; }
+    private void Resetserver_key() { server_keySpecified = false; }
+    
 
-    private bool _server_hibernation = default(bool);
+    private bool? _server_hibernation;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_hibernation", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool server_hibernation
     {
-      get { return _server_hibernation; }
+      get { return _server_hibernation?? default(bool); }
       set { _server_hibernation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_hibernationSpecified
+    {
+      get { return _server_hibernation != null; }
+      set { if (value == (_server_hibernation== null)) _server_hibernation = value ? this.server_hibernation : (bool?)null; }
+    }
+    private bool ShouldSerializeserver_hibernation() { return server_hibernationSpecified; }
+    private void Resetserver_hibernation() { server_hibernationSpecified = false; }
+    
 
-    private CMsgGameServerInfo.ServerType _server_type = CMsgGameServerInfo.ServerType.UNSPECIFIED;
+    private CMsgGameServerInfo.ServerType? _server_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"server_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerInfo.ServerType.UNSPECIFIED)]
     public CMsgGameServerInfo.ServerType server_type
     {
-      get { return _server_type; }
+      get { return _server_type?? CMsgGameServerInfo.ServerType.UNSPECIFIED; }
       set { _server_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_typeSpecified
+    {
+      get { return _server_type != null; }
+      set { if (value == (_server_type== null)) _server_type = value ? this.server_type : (CMsgGameServerInfo.ServerType?)null; }
+    }
+    private bool ShouldSerializeserver_type() { return server_typeSpecified; }
+    private void Resetserver_type() { server_typeSpecified = false; }
+    
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private float _server_loadavg = default(float);
+    private float? _server_loadavg;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"server_loadavg", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_loadavg
     {
-      get { return _server_loadavg; }
+      get { return _server_loadavg?? default(float); }
       set { _server_loadavg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_loadavgSpecified
+    {
+      get { return _server_loadavg != null; }
+      set { if (value == (_server_loadavg== null)) _server_loadavg = value ? this.server_loadavg : (float?)null; }
+    }
+    private bool ShouldSerializeserver_loadavg() { return server_loadavgSpecified; }
+    private void Resetserver_loadavg() { server_loadavgSpecified = false; }
+    
 
-    private float _server_tv_broadcast_time = default(float);
+    private float? _server_tv_broadcast_time;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"server_tv_broadcast_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_tv_broadcast_time
     {
-      get { return _server_tv_broadcast_time; }
+      get { return _server_tv_broadcast_time?? default(float); }
       set { _server_tv_broadcast_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_tv_broadcast_timeSpecified
+    {
+      get { return _server_tv_broadcast_time != null; }
+      set { if (value == (_server_tv_broadcast_time== null)) _server_tv_broadcast_time = value ? this.server_tv_broadcast_time : (float?)null; }
+    }
+    private bool ShouldSerializeserver_tv_broadcast_time() { return server_tv_broadcast_timeSpecified; }
+    private void Resetserver_tv_broadcast_time() { server_tv_broadcast_timeSpecified = false; }
+    
 
-    private float _server_game_time = default(float);
+    private float? _server_game_time;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"server_game_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_game_time
     {
-      get { return _server_game_time; }
+      get { return _server_game_time?? default(float); }
       set { _server_game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_game_timeSpecified
+    {
+      get { return _server_game_time != null; }
+      set { if (value == (_server_game_time== null)) _server_game_time = value ? this.server_game_time : (float?)null; }
+    }
+    private bool ShouldSerializeserver_game_time() { return server_game_timeSpecified; }
+    private void Resetserver_game_time() { server_game_timeSpecified = false; }
+    
 
-    private ulong _server_relay_connected_steam_id = default(ulong);
+    private ulong? _server_relay_connected_steam_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"server_relay_connected_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_relay_connected_steam_id
     {
-      get { return _server_relay_connected_steam_id; }
+      get { return _server_relay_connected_steam_id?? default(ulong); }
       set { _server_relay_connected_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_relay_connected_steam_idSpecified
+    {
+      get { return _server_relay_connected_steam_id != null; }
+      set { if (value == (_server_relay_connected_steam_id== null)) _server_relay_connected_steam_id = value ? this.server_relay_connected_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_relay_connected_steam_id() { return server_relay_connected_steam_idSpecified; }
+    private void Resetserver_relay_connected_steam_id() { server_relay_connected_steam_idSpecified = false; }
+    
 
-    private uint _relay_slots_max = default(uint);
+    private uint? _relay_slots_max;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"relay_slots_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint relay_slots_max
     {
-      get { return _relay_slots_max; }
+      get { return _relay_slots_max?? default(uint); }
       set { _relay_slots_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relay_slots_maxSpecified
+    {
+      get { return _relay_slots_max != null; }
+      set { if (value == (_relay_slots_max== null)) _relay_slots_max = value ? this.relay_slots_max : (uint?)null; }
+    }
+    private bool ShouldSerializerelay_slots_max() { return relay_slots_maxSpecified; }
+    private void Resetrelay_slots_max() { relay_slots_maxSpecified = false; }
+    
 
-    private int _relays_connected = default(int);
+    private int? _relays_connected;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"relays_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int relays_connected
     {
-      get { return _relays_connected; }
+      get { return _relays_connected?? default(int); }
       set { _relays_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relays_connectedSpecified
+    {
+      get { return _relays_connected != null; }
+      set { if (value == (_relays_connected== null)) _relays_connected = value ? this.relays_connected : (int?)null; }
+    }
+    private bool ShouldSerializerelays_connected() { return relays_connectedSpecified; }
+    private void Resetrelays_connected() { relays_connectedSpecified = false; }
+    
 
-    private int _relay_clients_connected = default(int);
+    private int? _relay_clients_connected;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"relay_clients_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int relay_clients_connected
     {
-      get { return _relay_clients_connected; }
+      get { return _relay_clients_connected?? default(int); }
       set { _relay_clients_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relay_clients_connectedSpecified
+    {
+      get { return _relay_clients_connected != null; }
+      set { if (value == (_relay_clients_connected== null)) _relay_clients_connected = value ? this.relay_clients_connected : (int?)null; }
+    }
+    private bool ShouldSerializerelay_clients_connected() { return relay_clients_connectedSpecified; }
+    private void Resetrelay_clients_connected() { relay_clients_connectedSpecified = false; }
+    
 
-    private ulong _relayed_game_server_steam_id = default(ulong);
+    private ulong? _relayed_game_server_steam_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"relayed_game_server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong relayed_game_server_steam_id
     {
-      get { return _relayed_game_server_steam_id; }
+      get { return _relayed_game_server_steam_id?? default(ulong); }
       set { _relayed_game_server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relayed_game_server_steam_idSpecified
+    {
+      get { return _relayed_game_server_steam_id != null; }
+      set { if (value == (_relayed_game_server_steam_id== null)) _relayed_game_server_steam_id = value ? this.relayed_game_server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerelayed_game_server_steam_id() { return relayed_game_server_steam_idSpecified; }
+    private void Resetrelayed_game_server_steam_id() { relayed_game_server_steam_idSpecified = false; }
+    
 
-    private uint _parent_relay_count = default(uint);
+    private uint? _parent_relay_count;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"parent_relay_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint parent_relay_count
     {
-      get { return _parent_relay_count; }
+      get { return _parent_relay_count?? default(uint); }
       set { _parent_relay_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parent_relay_countSpecified
+    {
+      get { return _parent_relay_count != null; }
+      set { if (value == (_parent_relay_count== null)) _parent_relay_count = value ? this.parent_relay_count : (uint?)null; }
+    }
+    private bool ShouldSerializeparent_relay_count() { return parent_relay_countSpecified; }
+    private void Resetparent_relay_count() { parent_relay_countSpecified = false; }
+    
 
-    private ulong _tv_secret_code = default(ulong);
+    private ulong? _tv_secret_code;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"tv_secret_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_secret_code
     {
-      get { return _tv_secret_code; }
+      get { return _tv_secret_code?? default(ulong); }
       set { _tv_secret_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_secret_codeSpecified
+    {
+      get { return _tv_secret_code != null; }
+      set { if (value == (_tv_secret_code== null)) _tv_secret_code = value ? this.tv_secret_code : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_secret_code() { return tv_secret_codeSpecified; }
+    private void Resettv_secret_code() { tv_secret_codeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ServerType", EnumPassthru=true)]
     public enum ServerType
     {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCEcon.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCEcon.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: econ_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCGiftedItems() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _giftdefindex = default(uint);
+    private uint? _giftdefindex;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"giftdefindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint giftdefindex
     {
-      get { return _giftdefindex; }
+      get { return _giftdefindex?? default(uint); }
       set { _giftdefindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool giftdefindexSpecified
+    {
+      get { return _giftdefindex != null; }
+      set { if (value == (_giftdefindex== null)) _giftdefindex = value ? this.giftdefindex : (uint?)null; }
+    }
+    private bool ShouldSerializegiftdefindex() { return giftdefindexSpecified; }
+    private void Resetgiftdefindex() { giftdefindexSpecified = false; }
+    
 
-    private uint _max_gifts_possible = default(uint);
+    private uint? _max_gifts_possible;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"max_gifts_possible", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_gifts_possible
     {
-      get { return _max_gifts_possible; }
+      get { return _max_gifts_possible?? default(uint); }
       set { _max_gifts_possible = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_gifts_possibleSpecified
+    {
+      get { return _max_gifts_possible != null; }
+      set { if (value == (_max_gifts_possible== null)) _max_gifts_possible = value ? this.max_gifts_possible : (uint?)null; }
+    }
+    private bool ShouldSerializemax_gifts_possible() { return max_gifts_possibleSpecified; }
+    private void Resetmax_gifts_possible() { max_gifts_possibleSpecified = false; }
+    
 
-    private uint _num_eligible_recipients = default(uint);
+    private uint? _num_eligible_recipients;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_eligible_recipients", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_eligible_recipients
     {
-      get { return _num_eligible_recipients; }
+      get { return _num_eligible_recipients?? default(uint); }
       set { _num_eligible_recipients = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_eligible_recipientsSpecified
+    {
+      get { return _num_eligible_recipients != null; }
+      set { if (value == (_num_eligible_recipients== null)) _num_eligible_recipients = value ? this.num_eligible_recipients : (uint?)null; }
+    }
+    private bool ShouldSerializenum_eligible_recipients() { return num_eligible_recipientsSpecified; }
+    private void Resetnum_eligible_recipients() { num_eligible_recipientsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _recipients_accountids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"recipients_accountids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> recipients_accountids
@@ -71,23 +109,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgApplyAutograph() {}
     
 
-    private ulong _autograph_item_id = default(ulong);
+    private ulong? _autograph_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"autograph_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong autograph_item_id
     {
-      get { return _autograph_item_id; }
+      get { return _autograph_item_id?? default(ulong); }
       set { _autograph_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autograph_item_idSpecified
+    {
+      get { return _autograph_item_id != null; }
+      set { if (value == (_autograph_item_id== null)) _autograph_item_id = value ? this.autograph_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeautograph_item_id() { return autograph_item_idSpecified; }
+    private void Resetautograph_item_id() { autograph_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCEngine.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCEngine.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: engine_gcmessages.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,86 +20,167 @@ namespace SteamKit2.GC.CSGO.Internal
     public CEngineGotvSyncPacket() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _instance_id = default(uint);
+    private uint? _instance_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint instance_id
     {
-      get { return _instance_id; }
+      get { return _instance_id?? default(uint); }
       set { _instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool instance_idSpecified
+    {
+      get { return _instance_id != null; }
+      set { if (value == (_instance_id== null)) _instance_id = value ? this.instance_id : (uint?)null; }
+    }
+    private bool ShouldSerializeinstance_id() { return instance_idSpecified; }
+    private void Resetinstance_id() { instance_idSpecified = false; }
+    
 
-    private uint _signupfragment = default(uint);
+    private uint? _signupfragment;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"signupfragment", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint signupfragment
     {
-      get { return _signupfragment; }
+      get { return _signupfragment?? default(uint); }
       set { _signupfragment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signupfragmentSpecified
+    {
+      get { return _signupfragment != null; }
+      set { if (value == (_signupfragment== null)) _signupfragment = value ? this.signupfragment : (uint?)null; }
+    }
+    private bool ShouldSerializesignupfragment() { return signupfragmentSpecified; }
+    private void Resetsignupfragment() { signupfragmentSpecified = false; }
+    
 
-    private uint _currentfragment = default(uint);
+    private uint? _currentfragment;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"currentfragment", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currentfragment
     {
-      get { return _currentfragment; }
+      get { return _currentfragment?? default(uint); }
       set { _currentfragment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currentfragmentSpecified
+    {
+      get { return _currentfragment != null; }
+      set { if (value == (_currentfragment== null)) _currentfragment = value ? this.currentfragment : (uint?)null; }
+    }
+    private bool ShouldSerializecurrentfragment() { return currentfragmentSpecified; }
+    private void Resetcurrentfragment() { currentfragmentSpecified = false; }
+    
 
-    private float _tickrate = default(float);
+    private float? _tickrate;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tickrate", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float tickrate
     {
-      get { return _tickrate; }
+      get { return _tickrate?? default(float); }
       set { _tickrate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tickrateSpecified
+    {
+      get { return _tickrate != null; }
+      set { if (value == (_tickrate== null)) _tickrate = value ? this.tickrate : (float?)null; }
+    }
+    private bool ShouldSerializetickrate() { return tickrateSpecified; }
+    private void Resettickrate() { tickrateSpecified = false; }
+    
 
-    private uint _tick = default(uint);
+    private uint? _tick;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tick
     {
-      get { return _tick; }
+      get { return _tick?? default(uint); }
       set { _tick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tickSpecified
+    {
+      get { return _tick != null; }
+      set { if (value == (_tick== null)) _tick = value ? this.tick : (uint?)null; }
+    }
+    private bool ShouldSerializetick() { return tickSpecified; }
+    private void Resettick() { tickSpecified = false; }
+    
 
-    private float _rtdelay = default(float);
+    private float? _rtdelay;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"rtdelay", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float rtdelay
     {
-      get { return _rtdelay; }
+      get { return _rtdelay?? default(float); }
       set { _rtdelay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtdelaySpecified
+    {
+      get { return _rtdelay != null; }
+      set { if (value == (_rtdelay== null)) _rtdelay = value ? this.rtdelay : (float?)null; }
+    }
+    private bool ShouldSerializertdelay() { return rtdelaySpecified; }
+    private void Resetrtdelay() { rtdelaySpecified = false; }
+    
 
-    private float _rcvage = default(float);
+    private float? _rcvage;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"rcvage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float rcvage
     {
-      get { return _rcvage; }
+      get { return _rcvage?? default(float); }
       set { _rcvage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rcvageSpecified
+    {
+      get { return _rcvage != null; }
+      set { if (value == (_rcvage== null)) _rcvage = value ? this.rcvage : (float?)null; }
+    }
+    private bool ShouldSerializercvage() { return rcvageSpecified; }
+    private void Resetrcvage() { rcvageSpecified = false; }
+    
 
-    private float _keyframe_interval = default(float);
+    private float? _keyframe_interval;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"keyframe_interval", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float keyframe_interval
     {
-      get { return _keyframe_interval; }
+      get { return _keyframe_interval?? default(float); }
       set { _keyframe_interval = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keyframe_intervalSpecified
+    {
+      get { return _keyframe_interval != null; }
+      set { if (value == (_keyframe_interval== null)) _keyframe_interval = value ? this.keyframe_interval : (float?)null; }
+    }
+    private bool ShouldSerializekeyframe_interval() { return keyframe_intervalSpecified; }
+    private void Resetkeyframe_interval() { keyframe_intervalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCSDK.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCSDK.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsdk_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.CSGO.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSOIDOwner() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,32 +66,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSOSingleObject() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -99,14 +146,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> _objects_added = new global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject>();
     [global::ProtoBuf.ProtoMember(4, Name=@"objects_added", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> objects_added
@@ -136,23 +192,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public SingleObject() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -176,14 +250,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -199,14 +282,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public SubscribedType() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _object_data = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> object_data
@@ -249,14 +341,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSOCacheSubscriptionCheck() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -296,14 +397,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgSOCacheVersion() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -315,167 +425,329 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgAccountDetails() {}
     
 
-    private bool _valid = default(bool);
+    private bool? _valid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"valid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool valid
     {
-      get { return _valid; }
+      get { return _valid?? default(bool); }
       set { _valid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool validSpecified
+    {
+      get { return _valid != null; }
+      set { if (value == (_valid== null)) _valid = value ? this.valid : (bool?)null; }
+    }
+    private bool ShouldSerializevalid() { return validSpecified; }
+    private void Resetvalid() { validSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private bool _public_profile = default(bool);
+    private bool? _public_profile;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"public_profile", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool public_profile
     {
-      get { return _public_profile; }
+      get { return _public_profile?? default(bool); }
       set { _public_profile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_profileSpecified
+    {
+      get { return _public_profile != null; }
+      set { if (value == (_public_profile== null)) _public_profile = value ? this.public_profile : (bool?)null; }
+    }
+    private bool ShouldSerializepublic_profile() { return public_profileSpecified; }
+    private void Resetpublic_profile() { public_profileSpecified = false; }
+    
 
-    private bool _public_inventory = default(bool);
+    private bool? _public_inventory;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"public_inventory", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool public_inventory
     {
-      get { return _public_inventory; }
+      get { return _public_inventory?? default(bool); }
       set { _public_inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_inventorySpecified
+    {
+      get { return _public_inventory != null; }
+      set { if (value == (_public_inventory== null)) _public_inventory = value ? this.public_inventory : (bool?)null; }
+    }
+    private bool ShouldSerializepublic_inventory() { return public_inventorySpecified; }
+    private void Resetpublic_inventory() { public_inventorySpecified = false; }
+    
 
-    private bool _vac_banned = default(bool);
+    private bool? _vac_banned;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"vac_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool vac_banned
     {
-      get { return _vac_banned; }
+      get { return _vac_banned?? default(bool); }
       set { _vac_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vac_bannedSpecified
+    {
+      get { return _vac_banned != null; }
+      set { if (value == (_vac_banned== null)) _vac_banned = value ? this.vac_banned : (bool?)null; }
+    }
+    private bool ShouldSerializevac_banned() { return vac_bannedSpecified; }
+    private void Resetvac_banned() { vac_bannedSpecified = false; }
+    
 
-    private bool _cyber_cafe = default(bool);
+    private bool? _cyber_cafe;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cyber_cafe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool cyber_cafe
     {
-      get { return _cyber_cafe; }
+      get { return _cyber_cafe?? default(bool); }
       set { _cyber_cafe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cyber_cafeSpecified
+    {
+      get { return _cyber_cafe != null; }
+      set { if (value == (_cyber_cafe== null)) _cyber_cafe = value ? this.cyber_cafe : (bool?)null; }
+    }
+    private bool ShouldSerializecyber_cafe() { return cyber_cafeSpecified; }
+    private void Resetcyber_cafe() { cyber_cafeSpecified = false; }
+    
 
-    private bool _school_account = default(bool);
+    private bool? _school_account;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"school_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool school_account
     {
-      get { return _school_account; }
+      get { return _school_account?? default(bool); }
       set { _school_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool school_accountSpecified
+    {
+      get { return _school_account != null; }
+      set { if (value == (_school_account== null)) _school_account = value ? this.school_account : (bool?)null; }
+    }
+    private bool ShouldSerializeschool_account() { return school_accountSpecified; }
+    private void Resetschool_account() { school_accountSpecified = false; }
+    
 
-    private bool _free_trial_account = default(bool);
+    private bool? _free_trial_account;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"free_trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool free_trial_account
     {
-      get { return _free_trial_account; }
+      get { return _free_trial_account?? default(bool); }
       set { _free_trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool free_trial_accountSpecified
+    {
+      get { return _free_trial_account != null; }
+      set { if (value == (_free_trial_account== null)) _free_trial_account = value ? this.free_trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializefree_trial_account() { return free_trial_accountSpecified; }
+    private void Resetfree_trial_account() { free_trial_accountSpecified = false; }
+    
 
-    private bool _subscribed = default(bool);
+    private bool? _subscribed;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"subscribed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool subscribed
     {
-      get { return _subscribed; }
+      get { return _subscribed?? default(bool); }
       set { _subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscribedSpecified
+    {
+      get { return _subscribed != null; }
+      set { if (value == (_subscribed== null)) _subscribed = value ? this.subscribed : (bool?)null; }
+    }
+    private bool ShouldSerializesubscribed() { return subscribedSpecified; }
+    private void Resetsubscribed() { subscribedSpecified = false; }
+    
 
-    private bool _low_violence = default(bool);
+    private bool? _low_violence;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"low_violence", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_violence
     {
-      get { return _low_violence; }
+      get { return _low_violence?? default(bool); }
       set { _low_violence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_violenceSpecified
+    {
+      get { return _low_violence != null; }
+      set { if (value == (_low_violence== null)) _low_violence = value ? this.low_violence : (bool?)null; }
+    }
+    private bool ShouldSerializelow_violence() { return low_violenceSpecified; }
+    private void Resetlow_violence() { low_violenceSpecified = false; }
+    
 
-    private bool _limited = default(bool);
+    private bool? _limited;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"limited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool limited
     {
-      get { return _limited; }
+      get { return _limited?? default(bool); }
       set { _limited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool limitedSpecified
+    {
+      get { return _limited != null; }
+      set { if (value == (_limited== null)) _limited = value ? this.limited : (bool?)null; }
+    }
+    private bool ShouldSerializelimited() { return limitedSpecified; }
+    private void Resetlimited() { limitedSpecified = false; }
+    
 
-    private bool _trusted = default(bool);
+    private bool? _trusted;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trusted
     {
-      get { return _trusted; }
+      get { return _trusted?? default(bool); }
       set { _trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trustedSpecified
+    {
+      get { return _trusted != null; }
+      set { if (value == (_trusted== null)) _trusted = value ? this.trusted : (bool?)null; }
+    }
+    private bool ShouldSerializetrusted() { return trustedSpecified; }
+    private void Resettrusted() { trustedSpecified = false; }
+    
 
-    private uint _package = default(uint);
+    private uint? _package;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"package", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package
     {
-      get { return _package; }
+      get { return _package?? default(uint); }
       set { _package = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageSpecified
+    {
+      get { return _package != null; }
+      set { if (value == (_package== null)) _package = value ? this.package : (uint?)null; }
+    }
+    private bool ShouldSerializepackage() { return packageSpecified; }
+    private void Resetpackage() { packageSpecified = false; }
+    
 
-    private uint _time_cached = default(uint);
+    private uint? _time_cached;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"time_cached", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_cached
     {
-      get { return _time_cached; }
+      get { return _time_cached?? default(uint); }
       set { _time_cached = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_cachedSpecified
+    {
+      get { return _time_cached != null; }
+      set { if (value == (_time_cached== null)) _time_cached = value ? this.time_cached : (uint?)null; }
+    }
+    private bool ShouldSerializetime_cached() { return time_cachedSpecified; }
+    private void Resettime_cached() { time_cachedSpecified = false; }
+    
 
-    private bool _account_locked = default(bool);
+    private bool? _account_locked;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"account_locked", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool account_locked
     {
-      get { return _account_locked; }
+      get { return _account_locked?? default(bool); }
       set { _account_locked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_lockedSpecified
+    {
+      get { return _account_locked != null; }
+      set { if (value == (_account_locked== null)) _account_locked = value ? this.account_locked : (bool?)null; }
+    }
+    private bool ShouldSerializeaccount_locked() { return account_lockedSpecified; }
+    private void Resetaccount_locked() { account_lockedSpecified = false; }
+    
 
-    private bool _community_banned = default(bool);
+    private bool? _community_banned;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"community_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool community_banned
     {
-      get { return _community_banned; }
+      get { return _community_banned?? default(bool); }
       set { _community_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool community_bannedSpecified
+    {
+      get { return _community_banned != null; }
+      set { if (value == (_community_banned== null)) _community_banned = value ? this.community_banned : (bool?)null; }
+    }
+    private bool ShouldSerializecommunity_banned() { return community_bannedSpecified; }
+    private void Resetcommunity_banned() { community_bannedSpecified = false; }
+    
 
-    private bool _trade_banned = default(bool);
+    private bool? _trade_banned;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"trade_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trade_banned
     {
-      get { return _trade_banned; }
+      get { return _trade_banned?? default(bool); }
       set { _trade_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_bannedSpecified
+    {
+      get { return _trade_banned != null; }
+      set { if (value == (_trade_banned== null)) _trade_banned = value ? this.trade_banned : (bool?)null; }
+    }
+    private bool ShouldSerializetrade_banned() { return trade_bannedSpecified; }
+    private void Resettrade_banned() { trade_bannedSpecified = false; }
+    
 
-    private bool _eligible_for_community_market = default(bool);
+    private bool? _eligible_for_community_market;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"eligible_for_community_market", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool eligible_for_community_market
     {
-      get { return _eligible_for_community_market; }
+      get { return _eligible_for_community_market?? default(bool); }
       set { _eligible_for_community_market = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eligible_for_community_marketSpecified
+    {
+      get { return _eligible_for_community_market != null; }
+      set { if (value == (_eligible_for_community_market== null)) _eligible_for_community_market = value ? this.eligible_for_community_market : (bool?)null; }
+    }
+    private bool ShouldSerializeeligible_for_community_market() { return eligible_for_community_marketSpecified; }
+    private void Reseteligible_for_community_market() { eligible_for_community_marketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -487,23 +759,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMultiplexMessage() {}
     
 
-    private uint _msgtype = default(uint);
+    private uint? _msgtype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msgtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgtype
     {
-      get { return _msgtype; }
+      get { return _msgtype?? default(uint); }
       set { _msgtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgtypeSpecified
+    {
+      get { return _msgtype != null; }
+      set { if (value == (_msgtype== null)) _msgtype = value ? this.msgtype : (uint?)null; }
+    }
+    private bool ShouldSerializemsgtype() { return msgtypeSpecified; }
+    private void Resetmsgtype() { msgtypeSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamids
@@ -512,14 +802,23 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private bool _replytogc = default(bool);
+    private bool? _replytogc;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"replytogc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool replytogc
     {
-      get { return _replytogc; }
+      get { return _replytogc?? default(bool); }
       set { _replytogc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replytogcSpecified
+    {
+      get { return _replytogc != null; }
+      set { if (value == (_replytogc== null)) _replytogc = value ? this.replytogc : (bool?)null; }
+    }
+    private bool ShouldSerializereplytogc() { return replytogcSpecified; }
+    private void Resetreplytogc() { replytogcSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -531,14 +830,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCMultiplexMessage_Response() {}
     
 
-    private uint _msgtype = default(uint);
+    private uint? _msgtype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msgtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgtype
     {
-      get { return _msgtype; }
+      get { return _msgtype?? default(uint); }
       set { _msgtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgtypeSpecified
+    {
+      get { return _msgtype != null; }
+      set { if (value == (_msgtype== null)) _msgtype = value ? this.msgtype : (uint?)null; }
+    }
+    private bool ShouldSerializemsgtype() { return msgtypeSpecified; }
+    private void Resetmsgtype() { msgtypeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -550,23 +858,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCToGCMsgMasterAck() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private uint _gc_type = default(uint);
+    private uint? _gc_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gc_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_type
     {
-      get { return _gc_type; }
+      get { return _gc_type?? default(uint); }
       set { _gc_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_typeSpecified
+    {
+      get { return _gc_type != null; }
+      set { if (value == (_gc_type== null)) _gc_type = value ? this.gc_type : (uint?)null; }
+    }
+    private bool ShouldSerializegc_type() { return gc_typeSpecified; }
+    private void Resetgc_type() { gc_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -578,14 +904,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCToGCMsgMasterAck_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -607,32 +942,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCToGCMsgRouted() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -644,23 +1006,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CGCToGCMsgRoutedReply() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -672,23 +1052,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCUpdateSessionIP() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -700,14 +1098,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCRequestSessionIP() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -719,14 +1126,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCRequestSessionIPResponse() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -747,14 +1163,23 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _soid = value; }
     }
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -766,14 +1191,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgClientHello() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> _socache_have_versions = new global::System.Collections.Generic.List<CMsgSOCacheHaveVersion>();
     [global::ProtoBuf.ProtoMember(2, Name=@"socache_have_versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> socache_have_versions
@@ -782,23 +1216,41 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _client_session_need = default(uint);
+    private uint? _client_session_need;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_session_need
     {
-      get { return _client_session_need; }
+      get { return _client_session_need?? default(uint); }
       set { _client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_needSpecified
+    {
+      get { return _client_session_need != null; }
+      set { if (value == (_client_session_need== null)) _client_session_need = value ? this.client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_session_need() { return client_session_needSpecified; }
+    private void Resetclient_session_need() { client_session_needSpecified = false; }
+    
 
-    private uint _client_launcher = default(uint);
+    private uint? _client_launcher;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_launcher", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_launcher
     {
-      get { return _client_launcher; }
+      get { return _client_launcher?? default(uint); }
       set { _client_launcher = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_launcherSpecified
+    {
+      get { return _client_launcher != null; }
+      set { if (value == (_client_launcher== null)) _client_launcher = value ? this.client_launcher : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_launcher() { return client_launcherSpecified; }
+    private void Resetclient_launcher() { client_launcherSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -810,14 +1262,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgServerHello() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> _socache_have_versions = new global::System.Collections.Generic.List<CMsgSOCacheHaveVersion>();
     [global::ProtoBuf.ProtoMember(2, Name=@"socache_have_versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> socache_have_versions
@@ -826,32 +1287,59 @@ namespace SteamKit2.GC.CSGO.Internal
     }
   
 
-    private uint _legacy_client_session_need = default(uint);
+    private uint? _legacy_client_session_need;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"legacy_client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint legacy_client_session_need
     {
-      get { return _legacy_client_session_need; }
+      get { return _legacy_client_session_need?? default(uint); }
       set { _legacy_client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_client_session_needSpecified
+    {
+      get { return _legacy_client_session_need != null; }
+      set { if (value == (_legacy_client_session_need== null)) _legacy_client_session_need = value ? this.legacy_client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_client_session_need() { return legacy_client_session_needSpecified; }
+    private void Resetlegacy_client_session_need() { legacy_client_session_needSpecified = false; }
+    
 
-    private uint _legacy_client_launcher = default(uint);
+    private uint? _legacy_client_launcher;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"legacy_client_launcher", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint legacy_client_launcher
     {
-      get { return _legacy_client_launcher; }
+      get { return _legacy_client_launcher?? default(uint); }
       set { _legacy_client_launcher = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_client_launcherSpecified
+    {
+      get { return _legacy_client_launcher != null; }
+      set { if (value == (_legacy_client_launcher== null)) _legacy_client_launcher = value ? this.legacy_client_launcher : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_client_launcher() { return legacy_client_launcherSpecified; }
+    private void Resetlegacy_client_launcher() { legacy_client_launcherSpecified = false; }
+    
 
-    private uint _steamdatagram_port = default(uint);
+    private uint? _steamdatagram_port;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steamdatagram_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamdatagram_port
     {
-      get { return _steamdatagram_port; }
+      get { return _steamdatagram_port?? default(uint); }
       set { _steamdatagram_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamdatagram_portSpecified
+    {
+      get { return _steamdatagram_port != null; }
+      set { if (value == (_steamdatagram_port== null)) _steamdatagram_port = value ? this.steamdatagram_port : (uint?)null; }
+    }
+    private bool ShouldSerializesteamdatagram_port() { return steamdatagram_portSpecified; }
+    private void Resetsteamdatagram_port() { steamdatagram_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -863,23 +1351,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgClientWelcome() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private byte[] _game_data = null;
+    private byte[] _game_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data
     {
-      get { return _game_data; }
+      get { return _game_data?? null; }
       set { _game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_dataSpecified
+    {
+      get { return _game_data != null; }
+      set { if (value == (_game_data== null)) _game_data = value ? this.game_data : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data() { return game_dataSpecified; }
+    private void Resetgame_data() { game_dataSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheSubscribed> _outofdate_subscribed_caches = new global::System.Collections.Generic.List<CMsgSOCacheSubscribed>();
     [global::ProtoBuf.ProtoMember(3, Name=@"outofdate_subscribed_caches", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheSubscribed> outofdate_subscribed_caches
@@ -904,64 +1410,118 @@ namespace SteamKit2.GC.CSGO.Internal
       set { _location = value; }
     }
 
-    private byte[] _game_data2 = null;
+    private byte[] _game_data2;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_data2", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data2
     {
-      get { return _game_data2; }
+      get { return _game_data2?? null; }
       set { _game_data2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_data2Specified
+    {
+      get { return _game_data2 != null; }
+      set { if (value == (_game_data2== null)) _game_data2 = value ? this.game_data2 : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data2() { return game_data2Specified; }
+    private void Resetgame_data2() { game_data2Specified = false; }
+    
 
-    private uint _rtime32_gc_welcome_timestamp = default(uint);
+    private uint? _rtime32_gc_welcome_timestamp;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"rtime32_gc_welcome_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_gc_welcome_timestamp
     {
-      get { return _rtime32_gc_welcome_timestamp; }
+      get { return _rtime32_gc_welcome_timestamp?? default(uint); }
       set { _rtime32_gc_welcome_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_gc_welcome_timestampSpecified
+    {
+      get { return _rtime32_gc_welcome_timestamp != null; }
+      set { if (value == (_rtime32_gc_welcome_timestamp== null)) _rtime32_gc_welcome_timestamp = value ? this.rtime32_gc_welcome_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_gc_welcome_timestamp() { return rtime32_gc_welcome_timestampSpecified; }
+    private void Resetrtime32_gc_welcome_timestamp() { rtime32_gc_welcome_timestampSpecified = false; }
+    
 
-    private uint _currency = default(uint);
+    private uint? _currency;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currency
     {
-      get { return _currency; }
+      get { return _currency?? default(uint); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (uint?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Location")]
   public partial class Location : global::ProtoBuf.IExtensible
   {
     public Location() {}
     
 
-    private float _latitude = default(float);
+    private float? _latitude;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float latitude
     {
-      get { return _latitude; }
+      get { return _latitude?? default(float); }
       set { _latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latitudeSpecified
+    {
+      get { return _latitude != null; }
+      set { if (value == (_latitude== null)) _latitude = value ? this.latitude : (float?)null; }
+    }
+    private bool ShouldSerializelatitude() { return latitudeSpecified; }
+    private void Resetlatitude() { latitudeSpecified = false; }
+    
 
-    private float _longitude = default(float);
+    private float? _longitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float longitude
     {
-      get { return _longitude; }
+      get { return _longitude?? default(float); }
       set { _longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool longitudeSpecified
+    {
+      get { return _longitude != null; }
+      set { if (value == (_longitude== null)) _longitude = value ? this.longitude : (float?)null; }
+    }
+    private bool ShouldSerializelongitude() { return longitudeSpecified; }
+    private void Resetlongitude() { longitudeSpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -978,59 +1538,113 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgConnectionStatus() {}
     
 
-    private GCConnectionStatus _status = GCConnectionStatus.GCConnectionStatus_HAVE_SESSION;
+    private GCConnectionStatus? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCConnectionStatus.GCConnectionStatus_HAVE_SESSION)]
     public GCConnectionStatus status
     {
-      get { return _status; }
+      get { return _status?? GCConnectionStatus.GCConnectionStatus_HAVE_SESSION; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (GCConnectionStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _client_session_need = default(uint);
+    private uint? _client_session_need;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_session_need
     {
-      get { return _client_session_need; }
+      get { return _client_session_need?? default(uint); }
       set { _client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_needSpecified
+    {
+      get { return _client_session_need != null; }
+      set { if (value == (_client_session_need== null)) _client_session_need = value ? this.client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_session_need() { return client_session_needSpecified; }
+    private void Resetclient_session_need() { client_session_needSpecified = false; }
+    
 
-    private int _queue_position = default(int);
+    private int? _queue_position;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"queue_position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_position
     {
-      get { return _queue_position; }
+      get { return _queue_position?? default(int); }
       set { _queue_position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_positionSpecified
+    {
+      get { return _queue_position != null; }
+      set { if (value == (_queue_position== null)) _queue_position = value ? this.queue_position : (int?)null; }
+    }
+    private bool ShouldSerializequeue_position() { return queue_positionSpecified; }
+    private void Resetqueue_position() { queue_positionSpecified = false; }
+    
 
-    private int _queue_size = default(int);
+    private int? _queue_size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"queue_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_size
     {
-      get { return _queue_size; }
+      get { return _queue_size?? default(int); }
       set { _queue_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_sizeSpecified
+    {
+      get { return _queue_size != null; }
+      set { if (value == (_queue_size== null)) _queue_size = value ? this.queue_size : (int?)null; }
+    }
+    private bool ShouldSerializequeue_size() { return queue_sizeSpecified; }
+    private void Resetqueue_size() { queue_sizeSpecified = false; }
+    
 
-    private int _wait_seconds = default(int);
+    private int? _wait_seconds;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"wait_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int wait_seconds
     {
-      get { return _wait_seconds; }
+      get { return _wait_seconds?? default(int); }
       set { _wait_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wait_secondsSpecified
+    {
+      get { return _wait_seconds != null; }
+      set { if (value == (_wait_seconds== null)) _wait_seconds = value ? this.wait_seconds : (int?)null; }
+    }
+    private bool ShouldSerializewait_seconds() { return wait_secondsSpecified; }
+    private void Resetwait_seconds() { wait_secondsSpecified = false; }
+    
 
-    private int _estimated_wait_seconds_remaining = default(int);
+    private int? _estimated_wait_seconds_remaining;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"estimated_wait_seconds_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int estimated_wait_seconds_remaining
     {
-      get { return _estimated_wait_seconds_remaining; }
+      get { return _estimated_wait_seconds_remaining?? default(int); }
       set { _estimated_wait_seconds_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estimated_wait_seconds_remainingSpecified
+    {
+      get { return _estimated_wait_seconds_remaining != null; }
+      set { if (value == (_estimated_wait_seconds_remaining== null)) _estimated_wait_seconds_remaining = value ? this.estimated_wait_seconds_remaining : (int?)null; }
+    }
+    private bool ShouldSerializeestimated_wait_seconds_remaining() { return estimated_wait_seconds_remainingSpecified; }
+    private void Resetestimated_wait_seconds_remaining() { estimated_wait_seconds_remainingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1042,14 +1656,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public CWorkshop_PopulateItemDescriptions_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> _languages = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock>();
     [global::ProtoBuf.ProtoMember(2, Name=@"languages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> languages
@@ -1063,32 +1686,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public SingleItemDescription() {}
     
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
 
-    private string _item_description = "";
+    private string _item_description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_description
     {
-      get { return _item_description; }
+      get { return _item_description?? ""; }
       set { _item_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_descriptionSpecified
+    {
+      get { return _item_description != null; }
+      set { if (value == (_item_description== null)) _item_description = value ? this.item_description : (string)null; }
+    }
+    private bool ShouldSerializeitem_description() { return item_descriptionSpecified; }
+    private void Resetitem_description() { item_descriptionSpecified = false; }
+    
 
-    private bool _one_per_account = default(bool);
+    private bool? _one_per_account;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"one_per_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool one_per_account
     {
-      get { return _one_per_account; }
+      get { return _one_per_account?? default(bool); }
       set { _one_per_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool one_per_accountSpecified
+    {
+      get { return _one_per_account != null; }
+      set { if (value == (_one_per_account== null)) _one_per_account = value ? this.one_per_account : (bool?)null; }
+    }
+    private bool ShouldSerializeone_per_account() { return one_per_accountSpecified; }
+    private void Resetone_per_account() { one_per_accountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1100,14 +1750,23 @@ namespace SteamKit2.GC.CSGO.Internal
     public ItemDescriptionsLanguageBlock() {}
     
 
-    private string _language = "";
+    private string _language;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language
     {
-      get { return _language; }
+      get { return _language?? ""; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (string)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> _descriptions = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription>();
     [global::ProtoBuf.ProtoMember(2, Name=@"descriptions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> descriptions
@@ -1131,23 +1790,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CWorkshop_GetContributors_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1176,23 +1853,41 @@ namespace SteamKit2.GC.CSGO.Internal
     public CWorkshop_SetItemPaymentRules_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> _associated_workshop_files = new global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule>();
     [global::ProtoBuf.ProtoMember(3, Name=@"associated_workshop_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> associated_workshop_files
@@ -1213,32 +1908,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public WorkshopItemPaymentRule() {}
     
 
-    private ulong _workshop_file_id = default(ulong);
+    private ulong? _workshop_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"workshop_file_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong workshop_file_id
     {
-      get { return _workshop_file_id; }
+      get { return _workshop_file_id?? default(ulong); }
       set { _workshop_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_file_idSpecified
+    {
+      get { return _workshop_file_id != null; }
+      set { if (value == (_workshop_file_id== null)) _workshop_file_id = value ? this.workshop_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeworkshop_file_id() { return workshop_file_idSpecified; }
+    private void Resetworkshop_file_id() { workshop_file_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1250,32 +1972,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public PartnerItemPaymentRule() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCSystem.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/CSGO/SteamMsgGCSystem.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsystemmsgs.proto
 namespace SteamKit2.GC.CSGO.Internal
 {
@@ -17,32 +19,59 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCHVacVerificationChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_verified = default(bool);
+    private bool? _is_verified;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_verified
     {
-      get { return _is_verified; }
+      get { return _is_verified?? default(bool); }
       set { _is_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_verifiedSpecified
+    {
+      get { return _is_verified != null; }
+      set { if (value == (_is_verified== null)) _is_verified = value ? this.is_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_verified() { return is_verifiedSpecified; }
+    private void Resetis_verified() { is_verifiedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -54,50 +83,95 @@ namespace SteamKit2.GC.CSGO.Internal
     public CMsgGCHAccountPhoneNumberChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _phone_id = default(ulong);
+    private ulong? _phone_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"phone_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong phone_id
     {
-      get { return _phone_id; }
+      get { return _phone_id?? default(ulong); }
       set { _phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_idSpecified
+    {
+      get { return _phone_id != null; }
+      set { if (value == (_phone_id== null)) _phone_id = value ? this.phone_id : (ulong?)null; }
+    }
+    private bool ShouldSerializephone_id() { return phone_idSpecified; }
+    private void Resetphone_id() { phone_idSpecified = false; }
+    
 
-    private bool _is_verified = default(bool);
+    private bool? _is_verified;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_verified
     {
-      get { return _is_verified; }
+      get { return _is_verified?? default(bool); }
       set { _is_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_verifiedSpecified
+    {
+      get { return _is_verified != null; }
+      set { if (value == (_is_verified== null)) _is_verified = value ? this.is_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_verified() { return is_verifiedSpecified; }
+    private void Resetis_verified() { is_verifiedSpecified = false; }
+    
 
-    private bool _is_identifying = default(bool);
+    private bool? _is_identifying;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_identifying
     {
-      get { return _is_identifying; }
+      get { return _is_identifying?? default(bool); }
       set { _is_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_identifyingSpecified
+    {
+      get { return _is_identifying != null; }
+      set { if (value == (_is_identifying== null)) _is_identifying = value ? this.is_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_identifying() { return is_identifyingSpecified; }
+    private void Resetis_identifying() { is_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgClientEnums.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgClientEnums.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_client_enums.proto
 namespace SteamKit2.GC.Dota.Internal
 {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClient.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClient.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
@@ -22,14 +24,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientSuspended() {}
     
 
-    private uint _time_end = default(uint);
+    private uint? _time_end;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"time_end", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_end
     {
-      get { return _time_end; }
+      get { return _time_end?? default(uint); }
       set { _time_end = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_endSpecified
+    {
+      get { return _time_end != null; }
+      set { if (value == (_time_end== null)) _time_end = value ? this.time_end : (uint?)null; }
+    }
+    private bool ShouldSerializetime_end() { return time_endSpecified; }
+    private void Resettime_end() { time_endSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -61,14 +72,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgInitialQuestionnaireResponse() {}
     
 
-    private uint _initial_skill = default(uint);
+    private uint? _initial_skill;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"initial_skill", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_skill
     {
-      get { return _initial_skill; }
+      get { return _initial_skill?? default(uint); }
       set { _initial_skill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_skillSpecified
+    {
+      get { return _initial_skill != null; }
+      set { if (value == (_initial_skill== null)) _initial_skill = value ? this.initial_skill : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_skill() { return initial_skillSpecified; }
+    private void Resetinitial_skill() { initial_skillSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -104,23 +124,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _newest_match_id_at_last_query = default(ulong);
+    private ulong? _newest_match_id_at_last_query;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"newest_match_id_at_last_query", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong newest_match_id_at_last_query
     {
-      get { return _newest_match_id_at_last_query; }
+      get { return _newest_match_id_at_last_query?? default(ulong); }
       set { _newest_match_id_at_last_query = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool newest_match_id_at_last_querySpecified
+    {
+      get { return _newest_match_id_at_last_query != null; }
+      set { if (value == (_newest_match_id_at_last_query== null)) _newest_match_id_at_last_query = value ? this.newest_match_id_at_last_query : (ulong?)null; }
+    }
+    private bool ShouldSerializenewest_match_id_at_last_query() { return newest_match_id_at_last_querySpecified; }
+    private void Resetnewest_match_id_at_last_query() { newest_match_id_at_last_querySpecified = false; }
+    
 
-    private uint _time_last_query = default(uint);
+    private uint? _time_last_query;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_last_query", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_last_query
     {
-      get { return _time_last_query; }
+      get { return _time_last_query?? default(uint); }
       set { _time_last_query = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_last_querySpecified
+    {
+      get { return _time_last_query != null; }
+      set { if (value == (_time_last_query== null)) _time_last_query = value ? this.time_last_query : (uint?)null; }
+    }
+    private bool ShouldSerializetime_last_query() { return time_last_querySpecified; }
+    private void Resettime_last_query() { time_last_querySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -132,131 +170,257 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARequestMatches() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _date_min = default(uint);
+    private uint? _date_min;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"date_min", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date_min
     {
-      get { return _date_min; }
+      get { return _date_min?? default(uint); }
       set { _date_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool date_minSpecified
+    {
+      get { return _date_min != null; }
+      set { if (value == (_date_min== null)) _date_min = value ? this.date_min : (uint?)null; }
+    }
+    private bool ShouldSerializedate_min() { return date_minSpecified; }
+    private void Resetdate_min() { date_minSpecified = false; }
+    
 
-    private uint _date_max = default(uint);
+    private uint? _date_max;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"date_max", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date_max
     {
-      get { return _date_max; }
+      get { return _date_max?? default(uint); }
       set { _date_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool date_maxSpecified
+    {
+      get { return _date_max != null; }
+      set { if (value == (_date_max== null)) _date_max = value ? this.date_max : (uint?)null; }
+    }
+    private bool ShouldSerializedate_max() { return date_maxSpecified; }
+    private void Resetdate_max() { date_maxSpecified = false; }
+    
 
-    private uint _matches_requested = default(uint);
+    private uint? _matches_requested;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"matches_requested", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_requested
     {
-      get { return _matches_requested; }
+      get { return _matches_requested?? default(uint); }
       set { _matches_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_requestedSpecified
+    {
+      get { return _matches_requested != null; }
+      set { if (value == (_matches_requested== null)) _matches_requested = value ? this.matches_requested : (uint?)null; }
+    }
+    private bool ShouldSerializematches_requested() { return matches_requestedSpecified; }
+    private void Resetmatches_requested() { matches_requestedSpecified = false; }
+    
 
-    private ulong _start_at_match_id = default(ulong);
+    private ulong? _start_at_match_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"start_at_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong start_at_match_id
     {
-      get { return _start_at_match_id; }
+      get { return _start_at_match_id?? default(ulong); }
       set { _start_at_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_at_match_idSpecified
+    {
+      get { return _start_at_match_id != null; }
+      set { if (value == (_start_at_match_id== null)) _start_at_match_id = value ? this.start_at_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestart_at_match_id() { return start_at_match_idSpecified; }
+    private void Resetstart_at_match_id() { start_at_match_idSpecified = false; }
+    
 
-    private uint _min_players = default(uint);
+    private uint? _min_players;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"min_players", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint min_players
     {
-      get { return _min_players; }
+      get { return _min_players?? default(uint); }
       set { _min_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_playersSpecified
+    {
+      get { return _min_players != null; }
+      set { if (value == (_min_players== null)) _min_players = value ? this.min_players : (uint?)null; }
+    }
+    private bool ShouldSerializemin_players() { return min_playersSpecified; }
+    private void Resetmin_players() { min_playersSpecified = false; }
+    
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
 
-    private bool _tournament_games_only = default(bool);
+    private bool? _tournament_games_only;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"tournament_games_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tournament_games_only
     {
-      get { return _tournament_games_only; }
+      get { return _tournament_games_only?? default(bool); }
       set { _tournament_games_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_games_onlySpecified
+    {
+      get { return _tournament_games_only != null; }
+      set { if (value == (_tournament_games_only== null)) _tournament_games_only = value ? this.tournament_games_only : (bool?)null; }
+    }
+    private bool ShouldSerializetournament_games_only() { return tournament_games_onlySpecified; }
+    private void Resettournament_games_only() { tournament_games_onlySpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private CMsgDOTARequestMatches.SkillLevel _skill = CMsgDOTARequestMatches.SkillLevel.Any;
+    private CMsgDOTARequestMatches.SkillLevel? _skill;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"skill", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTARequestMatches.SkillLevel.Any)]
     public CMsgDOTARequestMatches.SkillLevel skill
     {
-      get { return _skill; }
+      get { return _skill?? CMsgDOTARequestMatches.SkillLevel.Any; }
       set { _skill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillSpecified
+    {
+      get { return _skill != null; }
+      set { if (value == (_skill== null)) _skill = value ? this.skill : (CMsgDOTARequestMatches.SkillLevel?)null; }
+    }
+    private bool ShouldSerializeskill() { return skillSpecified; }
+    private void Resetskill() { skillSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"SkillLevel", EnumPassthru=true)]
     public enum SkillLevel
     {
@@ -299,32 +463,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
 
-    private uint _results_remaining = default(uint);
+    private uint? _results_remaining;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"results_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint results_remaining
     {
-      get { return _results_remaining; }
+      get { return _results_remaining?? default(uint); }
       set { _results_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool results_remainingSpecified
+    {
+      get { return _results_remaining != null; }
+      set { if (value == (_results_remaining== null)) _results_remaining = value ? this.results_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializeresults_remaining() { return results_remainingSpecified; }
+    private void Resetresults_remaining() { results_remainingSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Series")]
   public partial class Series : global::ProtoBuf.IExtensible
   {
@@ -338,23 +529,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -371,59 +580,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPopup() {}
     
 
-    private CMsgDOTAPopup.PopupID _id = CMsgDOTAPopup.PopupID.NONE;
+    private CMsgDOTAPopup.PopupID? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAPopup.PopupID.NONE)]
     public CMsgDOTAPopup.PopupID id
     {
-      get { return _id; }
+      get { return _id?? CMsgDOTAPopup.PopupID.NONE; }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (CMsgDOTAPopup.PopupID?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private string _custom_text = "";
+    private string _custom_text;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"custom_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_text
     {
-      get { return _custom_text; }
+      get { return _custom_text?? ""; }
       set { _custom_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_textSpecified
+    {
+      get { return _custom_text != null; }
+      set { if (value == (_custom_text== null)) _custom_text = value ? this.custom_text : (string)null; }
+    }
+    private bool ShouldSerializecustom_text() { return custom_textSpecified; }
+    private void Resetcustom_text() { custom_textSpecified = false; }
+    
 
-    private int _int_data = default(int);
+    private int? _int_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"int_data", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int int_data
     {
-      get { return _int_data; }
+      get { return _int_data?? default(int); }
       set { _int_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool int_dataSpecified
+    {
+      get { return _int_data != null; }
+      set { if (value == (_int_data== null)) _int_data = value ? this.int_data : (int?)null; }
+    }
+    private bool ShouldSerializeint_data() { return int_dataSpecified; }
+    private void Resetint_data() { int_dataSpecified = false; }
+    
 
-    private byte[] _popup_data = null;
+    private byte[] _popup_data;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"popup_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] popup_data
     {
-      get { return _popup_data; }
+      get { return _popup_data?? null; }
       set { _popup_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool popup_dataSpecified
+    {
+      get { return _popup_data != null; }
+      set { if (value == (_popup_data== null)) _popup_data = value ? this.popup_data : (byte[])null; }
+    }
+    private bool ShouldSerializepopup_data() { return popup_dataSpecified; }
+    private void Resetpopup_data() { popup_dataSpecified = false; }
+    
 
-    private string _loc_token_header = "";
+    private string _loc_token_header;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"loc_token_header", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loc_token_header
     {
-      get { return _loc_token_header; }
+      get { return _loc_token_header?? ""; }
       set { _loc_token_header = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loc_token_headerSpecified
+    {
+      get { return _loc_token_header != null; }
+      set { if (value == (_loc_token_header== null)) _loc_token_header = value ? this.loc_token_header : (string)null; }
+    }
+    private bool ShouldSerializeloc_token_header() { return loc_token_headerSpecified; }
+    private void Resetloc_token_header() { loc_token_headerSpecified = false; }
+    
 
-    private string _loc_token_msg = "";
+    private string _loc_token_msg;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"loc_token_msg", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loc_token_msg
     {
-      get { return _loc_token_msg; }
+      get { return _loc_token_msg?? ""; }
       set { _loc_token_msg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loc_token_msgSpecified
+    {
+      get { return _loc_token_msg != null; }
+      set { if (value == (_loc_token_msg== null)) _loc_token_msg = value ? this.loc_token_msg : (string)null; }
+    }
+    private bool ShouldSerializeloc_token_msg() { return loc_token_msgSpecified; }
+    private void Resetloc_token_msg() { loc_token_msgSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _var_names = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(7, Name=@"var_names", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> var_names
@@ -439,14 +702,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _debug_text = "";
+    private string _debug_text;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"debug_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string debug_text
     {
-      get { return _debug_text; }
+      get { return _debug_text?? ""; }
       set { _debug_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool debug_textSpecified
+    {
+      get { return _debug_text != null; }
+      set { if (value == (_debug_text== null)) _debug_text = value ? this.debug_text : (string)null; }
+    }
+    private bool ShouldSerializedebug_text() { return debug_textSpecified; }
+    private void Resetdebug_text() { debug_textSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"PopupID", EnumPassthru=true)]
     public enum PopupID
     {
@@ -644,41 +916,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAReportsRemainingResponse() {}
     
 
-    private uint _num_positive_reports_remaining = default(uint);
+    private uint? _num_positive_reports_remaining;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"num_positive_reports_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_positive_reports_remaining
     {
-      get { return _num_positive_reports_remaining; }
+      get { return _num_positive_reports_remaining?? default(uint); }
       set { _num_positive_reports_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_positive_reports_remainingSpecified
+    {
+      get { return _num_positive_reports_remaining != null; }
+      set { if (value == (_num_positive_reports_remaining== null)) _num_positive_reports_remaining = value ? this.num_positive_reports_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializenum_positive_reports_remaining() { return num_positive_reports_remainingSpecified; }
+    private void Resetnum_positive_reports_remaining() { num_positive_reports_remainingSpecified = false; }
+    
 
-    private uint _num_negative_reports_remaining = default(uint);
+    private uint? _num_negative_reports_remaining;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_negative_reports_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_negative_reports_remaining
     {
-      get { return _num_negative_reports_remaining; }
+      get { return _num_negative_reports_remaining?? default(uint); }
       set { _num_negative_reports_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_negative_reports_remainingSpecified
+    {
+      get { return _num_negative_reports_remaining != null; }
+      set { if (value == (_num_negative_reports_remaining== null)) _num_negative_reports_remaining = value ? this.num_negative_reports_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializenum_negative_reports_remaining() { return num_negative_reports_remainingSpecified; }
+    private void Resetnum_negative_reports_remaining() { num_negative_reports_remainingSpecified = false; }
+    
 
-    private uint _num_positive_reports_total = default(uint);
+    private uint? _num_positive_reports_total;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_positive_reports_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_positive_reports_total
     {
-      get { return _num_positive_reports_total; }
+      get { return _num_positive_reports_total?? default(uint); }
       set { _num_positive_reports_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_positive_reports_totalSpecified
+    {
+      get { return _num_positive_reports_total != null; }
+      set { if (value == (_num_positive_reports_total== null)) _num_positive_reports_total = value ? this.num_positive_reports_total : (uint?)null; }
+    }
+    private bool ShouldSerializenum_positive_reports_total() { return num_positive_reports_totalSpecified; }
+    private void Resetnum_positive_reports_total() { num_positive_reports_totalSpecified = false; }
+    
 
-    private uint _num_negative_reports_total = default(uint);
+    private uint? _num_negative_reports_total;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_negative_reports_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_negative_reports_total
     {
-      get { return _num_negative_reports_total; }
+      get { return _num_negative_reports_total?? default(uint); }
       set { _num_negative_reports_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_negative_reports_totalSpecified
+    {
+      get { return _num_negative_reports_total != null; }
+      set { if (value == (_num_negative_reports_total== null)) _num_negative_reports_total = value ? this.num_negative_reports_total : (uint?)null; }
+    }
+    private bool ShouldSerializenum_negative_reports_total() { return num_negative_reports_totalSpecified; }
+    private void Resetnum_negative_reports_total() { num_negative_reports_totalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -690,41 +998,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASubmitPlayerReport() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
 
-    private uint _report_flags = default(uint);
+    private uint? _report_flags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"report_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint report_flags
     {
-      get { return _report_flags; }
+      get { return _report_flags?? default(uint); }
       set { _report_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool report_flagsSpecified
+    {
+      get { return _report_flags != null; }
+      set { if (value == (_report_flags== null)) _report_flags = value ? this.report_flags : (uint?)null; }
+    }
+    private bool ShouldSerializereport_flags() { return report_flagsSpecified; }
+    private void Resetreport_flags() { report_flagsSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -736,41 +1080,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASubmitPlayerReportResponse() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
 
-    private uint _report_flags = default(uint);
+    private uint? _report_flags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"report_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint report_flags
     {
-      get { return _report_flags; }
+      get { return _report_flags?? default(uint); }
       set { _report_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool report_flagsSpecified
+    {
+      get { return _report_flags != null; }
+      set { if (value == (_report_flags== null)) _report_flags = value ? this.report_flags : (uint?)null; }
+    }
+    private bool ShouldSerializereport_flags() { return report_flagsSpecified; }
+    private void Resetreport_flags() { report_flagsSpecified = false; }
+    
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _debug_message = "";
+    private string _debug_message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"debug_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string debug_message
     {
-      get { return _debug_message; }
+      get { return _debug_message?? ""; }
       set { _debug_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool debug_messageSpecified
+    {
+      get { return _debug_message != null; }
+      set { if (value == (_debug_message== null)) _debug_message = value ? this.debug_message : (string)null; }
+    }
+    private bool ShouldSerializedebug_message() { return debug_messageSpecified; }
+    private void Resetdebug_message() { debug_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -782,14 +1162,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAReportCountsRequest() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -801,50 +1190,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAReportCountsResponse() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
 
-    private uint _leadership_count = default(uint);
+    private uint? _leadership_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leadership_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leadership_count
     {
-      get { return _leadership_count; }
+      get { return _leadership_count?? default(uint); }
       set { _leadership_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leadership_countSpecified
+    {
+      get { return _leadership_count != null; }
+      set { if (value == (_leadership_count== null)) _leadership_count = value ? this.leadership_count : (uint?)null; }
+    }
+    private bool ShouldSerializeleadership_count() { return leadership_countSpecified; }
+    private void Resetleadership_count() { leadership_countSpecified = false; }
+    
 
-    private uint _teaching_count = default(uint);
+    private uint? _teaching_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"teaching_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teaching_count
     {
-      get { return _teaching_count; }
+      get { return _teaching_count?? default(uint); }
       set { _teaching_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teaching_countSpecified
+    {
+      get { return _teaching_count != null; }
+      set { if (value == (_teaching_count== null)) _teaching_count = value ? this.teaching_count : (uint?)null; }
+    }
+    private bool ShouldSerializeteaching_count() { return teaching_countSpecified; }
+    private void Resetteaching_count() { teaching_countSpecified = false; }
+    
 
-    private uint _friendly_count = default(uint);
+    private uint? _friendly_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"friendly_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friendly_count
     {
-      get { return _friendly_count; }
+      get { return _friendly_count?? default(uint); }
       set { _friendly_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendly_countSpecified
+    {
+      get { return _friendly_count != null; }
+      set { if (value == (_friendly_count== null)) _friendly_count = value ? this.friendly_count : (uint?)null; }
+    }
+    private bool ShouldSerializefriendly_count() { return friendly_countSpecified; }
+    private void Resetfriendly_count() { friendly_countSpecified = false; }
+    
 
-    private uint _forgiving_count = default(uint);
+    private uint? _forgiving_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"forgiving_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint forgiving_count
     {
-      get { return _forgiving_count; }
+      get { return _forgiving_count?? default(uint); }
       set { _forgiving_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool forgiving_countSpecified
+    {
+      get { return _forgiving_count != null; }
+      set { if (value == (_forgiving_count== null)) _forgiving_count = value ? this.forgiving_count : (uint?)null; }
+    }
+    private bool ShouldSerializeforgiving_count() { return forgiving_countSpecified; }
+    private void Resetforgiving_count() { forgiving_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -856,14 +1290,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASubmitLobbyMVPVote() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -875,23 +1318,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASubmitLobbyMVPVoteResponse() {}
     
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -903,32 +1364,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALobbyMVPNotifyRecipient() {}
     
 
-    private uint _voter_account_id = default(uint);
+    private uint? _voter_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"voter_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint voter_account_id
     {
-      get { return _voter_account_id; }
+      get { return _voter_account_id?? default(uint); }
       set { _voter_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voter_account_idSpecified
+    {
+      get { return _voter_account_id != null; }
+      set { if (value == (_voter_account_id== null)) _voter_account_id = value ? this.voter_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializevoter_account_id() { return voter_account_idSpecified; }
+    private void Resetvoter_account_id() { voter_account_idSpecified = false; }
+    
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
 
-    private uint _num_votes = default(uint);
+    private uint? _num_votes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_votes
     {
-      get { return _num_votes; }
+      get { return _num_votes?? default(uint); }
       set { _num_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_votesSpecified
+    {
+      get { return _num_votes != null; }
+      set { if (value == (_num_votes== null)) _num_votes = value ? this.num_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenum_votes() { return num_votesSpecified; }
+    private void Resetnum_votes() { num_votesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -940,14 +1428,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALobbyMVPAwarded() {}
     
 
-    private uint _mvp_account_id = default(uint);
+    private uint? _mvp_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"mvp_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mvp_account_id
     {
-      get { return _mvp_account_id; }
+      get { return _mvp_account_id?? default(uint); }
       set { _mvp_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mvp_account_idSpecified
+    {
+      get { return _mvp_account_id != null; }
+      set { if (value == (_mvp_account_id== null)) _mvp_account_id = value ? this.mvp_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializemvp_account_id() { return mvp_account_idSpecified; }
+    private void Resetmvp_account_id() { mvp_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -959,14 +1456,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAKickedFromMatchmakingQueue() {}
     
 
-    private MatchType _match_type = MatchType.MATCH_TYPE_CASUAL;
+    private MatchType? _match_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchType.MATCH_TYPE_CASUAL)]
     public MatchType match_type
     {
-      get { return _match_type; }
+      get { return _match_type?? MatchType.MATCH_TYPE_CASUAL; }
       set { _match_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_typeSpecified
+    {
+      get { return _match_type != null; }
+      set { if (value == (_match_type== null)) _match_type = value ? this.match_type : (MatchType?)null; }
+    }
+    private bool ShouldSerializematch_type() { return match_typeSpecified; }
+    private void Resetmatch_type() { match_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -978,14 +1484,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARequestSaveGames() {}
     
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -997,14 +1512,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARequestSaveGamesResponse() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDOTASaveGame> _save_games = new global::System.Collections.Generic.List<CDOTASaveGame>();
     [global::ProtoBuf.ProtoMember(2, Name=@"save_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDOTASaveGame> save_games
@@ -1023,14 +1547,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMatchDetailsRequest() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1042,14 +1575,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMatchDetailsResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
     private CMsgDOTAMatch _match = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1060,14 +1602,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _match = value; }
     }
 
-    private DOTAMatchVote _vote = DOTAMatchVote.DOTAMatchVote_INVALID;
+    private DOTAMatchVote? _vote;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAMatchVote.DOTAMatchVote_INVALID)]
     public DOTAMatchVote vote
     {
-      get { return _vote; }
+      get { return _vote?? DOTAMatchVote.DOTAMatchVote_INVALID; }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (DOTAMatchVote?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1113,23 +1664,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAProfileRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _request_name = default(bool);
+    private bool? _request_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"request_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool request_name
     {
-      get { return _request_name; }
+      get { return _request_name?? default(bool); }
       set { _request_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_nameSpecified
+    {
+      get { return _request_name != null; }
+      set { if (value == (_request_name== null)) _request_name = value ? this.request_name : (bool?)null; }
+    }
+    private bool ShouldSerializerequest_name() { return request_nameSpecified; }
+    private void Resetrequest_name() { request_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1141,14 +1710,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAProfileResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
     private CSODOTAGameAccountClient _game_account_client = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_account_client", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1173,41 +1751,77 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
     private CMsgDOTAProfileResponse.ShowcaseHero _showcase_hero = null;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"showcase_hero", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1232,23 +1846,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private bool _has_passport = default(bool);
+    private bool? _has_passport;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"has_passport", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_passport
     {
-      get { return _has_passport; }
+      get { return _has_passport?? default(bool); }
       set { _has_passport = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_passportSpecified
+    {
+      get { return _has_passport != null; }
+      set { if (value == (_has_passport== null)) _has_passport = value ? this.has_passport : (bool?)null; }
+    }
+    private bool ShouldSerializehas_passport() { return has_passportSpecified; }
+    private void Resethas_passport() { has_passportSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAProfileResponse.FeaturedItem> _featured_items = new global::System.Collections.Generic.List<CMsgDOTAProfileResponse.FeaturedItem>();
     [global::ProtoBuf.ProtoMember(14, Name=@"featured_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAProfileResponse.FeaturedItem> featured_items
@@ -1257,37 +1889,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _abandon_percent = default(uint);
+    private uint? _abandon_percent;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"abandon_percent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint abandon_percent
     {
-      get { return _abandon_percent; }
+      get { return _abandon_percent?? default(uint); }
       set { _abandon_percent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abandon_percentSpecified
+    {
+      get { return _abandon_percent != null; }
+      set { if (value == (_abandon_percent== null)) _abandon_percent = value ? this.abandon_percent : (uint?)null; }
+    }
+    private bool ShouldSerializeabandon_percent() { return abandon_percentSpecified; }
+    private void Resetabandon_percent() { abandon_percentSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PlayedHero")]
   public partial class PlayedHero : global::ProtoBuf.IExtensible
   {
     public PlayedHero() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1299,14 +1958,23 @@ namespace SteamKit2.GC.Dota.Internal
     public ShowcaseHero() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _object_data = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> object_data
@@ -1325,23 +1993,41 @@ namespace SteamKit2.GC.Dota.Internal
     public LeaguePass() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1353,14 +2039,23 @@ namespace SteamKit2.GC.Dota.Internal
     public EventTicket() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1372,32 +2067,59 @@ namespace SteamKit2.GC.Dota.Internal
     public FeaturedItem() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
 
-    private uint _slot_index = default(uint);
+    private uint? _slot_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_index
     {
-      get { return _slot_index; }
+      get { return _slot_index?? default(uint); }
       set { _slot_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_indexSpecified
+    {
+      get { return _slot_index != null; }
+      set { if (value == (_slot_index== null)) _slot_index = value ? this.slot_index : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_index() { return slot_indexSpecified; }
+    private void Resetslot_index() { slot_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1414,23 +2136,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAProfileTickets() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAProfileTickets.LeaguePass> _league_passes = new global::System.Collections.Generic.List<CMsgDOTAProfileTickets.LeaguePass>();
     [global::ProtoBuf.ProtoMember(3, Name=@"league_passes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAProfileTickets.LeaguePass> league_passes
@@ -1451,23 +2191,41 @@ namespace SteamKit2.GC.Dota.Internal
     public LeaguePass() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1479,14 +2237,23 @@ namespace SteamKit2.GC.Dota.Internal
     public EventTicket() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1503,14 +2270,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetProfileTickets() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1522,14 +2298,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCSteamProfileRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1541,14 +2326,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCSteamProfileRequestResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1570,149 +2364,293 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWelcome() {}
     
 
-    private uint _store_item_hash = default(uint);
+    private uint? _store_item_hash;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"store_item_hash", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint store_item_hash
     {
-      get { return _store_item_hash; }
+      get { return _store_item_hash?? default(uint); }
       set { _store_item_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_item_hashSpecified
+    {
+      get { return _store_item_hash != null; }
+      set { if (value == (_store_item_hash== null)) _store_item_hash = value ? this.store_item_hash : (uint?)null; }
+    }
+    private bool ShouldSerializestore_item_hash() { return store_item_hashSpecified; }
+    private void Resetstore_item_hash() { store_item_hashSpecified = false; }
+    
 
-    private uint _timeplayedconsecutively = default(uint);
+    private uint? _timeplayedconsecutively;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"timeplayedconsecutively", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timeplayedconsecutively
     {
-      get { return _timeplayedconsecutively; }
+      get { return _timeplayedconsecutively?? default(uint); }
       set { _timeplayedconsecutively = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeplayedconsecutivelySpecified
+    {
+      get { return _timeplayedconsecutively != null; }
+      set { if (value == (_timeplayedconsecutively== null)) _timeplayedconsecutively = value ? this.timeplayedconsecutively : (uint?)null; }
+    }
+    private bool ShouldSerializetimeplayedconsecutively() { return timeplayedconsecutivelySpecified; }
+    private void Resettimeplayedconsecutively() { timeplayedconsecutivelySpecified = false; }
+    
 
-    private bool _allow_3rd_party_match_history = default(bool);
+    private bool? _allow_3rd_party_match_history;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"allow_3rd_party_match_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_3rd_party_match_history
     {
-      get { return _allow_3rd_party_match_history; }
+      get { return _allow_3rd_party_match_history?? default(bool); }
       set { _allow_3rd_party_match_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_3rd_party_match_historySpecified
+    {
+      get { return _allow_3rd_party_match_history != null; }
+      set { if (value == (_allow_3rd_party_match_history== null)) _allow_3rd_party_match_history = value ? this.allow_3rd_party_match_history : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_3rd_party_match_history() { return allow_3rd_party_match_historySpecified; }
+    private void Resetallow_3rd_party_match_history() { allow_3rd_party_match_historySpecified = false; }
+    
 
-    private PartnerAccountType _partner_account_type = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _partner_account_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"partner_account_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType partner_account_type
     {
-      get { return _partner_account_type; }
+      get { return _partner_account_type?? PartnerAccountType.PARTNER_NONE; }
       set { _partner_account_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_account_typeSpecified
+    {
+      get { return _partner_account_type != null; }
+      set { if (value == (_partner_account_type== null)) _partner_account_type = value ? this.partner_account_type : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializepartner_account_type() { return partner_account_typeSpecified; }
+    private void Resetpartner_account_type() { partner_account_typeSpecified = false; }
+    
 
-    private uint _banned_word_list_word_id = default(uint);
+    private uint? _banned_word_list_word_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"banned_word_list_word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint banned_word_list_word_id
     {
-      get { return _banned_word_list_word_id; }
+      get { return _banned_word_list_word_id?? default(uint); }
       set { _banned_word_list_word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banned_word_list_word_idSpecified
+    {
+      get { return _banned_word_list_word_id != null; }
+      set { if (value == (_banned_word_list_word_id== null)) _banned_word_list_word_id = value ? this.banned_word_list_word_id : (uint?)null; }
+    }
+    private bool ShouldSerializebanned_word_list_word_id() { return banned_word_list_word_idSpecified; }
+    private void Resetbanned_word_list_word_id() { banned_word_list_word_idSpecified = false; }
+    
 
-    private uint _partner_account_state = default(uint);
+    private uint? _partner_account_state;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"partner_account_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint partner_account_state
     {
-      get { return _partner_account_state; }
+      get { return _partner_account_state?? default(uint); }
       set { _partner_account_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_account_stateSpecified
+    {
+      get { return _partner_account_state != null; }
+      set { if (value == (_partner_account_state== null)) _partner_account_state = value ? this.partner_account_state : (uint?)null; }
+    }
+    private bool ShouldSerializepartner_account_state() { return partner_account_stateSpecified; }
+    private void Resetpartner_account_state() { partner_account_stateSpecified = false; }
+    
 
-    private uint _last_time_played = default(uint);
+    private uint? _last_time_played;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"last_time_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_played
     {
-      get { return _last_time_played; }
+      get { return _last_time_played?? default(uint); }
       set { _last_time_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_playedSpecified
+    {
+      get { return _last_time_played != null; }
+      set { if (value == (_last_time_played== null)) _last_time_played = value ? this.last_time_played : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_played() { return last_time_playedSpecified; }
+    private void Resetlast_time_played() { last_time_playedSpecified = false; }
+    
 
-    private uint _last_ip_address = default(uint);
+    private uint? _last_ip_address;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"last_ip_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_ip_address
     {
-      get { return _last_ip_address; }
+      get { return _last_ip_address?? default(uint); }
       set { _last_ip_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_ip_addressSpecified
+    {
+      get { return _last_ip_address != null; }
+      set { if (value == (_last_ip_address== null)) _last_ip_address = value ? this.last_ip_address : (uint?)null; }
+    }
+    private bool ShouldSerializelast_ip_address() { return last_ip_addressSpecified; }
+    private void Resetlast_ip_address() { last_ip_addressSpecified = false; }
+    
 
-    private uint _shutdownlawterminateminutes = default(uint);
+    private uint? _shutdownlawterminateminutes;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"shutdownlawterminateminutes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint shutdownlawterminateminutes
     {
-      get { return _shutdownlawterminateminutes; }
+      get { return _shutdownlawterminateminutes?? default(uint); }
       set { _shutdownlawterminateminutes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shutdownlawterminateminutesSpecified
+    {
+      get { return _shutdownlawterminateminutes != null; }
+      set { if (value == (_shutdownlawterminateminutes== null)) _shutdownlawterminateminutes = value ? this.shutdownlawterminateminutes : (uint?)null; }
+    }
+    private bool ShouldSerializeshutdownlawterminateminutes() { return shutdownlawterminateminutesSpecified; }
+    private void Resetshutdownlawterminateminutes() { shutdownlawterminateminutesSpecified = false; }
+    
 
-    private uint _banned_word_list_version = default(uint);
+    private uint? _banned_word_list_version;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"banned_word_list_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint banned_word_list_version
     {
-      get { return _banned_word_list_version; }
+      get { return _banned_word_list_version?? default(uint); }
       set { _banned_word_list_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banned_word_list_versionSpecified
+    {
+      get { return _banned_word_list_version != null; }
+      set { if (value == (_banned_word_list_version== null)) _banned_word_list_version = value ? this.banned_word_list_version : (uint?)null; }
+    }
+    private bool ShouldSerializebanned_word_list_version() { return banned_word_list_versionSpecified; }
+    private void Resetbanned_word_list_version() { banned_word_list_versionSpecified = false; }
+    
 
-    private bool _profile_private = default(bool);
+    private bool? _profile_private;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"profile_private", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool profile_private
     {
-      get { return _profile_private; }
+      get { return _profile_private?? default(bool); }
       set { _profile_private = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool profile_privateSpecified
+    {
+      get { return _profile_private != null; }
+      set { if (value == (_profile_private== null)) _profile_private = value ? this.profile_private : (bool?)null; }
+    }
+    private bool ShouldSerializeprofile_private() { return profile_privateSpecified; }
+    private void Resetprofile_private() { profile_privateSpecified = false; }
+    
 
-    private uint _currency = default(uint);
+    private uint? _currency;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currency
     {
-      get { return _currency; }
+      get { return _currency?? default(uint); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (uint?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private uint _bang_no = default(uint);
+    private uint? _bang_no;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"bang_no", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bang_no
     {
-      get { return _bang_no; }
+      get { return _bang_no?? default(uint); }
       set { _bang_no = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bang_noSpecified
+    {
+      get { return _bang_no != null; }
+      set { if (value == (_bang_no== null)) _bang_no = value ? this.bang_no : (uint?)null; }
+    }
+    private bool ShouldSerializebang_no() { return bang_noSpecified; }
+    private void Resetbang_no() { bang_noSpecified = false; }
+    
 
-    private bool _should_request_player_origin = default(bool);
+    private bool? _should_request_player_origin;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"should_request_player_origin", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool should_request_player_origin
     {
-      get { return _should_request_player_origin; }
+      get { return _should_request_player_origin?? default(bool); }
       set { _should_request_player_origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool should_request_player_originSpecified
+    {
+      get { return _should_request_player_origin != null; }
+      set { if (value == (_should_request_player_origin== null)) _should_request_player_origin = value ? this.should_request_player_origin : (bool?)null; }
+    }
+    private bool ShouldSerializeshould_request_player_origin() { return should_request_player_originSpecified; }
+    private void Resetshould_request_player_origin() { should_request_player_originSpecified = false; }
+    
 
-    private ulong _compendium_unlocks = default(ulong);
+    private ulong? _compendium_unlocks;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"compendium_unlocks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong compendium_unlocks
     {
-      get { return _compendium_unlocks; }
+      get { return _compendium_unlocks?? default(ulong); }
       set { _compendium_unlocks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool compendium_unlocksSpecified
+    {
+      get { return _compendium_unlocks != null; }
+      set { if (value == (_compendium_unlocks== null)) _compendium_unlocks = value ? this.compendium_unlocks : (ulong?)null; }
+    }
+    private bool ShouldSerializecompendium_unlocks() { return compendium_unlocksSpecified; }
+    private void Resetcompendium_unlocks() { compendium_unlocksSpecified = false; }
+    
 
-    private uint _gc_socache_file_version = default(uint);
+    private uint? _gc_socache_file_version;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"gc_socache_file_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_socache_file_version
     {
-      get { return _gc_socache_file_version; }
+      get { return _gc_socache_file_version?? default(uint); }
       set { _gc_socache_file_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_socache_file_versionSpecified
+    {
+      get { return _gc_socache_file_version != null; }
+      set { if (value == (_gc_socache_file_version== null)) _gc_socache_file_version = value ? this.gc_socache_file_version : (uint?)null; }
+    }
+    private bool ShouldSerializegc_socache_file_version() { return gc_socache_file_versionSpecified; }
+    private void Resetgc_socache_file_version() { gc_socache_file_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAWelcome.LocalizationDigest> _localization_digests = new global::System.Collections.Generic.List<CMsgDOTAWelcome.LocalizationDigest>();
     [global::ProtoBuf.ProtoMember(23, Name=@"localization_digests", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAWelcome.LocalizationDigest> localization_digests
@@ -1721,14 +2659,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _is_perfect_world_test_account = default(bool);
+    private bool? _is_perfect_world_test_account;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"is_perfect_world_test_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_perfect_world_test_account
     {
-      get { return _is_perfect_world_test_account; }
+      get { return _is_perfect_world_test_account?? default(bool); }
       set { _is_perfect_world_test_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_perfect_world_test_accountSpecified
+    {
+      get { return _is_perfect_world_test_account != null; }
+      set { if (value == (_is_perfect_world_test_account== null)) _is_perfect_world_test_account = value ? this.is_perfect_world_test_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_perfect_world_test_account() { return is_perfect_world_test_accountSpecified; }
+    private void Resetis_perfect_world_test_account() { is_perfect_world_test_accountSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<EEvent> _active_events = new global::System.Collections.Generic.List<EEvent>();
     [global::ProtoBuf.ProtoMember(25, Name=@"active_events", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<EEvent> active_events
@@ -1744,28 +2691,46 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _minimum_recent_item_id = default(ulong);
+    private ulong? _minimum_recent_item_id;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"minimum_recent_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong minimum_recent_item_id
     {
-      get { return _minimum_recent_item_id; }
+      get { return _minimum_recent_item_id?? default(ulong); }
       set { _minimum_recent_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool minimum_recent_item_idSpecified
+    {
+      get { return _minimum_recent_item_id != null; }
+      set { if (value == (_minimum_recent_item_id== null)) _minimum_recent_item_id = value ? this.minimum_recent_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeminimum_recent_item_id() { return minimum_recent_item_idSpecified; }
+    private void Resetminimum_recent_item_id() { minimum_recent_item_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"LocalizationDigest")]
   public partial class LocalizationDigest : global::ProtoBuf.IExtensible
   {
     public LocalizationDigest() {}
     
 
-    private string _context = "";
+    private string _context;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"context", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string context
     {
-      get { return _context; }
+      get { return _context?? ""; }
       set { _context = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contextSpecified
+    {
+      get { return _context != null; }
+      set { if (value == (_context== null)) _context = value ? this.context : (string)null; }
+    }
+    private bool ShouldSerializecontext() { return contextSpecified; }
+    private void Resetcontext() { contextSpecified = false; }
+    
 
     private CMsgSHA1Digest _english_language_file_sha1 = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"english_language_file_sha1", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1795,23 +2760,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CExtraMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private byte[] _contents = null;
+    private byte[] _contents;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"contents", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] contents
     {
-      get { return _contents; }
+      get { return _contents?? null; }
       set { _contents = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contentsSpecified
+    {
+      get { return _contents != null; }
+      set { if (value == (_contents== null)) _contents = value ? this.contents : (byte[])null; }
+    }
+    private bool ShouldSerializecontents() { return contentsSpecified; }
+    private void Resetcontents() { contentsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1828,23 +2811,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAGameHeroFavorites() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1856,14 +2857,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHeroFavoritesAdd() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1875,14 +2885,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHeroFavoritesRemove() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1894,14 +2913,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSetShowcaseHero() {}
     
 
-    private uint _showcase_hero_id = default(uint);
+    private uint? _showcase_hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"showcase_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint showcase_hero_id
     {
-      get { return _showcase_hero_id; }
+      get { return _showcase_hero_id?? default(uint); }
       set { _showcase_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool showcase_hero_idSpecified
+    {
+      get { return _showcase_hero_id != null; }
+      set { if (value == (_showcase_hero_id== null)) _showcase_hero_id = value ? this.showcase_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializeshowcase_hero_id() { return showcase_hero_idSpecified; }
+    private void Resetshowcase_hero_id() { showcase_hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1930,14 +2958,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFeaturedItems() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _featured_item_id = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"featured_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> featured_item_id
@@ -1973,68 +3010,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CDynamicLeagueData() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _last_match_time = default(uint);
+    private uint? _last_match_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_match_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_match_time
     {
-      get { return _last_match_time; }
+      get { return _last_match_time?? default(uint); }
       set { _last_match_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_match_timeSpecified
+    {
+      get { return _last_match_time != null; }
+      set { if (value == (_last_match_time== null)) _last_match_time = value ? this.last_match_time : (uint?)null; }
+    }
+    private bool ShouldSerializelast_match_time() { return last_match_timeSpecified; }
+    private void Resetlast_match_time() { last_match_timeSpecified = false; }
+    
 
-    private uint _prize_pool_usd = default(uint);
+    private uint? _prize_pool_usd;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"prize_pool_usd", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_pool_usd
     {
-      get { return _prize_pool_usd; }
+      get { return _prize_pool_usd?? default(uint); }
       set { _prize_pool_usd = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_pool_usdSpecified
+    {
+      get { return _prize_pool_usd != null; }
+      set { if (value == (_prize_pool_usd== null)) _prize_pool_usd = value ? this.prize_pool_usd : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_pool_usd() { return prize_pool_usdSpecified; }
+    private void Resetprize_pool_usd() { prize_pool_usdSpecified = false; }
+    
 
-    private bool _has_live_matches = default(bool);
+    private bool? _has_live_matches;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"has_live_matches", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_live_matches
     {
-      get { return _has_live_matches; }
+      get { return _has_live_matches?? default(bool); }
       set { _has_live_matches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_live_matchesSpecified
+    {
+      get { return _has_live_matches != null; }
+      set { if (value == (_has_live_matches== null)) _has_live_matches = value ? this.has_live_matches : (bool?)null; }
+    }
+    private bool ShouldSerializehas_live_matches() { return has_live_matchesSpecified; }
+    private void Resethas_live_matches() { has_live_matchesSpecified = false; }
+    
 
-    private bool _is_compendium_public = default(bool);
+    private bool? _is_compendium_public;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_compendium_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_compendium_public
     {
-      get { return _is_compendium_public; }
+      get { return _is_compendium_public?? default(bool); }
       set { _is_compendium_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_compendium_publicSpecified
+    {
+      get { return _is_compendium_public != null; }
+      set { if (value == (_is_compendium_public== null)) _is_compendium_public = value ? this.is_compendium_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_compendium_public() { return is_compendium_publicSpecified; }
+    private void Resetis_compendium_public() { is_compendium_publicSpecified = false; }
+    
 
-    private uint _compendium_version = default(uint);
+    private uint? _compendium_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"compendium_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint compendium_version
     {
-      get { return _compendium_version; }
+      get { return _compendium_version?? default(uint); }
       set { _compendium_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool compendium_versionSpecified
+    {
+      get { return _compendium_version != null; }
+      set { if (value == (_compendium_version== null)) _compendium_version = value ? this.compendium_version : (uint?)null; }
+    }
+    private bool ShouldSerializecompendium_version() { return compendium_versionSpecified; }
+    private void Resetcompendium_version() { compendium_versionSpecified = false; }
+    
 
-    private uint _compendium_content_version = default(uint);
+    private uint? _compendium_content_version;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"compendium_content_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint compendium_content_version
     {
-      get { return _compendium_content_version; }
+      get { return _compendium_content_version?? default(uint); }
       set { _compendium_content_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool compendium_content_versionSpecified
+    {
+      get { return _compendium_content_version != null; }
+      set { if (value == (_compendium_content_version== null)) _compendium_content_version = value ? this.compendium_content_version : (uint?)null; }
+    }
+    private bool ShouldSerializecompendium_content_version() { return compendium_content_versionSpecified; }
+    private void Resetcompendium_content_version() { compendium_content_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2046,194 +3146,383 @@ namespace SteamKit2.GC.Dota.Internal
     public CStaticLeagueData() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private string _banner_name = "";
+    private string _banner_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"banner_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string banner_name
     {
-      get { return _banner_name; }
+      get { return _banner_name?? ""; }
       set { _banner_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_nameSpecified
+    {
+      get { return _banner_name != null; }
+      set { if (value == (_banner_name== null)) _banner_name = value ? this.banner_name : (string)null; }
+    }
+    private bool ShouldSerializebanner_name() { return banner_nameSpecified; }
+    private void Resetbanner_name() { banner_nameSpecified = false; }
+    
 
-    private string _itemdef_name = "";
+    private string _itemdef_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"itemdef_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string itemdef_name
     {
-      get { return _itemdef_name; }
+      get { return _itemdef_name?? ""; }
       set { _itemdef_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdef_nameSpecified
+    {
+      get { return _itemdef_name != null; }
+      set { if (value == (_itemdef_name== null)) _itemdef_name = value ? this.itemdef_name : (string)null; }
+    }
+    private bool ShouldSerializeitemdef_name() { return itemdef_nameSpecified; }
+    private void Resetitemdef_name() { itemdef_nameSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _hud_skin_item_def_index = default(uint);
+    private uint? _hud_skin_item_def_index;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"hud_skin_item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hud_skin_item_def_index
     {
-      get { return _hud_skin_item_def_index; }
+      get { return _hud_skin_item_def_index?? default(uint); }
       set { _hud_skin_item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hud_skin_item_def_indexSpecified
+    {
+      get { return _hud_skin_item_def_index != null; }
+      set { if (value == (_hud_skin_item_def_index== null)) _hud_skin_item_def_index = value ? this.hud_skin_item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializehud_skin_item_def_index() { return hud_skin_item_def_indexSpecified; }
+    private void Resethud_skin_item_def_index() { hud_skin_item_def_indexSpecified = false; }
+    
 
-    private string _loading_screen_name = "";
+    private string _loading_screen_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"loading_screen_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loading_screen_name
     {
-      get { return _loading_screen_name; }
+      get { return _loading_screen_name?? ""; }
       set { _loading_screen_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loading_screen_nameSpecified
+    {
+      get { return _loading_screen_name != null; }
+      set { if (value == (_loading_screen_name== null)) _loading_screen_name = value ? this.loading_screen_name : (string)null; }
+    }
+    private bool ShouldSerializeloading_screen_name() { return loading_screen_nameSpecified; }
+    private void Resetloading_screen_name() { loading_screen_nameSpecified = false; }
+    
 
-    private uint _base_prize_pool = default(uint);
+    private uint? _base_prize_pool;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"base_prize_pool", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_prize_pool
     {
-      get { return _base_prize_pool; }
+      get { return _base_prize_pool?? default(uint); }
       set { _base_prize_pool = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_prize_poolSpecified
+    {
+      get { return _base_prize_pool != null; }
+      set { if (value == (_base_prize_pool== null)) _base_prize_pool = value ? this.base_prize_pool : (uint?)null; }
+    }
+    private bool ShouldSerializebase_prize_pool() { return base_prize_poolSpecified; }
+    private void Resetbase_prize_pool() { base_prize_poolSpecified = false; }
+    
 
-    private bool _is_major = default(bool);
+    private bool? _is_major;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_major", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_major
     {
-      get { return _is_major; }
+      get { return _is_major?? default(bool); }
       set { _is_major = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_majorSpecified
+    {
+      get { return _is_major != null; }
+      set { if (value == (_is_major== null)) _is_major = value ? this.is_major : (bool?)null; }
+    }
+    private bool ShouldSerializeis_major() { return is_majorSpecified; }
+    private void Resetis_major() { is_majorSpecified = false; }
+    
 
-    private uint _sort_order = default(uint);
+    private uint? _sort_order;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"sort_order", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_order
     {
-      get { return _sort_order; }
+      get { return _sort_order?? default(uint); }
       set { _sort_order = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_orderSpecified
+    {
+      get { return _sort_order != null; }
+      set { if (value == (_sort_order== null)) _sort_order = value ? this.sort_order : (uint?)null; }
+    }
+    private bool ShouldSerializesort_order() { return sort_orderSpecified; }
+    private void Resetsort_order() { sort_orderSpecified = false; }
+    
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
 
-    private uint _amateur_region = default(uint);
+    private uint? _amateur_region;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"amateur_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint amateur_region
     {
-      get { return _amateur_region; }
+      get { return _amateur_region?? default(uint); }
       set { _amateur_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool amateur_regionSpecified
+    {
+      get { return _amateur_region != null; }
+      set { if (value == (_amateur_region== null)) _amateur_region = value ? this.amateur_region : (uint?)null; }
+    }
+    private bool ShouldSerializeamateur_region() { return amateur_regionSpecified; }
+    private void Resetamateur_region() { amateur_regionSpecified = false; }
+    
 
-    private string _organizer = "";
+    private string _organizer;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"organizer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string organizer
     {
-      get { return _organizer; }
+      get { return _organizer?? ""; }
       set { _organizer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool organizerSpecified
+    {
+      get { return _organizer != null; }
+      set { if (value == (_organizer== null)) _organizer = value ? this.organizer : (string)null; }
+    }
+    private bool ShouldSerializeorganizer() { return organizerSpecified; }
+    private void Resetorganizer() { organizerSpecified = false; }
+    
 
-    private uint _start_date = default(uint);
+    private uint? _start_date;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"start_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_date
     {
-      get { return _start_date; }
+      get { return _start_date?? default(uint); }
       set { _start_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_dateSpecified
+    {
+      get { return _start_date != null; }
+      set { if (value == (_start_date== null)) _start_date = value ? this.start_date : (uint?)null; }
+    }
+    private bool ShouldSerializestart_date() { return start_dateSpecified; }
+    private void Resetstart_date() { start_dateSpecified = false; }
+    
 
-    private uint _end_date = default(uint);
+    private uint? _end_date;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"end_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_date
     {
-      get { return _end_date; }
+      get { return _end_date?? default(uint); }
       set { _end_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_dateSpecified
+    {
+      get { return _end_date != null; }
+      set { if (value == (_end_date== null)) _end_date = value ? this.end_date : (uint?)null; }
+    }
+    private bool ShouldSerializeend_date() { return end_dateSpecified; }
+    private void Resetend_date() { end_dateSpecified = false; }
+    
 
-    private string _location = "";
+    private string _location;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"location", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string location
     {
-      get { return _location; }
+      get { return _location?? ""; }
       set { _location = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool locationSpecified
+    {
+      get { return _location != null; }
+      set { if (value == (_location== null)) _location = value ? this.location : (string)null; }
+    }
+    private bool ShouldSerializelocation() { return locationSpecified; }
+    private void Resetlocation() { locationSpecified = false; }
+    
 
-    private string _inventory_image = "";
+    private string _inventory_image;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"inventory_image", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string inventory_image
     {
-      get { return _inventory_image; }
+      get { return _inventory_image?? ""; }
       set { _inventory_image = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventory_imageSpecified
+    {
+      get { return _inventory_image != null; }
+      set { if (value == (_inventory_image== null)) _inventory_image = value ? this.inventory_image : (string)null; }
+    }
+    private bool ShouldSerializeinventory_image() { return inventory_imageSpecified; }
+    private void Resetinventory_image() { inventory_imageSpecified = false; }
+    
 
-    private string _square_image = "";
+    private string _square_image;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"square_image", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string square_image
     {
-      get { return _square_image; }
+      get { return _square_image?? ""; }
       set { _square_image = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool square_imageSpecified
+    {
+      get { return _square_image != null; }
+      set { if (value == (_square_image== null)) _square_image = value ? this.square_image : (string)null; }
+    }
+    private bool ShouldSerializesquare_image() { return square_imageSpecified; }
+    private void Resetsquare_image() { square_imageSpecified = false; }
+    
 
-    private bool _battle_pass_rollup = default(bool);
+    private bool? _battle_pass_rollup;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"battle_pass_rollup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool battle_pass_rollup
     {
-      get { return _battle_pass_rollup; }
+      get { return _battle_pass_rollup?? default(bool); }
       set { _battle_pass_rollup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool battle_pass_rollupSpecified
+    {
+      get { return _battle_pass_rollup != null; }
+      set { if (value == (_battle_pass_rollup== null)) _battle_pass_rollup = value ? this.battle_pass_rollup : (bool?)null; }
+    }
+    private bool ShouldSerializebattle_pass_rollup() { return battle_pass_rollupSpecified; }
+    private void Resetbattle_pass_rollup() { battle_pass_rollupSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2263,14 +3552,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _static_data = value; }
     }
 
-    private bool _is_owned = default(bool);
+    private bool? _is_owned;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_owned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_owned
     {
-      get { return _is_owned; }
+      get { return _is_owned?? default(bool); }
       set { _is_owned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_ownedSpecified
+    {
+      get { return _is_owned != null; }
+      set { if (value == (_is_owned== null)) _is_owned = value ? this.is_owned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_owned() { return is_ownedSpecified; }
+    private void Resetis_owned() { is_ownedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2299,14 +3597,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAMatchVotes() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAMatchVotes.PlayerVote> _votes = new global::System.Collections.Generic.List<CMsgDOTAMatchVotes.PlayerVote>();
     [global::ProtoBuf.ProtoMember(2, Name=@"votes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAMatchVotes.PlayerVote> votes
@@ -2320,23 +3627,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerVote() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _vote = default(uint);
+    private uint? _vote;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote
     {
-      get { return _vote; }
+      get { return _vote?? default(uint); }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (uint?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2353,23 +3678,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgCastMatchVote() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private DOTAMatchVote _vote = DOTAMatchVote.DOTAMatchVote_INVALID;
+    private DOTAMatchVote? _vote;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAMatchVote.DOTAMatchVote_INVALID)]
     public DOTAMatchVote vote
     {
-      get { return _vote; }
+      get { return _vote?? DOTAMatchVote.DOTAMatchVote_INVALID; }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (DOTAMatchVote?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2381,23 +3724,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRetrieveMatchVote() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _incremental = default(uint);
+    private uint? _incremental;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"incremental", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint incremental
     {
-      get { return _incremental; }
+      get { return _incremental?? default(uint); }
       set { _incremental = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incrementalSpecified
+    {
+      get { return _incremental != null; }
+      set { if (value == (_incremental== null)) _incremental = value ? this.incremental : (uint?)null; }
+    }
+    private bool ShouldSerializeincremental() { return incrementalSpecified; }
+    private void Resetincremental() { incrementalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2409,41 +3770,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgMatchVoteResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private DOTAMatchVote _vote = DOTAMatchVote.DOTAMatchVote_INVALID;
+    private DOTAMatchVote? _vote;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAMatchVote.DOTAMatchVote_INVALID)]
     public DOTAMatchVote vote
     {
-      get { return _vote; }
+      get { return _vote?? DOTAMatchVote.DOTAMatchVote_INVALID; }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (DOTAMatchVote?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
 
-    private uint _positive_votes = default(uint);
+    private uint? _positive_votes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"positive_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint positive_votes
     {
-      get { return _positive_votes; }
+      get { return _positive_votes?? default(uint); }
       set { _positive_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool positive_votesSpecified
+    {
+      get { return _positive_votes != null; }
+      set { if (value == (_positive_votes== null)) _positive_votes = value ? this.positive_votes : (uint?)null; }
+    }
+    private bool ShouldSerializepositive_votes() { return positive_votesSpecified; }
+    private void Resetpositive_votes() { positive_votesSpecified = false; }
+    
 
-    private uint _negative_votes = default(uint);
+    private uint? _negative_votes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"negative_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint negative_votes
     {
-      get { return _negative_votes; }
+      get { return _negative_votes?? default(uint); }
       set { _negative_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool negative_votesSpecified
+    {
+      get { return _negative_votes != null; }
+      set { if (value == (_negative_votes== null)) _negative_votes = value ? this.negative_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenegative_votes() { return negative_votesSpecified; }
+    private void Resetnegative_votes() { negative_votesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2455,14 +3852,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHallOfFame() {}
     
 
-    private uint _week = default(uint);
+    private uint? _week;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"week", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint week
     {
-      get { return _week; }
+      get { return _week?? default(uint); }
       set { _week = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekSpecified
+    {
+      get { return _week != null; }
+      set { if (value == (_week== null)) _week = value ? this.week : (uint?)null; }
+    }
+    private bool ShouldSerializeweek() { return weekSpecified; }
+    private void Resetweek() { weekSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAHallOfFame.FeaturedPlayer> _featured_players = new global::System.Collections.Generic.List<CMsgDOTAHallOfFame.FeaturedPlayer>();
     [global::ProtoBuf.ProtoMember(2, Name=@"featured_players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAHallOfFame.FeaturedPlayer> featured_players
@@ -2485,41 +3891,77 @@ namespace SteamKit2.GC.Dota.Internal
     public FeaturedPlayer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private float _average_scaled_metric = default(float);
+    private float? _average_scaled_metric;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"average_scaled_metric", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float average_scaled_metric
     {
-      get { return _average_scaled_metric; }
+      get { return _average_scaled_metric?? default(float); }
       set { _average_scaled_metric = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_scaled_metricSpecified
+    {
+      get { return _average_scaled_metric != null; }
+      set { if (value == (_average_scaled_metric== null)) _average_scaled_metric = value ? this.average_scaled_metric : (float?)null; }
+    }
+    private bool ShouldSerializeaverage_scaled_metric() { return average_scaled_metricSpecified; }
+    private void Resetaverage_scaled_metric() { average_scaled_metricSpecified = false; }
+    
 
-    private uint _num_games = default(uint);
+    private uint? _num_games;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_games
     {
-      get { return _num_games; }
+      get { return _num_games?? default(uint); }
       set { _num_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_gamesSpecified
+    {
+      get { return _num_games != null; }
+      set { if (value == (_num_games== null)) _num_games = value ? this.num_games : (uint?)null; }
+    }
+    private bool ShouldSerializenum_games() { return num_gamesSpecified; }
+    private void Resetnum_games() { num_gamesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2531,41 +3973,77 @@ namespace SteamKit2.GC.Dota.Internal
     public FeaturedFarmer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _gold_per_min = default(uint);
+    private uint? _gold_per_min;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gold_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_per_min
     {
-      get { return _gold_per_min; }
+      get { return _gold_per_min?? default(uint); }
       set { _gold_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_per_minSpecified
+    {
+      get { return _gold_per_min != null; }
+      set { if (value == (_gold_per_min== null)) _gold_per_min = value ? this.gold_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializegold_per_min() { return gold_per_minSpecified; }
+    private void Resetgold_per_min() { gold_per_minSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2582,14 +4060,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHallOfFameRequest() {}
     
 
-    private uint _week = default(uint);
+    private uint? _week;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"week", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint week
     {
-      get { return _week; }
+      get { return _week?? default(uint); }
       set { _week = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekSpecified
+    {
+      get { return _week != null; }
+      set { if (value == (_week== null)) _week = value ? this.week : (uint?)null; }
+    }
+    private bool ShouldSerializeweek() { return weekSpecified; }
+    private void Resetweek() { weekSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2610,14 +4097,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _hall_of_fame = value; }
     }
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2629,14 +4125,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHalloweenHighScoreRequest() {}
     
 
-    private int _round = (int)-1;
+    private int? _round;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)-1)]
     public int round
     {
-      get { return _round; }
+      get { return _round?? (int)-1; }
       set { _round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roundSpecified
+    {
+      get { return _round != null; }
+      set { if (value == (_round== null)) _round = value ? this.round : (int?)null; }
+    }
+    private bool ShouldSerializeround() { return roundSpecified; }
+    private void Resetround() { roundSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2648,14 +4153,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHalloweenHighScoreResponse() {}
     
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
     private CMsgDOTAMatch _match = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2666,23 +4180,41 @@ namespace SteamKit2.GC.Dota.Internal
       set { _match = value; }
     }
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _round = default(int);
+    private int? _round;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int round
     {
-      get { return _round; }
+      get { return _round?? default(int); }
       set { _round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roundSpecified
+    {
+      get { return _round != null; }
+      set { if (value == (_round== null)) _round = value ? this.round : (int?)null; }
+    }
+    private bool ShouldSerializeround() { return roundSpecified; }
+    private void Resetround() { roundSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2694,14 +4226,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAStorePromoPagesRequest() {}
     
 
-    private uint _version_seen = default(uint);
+    private uint? _version_seen;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version_seen", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_seen
     {
-      get { return _version_seen; }
+      get { return _version_seen?? default(uint); }
       set { _version_seen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_seenSpecified
+    {
+      get { return _version_seen != null; }
+      set { if (value == (_version_seen== null)) _version_seen = value ? this.version_seen : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_seen() { return version_seenSpecified; }
+    private void Resetversion_seen() { version_seenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2725,32 +4266,59 @@ namespace SteamKit2.GC.Dota.Internal
     public PromoPage() {}
     
 
-    private uint _promo_id = default(uint);
+    private uint? _promo_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"promo_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint promo_id
     {
-      get { return _promo_id; }
+      get { return _promo_id?? default(uint); }
       set { _promo_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool promo_idSpecified
+    {
+      get { return _promo_id != null; }
+      set { if (value == (_promo_id== null)) _promo_id = value ? this.promo_id : (uint?)null; }
+    }
+    private bool ShouldSerializepromo_id() { return promo_idSpecified; }
+    private void Resetpromo_id() { promo_idSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2767,32 +4335,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeagueScheduleBlockTeamInfo() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2804,41 +4399,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeagueScheduleBlock() {}
     
 
-    private uint _block_id = default(uint);
+    private uint? _block_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"block_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint block_id
     {
-      get { return _block_id; }
+      get { return _block_id?? default(uint); }
       set { _block_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool block_idSpecified
+    {
+      get { return _block_id != null; }
+      set { if (value == (_block_id== null)) _block_id = value ? this.block_id : (uint?)null; }
+    }
+    private bool ShouldSerializeblock_id() { return block_idSpecified; }
+    private void Resetblock_id() { block_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private bool _finals = default(bool);
+    private bool? _finals;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"finals", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool finals
     {
-      get { return _finals; }
+      get { return _finals?? default(bool); }
       set { _finals = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool finalsSpecified
+    {
+      get { return _finals != null; }
+      set { if (value == (_finals== null)) _finals = value ? this.finals : (bool?)null; }
+    }
+    private bool ShouldSerializefinals() { return finalsSpecified; }
+    private void Resetfinals() { finalsSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgLeagueScheduleBlockTeamInfo> _teams = new global::System.Collections.Generic.List<CMsgLeagueScheduleBlockTeamInfo>();
     [global::ProtoBuf.ProtoMember(6, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgLeagueScheduleBlockTeamInfo> teams
@@ -2857,14 +4488,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeague() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgLeagueScheduleBlock> _schedule = new global::System.Collections.Generic.List<CMsgLeagueScheduleBlock>();
     [global::ProtoBuf.ProtoMember(2, Name=@"schedule", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgLeagueScheduleBlock> schedule
@@ -2883,14 +4523,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeagueScheduleRequest() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2911,14 +4560,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _league = value; }
     }
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2930,14 +4588,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeagueScheduleEdit() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
     private CMsgLeagueScheduleBlock _schedule = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"schedule", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2948,14 +4615,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _schedule = value; }
     }
 
-    private bool _delete_block = default(bool);
+    private bool? _delete_block;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"delete_block", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool delete_block
     {
-      get { return _delete_block; }
+      get { return _delete_block?? default(bool); }
       set { _delete_block = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_blockSpecified
+    {
+      get { return _delete_block != null; }
+      set { if (value == (_delete_block== null)) _delete_block = value ? this.delete_block : (bool?)null; }
+    }
+    private bool ShouldSerializedelete_block() { return delete_blockSpecified; }
+    private void Resetdelete_block() { delete_blockSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2976,14 +4652,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _league = value; }
     }
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2995,32 +4680,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeaguesInMonthRequest() {}
     
 
-    private uint _month = default(uint);
+    private uint? _month;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"month", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint month
     {
-      get { return _month; }
+      get { return _month?? default(uint); }
       set { _month = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool monthSpecified
+    {
+      get { return _month != null; }
+      set { if (value == (_month== null)) _month = value ? this.month : (uint?)null; }
+    }
+    private bool ShouldSerializemonth() { return monthSpecified; }
+    private void Resetmonth() { monthSpecified = false; }
+    
 
-    private uint _year = default(uint);
+    private uint? _year;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"year", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint year
     {
-      get { return _year; }
+      get { return _year?? default(uint); }
       set { _year = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool yearSpecified
+    {
+      get { return _year != null; }
+      set { if (value == (_year== null)) _year = value ? this.year : (uint?)null; }
+    }
+    private bool ShouldSerializeyear() { return yearSpecified; }
+    private void Resetyear() { yearSpecified = false; }
+    
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3032,32 +4744,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeaguesInMonthResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _month = default(uint);
+    private uint? _month;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"month", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint month
     {
-      get { return _month; }
+      get { return _month?? default(uint); }
       set { _month = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool monthSpecified
+    {
+      get { return _month != null; }
+      set { if (value == (_month== null)) _month = value ? this.month : (uint?)null; }
+    }
+    private bool ShouldSerializemonth() { return monthSpecified; }
+    private void Resetmonth() { monthSpecified = false; }
+    
 
-    private uint _year = default(uint);
+    private uint? _year;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"year", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint year
     {
-      get { return _year; }
+      get { return _year?? default(uint); }
       set { _year = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool yearSpecified
+    {
+      get { return _year != null; }
+      set { if (value == (_year== null)) _year = value ? this.year : (uint?)null; }
+    }
+    private bool ShouldSerializeyear() { return yearSpecified; }
+    private void Resetyear() { yearSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTALeague> _leagues = new global::System.Collections.Generic.List<CMsgDOTALeague>();
     [global::ProtoBuf.ProtoMember(4, Name=@"leagues", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTALeague> leagues
@@ -3076,32 +4815,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgMatchmakingMatchGroupInfo() {}
     
 
-    private uint _players_searching = default(uint);
+    private uint? _players_searching;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"players_searching", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_searching
     {
-      get { return _players_searching; }
+      get { return _players_searching?? default(uint); }
       set { _players_searching = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_searchingSpecified
+    {
+      get { return _players_searching != null; }
+      set { if (value == (_players_searching== null)) _players_searching = value ? this.players_searching : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_searching() { return players_searchingSpecified; }
+    private void Resetplayers_searching() { players_searchingSpecified = false; }
+    
 
-    private int _auto_region_select_ping_penalty = default(int);
+    private int? _auto_region_select_ping_penalty;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"auto_region_select_ping_penalty", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int auto_region_select_ping_penalty
     {
-      get { return _auto_region_select_ping_penalty; }
+      get { return _auto_region_select_ping_penalty?? default(int); }
       set { _auto_region_select_ping_penalty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auto_region_select_ping_penaltySpecified
+    {
+      get { return _auto_region_select_ping_penalty != null; }
+      set { if (value == (_auto_region_select_ping_penalty== null)) _auto_region_select_ping_penalty = value ? this.auto_region_select_ping_penalty : (int?)null; }
+    }
+    private bool ShouldSerializeauto_region_select_ping_penalty() { return auto_region_select_ping_penaltySpecified; }
+    private void Resetauto_region_select_ping_penalty() { auto_region_select_ping_penaltySpecified = false; }
+    
 
-    private EMatchGroupServerStatus _status = EMatchGroupServerStatus.k_EMatchGroupServerStatus_OK;
+    private EMatchGroupServerStatus? _status;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EMatchGroupServerStatus.k_EMatchGroupServerStatus_OK)]
     public EMatchGroupServerStatus status
     {
-      get { return _status; }
+      get { return _status?? EMatchGroupServerStatus.k_EMatchGroupServerStatus_OK; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (EMatchGroupServerStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3123,14 +4889,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAMatchmakingStatsResponse() {}
     
 
-    private uint _matchgroups_version = default(uint);
+    private uint? _matchgroups_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchgroups_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchgroups_version
     {
-      get { return _matchgroups_version; }
+      get { return _matchgroups_version?? default(uint); }
       set { _matchgroups_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroups_versionSpecified
+    {
+      get { return _matchgroups_version != null; }
+      set { if (value == (_matchgroups_version== null)) _matchgroups_version = value ? this.matchgroups_version : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroups_version() { return matchgroups_versionSpecified; }
+    private void Resetmatchgroups_version() { matchgroups_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _legacy_searching_players_by_group_source2 = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"legacy_searching_players_by_group_source2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> legacy_searching_players_by_group_source2
@@ -3194,14 +4969,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetMatchHistoryAccess() {}
     
 
-    private bool _allow_3rd_party_match_history = default(bool);
+    private bool? _allow_3rd_party_match_history;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"allow_3rd_party_match_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_3rd_party_match_history
     {
-      get { return _allow_3rd_party_match_history; }
+      get { return _allow_3rd_party_match_history?? default(bool); }
       set { _allow_3rd_party_match_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_3rd_party_match_historySpecified
+    {
+      get { return _allow_3rd_party_match_history != null; }
+      set { if (value == (_allow_3rd_party_match_history== null)) _allow_3rd_party_match_history = value ? this.allow_3rd_party_match_history : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_3rd_party_match_history() { return allow_3rd_party_match_historySpecified; }
+    private void Resetallow_3rd_party_match_history() { allow_3rd_party_match_historySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3213,14 +4997,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetMatchHistoryAccessResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3232,23 +5025,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTANotifyAccountFlagsChange() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _account_flags = default(uint);
+    private uint? _account_flags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_flags
     {
-      get { return _account_flags; }
+      get { return _account_flags?? default(uint); }
       set { _account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_flagsSpecified
+    {
+      get { return _account_flags != null; }
+      set { if (value == (_account_flags== null)) _account_flags = value ? this.account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_flags() { return account_flagsSpecified; }
+    private void Resetaccount_flags() { account_flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3260,14 +5071,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetProfilePrivacy() {}
     
 
-    private bool _profile_private = default(bool);
+    private bool? _profile_private;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"profile_private", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool profile_private
     {
-      get { return _profile_private; }
+      get { return _profile_private?? default(bool); }
       set { _profile_private = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool profile_privateSpecified
+    {
+      get { return _profile_private != null; }
+      set { if (value == (_profile_private== null)) _profile_private = value ? this.profile_private : (bool?)null; }
+    }
+    private bool ShouldSerializeprofile_private() { return profile_privateSpecified; }
+    private void Resetprofile_private() { profile_privateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3279,14 +5099,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetProfilePrivacyResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3298,23 +5127,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgUpgradeLeagueItem() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3336,23 +5183,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCWatchDownloadedReplay() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private DOTA_WatchReplayType _watch_type = DOTA_WatchReplayType.DOTA_WATCH_REPLAY_NORMAL;
+    private DOTA_WatchReplayType? _watch_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"watch_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_WatchReplayType.DOTA_WATCH_REPLAY_NORMAL)]
     public DOTA_WatchReplayType watch_type
     {
-      get { return _watch_type; }
+      get { return _watch_type?? DOTA_WatchReplayType.DOTA_WATCH_REPLAY_NORMAL; }
       set { _watch_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watch_typeSpecified
+    {
+      get { return _watch_type != null; }
+      set { if (value == (_watch_type== null)) _watch_type = value ? this.watch_type : (DOTA_WatchReplayType?)null; }
+    }
+    private bool ShouldSerializewatch_type() { return watch_typeSpecified; }
+    private void Resetwatch_type() { watch_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3364,23 +5229,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSetMapLocationState() {}
     
 
-    private int _location_id = default(int);
+    private int? _location_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"location_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int location_id
     {
-      get { return _location_id; }
+      get { return _location_id?? default(int); }
       set { _location_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool location_idSpecified
+    {
+      get { return _location_id != null; }
+      set { if (value == (_location_id== null)) _location_id = value ? this.location_id : (int?)null; }
+    }
+    private bool ShouldSerializelocation_id() { return location_idSpecified; }
+    private void Resetlocation_id() { location_idSpecified = false; }
+    
 
-    private bool _completed = default(bool);
+    private bool? _completed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool completed
     {
-      get { return _completed; }
+      get { return _completed?? default(bool); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (bool?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3392,14 +5275,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSetMapLocationStateResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3421,14 +5313,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgResetMapLocationsResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3440,14 +5341,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRefreshPartnerAccountLink() {}
     
 
-    private int _partner_type = default(int);
+    private int? _partner_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"partner_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int partner_type
     {
-      get { return _partner_type; }
+      get { return _partner_type?? default(int); }
       set { _partner_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_typeSpecified
+    {
+      get { return _partner_type != null; }
+      set { if (value == (_partner_type== null)) _partner_type = value ? this.partner_type : (int?)null; }
+    }
+    private bool ShouldSerializepartner_type() { return partner_typeSpecified; }
+    private void Resetpartner_type() { partner_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3503,14 +5413,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFriendRecruitsResponse() {}
     
 
-    private CMsgDOTAFriendRecruitsResponse.EResult _result = CMsgDOTAFriendRecruitsResponse.EResult.SUCCESS;
+    private CMsgDOTAFriendRecruitsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFriendRecruitsResponse.EResult.SUCCESS)]
     public CMsgDOTAFriendRecruitsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFriendRecruitsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFriendRecruitsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFriendRecruitsResponse.FriendRecruitStatus> _recruits = new global::System.Collections.Generic.List<CMsgDOTAFriendRecruitsResponse.FriendRecruitStatus>();
     [global::ProtoBuf.ProtoMember(2, Name=@"recruits", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFriendRecruitsResponse.FriendRecruitStatus> recruits
@@ -3531,41 +5450,77 @@ namespace SteamKit2.GC.Dota.Internal
     public FriendRecruitStatus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _levels_earned = default(uint);
+    private uint? _levels_earned;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"levels_earned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint levels_earned
     {
-      get { return _levels_earned; }
+      get { return _levels_earned?? default(uint); }
       set { _levels_earned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levels_earnedSpecified
+    {
+      get { return _levels_earned != null; }
+      set { if (value == (_levels_earned== null)) _levels_earned = value ? this.levels_earned : (uint?)null; }
+    }
+    private bool ShouldSerializelevels_earned() { return levels_earnedSpecified; }
+    private void Resetlevels_earned() { levels_earnedSpecified = false; }
+    
 
-    private bool _bonus = default(bool);
+    private bool? _bonus;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bonus", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bonus
     {
-      get { return _bonus; }
+      get { return _bonus?? default(bool); }
       set { _bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonusSpecified
+    {
+      get { return _bonus != null; }
+      set { if (value == (_bonus== null)) _bonus = value ? this.bonus : (bool?)null; }
+    }
+    private bool ShouldSerializebonus() { return bonusSpecified; }
+    private void Resetbonus() { bonusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3593,23 +5548,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFriendRecruitInviteAcceptDecline() {}
     
 
-    private bool _accepted = default(bool);
+    private bool? _accepted;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accepted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accepted
     {
-      get { return _accepted; }
+      get { return _accepted?? default(bool); }
       set { _accepted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptedSpecified
+    {
+      get { return _accepted != null; }
+      set { if (value == (_accepted== null)) _accepted = value ? this.accepted : (bool?)null; }
+    }
+    private bool ShouldSerializeaccepted() { return acceptedSpecified; }
+    private void Resetaccepted() { acceptedSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3621,14 +5594,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestLeaguePrizePool() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3640,23 +5622,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestLeaguePrizePoolResponse() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _prize_pool = default(uint);
+    private uint? _prize_pool;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prize_pool", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_pool
     {
-      get { return _prize_pool; }
+      get { return _prize_pool?? default(uint); }
       set { _prize_pool = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_poolSpecified
+    {
+      get { return _prize_pool != null; }
+      set { if (value == (_prize_pool== null)) _prize_pool = value ? this.prize_pool : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_pool() { return prize_poolSpecified; }
+    private void Resetprize_pool() { prize_poolSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3690,140 +5690,275 @@ namespace SteamKit2.GC.Dota.Internal
     public Hero() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
 
-    private uint _win_streak = default(uint);
+    private uint? _win_streak;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"win_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint win_streak
     {
-      get { return _win_streak; }
+      get { return _win_streak?? default(uint); }
       set { _win_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool win_streakSpecified
+    {
+      get { return _win_streak != null; }
+      set { if (value == (_win_streak== null)) _win_streak = value ? this.win_streak : (uint?)null; }
+    }
+    private bool ShouldSerializewin_streak() { return win_streakSpecified; }
+    private void Resetwin_streak() { win_streakSpecified = false; }
+    
 
-    private uint _best_win_streak = default(uint);
+    private uint? _best_win_streak;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"best_win_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_win_streak
     {
-      get { return _best_win_streak; }
+      get { return _best_win_streak?? default(uint); }
       set { _best_win_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_win_streakSpecified
+    {
+      get { return _best_win_streak != null; }
+      set { if (value == (_best_win_streak== null)) _best_win_streak = value ? this.best_win_streak : (uint?)null; }
+    }
+    private bool ShouldSerializebest_win_streak() { return best_win_streakSpecified; }
+    private void Resetbest_win_streak() { best_win_streakSpecified = false; }
+    
 
-    private float _avg_kills = default(float);
+    private float? _avg_kills;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"avg_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float avg_kills
     {
-      get { return _avg_kills; }
+      get { return _avg_kills?? default(float); }
       set { _avg_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_killsSpecified
+    {
+      get { return _avg_kills != null; }
+      set { if (value == (_avg_kills== null)) _avg_kills = value ? this.avg_kills : (float?)null; }
+    }
+    private bool ShouldSerializeavg_kills() { return avg_killsSpecified; }
+    private void Resetavg_kills() { avg_killsSpecified = false; }
+    
 
-    private float _avg_deaths = default(float);
+    private float? _avg_deaths;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"avg_deaths", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float avg_deaths
     {
-      get { return _avg_deaths; }
+      get { return _avg_deaths?? default(float); }
       set { _avg_deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_deathsSpecified
+    {
+      get { return _avg_deaths != null; }
+      set { if (value == (_avg_deaths== null)) _avg_deaths = value ? this.avg_deaths : (float?)null; }
+    }
+    private bool ShouldSerializeavg_deaths() { return avg_deathsSpecified; }
+    private void Resetavg_deaths() { avg_deathsSpecified = false; }
+    
 
-    private float _avg_assists = default(float);
+    private float? _avg_assists;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"avg_assists", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float avg_assists
     {
-      get { return _avg_assists; }
+      get { return _avg_assists?? default(float); }
       set { _avg_assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_assistsSpecified
+    {
+      get { return _avg_assists != null; }
+      set { if (value == (_avg_assists== null)) _avg_assists = value ? this.avg_assists : (float?)null; }
+    }
+    private bool ShouldSerializeavg_assists() { return avg_assistsSpecified; }
+    private void Resetavg_assists() { avg_assistsSpecified = false; }
+    
 
-    private float _avg_gpm = default(float);
+    private float? _avg_gpm;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"avg_gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float avg_gpm
     {
-      get { return _avg_gpm; }
+      get { return _avg_gpm?? default(float); }
       set { _avg_gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_gpmSpecified
+    {
+      get { return _avg_gpm != null; }
+      set { if (value == (_avg_gpm== null)) _avg_gpm = value ? this.avg_gpm : (float?)null; }
+    }
+    private bool ShouldSerializeavg_gpm() { return avg_gpmSpecified; }
+    private void Resetavg_gpm() { avg_gpmSpecified = false; }
+    
 
-    private float _avg_xpm = default(float);
+    private float? _avg_xpm;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"avg_xpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float avg_xpm
     {
-      get { return _avg_xpm; }
+      get { return _avg_xpm?? default(float); }
       set { _avg_xpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_xpmSpecified
+    {
+      get { return _avg_xpm != null; }
+      set { if (value == (_avg_xpm== null)) _avg_xpm = value ? this.avg_xpm : (float?)null; }
+    }
+    private bool ShouldSerializeavg_xpm() { return avg_xpmSpecified; }
+    private void Resetavg_xpm() { avg_xpmSpecified = false; }
+    
 
-    private uint _best_kills = default(uint);
+    private uint? _best_kills;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"best_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_kills
     {
-      get { return _best_kills; }
+      get { return _best_kills?? default(uint); }
       set { _best_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_killsSpecified
+    {
+      get { return _best_kills != null; }
+      set { if (value == (_best_kills== null)) _best_kills = value ? this.best_kills : (uint?)null; }
+    }
+    private bool ShouldSerializebest_kills() { return best_killsSpecified; }
+    private void Resetbest_kills() { best_killsSpecified = false; }
+    
 
-    private uint _best_assists = default(uint);
+    private uint? _best_assists;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"best_assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_assists
     {
-      get { return _best_assists; }
+      get { return _best_assists?? default(uint); }
       set { _best_assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_assistsSpecified
+    {
+      get { return _best_assists != null; }
+      set { if (value == (_best_assists== null)) _best_assists = value ? this.best_assists : (uint?)null; }
+    }
+    private bool ShouldSerializebest_assists() { return best_assistsSpecified; }
+    private void Resetbest_assists() { best_assistsSpecified = false; }
+    
 
-    private uint _best_gpm = default(uint);
+    private uint? _best_gpm;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"best_gpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_gpm
     {
-      get { return _best_gpm; }
+      get { return _best_gpm?? default(uint); }
       set { _best_gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_gpmSpecified
+    {
+      get { return _best_gpm != null; }
+      set { if (value == (_best_gpm== null)) _best_gpm = value ? this.best_gpm : (uint?)null; }
+    }
+    private bool ShouldSerializebest_gpm() { return best_gpmSpecified; }
+    private void Resetbest_gpm() { best_gpmSpecified = false; }
+    
 
-    private uint _best_xpm = default(uint);
+    private uint? _best_xpm;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"best_xpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_xpm
     {
-      get { return _best_xpm; }
+      get { return _best_xpm?? default(uint); }
       set { _best_xpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_xpmSpecified
+    {
+      get { return _best_xpm != null; }
+      set { if (value == (_best_xpm== null)) _best_xpm = value ? this.best_xpm : (uint?)null; }
+    }
+    private bool ShouldSerializebest_xpm() { return best_xpmSpecified; }
+    private void Resetbest_xpm() { best_xpmSpecified = false; }
+    
 
-    private float _performance = default(float);
+    private float? _performance;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"performance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float performance
     {
-      get { return _performance; }
+      get { return _performance?? default(float); }
       set { _performance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool performanceSpecified
+    {
+      get { return _performance != null; }
+      set { if (value == (_performance== null)) _performance = value ? this.performance : (float?)null; }
+    }
+    private bool ShouldSerializeperformance() { return performanceSpecified; }
+    private void Resetperformance() { performanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3850,23 +5985,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorReservation() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3895,23 +6048,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorReserveItemDef() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _username = "";
+    private string _username;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"username", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string username
     {
-      get { return _username; }
+      get { return _username?? ""; }
       set { _username = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usernameSpecified
+    {
+      get { return _username != null; }
+      set { if (value == (_username== null)) _username = value ? this.username : (string)null; }
+    }
+    private bool ShouldSerializeusername() { return usernameSpecified; }
+    private void Resetusername() { usernameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3923,32 +6094,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorReserveItemDefResponse() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _username = "";
+    private string _username;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"username", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string username
     {
-      get { return _username; }
+      get { return _username?? ""; }
       set { _username = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usernameSpecified
+    {
+      get { return _username != null; }
+      set { if (value == (_username== null)) _username = value ? this.username : (string)null; }
+    }
+    private bool ShouldSerializeusername() { return usernameSpecified; }
+    private void Resetusername() { usernameSpecified = false; }
+    
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3960,23 +6158,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorReleaseReservation() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _username = "";
+    private string _username;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"username", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string username
     {
-      get { return _username; }
+      get { return _username?? ""; }
       set { _username = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usernameSpecified
+    {
+      get { return _username != null; }
+      set { if (value == (_username== null)) _username = value ? this.username : (string)null; }
+    }
+    private bool ShouldSerializeusername() { return usernameSpecified; }
+    private void Resetusername() { usernameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3988,23 +6204,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorReleaseReservationResponse() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private bool _released = default(bool);
+    private bool? _released;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"released", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool released
     {
-      get { return _released; }
+      get { return _released?? default(bool); }
       set { _released = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool releasedSpecified
+    {
+      get { return _released != null; }
+      set { if (value == (_released== null)) _released = value ? this.released : (bool?)null; }
+    }
+    private bool ShouldSerializereleased() { return releasedSpecified; }
+    private void Resetreleased() { releasedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4016,14 +6250,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorRequestLeagueInfo() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4035,77 +6278,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCItemEditorLeagueInfoResponse() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private string _league_name = "";
+    private string _league_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string league_name
     {
-      get { return _league_name; }
+      get { return _league_name?? ""; }
       set { _league_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_nameSpecified
+    {
+      get { return _league_name != null; }
+      set { if (value == (_league_name== null)) _league_name = value ? this.league_name : (string)null; }
+    }
+    private bool ShouldSerializeleague_name() { return league_nameSpecified; }
+    private void Resetleague_name() { league_nameSpecified = false; }
+    
 
-    private string _league_desc = "";
+    private string _league_desc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"league_desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string league_desc
     {
-      get { return _league_desc; }
+      get { return _league_desc?? ""; }
       set { _league_desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_descSpecified
+    {
+      get { return _league_desc != null; }
+      set { if (value == (_league_desc== null)) _league_desc = value ? this.league_desc : (string)null; }
+    }
+    private bool ShouldSerializeleague_desc() { return league_descSpecified; }
+    private void Resetleague_desc() { league_descSpecified = false; }
+    
 
-    private string _league_url = "";
+    private string _league_url;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"league_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string league_url
     {
-      get { return _league_url; }
+      get { return _league_url?? ""; }
       set { _league_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_urlSpecified
+    {
+      get { return _league_url != null; }
+      set { if (value == (_league_url== null)) _league_url = value ? this.league_url : (string)null; }
+    }
+    private bool ShouldSerializeleague_url() { return league_urlSpecified; }
+    private void Resetleague_url() { league_urlSpecified = false; }
+    
 
-    private string _revenue_url = "";
+    private string _revenue_url;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"revenue_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string revenue_url
     {
-      get { return _revenue_url; }
+      get { return _revenue_url?? ""; }
       set { _revenue_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_urlSpecified
+    {
+      get { return _revenue_url != null; }
+      set { if (value == (_revenue_url== null)) _revenue_url = value ? this.revenue_url : (string)null; }
+    }
+    private bool ShouldSerializerevenue_url() { return revenue_urlSpecified; }
+    private void Resetrevenue_url() { revenue_urlSpecified = false; }
+    
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
 
-    private uint _location = default(uint);
+    private uint? _location;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"location", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint location
     {
-      get { return _location; }
+      get { return _location?? default(uint); }
       set { _location = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool locationSpecified
+    {
+      get { return _location != null; }
+      set { if (value == (_location== null)) _location = value ? this.location : (uint?)null; }
+    }
+    private bool ShouldSerializelocation() { return locationSpecified; }
+    private void Resetlocation() { locationSpecified = false; }
+    
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4117,23 +6432,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARewardTutorialPrizes() {}
     
 
-    private uint _location_id = default(uint);
+    private uint? _location_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"location_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint location_id
     {
-      get { return _location_id; }
+      get { return _location_id?? default(uint); }
       set { _location_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool location_idSpecified
+    {
+      get { return _location_id != null; }
+      set { if (value == (_location_id== null)) _location_id = value ? this.location_id : (uint?)null; }
+    }
+    private bool ShouldSerializelocation_id() { return location_idSpecified; }
+    private void Resetlocation_id() { location_idSpecified = false; }
+    
 
-    private bool _tracking_only = default(bool);
+    private bool? _tracking_only;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tracking_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tracking_only
     {
-      get { return _tracking_only; }
+      get { return _tracking_only?? default(bool); }
       set { _tracking_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tracking_onlySpecified
+    {
+      get { return _tracking_only != null; }
+      set { if (value == (_tracking_only== null)) _tracking_only = value ? this.tracking_only : (bool?)null; }
+    }
+    private bool ShouldSerializetracking_only() { return tracking_onlySpecified; }
+    private void Resettracking_only() { tracking_onlySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4145,23 +6478,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALastHitChallengeHighScorePost() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _high_score = default(uint);
+    private uint? _high_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"high_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint high_score
     {
-      get { return _high_score; }
+      get { return _high_score?? default(uint); }
       set { _high_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool high_scoreSpecified
+    {
+      get { return _high_score != null; }
+      set { if (value == (_high_score== null)) _high_score = value ? this.high_score : (uint?)null; }
+    }
+    private bool ShouldSerializehigh_score() { return high_scoreSpecified; }
+    private void Resethigh_score() { high_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4173,14 +6524,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALastHitChallengeHighScoreRequest() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4192,23 +6552,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALastHitChallengeHighScoreResponse() {}
     
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4240,41 +6618,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCLobbyUpdateBroadcastChannelInfo() {}
     
 
-    private uint _channel_id = default(uint);
+    private uint? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(uint); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private string _language_code = "";
+    private string _language_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"language_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language_code
     {
-      get { return _language_code; }
+      get { return _language_code?? ""; }
       set { _language_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool language_codeSpecified
+    {
+      get { return _language_code != null; }
+      set { if (value == (_language_code== null)) _language_code = value ? this.language_code : (string)null; }
+    }
+    private bool ShouldSerializelanguage_code() { return language_codeSpecified; }
+    private void Resetlanguage_code() { language_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4286,32 +6700,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAClaimEventAction() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4323,14 +6764,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAClaimEventActionResponse() {}
     
 
-    private CMsgDOTAClaimEventActionResponse.ResultCode _result = CMsgDOTAClaimEventActionResponse.ResultCode.Success;
+    private CMsgDOTAClaimEventActionResponse.ResultCode? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAClaimEventActionResponse.ResultCode.Success)]
     public CMsgDOTAClaimEventActionResponse.ResultCode result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAClaimEventActionResponse.ResultCode.Success; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAClaimEventActionResponse.ResultCode?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAClaimEventActionResponse.GrantedRewardData> _reward_results = new global::System.Collections.Generic.List<CMsgDOTAClaimEventActionResponse.GrantedRewardData>();
     [global::ProtoBuf.ProtoMember(2, Name=@"reward_results", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAClaimEventActionResponse.GrantedRewardData> reward_results
@@ -4344,23 +6794,41 @@ namespace SteamKit2.GC.Dota.Internal
     public MysteryItemRewardData() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _item_category = default(uint);
+    private uint? _item_category;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_category
     {
-      get { return _item_category; }
+      get { return _item_category?? default(uint); }
       set { _item_category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_categorySpecified
+    {
+      get { return _item_category != null; }
+      set { if (value == (_item_category== null)) _item_category = value ? this.item_category : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_category() { return item_categorySpecified; }
+    private void Resetitem_category() { item_categorySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4389,41 +6857,77 @@ namespace SteamKit2.GC.Dota.Internal
     public GrantedRewardData() {}
     
 
-    private uint _grant_index = default(uint);
+    private uint? _grant_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"grant_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint grant_index
     {
-      get { return _grant_index; }
+      get { return _grant_index?? default(uint); }
       set { _grant_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool grant_indexSpecified
+    {
+      get { return _grant_index != null; }
+      set { if (value == (_grant_index== null)) _grant_index = value ? this.grant_index : (uint?)null; }
+    }
+    private bool ShouldSerializegrant_index() { return grant_indexSpecified; }
+    private void Resetgrant_index() { grant_indexSpecified = false; }
+    
 
-    private uint _score_index = default(uint);
+    private uint? _score_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_index
     {
-      get { return _score_index; }
+      get { return _score_index?? default(uint); }
       set { _score_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_indexSpecified
+    {
+      get { return _score_index != null; }
+      set { if (value == (_score_index== null)) _score_index = value ? this.score_index : (uint?)null; }
+    }
+    private bool ShouldSerializescore_index() { return score_indexSpecified; }
+    private void Resetscore_index() { score_indexSpecified = false; }
+    
 
-    private uint _reward_index = default(uint);
+    private uint? _reward_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"reward_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_index
     {
-      get { return _reward_index; }
+      get { return _reward_index?? default(uint); }
       set { _reward_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_indexSpecified
+    {
+      get { return _reward_index != null; }
+      set { if (value == (_reward_index== null)) _reward_index = value ? this.reward_index : (uint?)null; }
+    }
+    private bool ShouldSerializereward_index() { return reward_indexSpecified; }
+    private void Resetreward_index() { reward_indexSpecified = false; }
+    
 
-    private byte[] _reward_data = null;
+    private byte[] _reward_data;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reward_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] reward_data
     {
-      get { return _reward_data; }
+      get { return _reward_data?? null; }
       set { _reward_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_dataSpecified
+    {
+      get { return _reward_data != null; }
+      set { if (value == (_reward_data== null)) _reward_data = value ? this.reward_data : (byte[])null; }
+    }
+    private bool ShouldSerializereward_data() { return reward_dataSpecified; }
+    private void Resetreward_data() { reward_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4481,23 +6985,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGetEventPoints() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4509,50 +7031,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGetEventPointsResponse() {}
     
 
-    private uint _total_points = default(uint);
+    private uint? _total_points;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_points
     {
-      get { return _total_points; }
+      get { return _total_points?? default(uint); }
       set { _total_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_pointsSpecified
+    {
+      get { return _total_points != null; }
+      set { if (value == (_total_points== null)) _total_points = value ? this.total_points : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_points() { return total_pointsSpecified; }
+    private void Resettotal_points() { total_pointsSpecified = false; }
+    
 
-    private uint _total_premium_points = default(uint);
+    private uint? _total_premium_points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_premium_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_premium_points
     {
-      get { return _total_premium_points; }
+      get { return _total_premium_points?? default(uint); }
       set { _total_premium_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_premium_pointsSpecified
+    {
+      get { return _total_premium_points != null; }
+      set { if (value == (_total_premium_points== null)) _total_premium_points = value ? this.total_premium_points : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_premium_points() { return total_premium_pointsSpecified; }
+    private void Resettotal_premium_points() { total_premium_pointsSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
 
-    private uint _premium_points = default(uint);
+    private uint? _premium_points;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"premium_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint premium_points
     {
-      get { return _premium_points; }
+      get { return _premium_points?? default(uint); }
       set { _premium_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool premium_pointsSpecified
+    {
+      get { return _premium_points != null; }
+      set { if (value == (_premium_points== null)) _premium_points = value ? this.premium_points : (uint?)null; }
+    }
+    private bool ShouldSerializepremium_points() { return premium_pointsSpecified; }
+    private void Resetpremium_points() { premium_pointsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAGetEventPointsResponse.Action> _completed_actions = new global::System.Collections.Generic.List<CMsgDOTAGetEventPointsResponse.Action>();
     [global::ProtoBuf.ProtoMember(6, Name=@"completed_actions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAGetEventPointsResponse.Action> completed_actions
@@ -4561,64 +7128,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _owned = default(bool);
+    private bool? _owned;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"owned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool owned
     {
-      get { return _owned; }
+      get { return _owned?? default(bool); }
       set { _owned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownedSpecified
+    {
+      get { return _owned != null; }
+      set { if (value == (_owned== null)) _owned = value ? this.owned : (bool?)null; }
+    }
+    private bool ShouldSerializeowned() { return ownedSpecified; }
+    private void Resetowned() { ownedSpecified = false; }
+    
 
-    private uint _audit_action = default(uint);
+    private uint? _audit_action;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"audit_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint audit_action
     {
-      get { return _audit_action; }
+      get { return _audit_action?? default(uint); }
       set { _audit_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_actionSpecified
+    {
+      get { return _audit_action != null; }
+      set { if (value == (_audit_action== null)) _audit_action = value ? this.audit_action : (uint?)null; }
+    }
+    private bool ShouldSerializeaudit_action() { return audit_actionSpecified; }
+    private void Resetaudit_action() { audit_actionSpecified = false; }
+    
 
-    private uint _periodic_points_remaining = default(uint);
+    private uint? _periodic_points_remaining;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"periodic_points_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint periodic_points_remaining
     {
-      get { return _periodic_points_remaining; }
+      get { return _periodic_points_remaining?? default(uint); }
       set { _periodic_points_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool periodic_points_remainingSpecified
+    {
+      get { return _periodic_points_remaining != null; }
+      set { if (value == (_periodic_points_remaining== null)) _periodic_points_remaining = value ? this.periodic_points_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializeperiodic_points_remaining() { return periodic_points_remainingSpecified; }
+    private void Resetperiodic_points_remaining() { periodic_points_remainingSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Action")]
   public partial class Action : global::ProtoBuf.IExtensible
   {
     public Action() {}
     
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
 
-    private uint _times_completed = (uint)1;
+    private uint? _times_completed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"times_completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint times_completed
     {
-      get { return _times_completed; }
+      get { return _times_completed?? (uint)1; }
       set { _times_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_completedSpecified
+    {
+      get { return _times_completed != null; }
+      set { if (value == (_times_completed== null)) _times_completed = value ? this.times_completed : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_completed() { return times_completedSpecified; }
+    private void Resettimes_completed() { times_completedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4635,14 +7256,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALiveLeagueGameUpdate() {}
     
 
-    private uint _live_league_games = default(uint);
+    private uint? _live_league_games;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"live_league_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint live_league_games
     {
-      get { return _live_league_games; }
+      get { return _live_league_games?? default(uint); }
       set { _live_league_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool live_league_gamesSpecified
+    {
+      get { return _live_league_games != null; }
+      set { if (value == (_live_league_games== null)) _live_league_games = value ? this.live_league_games : (uint?)null; }
+    }
+    private bool ShouldSerializelive_league_games() { return live_league_gamesSpecified; }
+    private void Resetlive_league_games() { live_league_gamesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4654,32 +7284,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACompendiumSelection() {}
     
 
-    private uint _selection_index = default(uint);
+    private uint? _selection_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"selection_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection_index
     {
-      get { return _selection_index; }
+      get { return _selection_index?? default(uint); }
       set { _selection_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_indexSpecified
+    {
+      get { return _selection_index != null; }
+      set { if (value == (_selection_index== null)) _selection_index = value ? this.selection_index : (uint?)null; }
+    }
+    private bool ShouldSerializeselection_index() { return selection_indexSpecified; }
+    private void Resetselection_index() { selection_indexSpecified = false; }
+    
 
-    private uint _selection = default(uint);
+    private uint? _selection;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"selection", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection
     {
-      get { return _selection; }
+      get { return _selection?? default(uint); }
       set { _selection = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selectionSpecified
+    {
+      get { return _selection != null; }
+      set { if (value == (_selection== null)) _selection = value ? this.selection : (uint?)null; }
+    }
+    private bool ShouldSerializeselection() { return selectionSpecified; }
+    private void Resetselection() { selectionSpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4691,14 +7348,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACompendiumSelectionResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTACompendiumSelection> _extra_selections = new global::System.Collections.Generic.List<CMsgDOTACompendiumSelection>();
     [global::ProtoBuf.ProtoMember(2, Name=@"extra_selections", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTACompendiumSelection> extra_selections
@@ -4734,23 +7400,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACompendiumDataRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4762,32 +7446,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACompendiumDataResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
 
-    private uint _result = (uint)2;
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? (uint)2; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
     private CMsgDOTACompendiumData _compendium_data = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"compendium_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -4808,77 +7519,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGetPlayerMatchHistory() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _start_at_match_id = default(ulong);
+    private ulong? _start_at_match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_at_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong start_at_match_id
     {
-      get { return _start_at_match_id; }
+      get { return _start_at_match_id?? default(ulong); }
       set { _start_at_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_at_match_idSpecified
+    {
+      get { return _start_at_match_id != null; }
+      set { if (value == (_start_at_match_id== null)) _start_at_match_id = value ? this.start_at_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestart_at_match_id() { return start_at_match_idSpecified; }
+    private void Resetstart_at_match_id() { start_at_match_idSpecified = false; }
+    
 
-    private uint _matches_requested = default(uint);
+    private uint? _matches_requested;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"matches_requested", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_requested
     {
-      get { return _matches_requested; }
+      get { return _matches_requested?? default(uint); }
       set { _matches_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_requestedSpecified
+    {
+      get { return _matches_requested != null; }
+      set { if (value == (_matches_requested== null)) _matches_requested = value ? this.matches_requested : (uint?)null; }
+    }
+    private bool ShouldSerializematches_requested() { return matches_requestedSpecified; }
+    private void Resetmatches_requested() { matches_requestedSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
 
-    private bool _include_practice_matches = default(bool);
+    private bool? _include_practice_matches;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"include_practice_matches", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_practice_matches
     {
-      get { return _include_practice_matches; }
+      get { return _include_practice_matches?? default(bool); }
       set { _include_practice_matches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_practice_matchesSpecified
+    {
+      get { return _include_practice_matches != null; }
+      set { if (value == (_include_practice_matches== null)) _include_practice_matches = value ? this.include_practice_matches : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_practice_matches() { return include_practice_matchesSpecified; }
+    private void Resetinclude_practice_matches() { include_practice_matchesSpecified = false; }
+    
 
-    private bool _include_custom_games = default(bool);
+    private bool? _include_custom_games;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"include_custom_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_custom_games
     {
-      get { return _include_custom_games; }
+      get { return _include_custom_games?? default(bool); }
       set { _include_custom_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_custom_gamesSpecified
+    {
+      get { return _include_custom_games != null; }
+      set { if (value == (_include_custom_games== null)) _include_custom_games = value ? this.include_custom_games : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_custom_games() { return include_custom_gamesSpecified; }
+    private void Resetinclude_custom_games() { include_custom_gamesSpecified = false; }
+    
 
-    private bool _include_event_games = default(bool);
+    private bool? _include_event_games;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"include_event_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_event_games
     {
-      get { return _include_event_games; }
+      get { return _include_event_games?? default(bool); }
       set { _include_event_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_event_gamesSpecified
+    {
+      get { return _include_event_games != null; }
+      set { if (value == (_include_event_games== null)) _include_event_games = value ? this.include_event_games : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_event_games() { return include_event_gamesSpecified; }
+    private void Resetinclude_event_games() { include_event_gamesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4897,208 +7680,406 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _request_id = default(uint);
+    private uint? _request_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(uint); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Match")]
   public partial class Match : global::ProtoBuf.IExtensible
   {
     public Match() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private bool _winner = default(bool);
+    private bool? _winner;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"winner", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool winner
     {
-      get { return _winner; }
+      get { return _winner?? default(bool); }
       set { _winner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winnerSpecified
+    {
+      get { return _winner != null; }
+      set { if (value == (_winner== null)) _winner = value ? this.winner : (bool?)null; }
+    }
+    private bool ShouldSerializewinner() { return winnerSpecified; }
+    private void Resetwinner() { winnerSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private int _rank_change = default(int);
+    private int? _rank_change;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rank_change", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int rank_change
     {
-      get { return _rank_change; }
+      get { return _rank_change?? default(int); }
       set { _rank_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_changeSpecified
+    {
+      get { return _rank_change != null; }
+      set { if (value == (_rank_change== null)) _rank_change = value ? this.rank_change : (int?)null; }
+    }
+    private bool ShouldSerializerank_change() { return rank_changeSpecified; }
+    private void Resetrank_change() { rank_changeSpecified = false; }
+    
 
-    private uint _previous_rank = default(uint);
+    private uint? _previous_rank;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"previous_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint previous_rank
     {
-      get { return _previous_rank; }
+      get { return _previous_rank?? default(uint); }
       set { _previous_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool previous_rankSpecified
+    {
+      get { return _previous_rank != null; }
+      set { if (value == (_previous_rank== null)) _previous_rank = value ? this.previous_rank : (uint?)null; }
+    }
+    private bool ShouldSerializeprevious_rank() { return previous_rankSpecified; }
+    private void Resetprevious_rank() { previous_rankSpecified = false; }
+    
 
-    private uint _lobby_type = default(uint);
+    private uint? _lobby_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(uint); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private bool _solo_rank = default(bool);
+    private bool? _solo_rank;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"solo_rank", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool solo_rank
     {
-      get { return _solo_rank; }
+      get { return _solo_rank?? default(bool); }
       set { _solo_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_rankSpecified
+    {
+      get { return _solo_rank != null; }
+      set { if (value == (_solo_rank== null)) _solo_rank = value ? this.solo_rank : (bool?)null; }
+    }
+    private bool ShouldSerializesolo_rank() { return solo_rankSpecified; }
+    private void Resetsolo_rank() { solo_rankSpecified = false; }
+    
 
-    private bool _abandon = default(bool);
+    private bool? _abandon;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"abandon", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool abandon
     {
-      get { return _abandon; }
+      get { return _abandon?? default(bool); }
       set { _abandon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abandonSpecified
+    {
+      get { return _abandon != null; }
+      set { if (value == (_abandon== null)) _abandon = value ? this.abandon : (bool?)null; }
+    }
+    private bool ShouldSerializeabandon() { return abandonSpecified; }
+    private void Resetabandon() { abandonSpecified = false; }
+    
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private uint _engine = default(uint);
+    private uint? _engine;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"engine", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint engine
     {
-      get { return _engine; }
+      get { return _engine?? default(uint); }
       set { _engine = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool engineSpecified
+    {
+      get { return _engine != null; }
+      set { if (value == (_engine== null)) _engine = value ? this.engine : (uint?)null; }
+    }
+    private bool ShouldSerializeengine() { return engineSpecified; }
+    private void Resetengine() { engineSpecified = false; }
+    
 
-    private bool _active_battle_pass = default(bool);
+    private bool? _active_battle_pass;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"active_battle_pass", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool active_battle_pass
     {
-      get { return _active_battle_pass; }
+      get { return _active_battle_pass?? default(bool); }
       set { _active_battle_pass = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_battle_passSpecified
+    {
+      get { return _active_battle_pass != null; }
+      set { if (value == (_active_battle_pass== null)) _active_battle_pass = value ? this.active_battle_pass : (bool?)null; }
+    }
+    private bool ShouldSerializeactive_battle_pass() { return active_battle_passSpecified; }
+    private void Resetactive_battle_pass() { active_battle_passSpecified = false; }
+    
 
-    private bool _seasonal_rank = default(bool);
+    private bool? _seasonal_rank;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"seasonal_rank", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool seasonal_rank
     {
-      get { return _seasonal_rank; }
+      get { return _seasonal_rank?? default(bool); }
       set { _seasonal_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seasonal_rankSpecified
+    {
+      get { return _seasonal_rank != null; }
+      set { if (value == (_seasonal_rank== null)) _seasonal_rank = value ? this.seasonal_rank : (bool?)null; }
+    }
+    private bool ShouldSerializeseasonal_rank() { return seasonal_rankSpecified; }
+    private void Resetseasonal_rank() { seasonal_rankSpecified = false; }
+    
 
-    private uint _tourney_id = default(uint);
+    private uint? _tourney_id;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"tourney_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_id
     {
-      get { return _tourney_id; }
+      get { return _tourney_id?? default(uint); }
       set { _tourney_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_idSpecified
+    {
+      get { return _tourney_id != null; }
+      set { if (value == (_tourney_id== null)) _tourney_id = value ? this.tourney_id : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_id() { return tourney_idSpecified; }
+    private void Resettourney_id() { tourney_idSpecified = false; }
+    
 
-    private uint _tourney_round = default(uint);
+    private uint? _tourney_round;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"tourney_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_round
     {
-      get { return _tourney_round; }
+      get { return _tourney_round?? default(uint); }
       set { _tourney_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_roundSpecified
+    {
+      get { return _tourney_round != null; }
+      set { if (value == (_tourney_round== null)) _tourney_round = value ? this.tourney_round : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_round() { return tourney_roundSpecified; }
+    private void Resettourney_round() { tourney_roundSpecified = false; }
+    
 
-    private uint _tourney_tier = default(uint);
+    private uint? _tourney_tier;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"tourney_tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_tier
     {
-      get { return _tourney_tier; }
+      get { return _tourney_tier?? default(uint); }
       set { _tourney_tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_tierSpecified
+    {
+      get { return _tourney_tier != null; }
+      set { if (value == (_tourney_tier== null)) _tourney_tier = value ? this.tourney_tier : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_tier() { return tourney_tierSpecified; }
+    private void Resettourney_tier() { tourney_tierSpecified = false; }
+    
 
-    private uint _tourney_division = default(uint);
+    private uint? _tourney_division;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"tourney_division", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_division
     {
-      get { return _tourney_division; }
+      get { return _tourney_division?? default(uint); }
       set { _tourney_division = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_divisionSpecified
+    {
+      get { return _tourney_division != null; }
+      set { if (value == (_tourney_division== null)) _tourney_division = value ? this.tourney_division : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_division() { return tourney_divisionSpecified; }
+    private void Resettourney_division() { tourney_divisionSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _ugc_team_ui_logo = default(ulong);
+    private ulong? _ugc_team_ui_logo;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"ugc_team_ui_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_team_ui_logo
     {
-      get { return _ugc_team_ui_logo; }
+      get { return _ugc_team_ui_logo?? default(ulong); }
       set { _ugc_team_ui_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_team_ui_logoSpecified
+    {
+      get { return _ugc_team_ui_logo != null; }
+      set { if (value == (_ugc_team_ui_logo== null)) _ugc_team_ui_logo = value ? this.ugc_team_ui_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_team_ui_logo() { return ugc_team_ui_logoSpecified; }
+    private void Resetugc_team_ui_logo() { ugc_team_ui_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5135,14 +8116,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCNotificationsResponse() {}
     
 
-    private CMsgGCNotificationsResponse.EResult _result = CMsgGCNotificationsResponse.EResult.SUCCESS;
+    private CMsgGCNotificationsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCNotificationsResponse.EResult.SUCCESS)]
     public CMsgGCNotificationsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgGCNotificationsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGCNotificationsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCNotificationsResponse.Notification> _notifications = new global::System.Collections.Generic.List<CMsgGCNotificationsResponse.Notification>();
     [global::ProtoBuf.ProtoMember(2, Name=@"notifications", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCNotificationsResponse.Notification> notifications
@@ -5156,77 +8146,149 @@ namespace SteamKit2.GC.Dota.Internal
     public Notification() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _reference_a = default(uint);
+    private uint? _reference_a;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reference_a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_a
     {
-      get { return _reference_a; }
+      get { return _reference_a?? default(uint); }
       set { _reference_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_aSpecified
+    {
+      get { return _reference_a != null; }
+      set { if (value == (_reference_a== null)) _reference_a = value ? this.reference_a : (uint?)null; }
+    }
+    private bool ShouldSerializereference_a() { return reference_aSpecified; }
+    private void Resetreference_a() { reference_aSpecified = false; }
+    
 
-    private uint _reference_b = default(uint);
+    private uint? _reference_b;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"reference_b", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_b
     {
-      get { return _reference_b; }
+      get { return _reference_b?? default(uint); }
       set { _reference_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_bSpecified
+    {
+      get { return _reference_b != null; }
+      set { if (value == (_reference_b== null)) _reference_b = value ? this.reference_b : (uint?)null; }
+    }
+    private bool ShouldSerializereference_b() { return reference_bSpecified; }
+    private void Resetreference_b() { reference_bSpecified = false; }
+    
 
-    private uint _reference_c = default(uint);
+    private uint? _reference_c;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"reference_c", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_c
     {
-      get { return _reference_c; }
+      get { return _reference_c?? default(uint); }
       set { _reference_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_cSpecified
+    {
+      get { return _reference_c != null; }
+      set { if (value == (_reference_c== null)) _reference_c = value ? this.reference_c : (uint?)null; }
+    }
+    private bool ShouldSerializereference_c() { return reference_cSpecified; }
+    private void Resetreference_c() { reference_cSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private bool _unread = default(bool);
+    private bool? _unread;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"unread", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool unread
     {
-      get { return _unread; }
+      get { return _unread?? default(bool); }
       set { _unread = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unreadSpecified
+    {
+      get { return _unread != null; }
+      set { if (value == (_unread== null)) _unread = value ? this.unread : (bool?)null; }
+    }
+    private bool ShouldSerializeunread() { return unreadSpecified; }
+    private void Resetunread() { unreadSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5300,23 +8362,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PrivateLeagueKeys() {}
     
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
 
-    private uint _privatekey = default(uint);
+    private uint? _privatekey;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"privatekey", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint privatekey
     {
-      get { return _privatekey; }
+      get { return _privatekey?? default(uint); }
       set { _privatekey = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool privatekeySpecified
+    {
+      get { return _privatekey != null; }
+      set { if (value == (_privatekey== null)) _privatekey = value ? this.privatekey : (uint?)null; }
+    }
+    private bool ShouldSerializeprivatekey() { return privatekeySpecified; }
+    private void Resetprivatekey() { privatekeySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5345,23 +8425,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5378,50 +8476,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCPlayerInfoSubmit() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private uint _fantasy_role = default(uint);
+    private uint? _fantasy_role;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_role
     {
-      get { return _fantasy_role; }
+      get { return _fantasy_role?? default(uint); }
       set { _fantasy_role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_roleSpecified
+    {
+      get { return _fantasy_role != null; }
+      set { if (value == (_fantasy_role== null)) _fantasy_role = value ? this.fantasy_role : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_role() { return fantasy_roleSpecified; }
+    private void Resetfantasy_role() { fantasy_roleSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _sponsor = "";
+    private string _sponsor;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sponsor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sponsor
     {
-      get { return _sponsor; }
+      get { return _sponsor?? ""; }
       set { _sponsor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sponsorSpecified
+    {
+      get { return _sponsor != null; }
+      set { if (value == (_sponsor== null)) _sponsor = value ? this.sponsor : (string)null; }
+    }
+    private bool ShouldSerializesponsor() { return sponsorSpecified; }
+    private void Resetsponsor() { sponsorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5433,14 +8576,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCPlayerInfoSubmitResponse() {}
     
 
-    private CMsgGCPlayerInfoSubmitResponse.EResult _result = CMsgGCPlayerInfoSubmitResponse.EResult.SUCCESS;
+    private CMsgGCPlayerInfoSubmitResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCPlayerInfoSubmitResponse.EResult.SUCCESS)]
     public CMsgGCPlayerInfoSubmitResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgGCPlayerInfoSubmitResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGCPlayerInfoSubmitResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -5473,37 +8625,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _survey_key = default(ulong);
+    private ulong? _survey_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"survey_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong survey_key
     {
-      get { return _survey_key; }
+      get { return _survey_key?? default(ulong); }
       set { _survey_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_keySpecified
+    {
+      get { return _survey_key != null; }
+      set { if (value == (_survey_key== null)) _survey_key = value ? this.survey_key : (ulong?)null; }
+    }
+    private bool ShouldSerializesurvey_key() { return survey_keySpecified; }
+    private void Resetsurvey_key() { survey_keySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Response")]
   public partial class Response : global::ProtoBuf.IExtensible
   {
     public Response() {}
     
 
-    private uint _question_id = default(uint);
+    private uint? _question_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"question_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint question_id
     {
-      get { return _question_id; }
+      get { return _question_id?? default(uint); }
       set { _question_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool question_idSpecified
+    {
+      get { return _question_id != null; }
+      set { if (value == (_question_id== null)) _question_id = value ? this.question_id : (uint?)null; }
+    }
+    private bool ShouldSerializequestion_id() { return question_idSpecified; }
+    private void Resetquestion_id() { question_idSpecified = false; }
+    
 
-    private uint _survey_value = default(uint);
+    private uint? _survey_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"survey_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint survey_value
     {
-      get { return _survey_value; }
+      get { return _survey_value?? default(uint); }
       set { _survey_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_valueSpecified
+    {
+      get { return _survey_value != null; }
+      set { if (value == (_survey_value== null)) _survey_value = value ? this.survey_value : (uint?)null; }
+    }
+    private bool ShouldSerializesurvey_value() { return survey_valueSpecified; }
+    private void Resetsurvey_value() { survey_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5520,23 +8699,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAEmoticonAccessSDO() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private byte[] _unlocked_emoticons = null;
+    private byte[] _unlocked_emoticons;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"unlocked_emoticons", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] unlocked_emoticons
     {
-      get { return _unlocked_emoticons; }
+      get { return _unlocked_emoticons?? null; }
       set { _unlocked_emoticons = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unlocked_emoticonsSpecified
+    {
+      get { return _unlocked_emoticons != null; }
+      set { if (value == (_unlocked_emoticons== null)) _unlocked_emoticons = value ? this.unlocked_emoticons : (byte[])null; }
+    }
+    private bool ShouldSerializeunlocked_emoticons() { return unlocked_emoticonsSpecified; }
+    private void Resetunlocked_emoticons() { unlocked_emoticonsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5577,23 +8774,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCTrackDialogResult() {}
     
 
-    private uint _dialog_id = default(uint);
+    private uint? _dialog_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dialog_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dialog_id
     {
-      get { return _dialog_id; }
+      get { return _dialog_id?? default(uint); }
       set { _dialog_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dialog_idSpecified
+    {
+      get { return _dialog_id != null; }
+      set { if (value == (_dialog_id== null)) _dialog_id = value ? this.dialog_id : (uint?)null; }
+    }
+    private bool ShouldSerializedialog_id() { return dialog_idSpecified; }
+    private void Resetdialog_id() { dialog_idSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5605,23 +8820,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientTournamentItemDrop() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5714,14 +8947,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetAllHeroProgress() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5733,185 +8975,365 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetAllHeroProgressResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _curr_hero_id = default(uint);
+    private uint? _curr_hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"curr_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint curr_hero_id
     {
-      get { return _curr_hero_id; }
+      get { return _curr_hero_id?? default(uint); }
       set { _curr_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_hero_idSpecified
+    {
+      get { return _curr_hero_id != null; }
+      set { if (value == (_curr_hero_id== null)) _curr_hero_id = value ? this.curr_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializecurr_hero_id() { return curr_hero_idSpecified; }
+    private void Resetcurr_hero_id() { curr_hero_idSpecified = false; }
+    
 
-    private uint _laps_completed = default(uint);
+    private uint? _laps_completed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"laps_completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint laps_completed
     {
-      get { return _laps_completed; }
+      get { return _laps_completed?? default(uint); }
       set { _laps_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool laps_completedSpecified
+    {
+      get { return _laps_completed != null; }
+      set { if (value == (_laps_completed== null)) _laps_completed = value ? this.laps_completed : (uint?)null; }
+    }
+    private bool ShouldSerializelaps_completed() { return laps_completedSpecified; }
+    private void Resetlaps_completed() { laps_completedSpecified = false; }
+    
 
-    private uint _curr_hero_games = default(uint);
+    private uint? _curr_hero_games;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"curr_hero_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint curr_hero_games
     {
-      get { return _curr_hero_games; }
+      get { return _curr_hero_games?? default(uint); }
       set { _curr_hero_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_hero_gamesSpecified
+    {
+      get { return _curr_hero_games != null; }
+      set { if (value == (_curr_hero_games== null)) _curr_hero_games = value ? this.curr_hero_games : (uint?)null; }
+    }
+    private bool ShouldSerializecurr_hero_games() { return curr_hero_gamesSpecified; }
+    private void Resetcurr_hero_games() { curr_hero_gamesSpecified = false; }
+    
 
-    private uint _curr_lap_time_started = default(uint);
+    private uint? _curr_lap_time_started;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"curr_lap_time_started", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint curr_lap_time_started
     {
-      get { return _curr_lap_time_started; }
+      get { return _curr_lap_time_started?? default(uint); }
       set { _curr_lap_time_started = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_lap_time_startedSpecified
+    {
+      get { return _curr_lap_time_started != null; }
+      set { if (value == (_curr_lap_time_started== null)) _curr_lap_time_started = value ? this.curr_lap_time_started : (uint?)null; }
+    }
+    private bool ShouldSerializecurr_lap_time_started() { return curr_lap_time_startedSpecified; }
+    private void Resetcurr_lap_time_started() { curr_lap_time_startedSpecified = false; }
+    
 
-    private uint _curr_lap_games = default(uint);
+    private uint? _curr_lap_games;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"curr_lap_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint curr_lap_games
     {
-      get { return _curr_lap_games; }
+      get { return _curr_lap_games?? default(uint); }
       set { _curr_lap_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_lap_gamesSpecified
+    {
+      get { return _curr_lap_games != null; }
+      set { if (value == (_curr_lap_games== null)) _curr_lap_games = value ? this.curr_lap_games : (uint?)null; }
+    }
+    private bool ShouldSerializecurr_lap_games() { return curr_lap_gamesSpecified; }
+    private void Resetcurr_lap_games() { curr_lap_gamesSpecified = false; }
+    
 
-    private uint _best_lap_games = default(uint);
+    private uint? _best_lap_games;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"best_lap_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_lap_games
     {
-      get { return _best_lap_games; }
+      get { return _best_lap_games?? default(uint); }
       set { _best_lap_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_lap_gamesSpecified
+    {
+      get { return _best_lap_games != null; }
+      set { if (value == (_best_lap_games== null)) _best_lap_games = value ? this.best_lap_games : (uint?)null; }
+    }
+    private bool ShouldSerializebest_lap_games() { return best_lap_gamesSpecified; }
+    private void Resetbest_lap_games() { best_lap_gamesSpecified = false; }
+    
 
-    private uint _best_lap_time = default(uint);
+    private uint? _best_lap_time;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"best_lap_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_lap_time
     {
-      get { return _best_lap_time; }
+      get { return _best_lap_time?? default(uint); }
       set { _best_lap_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_lap_timeSpecified
+    {
+      get { return _best_lap_time != null; }
+      set { if (value == (_best_lap_time== null)) _best_lap_time = value ? this.best_lap_time : (uint?)null; }
+    }
+    private bool ShouldSerializebest_lap_time() { return best_lap_timeSpecified; }
+    private void Resetbest_lap_time() { best_lap_timeSpecified = false; }
+    
 
-    private uint _lap_heroes_completed = default(uint);
+    private uint? _lap_heroes_completed;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"lap_heroes_completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lap_heroes_completed
     {
-      get { return _lap_heroes_completed; }
+      get { return _lap_heroes_completed?? default(uint); }
       set { _lap_heroes_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lap_heroes_completedSpecified
+    {
+      get { return _lap_heroes_completed != null; }
+      set { if (value == (_lap_heroes_completed== null)) _lap_heroes_completed = value ? this.lap_heroes_completed : (uint?)null; }
+    }
+    private bool ShouldSerializelap_heroes_completed() { return lap_heroes_completedSpecified; }
+    private void Resetlap_heroes_completed() { lap_heroes_completedSpecified = false; }
+    
 
-    private uint _lap_heroes_remaining = default(uint);
+    private uint? _lap_heroes_remaining;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"lap_heroes_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lap_heroes_remaining
     {
-      get { return _lap_heroes_remaining; }
+      get { return _lap_heroes_remaining?? default(uint); }
       set { _lap_heroes_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lap_heroes_remainingSpecified
+    {
+      get { return _lap_heroes_remaining != null; }
+      set { if (value == (_lap_heroes_remaining== null)) _lap_heroes_remaining = value ? this.lap_heroes_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializelap_heroes_remaining() { return lap_heroes_remainingSpecified; }
+    private void Resetlap_heroes_remaining() { lap_heroes_remainingSpecified = false; }
+    
 
-    private uint _next_hero_id = default(uint);
+    private uint? _next_hero_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"next_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint next_hero_id
     {
-      get { return _next_hero_id; }
+      get { return _next_hero_id?? default(uint); }
       set { _next_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool next_hero_idSpecified
+    {
+      get { return _next_hero_id != null; }
+      set { if (value == (_next_hero_id== null)) _next_hero_id = value ? this.next_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializenext_hero_id() { return next_hero_idSpecified; }
+    private void Resetnext_hero_id() { next_hero_idSpecified = false; }
+    
 
-    private uint _prev_hero_id = default(uint);
+    private uint? _prev_hero_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"prev_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prev_hero_id
     {
-      get { return _prev_hero_id; }
+      get { return _prev_hero_id?? default(uint); }
       set { _prev_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prev_hero_idSpecified
+    {
+      get { return _prev_hero_id != null; }
+      set { if (value == (_prev_hero_id== null)) _prev_hero_id = value ? this.prev_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprev_hero_id() { return prev_hero_idSpecified; }
+    private void Resetprev_hero_id() { prev_hero_idSpecified = false; }
+    
 
-    private uint _prev_hero_games = default(uint);
+    private uint? _prev_hero_games;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"prev_hero_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prev_hero_games
     {
-      get { return _prev_hero_games; }
+      get { return _prev_hero_games?? default(uint); }
       set { _prev_hero_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prev_hero_gamesSpecified
+    {
+      get { return _prev_hero_games != null; }
+      set { if (value == (_prev_hero_games== null)) _prev_hero_games = value ? this.prev_hero_games : (uint?)null; }
+    }
+    private bool ShouldSerializeprev_hero_games() { return prev_hero_gamesSpecified; }
+    private void Resetprev_hero_games() { prev_hero_gamesSpecified = false; }
+    
 
-    private float _prev_avg_tries = default(float);
+    private float? _prev_avg_tries;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"prev_avg_tries", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float prev_avg_tries
     {
-      get { return _prev_avg_tries; }
+      get { return _prev_avg_tries?? default(float); }
       set { _prev_avg_tries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prev_avg_triesSpecified
+    {
+      get { return _prev_avg_tries != null; }
+      set { if (value == (_prev_avg_tries== null)) _prev_avg_tries = value ? this.prev_avg_tries : (float?)null; }
+    }
+    private bool ShouldSerializeprev_avg_tries() { return prev_avg_triesSpecified; }
+    private void Resetprev_avg_tries() { prev_avg_triesSpecified = false; }
+    
 
-    private float _curr_avg_tries = default(float);
+    private float? _curr_avg_tries;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"curr_avg_tries", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float curr_avg_tries
     {
-      get { return _curr_avg_tries; }
+      get { return _curr_avg_tries?? default(float); }
       set { _curr_avg_tries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_avg_triesSpecified
+    {
+      get { return _curr_avg_tries != null; }
+      set { if (value == (_curr_avg_tries== null)) _curr_avg_tries = value ? this.curr_avg_tries : (float?)null; }
+    }
+    private bool ShouldSerializecurr_avg_tries() { return curr_avg_triesSpecified; }
+    private void Resetcurr_avg_tries() { curr_avg_triesSpecified = false; }
+    
 
-    private float _next_avg_tries = default(float);
+    private float? _next_avg_tries;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"next_avg_tries", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float next_avg_tries
     {
-      get { return _next_avg_tries; }
+      get { return _next_avg_tries?? default(float); }
       set { _next_avg_tries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool next_avg_triesSpecified
+    {
+      get { return _next_avg_tries != null; }
+      set { if (value == (_next_avg_tries== null)) _next_avg_tries = value ? this.next_avg_tries : (float?)null; }
+    }
+    private bool ShouldSerializenext_avg_tries() { return next_avg_triesSpecified; }
+    private void Resetnext_avg_tries() { next_avg_triesSpecified = false; }
+    
 
-    private float _full_lap_avg_tries = default(float);
+    private float? _full_lap_avg_tries;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"full_lap_avg_tries", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float full_lap_avg_tries
     {
-      get { return _full_lap_avg_tries; }
+      get { return _full_lap_avg_tries?? default(float); }
       set { _full_lap_avg_tries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool full_lap_avg_triesSpecified
+    {
+      get { return _full_lap_avg_tries != null; }
+      set { if (value == (_full_lap_avg_tries== null)) _full_lap_avg_tries = value ? this.full_lap_avg_tries : (float?)null; }
+    }
+    private bool ShouldSerializefull_lap_avg_tries() { return full_lap_avg_triesSpecified; }
+    private void Resetfull_lap_avg_tries() { full_lap_avg_triesSpecified = false; }
+    
 
-    private float _curr_lap_avg_tries = default(float);
+    private float? _curr_lap_avg_tries;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"curr_lap_avg_tries", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float curr_lap_avg_tries
     {
-      get { return _curr_lap_avg_tries; }
+      get { return _curr_lap_avg_tries?? default(float); }
       set { _curr_lap_avg_tries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_lap_avg_triesSpecified
+    {
+      get { return _curr_lap_avg_tries != null; }
+      set { if (value == (_curr_lap_avg_tries== null)) _curr_lap_avg_tries = value ? this.curr_lap_avg_tries : (float?)null; }
+    }
+    private bool ShouldSerializecurr_lap_avg_tries() { return curr_lap_avg_triesSpecified; }
+    private void Resetcurr_lap_avg_tries() { curr_lap_avg_triesSpecified = false; }
+    
 
-    private string _profile_name = "";
+    private string _profile_name;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"profile_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string profile_name
     {
-      get { return _profile_name; }
+      get { return _profile_name?? ""; }
       set { _profile_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool profile_nameSpecified
+    {
+      get { return _profile_name != null; }
+      set { if (value == (_profile_name== null)) _profile_name = value ? this.profile_name : (string)null; }
+    }
+    private bool ShouldSerializeprofile_name() { return profile_nameSpecified; }
+    private void Resetprofile_name() { profile_nameSpecified = false; }
+    
 
-    private uint _start_hero_id = default(uint);
+    private uint? _start_hero_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"start_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_hero_id
     {
-      get { return _start_hero_id; }
+      get { return _start_hero_id?? default(uint); }
       set { _start_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_hero_idSpecified
+    {
+      get { return _start_hero_id != null; }
+      set { if (value == (_start_hero_id== null)) _start_hero_id = value ? this.start_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializestart_hero_id() { return start_hero_idSpecified; }
+    private void Resetstart_hero_id() { start_hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5923,14 +9345,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetTrophyList() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5942,14 +9373,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetTrophyListResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCGetTrophyListResponse.Trophy> _trophies = new global::System.Collections.Generic.List<CMsgClientToGCGetTrophyListResponse.Trophy>();
     [global::ProtoBuf.ProtoMember(2, Name=@"trophies", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCGetTrophyListResponse.Trophy> trophies
@@ -5958,46 +9398,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _profile_name = "";
+    private string _profile_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"profile_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string profile_name
     {
-      get { return _profile_name; }
+      get { return _profile_name?? ""; }
       set { _profile_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool profile_nameSpecified
+    {
+      get { return _profile_name != null; }
+      set { if (value == (_profile_name== null)) _profile_name = value ? this.profile_name : (string)null; }
+    }
+    private bool ShouldSerializeprofile_name() { return profile_nameSpecified; }
+    private void Resetprofile_name() { profile_nameSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Trophy")]
   public partial class Trophy : global::ProtoBuf.IExtensible
   {
     public Trophy() {}
     
 
-    private uint _trophy_id = default(uint);
+    private uint? _trophy_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_id
     {
-      get { return _trophy_id; }
+      get { return _trophy_id?? default(uint); }
       set { _trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_idSpecified
+    {
+      get { return _trophy_id != null; }
+      set { if (value == (_trophy_id== null)) _trophy_id = value ? this.trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_id() { return trophy_idSpecified; }
+    private void Resettrophy_id() { trophy_idSpecified = false; }
+    
 
-    private uint _trophy_score = default(uint);
+    private uint? _trophy_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trophy_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_score
     {
-      get { return _trophy_score; }
+      get { return _trophy_score?? default(uint); }
       set { _trophy_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_scoreSpecified
+    {
+      get { return _trophy_score != null; }
+      set { if (value == (_trophy_score== null)) _trophy_score = value ? this.trophy_score : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_score() { return trophy_scoreSpecified; }
+    private void Resettrophy_score() { trophy_scoreSpecified = false; }
+    
 
-    private uint _last_updated = default(uint);
+    private uint? _last_updated;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"last_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_updated
     {
-      get { return _last_updated; }
+      get { return _last_updated?? default(uint); }
       set { _last_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_updatedSpecified
+    {
+      get { return _last_updated != null; }
+      set { if (value == (_last_updated== null)) _last_updated = value ? this.last_updated : (uint?)null; }
+    }
+    private bool ShouldSerializelast_updated() { return last_updatedSpecified; }
+    private void Resetlast_updated() { last_updatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6014,41 +9490,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientTrophyAwarded() {}
     
 
-    private uint _trophy_id = default(uint);
+    private uint? _trophy_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_id
     {
-      get { return _trophy_id; }
+      get { return _trophy_id?? default(uint); }
       set { _trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_idSpecified
+    {
+      get { return _trophy_id != null; }
+      set { if (value == (_trophy_id== null)) _trophy_id = value ? this.trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_id() { return trophy_idSpecified; }
+    private void Resettrophy_id() { trophy_idSpecified = false; }
+    
 
-    private uint _trophy_score = default(uint);
+    private uint? _trophy_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trophy_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_score
     {
-      get { return _trophy_score; }
+      get { return _trophy_score?? default(uint); }
       set { _trophy_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_scoreSpecified
+    {
+      get { return _trophy_score != null; }
+      set { if (value == (_trophy_score== null)) _trophy_score = value ? this.trophy_score : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_score() { return trophy_scoreSpecified; }
+    private void Resettrophy_score() { trophy_scoreSpecified = false; }
+    
 
-    private uint _trophy_old_score = default(uint);
+    private uint? _trophy_old_score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"trophy_old_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_old_score
     {
-      get { return _trophy_old_score; }
+      get { return _trophy_old_score?? default(uint); }
       set { _trophy_old_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_old_scoreSpecified
+    {
+      get { return _trophy_old_score != null; }
+      set { if (value == (_trophy_old_score== null)) _trophy_old_score = value ? this.trophy_old_score : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_old_score() { return trophy_old_scoreSpecified; }
+    private void Resettrophy_old_score() { trophy_old_scoreSpecified = false; }
+    
 
-    private uint _last_updated = default(uint);
+    private uint? _last_updated;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"last_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_updated
     {
-      get { return _last_updated; }
+      get { return _last_updated?? default(uint); }
       set { _last_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_updatedSpecified
+    {
+      get { return _last_updated != null; }
+      set { if (value == (_last_updated== null)) _last_updated = value ? this.last_updated : (uint?)null; }
+    }
+    private bool ShouldSerializelast_updated() { return last_updatedSpecified; }
+    private void Resetlast_updated() { last_updatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6060,14 +9572,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetProfileCard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6091,32 +9612,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CardSlot() {}
     
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private EProfileCardSlotType _slot_type = EProfileCardSlotType.k_EProfileCardSlotType_Empty;
+    private EProfileCardSlotType? _slot_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EProfileCardSlotType.k_EProfileCardSlotType_Empty)]
     public EProfileCardSlotType slot_type
     {
-      get { return _slot_type; }
+      get { return _slot_type?? EProfileCardSlotType.k_EProfileCardSlotType_Empty; }
       set { _slot_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_typeSpecified
+    {
+      get { return _slot_type != null; }
+      set { if (value == (_slot_type== null)) _slot_type = value ? this.slot_type : (EProfileCardSlotType?)null; }
+    }
+    private bool ShouldSerializeslot_type() { return slot_typeSpecified; }
+    private void Resetslot_type() { slot_typeSpecified = false; }
+    
 
-    private ulong _slot_value = default(ulong);
+    private ulong? _slot_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong slot_value
     {
-      get { return _slot_value; }
+      get { return _slot_value?? default(ulong); }
       set { _slot_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_valueSpecified
+    {
+      get { return _slot_value != null; }
+      set { if (value == (_slot_value== null)) _slot_value = value ? this.slot_value : (ulong?)null; }
+    }
+    private bool ShouldSerializeslot_value() { return slot_valueSpecified; }
+    private void Resetslot_value() { slot_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6143,41 +9691,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCCreateHeroStatue() {}
     
 
-    private ulong _source_item = default(ulong);
+    private ulong? _source_item;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source_item", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong source_item
     {
-      get { return _source_item; }
+      get { return _source_item?? default(ulong); }
       set { _source_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_itemSpecified
+    {
+      get { return _source_item != null; }
+      set { if (value == (_source_item== null)) _source_item = value ? this.source_item : (ulong?)null; }
+    }
+    private bool ShouldSerializesource_item() { return source_itemSpecified; }
+    private void Resetsource_item() { source_itemSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private string _sequence_name = "";
+    private string _sequence_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sequence_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sequence_name
     {
-      get { return _sequence_name; }
+      get { return _sequence_name?? ""; }
       set { _sequence_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_nameSpecified
+    {
+      get { return _sequence_name != null; }
+      set { if (value == (_sequence_name== null)) _sequence_name = value ? this.sequence_name : (string)null; }
+    }
+    private bool ShouldSerializesequence_name() { return sequence_nameSpecified; }
+    private void Resetsequence_name() { sequence_nameSpecified = false; }
+    
 
-    private float _cycle = default(float);
+    private float? _cycle;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cycle", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cycle
     {
-      get { return _cycle; }
+      get { return _cycle?? default(float); }
       set { _cycle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cycleSpecified
+    {
+      get { return _cycle != null; }
+      set { if (value == (_cycle== null)) _cycle = value ? this.cycle : (float?)null; }
+    }
+    private bool ShouldSerializecycle() { return cycleSpecified; }
+    private void Resetcycle() { cycleSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _wearables = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"wearables", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> wearables
@@ -6186,14 +9770,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _inscription = "";
+    private string _inscription;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"inscription", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string inscription
     {
-      get { return _inscription; }
+      get { return _inscription?? ""; }
       set { _inscription = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inscriptionSpecified
+    {
+      get { return _inscription != null; }
+      set { if (value == (_inscription== null)) _inscription = value ? this.inscription : (string)null; }
+    }
+    private bool ShouldSerializeinscription() { return inscriptionSpecified; }
+    private void Resetinscription() { inscriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _styles = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(8, Name=@"styles", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> styles
@@ -6202,23 +9795,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _reforger_item = default(ulong);
+    private ulong? _reforger_item;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"reforger_item", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reforger_item
     {
-      get { return _reforger_item; }
+      get { return _reforger_item?? default(ulong); }
       set { _reforger_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reforger_itemSpecified
+    {
+      get { return _reforger_item != null; }
+      set { if (value == (_reforger_item== null)) _reforger_item = value ? this.reforger_item : (ulong?)null; }
+    }
+    private bool ShouldSerializereforger_item() { return reforger_itemSpecified; }
+    private void Resetreforger_item() { reforger_itemSpecified = false; }
+    
 
-    private bool _tournament_drop = default(bool);
+    private bool? _tournament_drop;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"tournament_drop", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tournament_drop
     {
-      get { return _tournament_drop; }
+      get { return _tournament_drop?? default(bool); }
       set { _tournament_drop = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_dropSpecified
+    {
+      get { return _tournament_drop != null; }
+      set { if (value == (_tournament_drop== null)) _tournament_drop = value ? this.tournament_drop : (bool?)null; }
+    }
+    private bool ShouldSerializetournament_drop() { return tournament_dropSpecified; }
+    private void Resettournament_drop() { tournament_dropSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6230,14 +9841,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientHeroStatueCreateResult() {}
     
 
-    private ulong _resulting_item = default(ulong);
+    private ulong? _resulting_item;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"resulting_item", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong resulting_item
     {
-      get { return _resulting_item; }
+      get { return _resulting_item?? default(ulong); }
       set { _resulting_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resulting_itemSpecified
+    {
+      get { return _resulting_item != null; }
+      set { if (value == (_resulting_item== null)) _resulting_item = value ? this.resulting_item : (ulong?)null; }
+    }
+    private bool ShouldSerializeresulting_item() { return resulting_itemSpecified; }
+    private void Resetresulting_item() { resulting_itemSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6249,50 +9869,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRecordCompendiumStats() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _view_duration_s = default(uint);
+    private uint? _view_duration_s;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"view_duration_s", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint view_duration_s
     {
-      get { return _view_duration_s; }
+      get { return _view_duration_s?? default(uint); }
       set { _view_duration_s = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool view_duration_sSpecified
+    {
+      get { return _view_duration_s != null; }
+      set { if (value == (_view_duration_s== null)) _view_duration_s = value ? this.view_duration_s : (uint?)null; }
+    }
+    private bool ShouldSerializeview_duration_s() { return view_duration_sSpecified; }
+    private void Resetview_duration_s() { view_duration_sSpecified = false; }
+    
 
-    private uint _videos_viewed = default(uint);
+    private uint? _videos_viewed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"videos_viewed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint videos_viewed
     {
-      get { return _videos_viewed; }
+      get { return _videos_viewed?? default(uint); }
       set { _videos_viewed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool videos_viewedSpecified
+    {
+      get { return _videos_viewed != null; }
+      set { if (value == (_videos_viewed== null)) _videos_viewed = value ? this.videos_viewed : (uint?)null; }
+    }
+    private bool ShouldSerializevideos_viewed() { return videos_viewedSpecified; }
+    private void Resetvideos_viewed() { videos_viewedSpecified = false; }
+    
 
-    private uint _page_turns = default(uint);
+    private uint? _page_turns;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"page_turns", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint page_turns
     {
-      get { return _page_turns; }
+      get { return _page_turns?? default(uint); }
       set { _page_turns = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool page_turnsSpecified
+    {
+      get { return _page_turns != null; }
+      set { if (value == (_page_turns== null)) _page_turns = value ? this.page_turns : (uint?)null; }
+    }
+    private bool ShouldSerializepage_turns() { return page_turnsSpecified; }
+    private void Resetpage_turns() { page_turnsSpecified = false; }
+    
 
-    private uint _links_followed = default(uint);
+    private uint? _links_followed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"links_followed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint links_followed
     {
-      get { return _links_followed; }
+      get { return _links_followed?? default(uint); }
       set { _links_followed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool links_followedSpecified
+    {
+      get { return _links_followed != null; }
+      set { if (value == (_links_followed== null)) _links_followed = value ? this.links_followed : (uint?)null; }
+    }
+    private bool ShouldSerializelinks_followed() { return links_followedSpecified; }
+    private void Resetlinks_followed() { links_followedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6321,14 +9986,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPlayerStatsRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6340,14 +10014,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPlayerStatsResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<float> _player_stats = new global::System.Collections.Generic.List<float>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_stats", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<float> player_stats
@@ -6356,158 +10039,311 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _match_count = default(uint);
+    private uint? _match_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_count
     {
-      get { return _match_count; }
+      get { return _match_count?? default(uint); }
       set { _match_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_countSpecified
+    {
+      get { return _match_count != null; }
+      set { if (value == (_match_count== null)) _match_count = value ? this.match_count : (uint?)null; }
+    }
+    private bool ShouldSerializematch_count() { return match_countSpecified; }
+    private void Resetmatch_count() { match_countSpecified = false; }
+    
 
-    private float _mean_gpm = default(float);
+    private float? _mean_gpm;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"mean_gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float mean_gpm
     {
-      get { return _mean_gpm; }
+      get { return _mean_gpm?? default(float); }
       set { _mean_gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mean_gpmSpecified
+    {
+      get { return _mean_gpm != null; }
+      set { if (value == (_mean_gpm== null)) _mean_gpm = value ? this.mean_gpm : (float?)null; }
+    }
+    private bool ShouldSerializemean_gpm() { return mean_gpmSpecified; }
+    private void Resetmean_gpm() { mean_gpmSpecified = false; }
+    
 
-    private float _mean_xppm = default(float);
+    private float? _mean_xppm;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"mean_xppm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float mean_xppm
     {
-      get { return _mean_xppm; }
+      get { return _mean_xppm?? default(float); }
       set { _mean_xppm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mean_xppmSpecified
+    {
+      get { return _mean_xppm != null; }
+      set { if (value == (_mean_xppm== null)) _mean_xppm = value ? this.mean_xppm : (float?)null; }
+    }
+    private bool ShouldSerializemean_xppm() { return mean_xppmSpecified; }
+    private void Resetmean_xppm() { mean_xppmSpecified = false; }
+    
 
-    private float _mean_lasthits = default(float);
+    private float? _mean_lasthits;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"mean_lasthits", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float mean_lasthits
     {
-      get { return _mean_lasthits; }
+      get { return _mean_lasthits?? default(float); }
       set { _mean_lasthits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mean_lasthitsSpecified
+    {
+      get { return _mean_lasthits != null; }
+      set { if (value == (_mean_lasthits== null)) _mean_lasthits = value ? this.mean_lasthits : (float?)null; }
+    }
+    private bool ShouldSerializemean_lasthits() { return mean_lasthitsSpecified; }
+    private void Resetmean_lasthits() { mean_lasthitsSpecified = false; }
+    
 
-    private uint _rampages = default(uint);
+    private uint? _rampages;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"rampages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rampages
     {
-      get { return _rampages; }
+      get { return _rampages?? default(uint); }
       set { _rampages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rampagesSpecified
+    {
+      get { return _rampages != null; }
+      set { if (value == (_rampages== null)) _rampages = value ? this.rampages : (uint?)null; }
+    }
+    private bool ShouldSerializerampages() { return rampagesSpecified; }
+    private void Resetrampages() { rampagesSpecified = false; }
+    
 
-    private uint _triple_kills = default(uint);
+    private uint? _triple_kills;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"triple_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint triple_kills
     {
-      get { return _triple_kills; }
+      get { return _triple_kills?? default(uint); }
       set { _triple_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool triple_killsSpecified
+    {
+      get { return _triple_kills != null; }
+      set { if (value == (_triple_kills== null)) _triple_kills = value ? this.triple_kills : (uint?)null; }
+    }
+    private bool ShouldSerializetriple_kills() { return triple_killsSpecified; }
+    private void Resettriple_kills() { triple_killsSpecified = false; }
+    
 
-    private uint _first_blood_claimed = default(uint);
+    private uint? _first_blood_claimed;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"first_blood_claimed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_claimed
     {
-      get { return _first_blood_claimed; }
+      get { return _first_blood_claimed?? default(uint); }
       set { _first_blood_claimed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_claimedSpecified
+    {
+      get { return _first_blood_claimed != null; }
+      set { if (value == (_first_blood_claimed== null)) _first_blood_claimed = value ? this.first_blood_claimed : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_claimed() { return first_blood_claimedSpecified; }
+    private void Resetfirst_blood_claimed() { first_blood_claimedSpecified = false; }
+    
 
-    private uint _first_blood_given = default(uint);
+    private uint? _first_blood_given;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"first_blood_given", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_given
     {
-      get { return _first_blood_given; }
+      get { return _first_blood_given?? default(uint); }
       set { _first_blood_given = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_givenSpecified
+    {
+      get { return _first_blood_given != null; }
+      set { if (value == (_first_blood_given== null)) _first_blood_given = value ? this.first_blood_given : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_given() { return first_blood_givenSpecified; }
+    private void Resetfirst_blood_given() { first_blood_givenSpecified = false; }
+    
 
-    private uint _couriers_killed = default(uint);
+    private uint? _couriers_killed;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"couriers_killed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint couriers_killed
     {
-      get { return _couriers_killed; }
+      get { return _couriers_killed?? default(uint); }
       set { _couriers_killed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool couriers_killedSpecified
+    {
+      get { return _couriers_killed != null; }
+      set { if (value == (_couriers_killed== null)) _couriers_killed = value ? this.couriers_killed : (uint?)null; }
+    }
+    private bool ShouldSerializecouriers_killed() { return couriers_killedSpecified; }
+    private void Resetcouriers_killed() { couriers_killedSpecified = false; }
+    
 
-    private uint _aegises_snatched = default(uint);
+    private uint? _aegises_snatched;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"aegises_snatched", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint aegises_snatched
     {
-      get { return _aegises_snatched; }
+      get { return _aegises_snatched?? default(uint); }
       set { _aegises_snatched = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool aegises_snatchedSpecified
+    {
+      get { return _aegises_snatched != null; }
+      set { if (value == (_aegises_snatched== null)) _aegises_snatched = value ? this.aegises_snatched : (uint?)null; }
+    }
+    private bool ShouldSerializeaegises_snatched() { return aegises_snatchedSpecified; }
+    private void Resetaegises_snatched() { aegises_snatchedSpecified = false; }
+    
 
-    private uint _cheeses_eaten = default(uint);
+    private uint? _cheeses_eaten;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"cheeses_eaten", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cheeses_eaten
     {
-      get { return _cheeses_eaten; }
+      get { return _cheeses_eaten?? default(uint); }
       set { _cheeses_eaten = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cheeses_eatenSpecified
+    {
+      get { return _cheeses_eaten != null; }
+      set { if (value == (_cheeses_eaten== null)) _cheeses_eaten = value ? this.cheeses_eaten : (uint?)null; }
+    }
+    private bool ShouldSerializecheeses_eaten() { return cheeses_eatenSpecified; }
+    private void Resetcheeses_eaten() { cheeses_eatenSpecified = false; }
+    
 
-    private uint _creeps_stacked = default(uint);
+    private uint? _creeps_stacked;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"creeps_stacked", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creeps_stacked
     {
-      get { return _creeps_stacked; }
+      get { return _creeps_stacked?? default(uint); }
       set { _creeps_stacked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creeps_stackedSpecified
+    {
+      get { return _creeps_stacked != null; }
+      set { if (value == (_creeps_stacked== null)) _creeps_stacked = value ? this.creeps_stacked : (uint?)null; }
+    }
+    private bool ShouldSerializecreeps_stacked() { return creeps_stackedSpecified; }
+    private void Resetcreeps_stacked() { creeps_stackedSpecified = false; }
+    
 
-    private float _fight_score = default(float);
+    private float? _fight_score;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"fight_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float fight_score
     {
-      get { return _fight_score; }
+      get { return _fight_score?? default(float); }
       set { _fight_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fight_scoreSpecified
+    {
+      get { return _fight_score != null; }
+      set { if (value == (_fight_score== null)) _fight_score = value ? this.fight_score : (float?)null; }
+    }
+    private bool ShouldSerializefight_score() { return fight_scoreSpecified; }
+    private void Resetfight_score() { fight_scoreSpecified = false; }
+    
 
-    private float _farm_score = default(float);
+    private float? _farm_score;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"farm_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float farm_score
     {
-      get { return _farm_score; }
+      get { return _farm_score?? default(float); }
       set { _farm_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool farm_scoreSpecified
+    {
+      get { return _farm_score != null; }
+      set { if (value == (_farm_score== null)) _farm_score = value ? this.farm_score : (float?)null; }
+    }
+    private bool ShouldSerializefarm_score() { return farm_scoreSpecified; }
+    private void Resetfarm_score() { farm_scoreSpecified = false; }
+    
 
-    private float _support_score = default(float);
+    private float? _support_score;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"support_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float support_score
     {
-      get { return _support_score; }
+      get { return _support_score?? default(float); }
       set { _support_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_scoreSpecified
+    {
+      get { return _support_score != null; }
+      set { if (value == (_support_score== null)) _support_score = value ? this.support_score : (float?)null; }
+    }
+    private bool ShouldSerializesupport_score() { return support_scoreSpecified; }
+    private void Resetsupport_score() { support_scoreSpecified = false; }
+    
 
-    private float _push_score = default(float);
+    private float? _push_score;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"push_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float push_score
     {
-      get { return _push_score; }
+      get { return _push_score?? default(float); }
       set { _push_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool push_scoreSpecified
+    {
+      get { return _push_score != null; }
+      set { if (value == (_push_score== null)) _push_score = value ? this.push_score : (float?)null; }
+    }
+    private bool ShouldSerializepush_score() { return push_scoreSpecified; }
+    private void Resetpush_score() { push_scoreSpecified = false; }
+    
 
-    private float _versatility_score = default(float);
+    private float? _versatility_score;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"versatility_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float versatility_score
     {
-      get { return _versatility_score; }
+      get { return _versatility_score?? default(float); }
       set { _versatility_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versatility_scoreSpecified
+    {
+      get { return _versatility_score != null; }
+      set { if (value == (_versatility_score== null)) _versatility_score = value ? this.versatility_score : (float?)null; }
+    }
+    private bool ShouldSerializeversatility_score() { return versatility_scoreSpecified; }
+    private void Resetversatility_score() { versatility_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6519,14 +10355,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCCustomGamePlayerCountRequest() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6538,32 +10383,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientCustomGamePlayerCountResponse() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private ulong _player_count = default(ulong);
+    private ulong? _player_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_count
     {
-      get { return _player_count; }
+      get { return _player_count?? default(ulong); }
       set { _player_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_countSpecified
+    {
+      get { return _player_count != null; }
+      set { if (value == (_player_count== null)) _player_count = value ? this.player_count : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_count() { return player_countSpecified; }
+    private void Resetplayer_count() { player_countSpecified = false; }
+    
 
-    private ulong _spectator_count = default(ulong);
+    private ulong? _spectator_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"spectator_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong spectator_count
     {
-      get { return _spectator_count; }
+      get { return _spectator_count?? default(ulong); }
       set { _spectator_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectator_countSpecified
+    {
+      get { return _spectator_count != null; }
+      set { if (value == (_spectator_count== null)) _spectator_count = value ? this.spectator_count : (ulong?)null; }
+    }
+    private bool ShouldSerializespectator_count() { return spectator_countSpecified; }
+    private void Resetspectator_count() { spectator_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6585,14 +10457,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientCustomGamesFriendsPlayedResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientCustomGamesFriendsPlayedResponse.CustomGame> _games = new global::System.Collections.Generic.List<CMsgGCToClientCustomGamesFriendsPlayedResponse.CustomGame>();
     [global::ProtoBuf.ProtoMember(2, Name=@"games", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientCustomGamesFriendsPlayedResponse.CustomGame> games
@@ -6606,14 +10487,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CustomGame() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids
@@ -6637,23 +10527,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSocialFeedPostCommentRequest() {}
     
 
-    private ulong _event_id = default(ulong);
+    private ulong? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(ulong); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6665,14 +10573,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientSocialFeedPostCommentResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6684,32 +10601,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSocialFeedPostMessageRequest() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _match_timestamp = default(uint);
+    private uint? _match_timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_timestamp
     {
-      get { return _match_timestamp; }
+      get { return _match_timestamp?? default(uint); }
       set { _match_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_timestampSpecified
+    {
+      get { return _match_timestamp != null; }
+      set { if (value == (_match_timestamp== null)) _match_timestamp = value ? this.match_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializematch_timestamp() { return match_timestampSpecified; }
+    private void Resetmatch_timestamp() { match_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6721,14 +10665,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientSocialFeedPostMessageResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6740,14 +10693,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCFriendsPlayedCustomGameRequest() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6759,14 +10721,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientFriendsPlayedCustomGameResponse() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids
@@ -6807,50 +10778,95 @@ namespace SteamKit2.GC.Dota.Internal
     public DataField() {}
     
 
-    private EFeaturedHeroDataType _data_type = EFeaturedHeroDataType.k_EFeaturedHeroDataType_HeroID;
+    private EFeaturedHeroDataType? _data_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"data_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EFeaturedHeroDataType.k_EFeaturedHeroDataType_HeroID)]
     public EFeaturedHeroDataType data_type
     {
-      get { return _data_type; }
+      get { return _data_type?? EFeaturedHeroDataType.k_EFeaturedHeroDataType_HeroID; }
       set { _data_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool data_typeSpecified
+    {
+      get { return _data_type != null; }
+      set { if (value == (_data_type== null)) _data_type = value ? this.data_type : (EFeaturedHeroDataType?)null; }
+    }
+    private bool ShouldSerializedata_type() { return data_typeSpecified; }
+    private void Resetdata_type() { data_typeSpecified = false; }
+    
 
-    private uint _uint32_value = default(uint);
+    private uint? _uint32_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"uint32_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint uint32_value
     {
-      get { return _uint32_value; }
+      get { return _uint32_value?? default(uint); }
       set { _uint32_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool uint32_valueSpecified
+    {
+      get { return _uint32_value != null; }
+      set { if (value == (_uint32_value== null)) _uint32_value = value ? this.uint32_value : (uint?)null; }
+    }
+    private bool ShouldSerializeuint32_value() { return uint32_valueSpecified; }
+    private void Resetuint32_value() { uint32_valueSpecified = false; }
+    
 
-    private ulong _uint64_value = default(ulong);
+    private ulong? _uint64_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"uint64_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong uint64_value
     {
-      get { return _uint64_value; }
+      get { return _uint64_value?? default(ulong); }
       set { _uint64_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool uint64_valueSpecified
+    {
+      get { return _uint64_value != null; }
+      set { if (value == (_uint64_value== null)) _uint64_value = value ? this.uint64_value : (ulong?)null; }
+    }
+    private bool ShouldSerializeuint64_value() { return uint64_valueSpecified; }
+    private void Resetuint64_value() { uint64_valueSpecified = false; }
+    
 
-    private string _string_value = "";
+    private string _string_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"string_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string string_value
     {
-      get { return _string_value; }
+      get { return _string_value?? ""; }
       set { _string_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool string_valueSpecified
+    {
+      get { return _string_value != null; }
+      set { if (value == (_string_value== null)) _string_value = value ? this.string_value : (string)null; }
+    }
+    private bool ShouldSerializestring_value() { return string_valueSpecified; }
+    private void Resetstring_value() { string_valueSpecified = false; }
+    
 
-    private float _float_value = default(float);
+    private float? _float_value;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"float_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float float_value
     {
-      get { return _float_value; }
+      get { return _float_value?? default(float); }
       set { _float_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool float_valueSpecified
+    {
+      get { return _float_value != null; }
+      set { if (value == (_float_value== null)) _float_value = value ? this.float_value : (float?)null; }
+    }
+    private bool ShouldSerializefloat_value() { return float_valueSpecified; }
+    private void Resetfloat_value() { float_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6879,14 +10895,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Category() {}
     
 
-    private int _category_weight = default(int);
+    private int? _category_weight;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"category_weight", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int category_weight
     {
-      get { return _category_weight; }
+      get { return _category_weight?? default(int); }
       set { _category_weight = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool category_weightSpecified
+    {
+      get { return _category_weight != null; }
+      set { if (value == (_category_weight== null)) _category_weight = value ? this.category_weight : (int?)null; }
+    }
+    private bool ShouldSerializecategory_weight() { return category_weightSpecified; }
+    private void Resetcategory_weight() { category_weightSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<EFeaturedHeroTextField> _text_fields = new global::System.Collections.Generic.List<EFeaturedHeroTextField>();
     [global::ProtoBuf.ProtoMember(2, Name=@"text_fields", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<EFeaturedHeroTextField> text_fields
@@ -6917,23 +10942,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSocialMatchPostCommentRequest() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6945,14 +10988,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientSocialMatchPostCommentResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6964,23 +11016,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSocialMatchDetailsRequest() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _pagination_timestamp = default(uint);
+    private uint? _pagination_timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pagination_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pagination_timestamp
     {
-      get { return _pagination_timestamp; }
+      get { return _pagination_timestamp?? default(uint); }
       set { _pagination_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pagination_timestampSpecified
+    {
+      get { return _pagination_timestamp != null; }
+      set { if (value == (_pagination_timestamp== null)) _pagination_timestamp = value ? this.pagination_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializepagination_timestamp() { return pagination_timestampSpecified; }
+    private void Resetpagination_timestamp() { pagination_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6992,14 +11062,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientSocialMatchDetailsResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientSocialMatchDetailsResponse.Comment> _comments = new global::System.Collections.Generic.List<CMsgGCToClientSocialMatchDetailsResponse.Comment>();
     [global::ProtoBuf.ProtoMember(2, Name=@"comments", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientSocialMatchDetailsResponse.Comment> comments
@@ -7013,41 +11092,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Comment() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7064,68 +11179,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPartyRichPresence() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private CSODOTAParty.State _party_state = CSODOTAParty.State.UI;
+    private CSODOTAParty.State? _party_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"party_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSODOTAParty.State.UI)]
     public CSODOTAParty.State party_state
     {
-      get { return _party_state; }
+      get { return _party_state?? CSODOTAParty.State.UI; }
       set { _party_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_stateSpecified
+    {
+      get { return _party_state != null; }
+      set { if (value == (_party_state== null)) _party_state = value ? this.party_state : (CSODOTAParty.State?)null; }
+    }
+    private bool ShouldSerializeparty_state() { return party_stateSpecified; }
+    private void Resetparty_state() { party_stateSpecified = false; }
+    
 
-    private bool _open = default(bool);
+    private bool? _open;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"open", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool open
     {
-      get { return _open; }
+      get { return _open?? default(bool); }
       set { _open = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool openSpecified
+    {
+      get { return _open != null; }
+      set { if (value == (_open== null)) _open = value ? this.open : (bool?)null; }
+    }
+    private bool ShouldSerializeopen() { return openSpecified; }
+    private void Resetopen() { openSpecified = false; }
+    
 
-    private bool _low_priority = default(bool);
+    private bool? _low_priority;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority
     {
-      get { return _low_priority; }
+      get { return _low_priority?? default(bool); }
       set { _low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_prioritySpecified
+    {
+      get { return _low_priority != null; }
+      set { if (value == (_low_priority== null)) _low_priority = value ? this.low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority() { return low_prioritySpecified; }
+    private void Resetlow_priority() { low_prioritySpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _ugc_team_ui_logo = default(ulong);
+    private ulong? _ugc_team_ui_logo;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"ugc_team_ui_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_team_ui_logo
     {
-      get { return _ugc_team_ui_logo; }
+      get { return _ugc_team_ui_logo?? default(ulong); }
       set { _ugc_team_ui_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_team_ui_logoSpecified
+    {
+      get { return _ugc_team_ui_logo != null; }
+      set { if (value == (_ugc_team_ui_logo== null)) _ugc_team_ui_logo = value ? this.ugc_team_ui_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_team_ui_logo() { return ugc_team_ui_logoSpecified; }
+    private void Resetugc_team_ui_logo() { ugc_team_ui_logoSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAPartyRichPresence.Member> _members = new global::System.Collections.Generic.List<CMsgDOTAPartyRichPresence.Member>();
     [global::ProtoBuf.ProtoMember(4, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAPartyRichPresence.Member> members
@@ -7148,23 +11326,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Member() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private bool _coach = default(bool);
+    private bool? _coach;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool coach
     {
-      get { return _coach; }
+      get { return _coach?? default(bool); }
       set { _coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coachSpecified
+    {
+      get { return _coach != null; }
+      set { if (value == (_coach== null)) _coach = value ? this.coach : (bool?)null; }
+    }
+    private bool ShouldSerializecoach() { return coachSpecified; }
+    private void Resetcoach() { coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7176,68 +11372,131 @@ namespace SteamKit2.GC.Dota.Internal
     public WeekendTourney() {}
     
 
-    private uint _division = default(uint);
+    private uint? _division;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"division", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division
     {
-      get { return _division; }
+      get { return _division?? default(uint); }
       set { _division = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool divisionSpecified
+    {
+      get { return _division != null; }
+      set { if (value == (_division== null)) _division = value ? this.division : (uint?)null; }
+    }
+    private bool ShouldSerializedivision() { return divisionSpecified; }
+    private void Resetdivision() { divisionSpecified = false; }
+    
 
-    private uint _skill_level = default(uint);
+    private uint? _skill_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_level
     {
-      get { return _skill_level; }
+      get { return _skill_level?? default(uint); }
       set { _skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_levelSpecified
+    {
+      get { return _skill_level != null; }
+      set { if (value == (_skill_level== null)) _skill_level = value ? this.skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_level() { return skill_levelSpecified; }
+    private void Resetskill_level() { skill_levelSpecified = false; }
+    
 
-    private uint _round = default(uint);
+    private uint? _round;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint round
     {
-      get { return _round; }
+      get { return _round?? default(uint); }
       set { _round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roundSpecified
+    {
+      get { return _round != null; }
+      set { if (value == (_round== null)) _round = value ? this.round : (uint?)null; }
+    }
+    private bool ShouldSerializeround() { return roundSpecified; }
+    private void Resetround() { roundSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _state_seq_num = default(uint);
+    private uint? _state_seq_num;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"state_seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint state_seq_num
     {
-      get { return _state_seq_num; }
+      get { return _state_seq_num?? default(uint); }
       set { _state_seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool state_seq_numSpecified
+    {
+      get { return _state_seq_num != null; }
+      set { if (value == (_state_seq_num== null)) _state_seq_num = value ? this.state_seq_num : (uint?)null; }
+    }
+    private bool ShouldSerializestate_seq_num() { return state_seq_numSpecified; }
+    private void Resetstate_seq_num() { state_seq_numSpecified = false; }
+    
 
-    private EWeekendTourneyRichPresenceEvent _event = EWeekendTourneyRichPresenceEvent.k_EWeekendTourneyRichPresenceEvent_None;
+    private EWeekendTourneyRichPresenceEvent? _event;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EWeekendTourneyRichPresenceEvent.k_EWeekendTourneyRichPresenceEvent_None)]
     public EWeekendTourneyRichPresenceEvent @event
     {
-      get { return _event; }
+      get { return _event?? EWeekendTourneyRichPresenceEvent.k_EWeekendTourneyRichPresenceEvent_None; }
       set { _event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventSpecified
+    {
+      get { return _event != null; }
+      set { if (value == (_event== null)) _event = value ? this.@event : (EWeekendTourneyRichPresenceEvent?)null; }
+    }
+    private bool ShouldSerializeevent() { return eventSpecified; }
+    private void Resetevent() { eventSpecified = false; }
+    
 
-    private uint _event_round = default(uint);
+    private uint? _event_round;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"event_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_round
     {
-      get { return _event_round; }
+      get { return _event_round?? default(uint); }
       set { _event_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_roundSpecified
+    {
+      get { return _event_round != null; }
+      set { if (value == (_event_round== null)) _event_round = value ? this.event_round : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_round() { return event_roundSpecified; }
+    private void Resetevent_round() { event_roundSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7254,86 +11513,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALobbyRichPresence() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private CSODOTALobby.State _lobby_state = CSODOTALobby.State.UI;
+    private CSODOTALobby.State? _lobby_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSODOTALobby.State.UI)]
     public CSODOTALobby.State lobby_state
     {
-      get { return _lobby_state; }
+      get { return _lobby_state?? CSODOTALobby.State.UI; }
       set { _lobby_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_stateSpecified
+    {
+      get { return _lobby_state != null; }
+      set { if (value == (_lobby_state== null)) _lobby_state = value ? this.lobby_state : (CSODOTALobby.State?)null; }
+    }
+    private bool ShouldSerializelobby_state() { return lobby_stateSpecified; }
+    private void Resetlobby_state() { lobby_stateSpecified = false; }
+    
 
-    private bool _password = default(bool);
+    private bool? _password;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool password
     {
-      get { return _password; }
+      get { return _password?? default(bool); }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (bool?)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
 
-    private uint _max_member_count = default(uint);
+    private uint? _max_member_count;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"max_member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_member_count
     {
-      get { return _max_member_count; }
+      get { return _max_member_count?? default(uint); }
       set { _max_member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_member_countSpecified
+    {
+      get { return _max_member_count != null; }
+      set { if (value == (_max_member_count== null)) _max_member_count = value ? this.max_member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemax_member_count() { return max_member_countSpecified; }
+    private void Resetmax_member_count() { max_member_countSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _lobby_type = default(uint);
+    private uint? _lobby_type;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(uint); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7345,23 +11685,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACustomGameListenServerStartedLoading() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _lobby_members = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"lobby_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> lobby_members
@@ -7370,14 +11728,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7389,59 +11756,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACustomGameClientFinishedLoading() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private uint _loading_duration = default(uint);
+    private uint? _loading_duration;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"loading_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint loading_duration
     {
-      get { return _loading_duration; }
+      get { return _loading_duration?? default(uint); }
       set { _loading_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loading_durationSpecified
+    {
+      get { return _loading_duration != null; }
+      set { if (value == (_loading_duration== null)) _loading_duration = value ? this.loading_duration : (uint?)null; }
+    }
+    private bool ShouldSerializeloading_duration() { return loading_durationSpecified; }
+    private void Resetloading_duration() { loading_durationSpecified = false; }
+    
 
-    private int _result_code = default(int);
+    private int? _result_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result_code", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result_code
     {
-      get { return _result_code; }
+      get { return _result_code?? default(int); }
       set { _result_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool result_codeSpecified
+    {
+      get { return _result_code != null; }
+      set { if (value == (_result_code== null)) _result_code = value ? this.result_code : (int?)null; }
+    }
+    private bool ShouldSerializeresult_code() { return result_codeSpecified; }
+    private void Resetresult_code() { result_codeSpecified = false; }
+    
 
-    private string _result_string = "";
+    private string _result_string;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"result_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string result_string
     {
-      get { return _result_string; }
+      get { return _result_string?? ""; }
       set { _result_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool result_stringSpecified
+    {
+      get { return _result_string != null; }
+      set { if (value == (_result_string== null)) _result_string = value ? this.result_string : (string)null; }
+    }
+    private bool ShouldSerializeresult_string() { return result_stringSpecified; }
+    private void Resetresult_string() { result_stringSpecified = false; }
+    
 
-    private uint _signon_states = default(uint);
+    private uint? _signon_states;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"signon_states", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint signon_states
     {
-      get { return _signon_states; }
+      get { return _signon_states?? default(uint); }
       set { _signon_states = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signon_statesSpecified
+    {
+      get { return _signon_states != null; }
+      set { if (value == (_signon_states== null)) _signon_states = value ? this.signon_states : (uint?)null; }
+    }
+    private bool ShouldSerializesignon_states() { return signon_statesSpecified; }
+    private void Resetsignon_states() { signon_statesSpecified = false; }
+    
 
-    private string _comment = "";
+    private string _comment;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"comment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string comment
     {
-      get { return _comment; }
+      get { return _comment?? ""; }
       set { _comment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commentSpecified
+    {
+      get { return _comment != null; }
+      set { if (value == (_comment== null)) _comment = value ? this.comment : (string)null; }
+    }
+    private bool ShouldSerializecomment() { return commentSpecified; }
+    private void Resetcomment() { commentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7453,14 +11874,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetLeagueSeries() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7484,23 +11914,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Series() {}
     
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _num_games = default(uint);
+    private uint? _num_games;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_games
     {
-      get { return _num_games; }
+      get { return _num_games?? default(uint); }
       set { _num_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_gamesSpecified
+    {
+      get { return _num_games != null; }
+      set { if (value == (_num_games== null)) _num_games = value ? this.num_games : (uint?)null; }
+    }
+    private bool ShouldSerializenum_games() { return num_gamesSpecified; }
+    private void Resetnum_games() { num_gamesSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCGetLeagueSeriesResponse.Series.Team> _teams = new global::System.Collections.Generic.List<CMsgClientToGCGetLeagueSeriesResponse.Series.Team>();
     [global::ProtoBuf.ProtoMember(3, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCGetLeagueSeriesResponse.Series.Team> teams
@@ -7509,100 +11957,190 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _series_name = "";
+    private string _series_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"series_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string series_name
     {
-      get { return _series_name; }
+      get { return _series_name?? ""; }
       set { _series_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_nameSpecified
+    {
+      get { return _series_name != null; }
+      set { if (value == (_series_name== null)) _series_name = value ? this.series_name : (string)null; }
+    }
+    private bool ShouldSerializeseries_name() { return series_nameSpecified; }
+    private void Resetseries_name() { series_nameSpecified = false; }
+    
 
-    private string _phase_name = "";
+    private string _phase_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"phase_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string phase_name
     {
-      get { return _phase_name; }
+      get { return _phase_name?? ""; }
       set { _phase_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phase_nameSpecified
+    {
+      get { return _phase_name != null; }
+      set { if (value == (_phase_name== null)) _phase_name = value ? this.phase_name : (string)null; }
+    }
+    private bool ShouldSerializephase_name() { return phase_nameSpecified; }
+    private void Resetphase_name() { phase_nameSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _after_series_id = default(uint);
+    private uint? _after_series_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"after_series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint after_series_id
     {
-      get { return _after_series_id; }
+      get { return _after_series_id?? default(uint); }
       set { _after_series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool after_series_idSpecified
+    {
+      get { return _after_series_id != null; }
+      set { if (value == (_after_series_id== null)) _after_series_id = value ? this.after_series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeafter_series_id() { return after_series_idSpecified; }
+    private void Resetafter_series_id() { after_series_idSpecified = false; }
+    
 
-    private uint _num_completed_games = default(uint);
+    private uint? _num_completed_games;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"num_completed_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_completed_games
     {
-      get { return _num_completed_games; }
+      get { return _num_completed_games?? default(uint); }
       set { _num_completed_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_completed_gamesSpecified
+    {
+      get { return _num_completed_games != null; }
+      set { if (value == (_num_completed_games== null)) _num_completed_games = value ? this.num_completed_games : (uint?)null; }
+    }
+    private bool ShouldSerializenum_completed_games() { return num_completed_gamesSpecified; }
+    private void Resetnum_completed_games() { num_completed_gamesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Team")]
   public partial class Team : global::ProtoBuf.IExtensible
   {
     public Team() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private uint _team_score = default(uint);
+    private uint? _team_score;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_score
     {
-      get { return _team_score; }
+      get { return _team_score?? default(uint); }
       set { _team_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_scoreSpecified
+    {
+      get { return _team_score != null; }
+      set { if (value == (_team_score== null)) _team_score = value ? this.team_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_score() { return team_scoreSpecified; }
+    private void Resetteam_score() { team_scoreSpecified = false; }
+    
 
-    private uint _team_wins = default(uint);
+    private uint? _team_wins;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_wins
     {
-      get { return _team_wins; }
+      get { return _team_wins?? default(uint); }
       set { _team_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_winsSpecified
+    {
+      get { return _team_wins != null; }
+      set { if (value == (_team_wins== null)) _team_wins = value ? this.team_wins : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_wins() { return team_winsSpecified; }
+    private void Resetteam_wins() { team_winsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7624,23 +12162,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCApplyGemCombiner() {}
     
 
-    private ulong _item_id_1 = default(ulong);
+    private ulong? _item_id_1;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id_1
     {
-      get { return _item_id_1; }
+      get { return _item_id_1?? default(ulong); }
       set { _item_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_id_1Specified
+    {
+      get { return _item_id_1 != null; }
+      set { if (value == (_item_id_1== null)) _item_id_1 = value ? this.item_id_1 : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id_1() { return item_id_1Specified; }
+    private void Resetitem_id_1() { item_id_1Specified = false; }
+    
 
-    private ulong _item_id_2 = default(ulong);
+    private ulong? _item_id_2;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id_2
     {
-      get { return _item_id_2; }
+      get { return _item_id_2?? default(ulong); }
       set { _item_id_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_id_2Specified
+    {
+      get { return _item_id_2 != null; }
+      set { if (value == (_item_id_2== null)) _item_id_2 = value ? this.item_id_2 : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id_2() { return item_id_2Specified; }
+    private void Resetitem_id_2() { item_id_2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7689,14 +12245,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetQuestProgressResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Quest> _quests = new global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Quest>();
     [global::ProtoBuf.ProtoMember(2, Name=@"quests", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Quest> quests
@@ -7710,59 +12275,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Challenge() {}
     
 
-    private uint _challenge_id = default(uint);
+    private uint? _challenge_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"challenge_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_id
     {
-      get { return _challenge_id; }
+      get { return _challenge_id?? default(uint); }
       set { _challenge_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_idSpecified
+    {
+      get { return _challenge_id != null; }
+      set { if (value == (_challenge_id== null)) _challenge_id = value ? this.challenge_id : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_id() { return challenge_idSpecified; }
+    private void Resetchallenge_id() { challenge_idSpecified = false; }
+    
 
-    private uint _time_completed = default(uint);
+    private uint? _time_completed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_completed
     {
-      get { return _time_completed; }
+      get { return _time_completed?? default(uint); }
       set { _time_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_completedSpecified
+    {
+      get { return _time_completed != null; }
+      set { if (value == (_time_completed== null)) _time_completed = value ? this.time_completed : (uint?)null; }
+    }
+    private bool ShouldSerializetime_completed() { return time_completedSpecified; }
+    private void Resettime_completed() { time_completedSpecified = false; }
+    
 
-    private uint _attempts = default(uint);
+    private uint? _attempts;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"attempts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attempts
     {
-      get { return _attempts; }
+      get { return _attempts?? default(uint); }
       set { _attempts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attemptsSpecified
+    {
+      get { return _attempts != null; }
+      set { if (value == (_attempts== null)) _attempts = value ? this.attempts : (uint?)null; }
+    }
+    private bool ShouldSerializeattempts() { return attemptsSpecified; }
+    private void Resetattempts() { attemptsSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _challenge_type = default(uint);
+    private uint? _challenge_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"challenge_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_type
     {
-      get { return _challenge_type; }
+      get { return _challenge_type?? default(uint); }
       set { _challenge_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_typeSpecified
+    {
+      get { return _challenge_type != null; }
+      set { if (value == (_challenge_type== null)) _challenge_type = value ? this.challenge_type : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_type() { return challenge_typeSpecified; }
+    private void Resetchallenge_type() { challenge_typeSpecified = false; }
+    
 
-    private uint _quest_rank = default(uint);
+    private uint? _quest_rank;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"quest_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_rank
     {
-      get { return _quest_rank; }
+      get { return _quest_rank?? default(uint); }
       set { _quest_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_rankSpecified
+    {
+      get { return _quest_rank != null; }
+      set { if (value == (_quest_rank== null)) _quest_rank = value ? this.quest_rank : (uint?)null; }
+    }
+    private bool ShouldSerializequest_rank() { return quest_rankSpecified; }
+    private void Resetquest_rank() { quest_rankSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7774,14 +12393,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Quest() {}
     
 
-    private uint _quest_id = default(uint);
+    private uint? _quest_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_id
     {
-      get { return _quest_id; }
+      get { return _quest_id?? default(uint); }
       set { _quest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_idSpecified
+    {
+      get { return _quest_id != null; }
+      set { if (value == (_quest_id== null)) _quest_id = value ? this.quest_id : (uint?)null; }
+    }
+    private bool ShouldSerializequest_id() { return quest_idSpecified; }
+    private void Resetquest_id() { quest_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Challenge> _completed_challenges = new global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Challenge>();
     [global::ProtoBuf.ProtoMember(2, Name=@"completed_challenges", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCGetQuestProgressResponse.Challenge> completed_challenges
@@ -7805,14 +12433,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientMatchSignedOut() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7824,14 +12461,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetHeroStatsHistory() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7843,14 +12489,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetHeroStatsHistoryResponse() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTASDOHeroStatsHistory> _records = new global::System.Collections.Generic.List<CMsgDOTASDOHeroStatsHistory>();
     [global::ProtoBuf.ProtoMember(2, Name=@"records", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTASDOHeroStatsHistory> records
@@ -7879,122 +12534,239 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPlayerConductScorecard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _seq_num = default(uint);
+    private uint? _seq_num;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seq_num
     {
-      get { return _seq_num; }
+      get { return _seq_num?? default(uint); }
       set { _seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seq_numSpecified
+    {
+      get { return _seq_num != null; }
+      set { if (value == (_seq_num== null)) _seq_num = value ? this.seq_num : (uint?)null; }
+    }
+    private bool ShouldSerializeseq_num() { return seq_numSpecified; }
+    private void Resetseq_num() { seq_numSpecified = false; }
+    
 
-    private uint _reasons = default(uint);
+    private uint? _reasons;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reasons", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reasons
     {
-      get { return _reasons; }
+      get { return _reasons?? default(uint); }
       set { _reasons = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonsSpecified
+    {
+      get { return _reasons != null; }
+      set { if (value == (_reasons== null)) _reasons = value ? this.reasons : (uint?)null; }
+    }
+    private bool ShouldSerializereasons() { return reasonsSpecified; }
+    private void Resetreasons() { reasonsSpecified = false; }
+    
 
-    private uint _matches_in_report = default(uint);
+    private uint? _matches_in_report;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"matches_in_report", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_in_report
     {
-      get { return _matches_in_report; }
+      get { return _matches_in_report?? default(uint); }
       set { _matches_in_report = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_in_reportSpecified
+    {
+      get { return _matches_in_report != null; }
+      set { if (value == (_matches_in_report== null)) _matches_in_report = value ? this.matches_in_report : (uint?)null; }
+    }
+    private bool ShouldSerializematches_in_report() { return matches_in_reportSpecified; }
+    private void Resetmatches_in_report() { matches_in_reportSpecified = false; }
+    
 
-    private uint _matches_clean = default(uint);
+    private uint? _matches_clean;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"matches_clean", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_clean
     {
-      get { return _matches_clean; }
+      get { return _matches_clean?? default(uint); }
       set { _matches_clean = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_cleanSpecified
+    {
+      get { return _matches_clean != null; }
+      set { if (value == (_matches_clean== null)) _matches_clean = value ? this.matches_clean : (uint?)null; }
+    }
+    private bool ShouldSerializematches_clean() { return matches_cleanSpecified; }
+    private void Resetmatches_clean() { matches_cleanSpecified = false; }
+    
 
-    private uint _matches_reported = default(uint);
+    private uint? _matches_reported;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"matches_reported", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_reported
     {
-      get { return _matches_reported; }
+      get { return _matches_reported?? default(uint); }
       set { _matches_reported = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_reportedSpecified
+    {
+      get { return _matches_reported != null; }
+      set { if (value == (_matches_reported== null)) _matches_reported = value ? this.matches_reported : (uint?)null; }
+    }
+    private bool ShouldSerializematches_reported() { return matches_reportedSpecified; }
+    private void Resetmatches_reported() { matches_reportedSpecified = false; }
+    
 
-    private uint _matches_abandoned = default(uint);
+    private uint? _matches_abandoned;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"matches_abandoned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches_abandoned
     {
-      get { return _matches_abandoned; }
+      get { return _matches_abandoned?? default(uint); }
       set { _matches_abandoned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matches_abandonedSpecified
+    {
+      get { return _matches_abandoned != null; }
+      set { if (value == (_matches_abandoned== null)) _matches_abandoned = value ? this.matches_abandoned : (uint?)null; }
+    }
+    private bool ShouldSerializematches_abandoned() { return matches_abandonedSpecified; }
+    private void Resetmatches_abandoned() { matches_abandonedSpecified = false; }
+    
 
-    private uint _reports_count = default(uint);
+    private uint? _reports_count;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"reports_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reports_count
     {
-      get { return _reports_count; }
+      get { return _reports_count?? default(uint); }
       set { _reports_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reports_countSpecified
+    {
+      get { return _reports_count != null; }
+      set { if (value == (_reports_count== null)) _reports_count = value ? this.reports_count : (uint?)null; }
+    }
+    private bool ShouldSerializereports_count() { return reports_countSpecified; }
+    private void Resetreports_count() { reports_countSpecified = false; }
+    
 
-    private uint _reports_parties = default(uint);
+    private uint? _reports_parties;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"reports_parties", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reports_parties
     {
-      get { return _reports_parties; }
+      get { return _reports_parties?? default(uint); }
       set { _reports_parties = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reports_partiesSpecified
+    {
+      get { return _reports_parties != null; }
+      set { if (value == (_reports_parties== null)) _reports_parties = value ? this.reports_parties : (uint?)null; }
+    }
+    private bool ShouldSerializereports_parties() { return reports_partiesSpecified; }
+    private void Resetreports_parties() { reports_partiesSpecified = false; }
+    
 
-    private uint _commend_count = default(uint);
+    private uint? _commend_count;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"commend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint commend_count
     {
-      get { return _commend_count; }
+      get { return _commend_count?? default(uint); }
       set { _commend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commend_countSpecified
+    {
+      get { return _commend_count != null; }
+      set { if (value == (_commend_count== null)) _commend_count = value ? this.commend_count : (uint?)null; }
+    }
+    private bool ShouldSerializecommend_count() { return commend_countSpecified; }
+    private void Resetcommend_count() { commend_countSpecified = false; }
+    
 
-    private uint _end_score = default(uint);
+    private uint? _end_score;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"end_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_score
     {
-      get { return _end_score; }
+      get { return _end_score?? default(uint); }
       set { _end_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_scoreSpecified
+    {
+      get { return _end_score != null; }
+      set { if (value == (_end_score== null)) _end_score = value ? this.end_score : (uint?)null; }
+    }
+    private bool ShouldSerializeend_score() { return end_scoreSpecified; }
+    private void Resetend_score() { end_scoreSpecified = false; }
+    
 
-    private uint _date = default(uint);
+    private uint? _date;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date
     {
-      get { return _date; }
+      get { return _date?? default(uint); }
       set { _date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dateSpecified
+    {
+      get { return _date != null; }
+      set { if (value == (_date== null)) _date = value ? this.date : (uint?)null; }
+    }
+    private bool ShouldSerializedate() { return dateSpecified; }
+    private void Resetdate() { dateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8006,14 +12778,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCWageringRequest() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8025,68 +12806,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientWageringResponse() {}
     
 
-    private uint _coins_remaining = default(uint);
+    private uint? _coins_remaining;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"coins_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint coins_remaining
     {
-      get { return _coins_remaining; }
+      get { return _coins_remaining?? default(uint); }
       set { _coins_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coins_remainingSpecified
+    {
+      get { return _coins_remaining != null; }
+      set { if (value == (_coins_remaining== null)) _coins_remaining = value ? this.coins_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializecoins_remaining() { return coins_remainingSpecified; }
+    private void Resetcoins_remaining() { coins_remainingSpecified = false; }
+    
 
-    private uint _total_points_won = default(uint);
+    private uint? _total_points_won;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_points_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_points_won
     {
-      get { return _total_points_won; }
+      get { return _total_points_won?? default(uint); }
       set { _total_points_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_points_wonSpecified
+    {
+      get { return _total_points_won != null; }
+      set { if (value == (_total_points_won== null)) _total_points_won = value ? this.total_points_won : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_points_won() { return total_points_wonSpecified; }
+    private void Resettotal_points_won() { total_points_wonSpecified = false; }
+    
 
-    private uint _total_points_wagered = default(uint);
+    private uint? _total_points_wagered;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_points_wagered", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_points_wagered
     {
-      get { return _total_points_wagered; }
+      get { return _total_points_wagered?? default(uint); }
       set { _total_points_wagered = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_points_wageredSpecified
+    {
+      get { return _total_points_wagered != null; }
+      set { if (value == (_total_points_wagered== null)) _total_points_wagered = value ? this.total_points_wagered : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_points_wagered() { return total_points_wageredSpecified; }
+    private void Resettotal_points_wagered() { total_points_wageredSpecified = false; }
+    
 
-    private uint _total_points_tipped = default(uint);
+    private uint? _total_points_tipped;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"total_points_tipped", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_points_tipped
     {
-      get { return _total_points_tipped; }
+      get { return _total_points_tipped?? default(uint); }
       set { _total_points_tipped = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_points_tippedSpecified
+    {
+      get { return _total_points_tipped != null; }
+      set { if (value == (_total_points_tipped== null)) _total_points_tipped = value ? this.total_points_tipped : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_points_tipped() { return total_points_tippedSpecified; }
+    private void Resettotal_points_tipped() { total_points_tippedSpecified = false; }
+    
 
-    private uint _success_rate = default(uint);
+    private uint? _success_rate;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"success_rate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint success_rate
     {
-      get { return _success_rate; }
+      get { return _success_rate?? default(uint); }
       set { _success_rate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool success_rateSpecified
+    {
+      get { return _success_rate != null; }
+      set { if (value == (_success_rate== null)) _success_rate = value ? this.success_rate : (uint?)null; }
+    }
+    private bool ShouldSerializesuccess_rate() { return success_rateSpecified; }
+    private void Resetsuccess_rate() { success_rateSpecified = false; }
+    
 
-    private uint _total_games_wagered = default(uint);
+    private uint? _total_games_wagered;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"total_games_wagered", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_games_wagered
     {
-      get { return _total_games_wagered; }
+      get { return _total_games_wagered?? default(uint); }
       set { _total_games_wagered = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_games_wageredSpecified
+    {
+      get { return _total_games_wagered != null; }
+      set { if (value == (_total_games_wagered== null)) _total_games_wagered = value ? this.total_games_wagered : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_games_wagered() { return total_games_wageredSpecified; }
+    private void Resettotal_games_wagered() { total_games_wageredSpecified = false; }
+    
 
-    private uint _coins_max = default(uint);
+    private uint? _coins_max;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"coins_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint coins_max
     {
-      get { return _coins_max; }
+      get { return _coins_max?? default(uint); }
       set { _coins_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coins_maxSpecified
+    {
+      get { return _coins_max != null; }
+      set { if (value == (_coins_max== null)) _coins_max = value ? this.coins_max : (uint?)null; }
+    }
+    private bool ShouldSerializecoins_max() { return coins_maxSpecified; }
+    private void Resetcoins_max() { coins_maxSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8098,14 +12942,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientWageringUpdate() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
     private CMsgGCToClientWageringResponse _wagering_info = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"wagering_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -8126,14 +12979,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientArcanaVotesUpdate() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
     private CMsgClientToGCRequestArcanaVotesRemainingResponse _arcana_votes = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"arcana_votes", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -8183,32 +13045,59 @@ namespace SteamKit2.GC.Dota.Internal
     public EventGoal() {}
     
 
-    private EEvent _event_id = EEvent.EVENT_ID_NONE;
+    private EEvent? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EEvent.EVENT_ID_NONE)]
     public EEvent event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? EEvent.EVENT_ID_NONE; }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (EEvent?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _goal_id = default(uint);
+    private uint? _goal_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"goal_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint goal_id
     {
-      get { return _goal_id; }
+      get { return _goal_id?? default(uint); }
       set { _goal_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goal_idSpecified
+    {
+      get { return _goal_id != null; }
+      set { if (value == (_goal_id== null)) _goal_id = value ? this.goal_id : (uint?)null; }
+    }
+    private bool ShouldSerializegoal_id() { return goal_idSpecified; }
+    private void Resetgoal_id() { goal_idSpecified = false; }
+    
 
-    private ulong _value = default(ulong);
+    private ulong? _value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong value
     {
-      get { return _value; }
+      get { return _value?? default(ulong); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (ulong?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8225,14 +13114,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCLeaguePredictions() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8256,41 +13154,77 @@ namespace SteamKit2.GC.Dota.Internal
     public PredictionLine() {}
     
 
-    private uint _answer_id = default(uint);
+    private uint? _answer_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"answer_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint answer_id
     {
-      get { return _answer_id; }
+      get { return _answer_id?? default(uint); }
       set { _answer_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_idSpecified
+    {
+      get { return _answer_id != null; }
+      set { if (value == (_answer_id== null)) _answer_id = value ? this.answer_id : (uint?)null; }
+    }
+    private bool ShouldSerializeanswer_id() { return answer_idSpecified; }
+    private void Resetanswer_id() { answer_idSpecified = false; }
+    
 
-    private string _answer_name = "";
+    private string _answer_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"answer_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string answer_name
     {
-      get { return _answer_name; }
+      get { return _answer_name?? ""; }
       set { _answer_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_nameSpecified
+    {
+      get { return _answer_name != null; }
+      set { if (value == (_answer_name== null)) _answer_name = value ? this.answer_name : (string)null; }
+    }
+    private bool ShouldSerializeanswer_name() { return answer_nameSpecified; }
+    private void Resetanswer_name() { answer_nameSpecified = false; }
+    
 
-    private ulong _answer_logo = default(ulong);
+    private ulong? _answer_logo;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"answer_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong answer_logo
     {
-      get { return _answer_logo; }
+      get { return _answer_logo?? default(ulong); }
       set { _answer_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_logoSpecified
+    {
+      get { return _answer_logo != null; }
+      set { if (value == (_answer_logo== null)) _answer_logo = value ? this.answer_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeanswer_logo() { return answer_logoSpecified; }
+    private void Resetanswer_logo() { answer_logoSpecified = false; }
+    
 
-    private float _answer_value = default(float);
+    private float? _answer_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"answer_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float answer_value
     {
-      get { return _answer_value; }
+      get { return _answer_value?? default(float); }
       set { _answer_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_valueSpecified
+    {
+      get { return _answer_value != null; }
+      set { if (value == (_answer_value== null)) _answer_value = value ? this.answer_value : (float?)null; }
+    }
+    private bool ShouldSerializeanswer_value() { return answer_valueSpecified; }
+    private void Resetanswer_value() { answer_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8302,14 +13236,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Prediction() {}
     
 
-    private uint _selection_id = default(uint);
+    private uint? _selection_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"selection_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection_id
     {
-      get { return _selection_id; }
+      get { return _selection_id?? default(uint); }
       set { _selection_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_idSpecified
+    {
+      get { return _selection_id != null; }
+      set { if (value == (_selection_id== null)) _selection_id = value ? this.selection_id : (uint?)null; }
+    }
+    private bool ShouldSerializeselection_id() { return selection_idSpecified; }
+    private void Resetselection_id() { selection_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPredictionRankings.PredictionLine> _prediction_lines = new global::System.Collections.Generic.List<CMsgPredictionRankings.PredictionLine>();
     [global::ProtoBuf.ProtoMember(2, Name=@"prediction_lines", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPredictionRankings.PredictionLine> prediction_lines
@@ -8345,23 +13288,41 @@ namespace SteamKit2.GC.Dota.Internal
     public ResultBreakdown() {}
     
 
-    private uint _answer_selection = default(uint);
+    private uint? _answer_selection;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"answer_selection", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint answer_selection
     {
-      get { return _answer_selection; }
+      get { return _answer_selection?? default(uint); }
       set { _answer_selection = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_selectionSpecified
+    {
+      get { return _answer_selection != null; }
+      set { if (value == (_answer_selection== null)) _answer_selection = value ? this.answer_selection : (uint?)null; }
+    }
+    private bool ShouldSerializeanswer_selection() { return answer_selectionSpecified; }
+    private void Resetanswer_selection() { answer_selectionSpecified = false; }
+    
 
-    private float _answer_value = default(float);
+    private float? _answer_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"answer_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float answer_value
     {
-      get { return _answer_value; }
+      get { return _answer_value?? default(float); }
       set { _answer_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_valueSpecified
+    {
+      get { return _answer_value != null; }
+      set { if (value == (_answer_value== null)) _answer_value = value ? this.answer_value : (float?)null; }
+    }
+    private bool ShouldSerializeanswer_value() { return answer_valueSpecified; }
+    private void Resetanswer_value() { answer_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8373,14 +13334,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Result() {}
     
 
-    private uint _selection_id = default(uint);
+    private uint? _selection_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"selection_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection_id
     {
-      get { return _selection_id; }
+      get { return _selection_id?? default(uint); }
       set { _selection_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_idSpecified
+    {
+      get { return _selection_id != null; }
+      set { if (value == (_selection_id== null)) _selection_id = value ? this.selection_id : (uint?)null; }
+    }
+    private bool ShouldSerializeselection_id() { return selection_idSpecified; }
+    private void Resetselection_id() { selection_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPredictionResults.ResultBreakdown> _result_breakdown = new global::System.Collections.Generic.List<CMsgPredictionResults.ResultBreakdown>();
     [global::ProtoBuf.ProtoMember(2, Name=@"result_breakdown", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPredictionResults.ResultBreakdown> result_breakdown
@@ -8404,14 +13374,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSuspiciousActivity() {}
     
 
-    private ulong _app_data = default(ulong);
+    private ulong? _app_data;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong app_data
     {
-      get { return _app_data; }
+      get { return _app_data?? default(ulong); }
       set { _app_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_dataSpecified
+    {
+      get { return _app_data != null; }
+      set { if (value == (_app_data== null)) _app_data = value ? this.app_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeapp_data() { return app_dataSpecified; }
+    private void Resetapp_data() { app_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8423,14 +13402,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCHasPlayerVotedForMVP() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8442,14 +13430,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCHasPlayerVotedForMVPResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8461,23 +13458,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCVoteForMVP() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8489,14 +13504,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCVoteForMVPResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8520,23 +13544,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _vote_count = default(uint);
+    private uint? _vote_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote_count
     {
-      get { return _vote_count; }
+      get { return _vote_count?? default(uint); }
       set { _vote_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_countSpecified
+    {
+      get { return _vote_count != null; }
+      set { if (value == (_vote_count== null)) _vote_count = value ? this.vote_count : (uint?)null; }
+    }
+    private bool ShouldSerializevote_count() { return vote_countSpecified; }
+    private void Resetvote_count() { vote_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8553,23 +13595,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeaguePrizePool() {}
     
 
-    private uint _prize_pool = default(uint);
+    private uint? _prize_pool;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prize_pool", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_pool
     {
-      get { return _prize_pool; }
+      get { return _prize_pool?? default(uint); }
       set { _prize_pool = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_poolSpecified
+    {
+      get { return _prize_pool != null; }
+      set { if (value == (_prize_pool== null)) _prize_pool = value ? this.prize_pool : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_pool() { return prize_poolSpecified; }
+    private void Resetprize_pool() { prize_poolSpecified = false; }
+    
 
-    private float _increment_per_second = default(float);
+    private float? _increment_per_second;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"increment_per_second", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float increment_per_second
     {
-      get { return _increment_per_second; }
+      get { return _increment_per_second?? default(float); }
       set { _increment_per_second = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool increment_per_secondSpecified
+    {
+      get { return _increment_per_second != null; }
+      set { if (value == (_increment_per_second== null)) _increment_per_second = value ? this.increment_per_second : (float?)null; }
+    }
+    private bool ShouldSerializeincrement_per_second() { return increment_per_secondSpecified; }
+    private void Resetincrement_per_second() { increment_per_secondSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8591,14 +13651,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCTeammateStatsResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCTeammateStatsResponse.TeammateStat> _teammate_stats = new global::System.Collections.Generic.List<CMsgClientToGCTeammateStatsResponse.TeammateStat>();
     [global::ProtoBuf.ProtoMember(2, Name=@"teammate_stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCTeammateStatsResponse.TeammateStat> teammate_stats
@@ -8612,59 +13681,113 @@ namespace SteamKit2.GC.Dota.Internal
     public TeammateStat() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _games = default(uint);
+    private uint? _games;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games
     {
-      get { return _games; }
+      get { return _games?? default(uint); }
       set { _games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamesSpecified
+    {
+      get { return _games != null; }
+      set { if (value == (_games== null)) _games = value ? this.games : (uint?)null; }
+    }
+    private bool ShouldSerializegames() { return gamesSpecified; }
+    private void Resetgames() { gamesSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _most_recent_game_timestamp = default(uint);
+    private uint? _most_recent_game_timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"most_recent_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint most_recent_game_timestamp
     {
-      get { return _most_recent_game_timestamp; }
+      get { return _most_recent_game_timestamp?? default(uint); }
       set { _most_recent_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool most_recent_game_timestampSpecified
+    {
+      get { return _most_recent_game_timestamp != null; }
+      set { if (value == (_most_recent_game_timestamp== null)) _most_recent_game_timestamp = value ? this.most_recent_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializemost_recent_game_timestamp() { return most_recent_game_timestampSpecified; }
+    private void Resetmost_recent_game_timestamp() { most_recent_game_timestampSpecified = false; }
+    
 
-    private ulong _most_recent_game_match_id = default(ulong);
+    private ulong? _most_recent_game_match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"most_recent_game_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong most_recent_game_match_id
     {
-      get { return _most_recent_game_match_id; }
+      get { return _most_recent_game_match_id?? default(ulong); }
       set { _most_recent_game_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool most_recent_game_match_idSpecified
+    {
+      get { return _most_recent_game_match_id != null; }
+      set { if (value == (_most_recent_game_match_id== null)) _most_recent_game_match_id = value ? this.most_recent_game_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemost_recent_game_match_id() { return most_recent_game_match_idSpecified; }
+    private void Resetmost_recent_game_match_id() { most_recent_game_match_idSpecified = false; }
+    
 
-    private float _performance = default(float);
+    private float? _performance;
     [global::ProtoBuf.ProtoMember(100, IsRequired = false, Name=@"performance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float performance
     {
-      get { return _performance; }
+      get { return _performance?? default(float); }
       set { _performance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool performanceSpecified
+    {
+      get { return _performance != null; }
+      set { if (value == (_performance== null)) _performance = value ? this.performance : (float?)null; }
+    }
+    private bool ShouldSerializeperformance() { return performanceSpecified; }
+    private void Resetperformance() { performanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8693,32 +13816,59 @@ namespace SteamKit2.GC.Dota.Internal
     public MatchVote() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _vote_count = default(uint);
+    private uint? _vote_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"vote_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote_count
     {
-      get { return _vote_count; }
+      get { return _vote_count?? default(uint); }
       set { _vote_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_countSpecified
+    {
+      get { return _vote_count != null; }
+      set { if (value == (_vote_count== null)) _vote_count = value ? this.vote_count : (uint?)null; }
+    }
+    private bool ShouldSerializevote_count() { return vote_countSpecified; }
+    private void Resetvote_count() { vote_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8735,14 +13885,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCVoteForArcanaResponse() {}
     
 
-    private CMsgClientToGCVoteForArcanaResponse.Result _result = CMsgClientToGCVoteForArcanaResponse.Result.SUCCEEDED;
+    private CMsgClientToGCVoteForArcanaResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCVoteForArcanaResponse.Result.SUCCEEDED)]
     public CMsgClientToGCVoteForArcanaResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCVoteForArcanaResponse.Result.SUCCEEDED; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCVoteForArcanaResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -8775,154 +13934,298 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _round_time_remaining = default(uint);
+    private uint? _round_time_remaining;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"round_time_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint round_time_remaining
     {
-      get { return _round_time_remaining; }
+      get { return _round_time_remaining?? default(uint); }
       set { _round_time_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool round_time_remainingSpecified
+    {
+      get { return _round_time_remaining != null; }
+      set { if (value == (_round_time_remaining== null)) _round_time_remaining = value ? this.round_time_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializeround_time_remaining() { return round_time_remainingSpecified; }
+    private void Resetround_time_remaining() { round_time_remainingSpecified = false; }
+    
 
-    private uint _round_number = default(uint);
+    private uint? _round_number;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"round_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint round_number
     {
-      get { return _round_number; }
+      get { return _round_number?? default(uint); }
       set { _round_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool round_numberSpecified
+    {
+      get { return _round_number != null; }
+      set { if (value == (_round_number== null)) _round_number = value ? this.round_number : (uint?)null; }
+    }
+    private bool ShouldSerializeround_number() { return round_numberSpecified; }
+    private void Resetround_number() { round_numberSpecified = false; }
+    
 
-    private uint _voting_state = default(uint);
+    private uint? _voting_state;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"voting_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint voting_state
     {
-      get { return _voting_state; }
+      get { return _voting_state?? default(uint); }
       set { _voting_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voting_stateSpecified
+    {
+      get { return _voting_state != null; }
+      set { if (value == (_voting_state== null)) _voting_state = value ? this.voting_state : (uint?)null; }
+    }
+    private bool ShouldSerializevoting_state() { return voting_stateSpecified; }
+    private void Resetvoting_state() { voting_stateSpecified = false; }
+    
 
-    private bool _is_current_round_calibrating = default(bool);
+    private bool? _is_current_round_calibrating;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_current_round_calibrating", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_current_round_calibrating
     {
-      get { return _is_current_round_calibrating; }
+      get { return _is_current_round_calibrating?? default(bool); }
       set { _is_current_round_calibrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_current_round_calibratingSpecified
+    {
+      get { return _is_current_round_calibrating != null; }
+      set { if (value == (_is_current_round_calibrating== null)) _is_current_round_calibrating = value ? this.is_current_round_calibrating : (bool?)null; }
+    }
+    private bool ShouldSerializeis_current_round_calibrating() { return is_current_round_calibratingSpecified; }
+    private void Resetis_current_round_calibrating() { is_current_round_calibratingSpecified = false; }
+    
 
-    private uint _closest_active_match_id = default(uint);
+    private uint? _closest_active_match_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"closest_active_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint closest_active_match_id
     {
-      get { return _closest_active_match_id; }
+      get { return _closest_active_match_id?? default(uint); }
       set { _closest_active_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool closest_active_match_idSpecified
+    {
+      get { return _closest_active_match_id != null; }
+      set { if (value == (_closest_active_match_id== null)) _closest_active_match_id = value ? this.closest_active_match_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclosest_active_match_id() { return closest_active_match_idSpecified; }
+    private void Resetclosest_active_match_id() { closest_active_match_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Match")]
   public partial class Match : global::ProtoBuf.IExtensible
   {
     public Match() {}
     
 
-    private uint _match_id = default(uint);
+    private uint? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(uint); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (uint?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _hero_id_0 = default(uint);
+    private uint? _hero_id_0;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id_0
     {
-      get { return _hero_id_0; }
+      get { return _hero_id_0?? default(uint); }
       set { _hero_id_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_id_0Specified
+    {
+      get { return _hero_id_0 != null; }
+      set { if (value == (_hero_id_0== null)) _hero_id_0 = value ? this.hero_id_0 : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id_0() { return hero_id_0Specified; }
+    private void Resethero_id_0() { hero_id_0Specified = false; }
+    
 
-    private uint _hero_id_1 = default(uint);
+    private uint? _hero_id_1;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id_1
     {
-      get { return _hero_id_1; }
+      get { return _hero_id_1?? default(uint); }
       set { _hero_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_id_1Specified
+    {
+      get { return _hero_id_1 != null; }
+      set { if (value == (_hero_id_1== null)) _hero_id_1 = value ? this.hero_id_1 : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id_1() { return hero_id_1Specified; }
+    private void Resethero_id_1() { hero_id_1Specified = false; }
+    
 
-    private uint _hero_seeding_0 = default(uint);
+    private uint? _hero_seeding_0;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_seeding_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_seeding_0
     {
-      get { return _hero_seeding_0; }
+      get { return _hero_seeding_0?? default(uint); }
       set { _hero_seeding_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_seeding_0Specified
+    {
+      get { return _hero_seeding_0 != null; }
+      set { if (value == (_hero_seeding_0== null)) _hero_seeding_0 = value ? this.hero_seeding_0 : (uint?)null; }
+    }
+    private bool ShouldSerializehero_seeding_0() { return hero_seeding_0Specified; }
+    private void Resethero_seeding_0() { hero_seeding_0Specified = false; }
+    
 
-    private uint _hero_seeding_1 = default(uint);
+    private uint? _hero_seeding_1;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"hero_seeding_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_seeding_1
     {
-      get { return _hero_seeding_1; }
+      get { return _hero_seeding_1?? default(uint); }
       set { _hero_seeding_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_seeding_1Specified
+    {
+      get { return _hero_seeding_1 != null; }
+      set { if (value == (_hero_seeding_1== null)) _hero_seeding_1 = value ? this.hero_seeding_1 : (uint?)null; }
+    }
+    private bool ShouldSerializehero_seeding_1() { return hero_seeding_1Specified; }
+    private void Resethero_seeding_1() { hero_seeding_1Specified = false; }
+    
 
-    private uint _vote_count_0 = default(uint);
+    private uint? _vote_count_0;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"vote_count_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote_count_0
     {
-      get { return _vote_count_0; }
+      get { return _vote_count_0?? default(uint); }
       set { _vote_count_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_count_0Specified
+    {
+      get { return _vote_count_0 != null; }
+      set { if (value == (_vote_count_0== null)) _vote_count_0 = value ? this.vote_count_0 : (uint?)null; }
+    }
+    private bool ShouldSerializevote_count_0() { return vote_count_0Specified; }
+    private void Resetvote_count_0() { vote_count_0Specified = false; }
+    
 
-    private uint _vote_count_1 = default(uint);
+    private uint? _vote_count_1;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"vote_count_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote_count_1
     {
-      get { return _vote_count_1; }
+      get { return _vote_count_1?? default(uint); }
       set { _vote_count_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_count_1Specified
+    {
+      get { return _vote_count_1 != null; }
+      set { if (value == (_vote_count_1== null)) _vote_count_1 = value ? this.vote_count_1 : (uint?)null; }
+    }
+    private bool ShouldSerializevote_count_1() { return vote_count_1Specified; }
+    private void Resetvote_count_1() { vote_count_1Specified = false; }
+    
 
-    private uint _voting_state = default(uint);
+    private uint? _voting_state;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"voting_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint voting_state
     {
-      get { return _voting_state; }
+      get { return _voting_state?? default(uint); }
       set { _voting_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voting_stateSpecified
+    {
+      get { return _voting_state != null; }
+      set { if (value == (_voting_state== null)) _voting_state = value ? this.voting_state : (uint?)null; }
+    }
+    private bool ShouldSerializevoting_state() { return voting_stateSpecified; }
+    private void Resetvoting_state() { voting_stateSpecified = false; }
+    
 
-    private uint _round_number = default(uint);
+    private uint? _round_number;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"round_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint round_number
     {
-      get { return _round_number; }
+      get { return _round_number?? default(uint); }
       set { _round_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool round_numberSpecified
+    {
+      get { return _round_number != null; }
+      set { if (value == (_round_number== null)) _round_number = value ? this.round_number : (uint?)null; }
+    }
+    private bool ShouldSerializeround_number() { return round_numberSpecified; }
+    private void Resetround_number() { round_numberSpecified = false; }
+    
 
-    private bool _is_votes_hidden = default(bool);
+    private bool? _is_votes_hidden;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_votes_hidden", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_votes_hidden
     {
-      get { return _is_votes_hidden; }
+      get { return _is_votes_hidden?? default(bool); }
       set { _is_votes_hidden = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_votes_hiddenSpecified
+    {
+      get { return _is_votes_hidden != null; }
+      set { if (value == (_is_votes_hidden== null)) _is_votes_hidden = value ? this.is_votes_hidden : (bool?)null; }
+    }
+    private bool ShouldSerializeis_votes_hidden() { return is_votes_hiddenSpecified; }
+    private void Resetis_votes_hidden() { is_votes_hiddenSpecified = false; }
+    
 
-    private uint _calibration_time_remaining = default(uint);
+    private uint? _calibration_time_remaining;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"calibration_time_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint calibration_time_remaining
     {
-      get { return _calibration_time_remaining; }
+      get { return _calibration_time_remaining?? default(uint); }
       set { _calibration_time_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool calibration_time_remainingSpecified
+    {
+      get { return _calibration_time_remaining != null; }
+      set { if (value == (_calibration_time_remaining== null)) _calibration_time_remaining = value ? this.calibration_time_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializecalibration_time_remaining() { return calibration_time_remainingSpecified; }
+    private void Resetcalibration_time_remaining() { calibration_time_remainingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8963,32 +14266,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestArcanaVotesRemainingResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _votes_remaining = default(uint);
+    private uint? _votes_remaining;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"votes_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint votes_remaining
     {
-      get { return _votes_remaining; }
+      get { return _votes_remaining?? default(uint); }
       set { _votes_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_remainingSpecified
+    {
+      get { return _votes_remaining != null; }
+      set { if (value == (_votes_remaining== null)) _votes_remaining = value ? this.votes_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializevotes_remaining() { return votes_remainingSpecified; }
+    private void Resetvotes_remaining() { votes_remainingSpecified = false; }
+    
 
-    private uint _votes_total = default(uint);
+    private uint? _votes_total;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"votes_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint votes_total
     {
-      get { return _votes_total; }
+      get { return _votes_total?? default(uint); }
       set { _votes_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_totalSpecified
+    {
+      get { return _votes_total != null; }
+      set { if (value == (_votes_total== null)) _votes_total = value ? this.votes_total : (uint?)null; }
+    }
+    private bool ShouldSerializevotes_total() { return votes_totalSpecified; }
+    private void Resetvotes_total() { votes_totalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCRequestArcanaVotesRemainingResponse.MatchVote> _matches_previously_voted_for = new global::System.Collections.Generic.List<CMsgClientToGCRequestArcanaVotesRemainingResponse.MatchVote>();
     [global::ProtoBuf.ProtoMember(4, Name=@"matches_previously_voted_for", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCRequestArcanaVotesRemainingResponse.MatchVote> matches_previously_voted_for
@@ -9002,32 +14332,59 @@ namespace SteamKit2.GC.Dota.Internal
     public MatchVote() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _vote_count = default(uint);
+    private uint? _vote_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"vote_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint vote_count
     {
-      get { return _vote_count; }
+      get { return _vote_count?? default(uint); }
       set { _vote_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_countSpecified
+    {
+      get { return _vote_count != null; }
+      set { if (value == (_vote_count== null)) _vote_count = value ? this.vote_count : (uint?)null; }
+    }
+    private bool ShouldSerializevote_count() { return vote_countSpecified; }
+    private void Resetvote_count() { vote_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9044,14 +14401,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestEventPointLog() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9063,14 +14429,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestEventPointLogResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCRequestEventPointLogResponse.EventPointTransaction> _transactions = new global::System.Collections.Generic.List<CMsgClientToGCRequestEventPointLogResponse.EventPointTransaction>();
     [global::ProtoBuf.ProtoMember(2, Name=@"transactions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCRequestEventPointLogResponse.EventPointTransaction> transactions
@@ -9079,46 +14454,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"QuestChallengeEvent")]
   public partial class QuestChallengeEvent : global::ProtoBuf.IExtensible
   {
     public QuestChallengeEvent() {}
     
 
-    private uint _quest_id = default(uint);
+    private uint? _quest_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_id
     {
-      get { return _quest_id; }
+      get { return _quest_id?? default(uint); }
       set { _quest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_idSpecified
+    {
+      get { return _quest_id != null; }
+      set { if (value == (_quest_id== null)) _quest_id = value ? this.quest_id : (uint?)null; }
+    }
+    private bool ShouldSerializequest_id() { return quest_idSpecified; }
+    private void Resetquest_id() { quest_idSpecified = false; }
+    
 
-    private uint _challenge_id = default(uint);
+    private uint? _challenge_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"challenge_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_id
     {
-      get { return _challenge_id; }
+      get { return _challenge_id?? default(uint); }
       set { _challenge_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_idSpecified
+    {
+      get { return _challenge_id != null; }
+      set { if (value == (_challenge_id== null)) _challenge_id = value ? this.challenge_id : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_id() { return challenge_idSpecified; }
+    private void Resetchallenge_id() { challenge_idSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9130,14 +14541,23 @@ namespace SteamKit2.GC.Dota.Internal
     public WagerWonEvent() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9149,23 +14569,41 @@ namespace SteamKit2.GC.Dota.Internal
     public TipGivenEvent() {}
     
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
 
-    private string _recipient_name = "";
+    private string _recipient_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"recipient_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string recipient_name
     {
-      get { return _recipient_name; }
+      get { return _recipient_name?? ""; }
       set { _recipient_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_nameSpecified
+    {
+      get { return _recipient_name != null; }
+      set { if (value == (_recipient_name== null)) _recipient_name = value ? this.recipient_name : (string)null; }
+    }
+    private bool ShouldSerializerecipient_name() { return recipient_nameSpecified; }
+    private void Resetrecipient_name() { recipient_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9177,23 +14615,41 @@ namespace SteamKit2.GC.Dota.Internal
     public TipReceivedEvent() {}
     
 
-    private uint _giver_account_id = default(uint);
+    private uint? _giver_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"giver_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint giver_account_id
     {
-      get { return _giver_account_id; }
+      get { return _giver_account_id?? default(uint); }
       set { _giver_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool giver_account_idSpecified
+    {
+      get { return _giver_account_id != null; }
+      set { if (value == (_giver_account_id== null)) _giver_account_id = value ? this.giver_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegiver_account_id() { return giver_account_idSpecified; }
+    private void Resetgiver_account_id() { giver_account_idSpecified = false; }
+    
 
-    private string _giver_name = "";
+    private string _giver_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"giver_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string giver_name
     {
-      get { return _giver_name; }
+      get { return _giver_name?? ""; }
       set { _giver_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool giver_nameSpecified
+    {
+      get { return _giver_name != null; }
+      set { if (value == (_giver_name== null)) _giver_name = value ? this.giver_name : (string)null; }
+    }
+    private bool ShouldSerializegiver_name() { return giver_nameSpecified; }
+    private void Resetgiver_name() { giver_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9205,14 +14661,23 @@ namespace SteamKit2.GC.Dota.Internal
     public RecycledItemEvent() {}
     
 
-    private uint _recipe_item_def_index = default(uint);
+    private uint? _recipe_item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"recipe_item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipe_item_def_index
     {
-      get { return _recipe_item_def_index; }
+      get { return _recipe_item_def_index?? default(uint); }
       set { _recipe_item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipe_item_def_indexSpecified
+    {
+      get { return _recipe_item_def_index != null; }
+      set { if (value == (_recipe_item_def_index== null)) _recipe_item_def_index = value ? this.recipe_item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializerecipe_item_def_index() { return recipe_item_def_indexSpecified; }
+    private void Resetrecipe_item_def_index() { recipe_item_def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9224,14 +14689,23 @@ namespace SteamKit2.GC.Dota.Internal
     public AchievementEvent() {}
     
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9243,14 +14717,23 @@ namespace SteamKit2.GC.Dota.Internal
     public MysteryItemReceivedEvent() {}
     
 
-    private bool _community_goal_item = default(bool);
+    private bool? _community_goal_item;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"community_goal_item", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool community_goal_item
     {
-      get { return _community_goal_item; }
+      get { return _community_goal_item?? default(bool); }
       set { _community_goal_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool community_goal_itemSpecified
+    {
+      get { return _community_goal_item != null; }
+      set { if (value == (_community_goal_item== null)) _community_goal_item = value ? this.community_goal_item : (bool?)null; }
+    }
+    private bool ShouldSerializecommunity_goal_item() { return community_goal_itemSpecified; }
+    private void Resetcommunity_goal_item() { community_goal_itemSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9262,14 +14745,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CorrectPredictionEvent() {}
     
 
-    private uint _prediction_id = default(uint);
+    private uint? _prediction_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prediction_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_id
     {
-      get { return _prediction_id; }
+      get { return _prediction_id?? default(uint); }
       set { _prediction_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_idSpecified
+    {
+      get { return _prediction_id != null; }
+      set { if (value == (_prediction_id== null)) _prediction_id = value ? this.prediction_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_id() { return prediction_idSpecified; }
+    private void Resetprediction_id() { prediction_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9281,14 +14773,23 @@ namespace SteamKit2.GC.Dota.Internal
     public InGamePredictionCorrectEvent() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9300,14 +14801,23 @@ namespace SteamKit2.GC.Dota.Internal
     public WeekendTourneyPayoutEvent() {}
     
 
-    private ulong _team_gid = default(ulong);
+    private ulong? _team_gid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_gid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_gid
     {
-      get { return _team_gid; }
+      get { return _team_gid?? default(ulong); }
       set { _team_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_gidSpecified
+    {
+      get { return _team_gid != null; }
+      set { if (value == (_team_gid== null)) _team_gid = value ? this.team_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_gid() { return team_gidSpecified; }
+    private void Resetteam_gid() { team_gidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9319,14 +14829,23 @@ namespace SteamKit2.GC.Dota.Internal
     public FantasyRewardEvent() {}
     
 
-    private uint _percentile = default(uint);
+    private uint? _percentile;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"percentile", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint percentile
     {
-      get { return _percentile; }
+      get { return _percentile?? default(uint); }
       set { _percentile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool percentileSpecified
+    {
+      get { return _percentile != null; }
+      set { if (value == (_percentile== null)) _percentile = value ? this.percentile : (uint?)null; }
+    }
+    private bool ShouldSerializepercentile() { return percentileSpecified; }
+    private void Resetpercentile() { percentileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9338,14 +14857,23 @@ namespace SteamKit2.GC.Dota.Internal
     public BracketRewardEvent() {}
     
 
-    private uint _correct_answers = default(uint);
+    private uint? _correct_answers;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"correct_answers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint correct_answers
     {
-      get { return _correct_answers; }
+      get { return _correct_answers?? default(uint); }
       set { _correct_answers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correct_answersSpecified
+    {
+      get { return _correct_answers != null; }
+      set { if (value == (_correct_answers== null)) _correct_answers = value ? this.correct_answers : (uint?)null; }
+    }
+    private bool ShouldSerializecorrect_answers() { return correct_answersSpecified; }
+    private void Resetcorrect_answers() { correct_answersSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9357,41 +14885,77 @@ namespace SteamKit2.GC.Dota.Internal
     public EventPointTransaction() {}
     
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
 
-    private int _event_points = default(int);
+    private int? _event_points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int event_points
     {
-      get { return _event_points; }
+      get { return _event_points?? default(int); }
       set { _event_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_pointsSpecified
+    {
+      get { return _event_points != null; }
+      set { if (value == (_event_points== null)) _event_points = value ? this.event_points : (int?)null; }
+    }
+    private bool ShouldSerializeevent_points() { return event_pointsSpecified; }
+    private void Resetevent_points() { event_pointsSpecified = false; }
+    
 
-    private bool _compendium_activated_event = default(bool);
+    private bool? _compendium_activated_event;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"compendium_activated_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool compendium_activated_event
     {
-      get { return _compendium_activated_event; }
+      get { return _compendium_activated_event?? default(bool); }
       set { _compendium_activated_event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool compendium_activated_eventSpecified
+    {
+      get { return _compendium_activated_event != null; }
+      set { if (value == (_compendium_activated_event== null)) _compendium_activated_event = value ? this.compendium_activated_event : (bool?)null; }
+    }
+    private bool ShouldSerializecompendium_activated_event() { return compendium_activated_eventSpecified; }
+    private void Resetcompendium_activated_event() { compendium_activated_eventSpecified = false; }
+    
 
-    private bool _point_item_used_event = default(bool);
+    private bool? _point_item_used_event;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"point_item_used_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool point_item_used_event
     {
-      get { return _point_item_used_event; }
+      get { return _point_item_used_event?? default(bool); }
       set { _point_item_used_event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool point_item_used_eventSpecified
+    {
+      get { return _point_item_used_event != null; }
+      set { if (value == (_point_item_used_event== null)) _point_item_used_event = value ? this.point_item_used_event : (bool?)null; }
+    }
+    private bool ShouldSerializepoint_item_used_event() { return point_item_used_eventSpecified; }
+    private void Resetpoint_item_used_event() { point_item_used_eventSpecified = false; }
+    
 
     private CMsgClientToGCRequestEventPointLogResponse.WagerWonEvent _wager_won_event = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"wager_won_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -9501,23 +15065,41 @@ namespace SteamKit2.GC.Dota.Internal
       set { _bracket_reward_event = value; }
     }
 
-    private bool _weekly_quest_completed_event = default(bool);
+    private bool? _weekly_quest_completed_event;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"weekly_quest_completed_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool weekly_quest_completed_event
     {
-      get { return _weekly_quest_completed_event; }
+      get { return _weekly_quest_completed_event?? default(bool); }
       set { _weekly_quest_completed_event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekly_quest_completed_eventSpecified
+    {
+      get { return _weekly_quest_completed_event != null; }
+      set { if (value == (_weekly_quest_completed_event== null)) _weekly_quest_completed_event = value ? this.weekly_quest_completed_event : (bool?)null; }
+    }
+    private bool ShouldSerializeweekly_quest_completed_event() { return weekly_quest_completed_eventSpecified; }
+    private void Resetweekly_quest_completed_event() { weekly_quest_completed_eventSpecified = false; }
+    
 
-    private bool _daily_quest_completed_event = default(bool);
+    private bool? _daily_quest_completed_event;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"daily_quest_completed_event", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool daily_quest_completed_event
     {
-      get { return _daily_quest_completed_event; }
+      get { return _daily_quest_completed_event?? default(bool); }
       set { _daily_quest_completed_event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool daily_quest_completed_eventSpecified
+    {
+      get { return _daily_quest_completed_event != null; }
+      set { if (value == (_daily_quest_completed_event== null)) _daily_quest_completed_event = value ? this.daily_quest_completed_event : (bool?)null; }
+    }
+    private bool ShouldSerializedaily_quest_completed_event() { return daily_quest_completed_eventSpecified; }
+    private void Resetdaily_quest_completed_event() { daily_quest_completed_eventSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9534,23 +15116,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPublishUserStat() {}
     
 
-    private uint _user_stats_event = default(uint);
+    private uint? _user_stats_event;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_stats_event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_stats_event
     {
-      get { return _user_stats_event; }
+      get { return _user_stats_event?? default(uint); }
       set { _user_stats_event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_stats_eventSpecified
+    {
+      get { return _user_stats_event != null; }
+      set { if (value == (_user_stats_event== null)) _user_stats_event = value ? this.user_stats_event : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_stats_event() { return user_stats_eventSpecified; }
+    private void Resetuser_stats_event() { user_stats_eventSpecified = false; }
+    
 
-    private ulong _reference_data = default(ulong);
+    private ulong? _reference_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reference_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong reference_data
     {
-      get { return _reference_data; }
+      get { return _reference_data?? default(ulong); }
       set { _reference_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_dataSpecified
+    {
+      get { return _reference_data != null; }
+      set { if (value == (_reference_data== null)) _reference_data = value ? this.reference_data : (ulong?)null; }
+    }
+    private bool ShouldSerializereference_data() { return reference_dataSpecified; }
+    private void Resetreference_data() { reference_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9562,14 +15162,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCAddTI6TreeProgress() {}
     
 
-    private uint _trees = default(uint);
+    private uint? _trees;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"trees", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trees
     {
-      get { return _trees; }
+      get { return _trees?? default(uint); }
       set { _trees = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool treesSpecified
+    {
+      get { return _trees != null; }
+      set { if (value == (_trees== null)) _trees = value ? this.trees : (uint?)null; }
+    }
+    private bool ShouldSerializetrees() { return treesSpecified; }
+    private void Resettrees() { treesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9581,14 +15190,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestLinaPlaysRemaining() {}
     
 
-    private EEvent _event_id = EEvent.EVENT_ID_NONE;
+    private EEvent? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EEvent.EVENT_ID_NONE)]
     public EEvent event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? EEvent.EVENT_ID_NONE; }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (EEvent?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9600,23 +15218,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestLinaPlaysRemainingResponse() {}
     
 
-    private uint _plays_remaining = default(uint);
+    private uint? _plays_remaining;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"plays_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint plays_remaining
     {
-      get { return _plays_remaining; }
+      get { return _plays_remaining?? default(uint); }
       set { _plays_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool plays_remainingSpecified
+    {
+      get { return _plays_remaining != null; }
+      set { if (value == (_plays_remaining== null)) _plays_remaining = value ? this.plays_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializeplays_remaining() { return plays_remainingSpecified; }
+    private void Resetplays_remaining() { plays_remainingSpecified = false; }
+    
 
-    private uint _plays_total = default(uint);
+    private uint? _plays_total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"plays_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint plays_total
     {
-      get { return _plays_total; }
+      get { return _plays_total?? default(uint); }
       set { _plays_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool plays_totalSpecified
+    {
+      get { return _plays_total != null; }
+      set { if (value == (_plays_total== null)) _plays_total = value ? this.plays_total : (uint?)null; }
+    }
+    private bool ShouldSerializeplays_total() { return plays_totalSpecified; }
+    private void Resetplays_total() { plays_totalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9628,23 +15264,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestLinaGameResult() {}
     
 
-    private EEvent _event_id = EEvent.EVENT_ID_NONE;
+    private EEvent? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EEvent.EVENT_ID_NONE)]
     public EEvent event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? EEvent.EVENT_ID_NONE; }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (EEvent?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _slot_chosen = default(uint);
+    private uint? _slot_chosen;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot_chosen", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_chosen
     {
-      get { return _slot_chosen; }
+      get { return _slot_chosen?? default(uint); }
       set { _slot_chosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_chosenSpecified
+    {
+      get { return _slot_chosen != null; }
+      set { if (value == (_slot_chosen== null)) _slot_chosen = value ? this.slot_chosen : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_chosen() { return slot_chosenSpecified; }
+    private void Resetslot_chosen() { slot_chosenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9656,14 +15310,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestLinaGameResultResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9675,14 +15338,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientQuestProgressUpdated() {}
     
 
-    private uint _quest_id = default(uint);
+    private uint? _quest_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_id
     {
-      get { return _quest_id; }
+      get { return _quest_id?? default(uint); }
       set { _quest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_idSpecified
+    {
+      get { return _quest_id != null; }
+      set { if (value == (_quest_id== null)) _quest_id = value ? this.quest_id : (uint?)null; }
+    }
+    private bool ShouldSerializequest_id() { return quest_idSpecified; }
+    private void Resetquest_id() { quest_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientQuestProgressUpdated.Challenge> _completed_challenges = new global::System.Collections.Generic.List<CMsgGCToClientQuestProgressUpdated.Challenge>();
     [global::ProtoBuf.ProtoMember(2, Name=@"completed_challenges", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientQuestProgressUpdated.Challenge> completed_challenges
@@ -9696,59 +15368,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Challenge() {}
     
 
-    private uint _challenge_id = default(uint);
+    private uint? _challenge_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"challenge_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_id
     {
-      get { return _challenge_id; }
+      get { return _challenge_id?? default(uint); }
       set { _challenge_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_idSpecified
+    {
+      get { return _challenge_id != null; }
+      set { if (value == (_challenge_id== null)) _challenge_id = value ? this.challenge_id : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_id() { return challenge_idSpecified; }
+    private void Resetchallenge_id() { challenge_idSpecified = false; }
+    
 
-    private uint _time_completed = default(uint);
+    private uint? _time_completed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_completed
     {
-      get { return _time_completed; }
+      get { return _time_completed?? default(uint); }
       set { _time_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_completedSpecified
+    {
+      get { return _time_completed != null; }
+      set { if (value == (_time_completed== null)) _time_completed = value ? this.time_completed : (uint?)null; }
+    }
+    private bool ShouldSerializetime_completed() { return time_completedSpecified; }
+    private void Resettime_completed() { time_completedSpecified = false; }
+    
 
-    private uint _attempts = default(uint);
+    private uint? _attempts;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"attempts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attempts
     {
-      get { return _attempts; }
+      get { return _attempts?? default(uint); }
       set { _attempts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attemptsSpecified
+    {
+      get { return _attempts != null; }
+      set { if (value == (_attempts== null)) _attempts = value ? this.attempts : (uint?)null; }
+    }
+    private bool ShouldSerializeattempts() { return attemptsSpecified; }
+    private void Resetattempts() { attemptsSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _challenge_type = default(uint);
+    private uint? _challenge_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"challenge_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_type
     {
-      get { return _challenge_type; }
+      get { return _challenge_type?? default(uint); }
       set { _challenge_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_typeSpecified
+    {
+      get { return _challenge_type != null; }
+      set { if (value == (_challenge_type== null)) _challenge_type = value ? this.challenge_type : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_type() { return challenge_typeSpecified; }
+    private void Resetchallenge_type() { challenge_typeSpecified = false; }
+    
 
-    private uint _quest_rank = default(uint);
+    private uint? _quest_rank;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"quest_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_rank
     {
-      get { return _quest_rank; }
+      get { return _quest_rank?? default(uint); }
       set { _quest_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_rankSpecified
+    {
+      get { return _quest_rank != null; }
+      set { if (value == (_quest_rank== null)) _quest_rank = value ? this.quest_rank : (uint?)null; }
+    }
+    private bool ShouldSerializequest_rank() { return quest_rankSpecified; }
+    private void Resetquest_rank() { quest_rankSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9765,23 +15491,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARedeemItem() {}
     
 
-    private ulong _currency_id = default(ulong);
+    private ulong? _currency_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"currency_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong currency_id
     {
-      get { return _currency_id; }
+      get { return _currency_id?? default(ulong); }
       set { _currency_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currency_idSpecified
+    {
+      get { return _currency_id != null; }
+      set { if (value == (_currency_id== null)) _currency_id = value ? this.currency_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecurrency_id() { return currency_idSpecified; }
+    private void Resetcurrency_id() { currency_idSpecified = false; }
+    
 
-    private uint _purchase_def = default(uint);
+    private uint? _purchase_def;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"purchase_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint purchase_def
     {
-      get { return _purchase_def; }
+      get { return _purchase_def?? default(uint); }
       set { _purchase_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_defSpecified
+    {
+      get { return _purchase_def != null; }
+      set { if (value == (_purchase_def== null)) _purchase_def = value ? this.purchase_def : (uint?)null; }
+    }
+    private bool ShouldSerializepurchase_def() { return purchase_defSpecified; }
+    private void Resetpurchase_def() { purchase_defSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9793,14 +15537,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARedeemItemResponse() {}
     
 
-    private CMsgDOTARedeemItemResponse.EResultCode _response = CMsgDOTARedeemItemResponse.EResultCode.k_Succeeded;
+    private CMsgDOTARedeemItemResponse.EResultCode? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTARedeemItemResponse.EResultCode.k_Succeeded)]
     public CMsgDOTARedeemItemResponse.EResultCode response
     {
-      get { return _response; }
+      get { return _response?? CMsgDOTARedeemItemResponse.EResultCode.k_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgDOTARedeemItemResponse.EResultCode?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResultCode", EnumPassthru=true)]
     public enum EResultCode
     {
@@ -9823,14 +15576,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPerfectWorldUserLookupRequest() {}
     
 
-    private string _user_name = "";
+    private string _user_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string user_name
     {
-      get { return _user_name; }
+      get { return _user_name?? ""; }
       set { _user_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_nameSpecified
+    {
+      get { return _user_name != null; }
+      set { if (value == (_user_name== null)) _user_name = value ? this.user_name : (string)null; }
+    }
+    private bool ShouldSerializeuser_name() { return user_nameSpecified; }
+    private void Resetuser_name() { user_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9842,23 +15604,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPerfectWorldUserLookupResponse() {}
     
 
-    private CMsgPerfectWorldUserLookupResponse.EResultCode _result_code = CMsgPerfectWorldUserLookupResponse.EResultCode.SUCCESS_ACCOUNT_FOUND;
+    private CMsgPerfectWorldUserLookupResponse.EResultCode? _result_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgPerfectWorldUserLookupResponse.EResultCode.SUCCESS_ACCOUNT_FOUND)]
     public CMsgPerfectWorldUserLookupResponse.EResultCode result_code
     {
-      get { return _result_code; }
+      get { return _result_code?? CMsgPerfectWorldUserLookupResponse.EResultCode.SUCCESS_ACCOUNT_FOUND; }
       set { _result_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool result_codeSpecified
+    {
+      get { return _result_code != null; }
+      set { if (value == (_result_code== null)) _result_code = value ? this.result_code : (CMsgPerfectWorldUserLookupResponse.EResultCode?)null; }
+    }
+    private bool ShouldSerializeresult_code() { return result_codeSpecified; }
+    private void Resetresult_code() { result_codeSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResultCode", EnumPassthru=true)]
     public enum EResultCode
     {
@@ -9890,32 +15670,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgNexonPartnerUpdate() {}
     
 
-    private uint _messagetype = default(uint);
+    private uint? _messagetype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"messagetype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint messagetype
     {
-      get { return _messagetype; }
+      get { return _messagetype?? default(uint); }
       set { _messagetype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messagetypeSpecified
+    {
+      get { return _messagetype != null; }
+      set { if (value == (_messagetype== null)) _messagetype = value ? this.messagetype : (uint?)null; }
+    }
+    private bool ShouldSerializemessagetype() { return messagetypeSpecified; }
+    private void Resetmessagetype() { messagetypeSpecified = false; }
+    
 
-    private uint _timeremaining = default(uint);
+    private uint? _timeremaining;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timeremaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timeremaining
     {
-      get { return _timeremaining; }
+      get { return _timeremaining?? default(uint); }
       set { _timeremaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeremainingSpecified
+    {
+      get { return _timeremaining != null; }
+      set { if (value == (_timeremaining== null)) _timeremaining = value ? this.timeremaining : (uint?)null; }
+    }
+    private bool ShouldSerializetimeremaining() { return timeremainingSpecified; }
+    private void Resettimeremaining() { timeremainingSpecified = false; }
+    
 
-    private bool _terminate = default(bool);
+    private bool? _terminate;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"terminate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool terminate
     {
-      get { return _terminate; }
+      get { return _terminate?? default(bool); }
       set { _terminate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool terminateSpecified
+    {
+      get { return _terminate != null; }
+      set { if (value == (_terminate== null)) _terminate = value ? this.terminate : (bool?)null; }
+    }
+    private bool ShouldSerializeterminate() { return terminateSpecified; }
+    private void Resetterminate() { terminateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9927,14 +15734,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgMakeOffering() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9963,37 +15779,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _completed = default(bool);
+    private bool? _completed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool completed
     {
-      get { return _completed; }
+      get { return _completed?? default(bool); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (bool?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"NewYearsOffering")]
   public partial class NewYearsOffering : global::ProtoBuf.IExtensible
   {
     public NewYearsOffering() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10010,32 +15853,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPCBangTimedReward() {}
     
 
-    private string _persona = "";
+    private string _persona;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona
     {
-      get { return _persona; }
+      get { return _persona?? ""; }
       set { _persona = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool personaSpecified
+    {
+      get { return _persona != null; }
+      set { if (value == (_persona== null)) _persona = value ? this.persona : (string)null; }
+    }
+    private bool ShouldSerializepersona() { return personaSpecified; }
+    private void Resetpersona() { personaSpecified = false; }
+    
 
-    private uint _itemdef = default(uint);
+    private uint? _itemdef;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemdef", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint itemdef
     {
-      get { return _itemdef; }
+      get { return _itemdef?? default(uint); }
       set { _itemdef = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdefSpecified
+    {
+      get { return _itemdef != null; }
+      set { if (value == (_itemdef== null)) _itemdef = value ? this.itemdef : (uint?)null; }
+    }
+    private bool ShouldSerializeitemdef() { return itemdefSpecified; }
+    private void Resetitemdef() { itemdefSpecified = false; }
+    
 
-    private string _pcbangname = "";
+    private string _pcbangname;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pcbangname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pcbangname
     {
-      get { return _pcbangname; }
+      get { return _pcbangname?? ""; }
       set { _pcbangname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pcbangnameSpecified
+    {
+      get { return _pcbangname != null; }
+      set { if (value == (_pcbangname== null)) _pcbangname = value ? this.pcbangname : (string)null; }
+    }
+    private bool ShouldSerializepcbangname() { return pcbangnameSpecified; }
+    private void Resetpcbangname() { pcbangnameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10054,46 +15924,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private bool _predictions_closed = default(bool);
+    private bool? _predictions_closed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"predictions_closed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool predictions_closed
     {
-      get { return _predictions_closed; }
+      get { return _predictions_closed?? default(bool); }
       set { _predictions_closed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool predictions_closedSpecified
+    {
+      get { return _predictions_closed != null; }
+      set { if (value == (_predictions_closed== null)) _predictions_closed = value ? this.predictions_closed : (bool?)null; }
+    }
+    private bool ShouldSerializepredictions_closed() { return predictions_closedSpecified; }
+    private void Resetpredictions_closed() { predictions_closedSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PredictionResult")]
   public partial class PredictionResult : global::ProtoBuf.IExtensible
   {
     public PredictionResult() {}
     
 
-    private uint _prediction_id = default(uint);
+    private uint? _prediction_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prediction_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_id
     {
-      get { return _prediction_id; }
+      get { return _prediction_id?? default(uint); }
       set { _prediction_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_idSpecified
+    {
+      get { return _prediction_id != null; }
+      set { if (value == (_prediction_id== null)) _prediction_id = value ? this.prediction_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_id() { return prediction_idSpecified; }
+    private void Resetprediction_id() { prediction_idSpecified = false; }
+    
 
-    private uint _prediction_value = default(uint);
+    private uint? _prediction_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prediction_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_value
     {
-      get { return _prediction_value; }
+      get { return _prediction_value?? default(uint); }
       set { _prediction_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_valueSpecified
+    {
+      get { return _prediction_value != null; }
+      set { if (value == (_prediction_value== null)) _prediction_value = value ? this.prediction_value : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_value() { return prediction_valueSpecified; }
+    private void Resetprediction_value() { prediction_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10110,14 +16016,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSelectCompendiumInGamePrediction() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCSelectCompendiumInGamePrediction.Prediction> _predictions = new global::System.Collections.Generic.List<CMsgClientToGCSelectCompendiumInGamePrediction.Prediction>();
     [global::ProtoBuf.ProtoMember(2, Name=@"predictions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCSelectCompendiumInGamePrediction.Prediction> predictions
@@ -10131,23 +16046,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Prediction() {}
     
 
-    private uint _prediction_id = default(uint);
+    private uint? _prediction_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prediction_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_id
     {
-      get { return _prediction_id; }
+      get { return _prediction_id?? default(uint); }
       set { _prediction_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_idSpecified
+    {
+      get { return _prediction_id != null; }
+      set { if (value == (_prediction_id== null)) _prediction_id = value ? this.prediction_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_id() { return prediction_idSpecified; }
+    private void Resetprediction_id() { prediction_idSpecified = false; }
+    
 
-    private uint _prediction_value = default(uint);
+    private uint? _prediction_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prediction_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_value
     {
-      get { return _prediction_value; }
+      get { return _prediction_value?? default(uint); }
       set { _prediction_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_valueSpecified
+    {
+      get { return _prediction_value != null; }
+      set { if (value == (_prediction_value== null)) _prediction_value = value ? this.prediction_value : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_value() { return prediction_valueSpecified; }
+    private void Resetprediction_value() { prediction_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10164,14 +16097,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSelectCompendiumInGamePredictionResponse() {}
     
 
-    private CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult _result = CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult.SUCCESS;
+    private CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult.SUCCESS)]
     public CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCSelectCompendiumInGamePredictionResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -10200,14 +16142,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCOpenPlayerCardPack() {}
     
 
-    private ulong _player_card_pack_item_id = default(ulong);
+    private ulong? _player_card_pack_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_card_pack_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_card_pack_item_id
     {
-      get { return _player_card_pack_item_id; }
+      get { return _player_card_pack_item_id?? default(ulong); }
       set { _player_card_pack_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_card_pack_item_idSpecified
+    {
+      get { return _player_card_pack_item_id != null; }
+      set { if (value == (_player_card_pack_item_id== null)) _player_card_pack_item_id = value ? this.player_card_pack_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_card_pack_item_id() { return player_card_pack_item_idSpecified; }
+    private void Resetplayer_card_pack_item_id() { player_card_pack_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10219,14 +16170,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCOpenPlayerCardPackResponse() {}
     
 
-    private CMsgClientToGCOpenPlayerCardPackResponse.Result _result = CMsgClientToGCOpenPlayerCardPackResponse.Result.SUCCESS;
+    private CMsgClientToGCOpenPlayerCardPackResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCOpenPlayerCardPackResponse.Result.SUCCESS)]
     public CMsgClientToGCOpenPlayerCardPackResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCOpenPlayerCardPackResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCOpenPlayerCardPackResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _player_card_item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_card_item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> player_card_item_ids
@@ -10265,14 +16225,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRecyclePlayerCard() {}
     
 
-    private ulong _player_card_item_id = default(ulong);
+    private ulong? _player_card_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_card_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_card_item_id
     {
-      get { return _player_card_item_id; }
+      get { return _player_card_item_id?? default(ulong); }
       set { _player_card_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_card_item_idSpecified
+    {
+      get { return _player_card_item_id != null; }
+      set { if (value == (_player_card_item_id== null)) _player_card_item_id = value ? this.player_card_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_card_item_id() { return player_card_item_idSpecified; }
+    private void Resetplayer_card_item_id() { player_card_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10284,23 +16253,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRecyclePlayerCardResponse() {}
     
 
-    private CMsgClientToGCRecyclePlayerCardResponse.Result _result = CMsgClientToGCRecyclePlayerCardResponse.Result.SUCCESS;
+    private CMsgClientToGCRecyclePlayerCardResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCRecyclePlayerCardResponse.Result.SUCCESS)]
     public CMsgClientToGCRecyclePlayerCardResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCRecyclePlayerCardResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCRecyclePlayerCardResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _dust_amount = default(uint);
+    private uint? _dust_amount;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"dust_amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dust_amount
     {
-      get { return _dust_amount; }
+      get { return _dust_amount?? default(uint); }
       set { _dust_amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dust_amountSpecified
+    {
+      get { return _dust_amount != null; }
+      set { if (value == (_dust_amount== null)) _dust_amount = value ? this.dust_amount : (uint?)null; }
+    }
+    private bool ShouldSerializedust_amount() { return dust_amountSpecified; }
+    private void Resetdust_amount() { dust_amountSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -10335,14 +16322,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCCreatePlayerCardPack() {}
     
 
-    private ulong _card_dust_item_id = default(ulong);
+    private ulong? _card_dust_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"card_dust_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong card_dust_item_id
     {
-      get { return _card_dust_item_id; }
+      get { return _card_dust_item_id?? default(ulong); }
       set { _card_dust_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool card_dust_item_idSpecified
+    {
+      get { return _card_dust_item_id != null; }
+      set { if (value == (_card_dust_item_id== null)) _card_dust_item_id = value ? this.card_dust_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecard_dust_item_id() { return card_dust_item_idSpecified; }
+    private void Resetcard_dust_item_id() { card_dust_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10354,14 +16350,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCCreatePlayerCardPackResponse() {}
     
 
-    private CMsgClientToGCCreatePlayerCardPackResponse.Result _result = CMsgClientToGCCreatePlayerCardPackResponse.Result.SUCCESS;
+    private CMsgClientToGCCreatePlayerCardPackResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCCreatePlayerCardPackResponse.Result.SUCCESS)]
     public CMsgClientToGCCreatePlayerCardPackResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCCreatePlayerCardPackResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCCreatePlayerCardPackResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -10393,14 +16398,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientBattlePassRollup_International2016() {}
     
 
-    private uint _battle_pass_level = default(uint);
+    private uint? _battle_pass_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"battle_pass_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint battle_pass_level
     {
-      get { return _battle_pass_level; }
+      get { return _battle_pass_level?? default(uint); }
       set { _battle_pass_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool battle_pass_levelSpecified
+    {
+      get { return _battle_pass_level != null; }
+      set { if (value == (_battle_pass_level== null)) _battle_pass_level = value ? this.battle_pass_level : (uint?)null; }
+    }
+    private bool ShouldSerializebattle_pass_level() { return battle_pass_levelSpecified; }
+    private void Resetbattle_pass_level() { battle_pass_levelSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_International2016.Questlines> _questlines = new global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_International2016.Questlines>();
     [global::ProtoBuf.ProtoMember(2, Name=@"questlines", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_International2016.Questlines> questlines
@@ -10475,50 +16489,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Questlines() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _onestar = default(uint);
+    private uint? _onestar;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"onestar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint onestar
     {
-      get { return _onestar; }
+      get { return _onestar?? default(uint); }
       set { _onestar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onestarSpecified
+    {
+      get { return _onestar != null; }
+      set { if (value == (_onestar== null)) _onestar = value ? this.onestar : (uint?)null; }
+    }
+    private bool ShouldSerializeonestar() { return onestarSpecified; }
+    private void Resetonestar() { onestarSpecified = false; }
+    
 
-    private uint _twostar = default(uint);
+    private uint? _twostar;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"twostar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint twostar
     {
-      get { return _twostar; }
+      get { return _twostar?? default(uint); }
       set { _twostar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool twostarSpecified
+    {
+      get { return _twostar != null; }
+      set { if (value == (_twostar== null)) _twostar = value ? this.twostar : (uint?)null; }
+    }
+    private bool ShouldSerializetwostar() { return twostarSpecified; }
+    private void Resettwostar() { twostarSpecified = false; }
+    
 
-    private uint _threestar = default(uint);
+    private uint? _threestar;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"threestar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threestar
     {
-      get { return _threestar; }
+      get { return _threestar?? default(uint); }
       set { _threestar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threestarSpecified
+    {
+      get { return _threestar != null; }
+      set { if (value == (_threestar== null)) _threestar = value ? this.threestar : (uint?)null; }
+    }
+    private bool ShouldSerializethreestar() { return threestarSpecified; }
+    private void Resetthreestar() { threestarSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10530,50 +16589,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Wagering() {}
     
 
-    private uint _total_wagered = default(uint);
+    private uint? _total_wagered;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total_wagered", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_wagered
     {
-      get { return _total_wagered; }
+      get { return _total_wagered?? default(uint); }
       set { _total_wagered = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_wageredSpecified
+    {
+      get { return _total_wagered != null; }
+      set { if (value == (_total_wagered== null)) _total_wagered = value ? this.total_wagered : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_wagered() { return total_wageredSpecified; }
+    private void Resettotal_wagered() { total_wageredSpecified = false; }
+    
 
-    private uint _total_won = default(uint);
+    private uint? _total_won;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_won
     {
-      get { return _total_won; }
+      get { return _total_won?? default(uint); }
       set { _total_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_wonSpecified
+    {
+      get { return _total_won != null; }
+      set { if (value == (_total_won== null)) _total_won = value ? this.total_won : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_won() { return total_wonSpecified; }
+    private void Resettotal_won() { total_wonSpecified = false; }
+    
 
-    private uint _average_won = default(uint);
+    private uint? _average_won;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"average_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint average_won
     {
-      get { return _average_won; }
+      get { return _average_won?? default(uint); }
       set { _average_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_wonSpecified
+    {
+      get { return _average_won != null; }
+      set { if (value == (_average_won== null)) _average_won = value ? this.average_won : (uint?)null; }
+    }
+    private bool ShouldSerializeaverage_won() { return average_wonSpecified; }
+    private void Resetaverage_won() { average_wonSpecified = false; }
+    
 
-    private uint _success_rate = default(uint);
+    private uint? _success_rate;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"success_rate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint success_rate
     {
-      get { return _success_rate; }
+      get { return _success_rate?? default(uint); }
       set { _success_rate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool success_rateSpecified
+    {
+      get { return _success_rate != null; }
+      set { if (value == (_success_rate== null)) _success_rate = value ? this.success_rate : (uint?)null; }
+    }
+    private bool ShouldSerializesuccess_rate() { return success_rateSpecified; }
+    private void Resetsuccess_rate() { success_rateSpecified = false; }
+    
 
-    private uint _total_tips = default(uint);
+    private uint? _total_tips;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"total_tips", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_tips
     {
-      get { return _total_tips; }
+      get { return _total_tips?? default(uint); }
       set { _total_tips = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_tipsSpecified
+    {
+      get { return _total_tips != null; }
+      set { if (value == (_total_tips== null)) _total_tips = value ? this.total_tips : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_tips() { return total_tipsSpecified; }
+    private void Resettotal_tips() { total_tipsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10585,32 +16689,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Achievements() {}
     
 
-    private uint _completed = default(uint);
+    private uint? _completed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint completed
     {
-      get { return _completed; }
+      get { return _completed?? default(uint); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (uint?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10622,23 +16753,41 @@ namespace SteamKit2.GC.Dota.Internal
     public BattleCup() {}
     
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10650,32 +16799,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Predictions() {}
     
 
-    private uint _correct = default(uint);
+    private uint? _correct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"correct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint correct
     {
-      get { return _correct; }
+      get { return _correct?? default(uint); }
       set { _correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctSpecified
+    {
+      get { return _correct != null; }
+      set { if (value == (_correct== null)) _correct = value ? this.correct : (uint?)null; }
+    }
+    private bool ShouldSerializecorrect() { return correctSpecified; }
+    private void Resetcorrect() { correctSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10687,23 +16863,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Bracket() {}
     
 
-    private uint _correct = default(uint);
+    private uint? _correct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"correct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint correct
     {
-      get { return _correct; }
+      get { return _correct?? default(uint); }
       set { _correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctSpecified
+    {
+      get { return _correct != null; }
+      set { if (value == (_correct== null)) _correct = value ? this.correct : (uint?)null; }
+    }
+    private bool ShouldSerializecorrect() { return correctSpecified; }
+    private void Resetcorrect() { correctSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10715,23 +16909,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerCard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10743,23 +16955,41 @@ namespace SteamKit2.GC.Dota.Internal
     public FantasyChallenge() {}
     
 
-    private float _total_score = default(float);
+    private float? _total_score;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float total_score
     {
-      get { return _total_score; }
+      get { return _total_score?? default(float); }
       set { _total_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_scoreSpecified
+    {
+      get { return _total_score != null; }
+      set { if (value == (_total_score== null)) _total_score = value ? this.total_score : (float?)null; }
+    }
+    private bool ShouldSerializetotal_score() { return total_scoreSpecified; }
+    private void Resettotal_score() { total_scoreSpecified = false; }
+    
 
-    private float _percentile = default(float);
+    private float? _percentile;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"percentile", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float percentile
     {
-      get { return _percentile; }
+      get { return _percentile?? default(float); }
       set { _percentile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool percentileSpecified
+    {
+      get { return _percentile != null; }
+      set { if (value == (_percentile== null)) _percentile = value ? this.percentile : (float?)null; }
+    }
+    private bool ShouldSerializepercentile() { return percentileSpecified; }
+    private void Resetpercentile() { percentileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10776,14 +17006,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientBattlePassRollup_Fall2016() {}
     
 
-    private uint _battle_pass_level = default(uint);
+    private uint? _battle_pass_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"battle_pass_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint battle_pass_level
     {
-      get { return _battle_pass_level; }
+      get { return _battle_pass_level?? default(uint); }
       set { _battle_pass_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool battle_pass_levelSpecified
+    {
+      get { return _battle_pass_level != null; }
+      set { if (value == (_battle_pass_level== null)) _battle_pass_level = value ? this.battle_pass_level : (uint?)null; }
+    }
+    private bool ShouldSerializebattle_pass_level() { return battle_pass_levelSpecified; }
+    private void Resetbattle_pass_level() { battle_pass_levelSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_Fall2016.Questlines> _questlines = new global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_Fall2016.Questlines>();
     [global::ProtoBuf.ProtoMember(2, Name=@"questlines", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientBattlePassRollup_Fall2016.Questlines> questlines
@@ -10858,50 +17097,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Questlines() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _onestar = default(uint);
+    private uint? _onestar;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"onestar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint onestar
     {
-      get { return _onestar; }
+      get { return _onestar?? default(uint); }
       set { _onestar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onestarSpecified
+    {
+      get { return _onestar != null; }
+      set { if (value == (_onestar== null)) _onestar = value ? this.onestar : (uint?)null; }
+    }
+    private bool ShouldSerializeonestar() { return onestarSpecified; }
+    private void Resetonestar() { onestarSpecified = false; }
+    
 
-    private uint _twostar = default(uint);
+    private uint? _twostar;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"twostar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint twostar
     {
-      get { return _twostar; }
+      get { return _twostar?? default(uint); }
       set { _twostar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool twostarSpecified
+    {
+      get { return _twostar != null; }
+      set { if (value == (_twostar== null)) _twostar = value ? this.twostar : (uint?)null; }
+    }
+    private bool ShouldSerializetwostar() { return twostarSpecified; }
+    private void Resettwostar() { twostarSpecified = false; }
+    
 
-    private uint _threestar = default(uint);
+    private uint? _threestar;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"threestar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threestar
     {
-      get { return _threestar; }
+      get { return _threestar?? default(uint); }
       set { _threestar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threestarSpecified
+    {
+      get { return _threestar != null; }
+      set { if (value == (_threestar== null)) _threestar = value ? this.threestar : (uint?)null; }
+    }
+    private bool ShouldSerializethreestar() { return threestarSpecified; }
+    private void Resetthreestar() { threestarSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10913,50 +17197,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Wagering() {}
     
 
-    private uint _total_wagered = default(uint);
+    private uint? _total_wagered;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total_wagered", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_wagered
     {
-      get { return _total_wagered; }
+      get { return _total_wagered?? default(uint); }
       set { _total_wagered = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_wageredSpecified
+    {
+      get { return _total_wagered != null; }
+      set { if (value == (_total_wagered== null)) _total_wagered = value ? this.total_wagered : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_wagered() { return total_wageredSpecified; }
+    private void Resettotal_wagered() { total_wageredSpecified = false; }
+    
 
-    private uint _total_won = default(uint);
+    private uint? _total_won;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_won
     {
-      get { return _total_won; }
+      get { return _total_won?? default(uint); }
       set { _total_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_wonSpecified
+    {
+      get { return _total_won != null; }
+      set { if (value == (_total_won== null)) _total_won = value ? this.total_won : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_won() { return total_wonSpecified; }
+    private void Resettotal_won() { total_wonSpecified = false; }
+    
 
-    private uint _average_won = default(uint);
+    private uint? _average_won;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"average_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint average_won
     {
-      get { return _average_won; }
+      get { return _average_won?? default(uint); }
       set { _average_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_wonSpecified
+    {
+      get { return _average_won != null; }
+      set { if (value == (_average_won== null)) _average_won = value ? this.average_won : (uint?)null; }
+    }
+    private bool ShouldSerializeaverage_won() { return average_wonSpecified; }
+    private void Resetaverage_won() { average_wonSpecified = false; }
+    
 
-    private uint _success_rate = default(uint);
+    private uint? _success_rate;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"success_rate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint success_rate
     {
-      get { return _success_rate; }
+      get { return _success_rate?? default(uint); }
       set { _success_rate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool success_rateSpecified
+    {
+      get { return _success_rate != null; }
+      set { if (value == (_success_rate== null)) _success_rate = value ? this.success_rate : (uint?)null; }
+    }
+    private bool ShouldSerializesuccess_rate() { return success_rateSpecified; }
+    private void Resetsuccess_rate() { success_rateSpecified = false; }
+    
 
-    private uint _total_tips = default(uint);
+    private uint? _total_tips;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"total_tips", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_tips
     {
-      get { return _total_tips; }
+      get { return _total_tips?? default(uint); }
       set { _total_tips = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_tipsSpecified
+    {
+      get { return _total_tips != null; }
+      set { if (value == (_total_tips== null)) _total_tips = value ? this.total_tips : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_tips() { return total_tipsSpecified; }
+    private void Resettotal_tips() { total_tipsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -10968,32 +17297,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Achievements() {}
     
 
-    private uint _completed = default(uint);
+    private uint? _completed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint completed
     {
-      get { return _completed; }
+      get { return _completed?? default(uint); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (uint?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11005,23 +17361,41 @@ namespace SteamKit2.GC.Dota.Internal
     public BattleCup() {}
     
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11033,32 +17407,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Predictions() {}
     
 
-    private uint _correct = default(uint);
+    private uint? _correct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"correct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint correct
     {
-      get { return _correct; }
+      get { return _correct?? default(uint); }
       set { _correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctSpecified
+    {
+      get { return _correct != null; }
+      set { if (value == (_correct== null)) _correct = value ? this.correct : (uint?)null; }
+    }
+    private bool ShouldSerializecorrect() { return correctSpecified; }
+    private void Resetcorrect() { correctSpecified = false; }
+    
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11070,23 +17471,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Bracket() {}
     
 
-    private uint _correct = default(uint);
+    private uint? _correct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"correct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint correct
     {
-      get { return _correct; }
+      get { return _correct?? default(uint); }
       set { _correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctSpecified
+    {
+      get { return _correct != null; }
+      set { if (value == (_correct== null)) _correct = value ? this.correct : (uint?)null; }
+    }
+    private bool ShouldSerializecorrect() { return correctSpecified; }
+    private void Resetcorrect() { correctSpecified = false; }
+    
 
-    private uint _points = default(uint);
+    private uint? _points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points
     {
-      get { return _points; }
+      get { return _points?? default(uint); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (uint?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11098,23 +17517,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerCard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11126,23 +17563,41 @@ namespace SteamKit2.GC.Dota.Internal
     public FantasyChallenge() {}
     
 
-    private float _total_score = default(float);
+    private float? _total_score;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float total_score
     {
-      get { return _total_score; }
+      get { return _total_score?? default(float); }
       set { _total_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_scoreSpecified
+    {
+      get { return _total_score != null; }
+      set { if (value == (_total_score== null)) _total_score = value ? this.total_score : (float?)null; }
+    }
+    private bool ShouldSerializetotal_score() { return total_scoreSpecified; }
+    private void Resettotal_score() { total_scoreSpecified = false; }
+    
 
-    private float _percentile = default(float);
+    private float? _percentile;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"percentile", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float percentile
     {
-      get { return _percentile; }
+      get { return _percentile?? default(float); }
       set { _percentile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool percentileSpecified
+    {
+      get { return _percentile != null; }
+      set { if (value == (_percentile== null)) _percentile = value ? this.percentile : (float?)null; }
+    }
+    private bool ShouldSerializepercentile() { return percentileSpecified; }
+    private void Resetpercentile() { percentileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11159,23 +17614,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientBattlePassRollupRequest() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11215,14 +17688,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientBattlePassRollupListRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11251,14 +17733,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCTransferSeasonalMMRRequest() {}
     
 
-    private bool _is_party = default(bool);
+    private bool? _is_party;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_party", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_party
     {
-      get { return _is_party; }
+      get { return _is_party?? default(bool); }
       set { _is_party = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_partySpecified
+    {
+      get { return _is_party != null; }
+      set { if (value == (_is_party== null)) _is_party = value ? this.is_party : (bool?)null; }
+    }
+    private bool ShouldSerializeis_party() { return is_partySpecified; }
+    private void Resetis_party() { is_partySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11270,14 +17761,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCTransferSeasonalMMRResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11289,14 +17789,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPlaytestStatus() {}
     
 
-    private bool _active = default(bool);
+    private bool? _active;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"active", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool active
     {
-      get { return _active; }
+      get { return _active?? default(bool); }
       set { _active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activeSpecified
+    {
+      get { return _active != null; }
+      set { if (value == (_active== null)) _active = value ? this.active : (bool?)null; }
+    }
+    private bool ShouldSerializeactive() { return activeSpecified; }
+    private void Resetactive() { activeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11308,14 +17817,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCJoinPlaytest() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11327,14 +17845,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCJoinPlaytestResponse() {}
     
 
-    private string _error = "";
+    private string _error;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"error", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error
     {
-      get { return _error; }
+      get { return _error?? ""; }
       set { _error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorSpecified
+    {
+      get { return _error != null; }
+      set { if (value == (_error== null)) _error = value ? this.error : (string)null; }
+    }
+    private bool ShouldSerializeerror() { return errorSpecified; }
+    private void Reseterror() { errorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11358,41 +17885,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Team() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private uint _announcement_date = default(uint);
+    private uint? _announcement_date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"announcement_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint announcement_date
     {
-      get { return _announcement_date; }
+      get { return _announcement_date?? default(uint); }
       set { _announcement_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool announcement_dateSpecified
+    {
+      get { return _announcement_date != null; }
+      set { if (value == (_announcement_date== null)) _announcement_date = value ? this.announcement_date : (uint?)null; }
+    }
+    private bool ShouldSerializeannouncement_date() { return announcement_dateSpecified; }
+    private void Resetannouncement_date() { announcement_dateSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private uint _invite_type = default(uint);
+    private uint? _invite_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"invite_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint invite_type
     {
-      get { return _invite_type; }
+      get { return _invite_type?? default(uint); }
       set { _invite_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invite_typeSpecified
+    {
+      get { return _invite_type != null; }
+      set { if (value == (_invite_type== null)) _invite_type = value ? this.invite_type : (uint?)null; }
+    }
+    private bool ShouldSerializeinvite_type() { return invite_typeSpecified; }
+    private void Resetinvite_type() { invite_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -11409,14 +17972,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetFavoriteTeam() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientChat.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientChat.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_chat.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPrivateChatInvite() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
 
-    private uint _invited_account_id = default(uint);
+    private uint? _invited_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"invited_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint invited_account_id
     {
-      get { return _invited_account_id; }
+      get { return _invited_account_id?? default(uint); }
       set { _invited_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invited_account_idSpecified
+    {
+      get { return _invited_account_id != null; }
+      set { if (value == (_invited_account_id== null)) _invited_account_id = value ? this.invited_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeinvited_account_id() { return invited_account_idSpecified; }
+    private void Resetinvited_account_id() { invited_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,23 +66,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPrivateChatKick() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
 
-    private uint _kick_account_id = default(uint);
+    private uint? _kick_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"kick_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kick_account_id
     {
-      get { return _kick_account_id; }
+      get { return _kick_account_id?? default(uint); }
       set { _kick_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kick_account_idSpecified
+    {
+      get { return _kick_account_id != null; }
+      set { if (value == (_kick_account_id== null)) _kick_account_id = value ? this.kick_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekick_account_id() { return kick_account_idSpecified; }
+    private void Resetkick_account_id() { kick_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -74,23 +112,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPrivateChatPromote() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
 
-    private uint _promote_account_id = default(uint);
+    private uint? _promote_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"promote_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint promote_account_id
     {
-      get { return _promote_account_id; }
+      get { return _promote_account_id?? default(uint); }
       set { _promote_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool promote_account_idSpecified
+    {
+      get { return _promote_account_id != null; }
+      set { if (value == (_promote_account_id== null)) _promote_account_id = value ? this.promote_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializepromote_account_id() { return promote_account_idSpecified; }
+    private void Resetpromote_account_id() { promote_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -102,23 +158,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPrivateChatDemote() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
 
-    private uint _demote_account_id = default(uint);
+    private uint? _demote_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"demote_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint demote_account_id
     {
-      get { return _demote_account_id; }
+      get { return _demote_account_id?? default(uint); }
       set { _demote_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool demote_account_idSpecified
+    {
+      get { return _demote_account_id != null; }
+      set { if (value == (_demote_account_id== null)) _demote_account_id = value ? this.demote_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializedemote_account_id() { return demote_account_idSpecified; }
+    private void Resetdemote_account_id() { demote_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -130,32 +204,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPrivateChatResponse() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
 
-    private CMsgGCToClientPrivateChatResponse.Result _result = CMsgGCToClientPrivateChatResponse.Result.SUCCESS;
+    private CMsgGCToClientPrivateChatResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCToClientPrivateChatResponse.Result.SUCCESS)]
     public CMsgGCToClientPrivateChatResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgGCToClientPrivateChatResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGCToClientPrivateChatResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _username = "";
+    private string _username;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"username", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string username
     {
-      get { return _username; }
+      get { return _username?? ""; }
       set { _username = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usernameSpecified
+    {
+      get { return _username != null; }
+      set { if (value == (_username== null)) _username = value ? this.username : (string)null; }
+    }
+    private bool ShouldSerializeusername() { return usernameSpecified; }
+    private void Resetusername() { usernameSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -217,14 +318,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCPrivateChatInfoRequest() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -236,14 +346,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPrivateChatInfoResponse() {}
     
 
-    private string _private_chat_channel_name = "";
+    private string _private_chat_channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"private_chat_channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string private_chat_channel_name
     {
-      get { return _private_chat_channel_name; }
+      get { return _private_chat_channel_name?? ""; }
       set { _private_chat_channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_nameSpecified
+    {
+      get { return _private_chat_channel_name != null; }
+      set { if (value == (_private_chat_channel_name== null)) _private_chat_channel_name = value ? this.private_chat_channel_name : (string)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_name() { return private_chat_channel_nameSpecified; }
+    private void Resetprivate_chat_channel_name() { private_chat_channel_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToClientPrivateChatInfoResponse.Member> _members = new global::System.Collections.Generic.List<CMsgGCToClientPrivateChatInfoResponse.Member>();
     [global::ProtoBuf.ProtoMember(2, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToClientPrivateChatInfoResponse.Member> members
@@ -252,55 +371,100 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _creator = default(uint);
+    private uint? _creator;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"creator", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creator
     {
-      get { return _creator; }
+      get { return _creator?? default(uint); }
       set { _creator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creatorSpecified
+    {
+      get { return _creator != null; }
+      set { if (value == (_creator== null)) _creator = value ? this.creator : (uint?)null; }
+    }
+    private bool ShouldSerializecreator() { return creatorSpecified; }
+    private void Resetcreator() { creatorSpecified = false; }
+    
 
-    private uint _creation_date = default(uint);
+    private uint? _creation_date;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"creation_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creation_date
     {
-      get { return _creation_date; }
+      get { return _creation_date?? default(uint); }
       set { _creation_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creation_dateSpecified
+    {
+      get { return _creation_date != null; }
+      set { if (value == (_creation_date== null)) _creation_date = value ? this.creation_date : (uint?)null; }
+    }
+    private bool ShouldSerializecreation_date() { return creation_dateSpecified; }
+    private void Resetcreation_date() { creation_dateSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Member")]
   public partial class Member : global::ProtoBuf.IExtensible
   {
     public Member() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -317,23 +481,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAJoinChatChannel() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private DOTAChatChannelType_t _channel_type = DOTAChatChannelType_t.DOTAChannelType_Regional;
+    private DOTAChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAChatChannelType_t.DOTAChannelType_Regional)]
     public DOTAChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? DOTAChatChannelType_t.DOTAChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (DOTAChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -345,14 +527,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeaveChatChannel() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -364,23 +555,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCChatReportPublicSpam() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -392,14 +601,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAClientIgnoredUser() {}
     
 
-    private uint _ignored_account_id = default(uint);
+    private uint? _ignored_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ignored_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ignored_account_id
     {
-      get { return _ignored_account_id; }
+      get { return _ignored_account_id?? default(uint); }
       set { _ignored_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ignored_account_idSpecified
+    {
+      get { return _ignored_account_id != null; }
+      set { if (value == (_ignored_account_id== null)) _ignored_account_id = value ? this.ignored_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeignored_account_id() { return ignored_account_idSpecified; }
+    private void Resetignored_account_id() { ignored_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -411,149 +629,293 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatMessage() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _suggest_invite_account_id = default(uint);
+    private uint? _suggest_invite_account_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"suggest_invite_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suggest_invite_account_id
     {
-      get { return _suggest_invite_account_id; }
+      get { return _suggest_invite_account_id?? default(uint); }
       set { _suggest_invite_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suggest_invite_account_idSpecified
+    {
+      get { return _suggest_invite_account_id != null; }
+      set { if (value == (_suggest_invite_account_id== null)) _suggest_invite_account_id = value ? this.suggest_invite_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializesuggest_invite_account_id() { return suggest_invite_account_idSpecified; }
+    private void Resetsuggest_invite_account_id() { suggest_invite_account_idSpecified = false; }
+    
 
-    private string _suggest_invite_name = "";
+    private string _suggest_invite_name;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"suggest_invite_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string suggest_invite_name
     {
-      get { return _suggest_invite_name; }
+      get { return _suggest_invite_name?? ""; }
       set { _suggest_invite_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suggest_invite_nameSpecified
+    {
+      get { return _suggest_invite_name != null; }
+      set { if (value == (_suggest_invite_name== null)) _suggest_invite_name = value ? this.suggest_invite_name : (string)null; }
+    }
+    private bool ShouldSerializesuggest_invite_name() { return suggest_invite_nameSpecified; }
+    private void Resetsuggest_invite_name() { suggest_invite_nameSpecified = false; }
+    
 
-    private uint _fantasy_draft_owner_account_id = default(uint);
+    private uint? _fantasy_draft_owner_account_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"fantasy_draft_owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_draft_owner_account_id
     {
-      get { return _fantasy_draft_owner_account_id; }
+      get { return _fantasy_draft_owner_account_id?? default(uint); }
       set { _fantasy_draft_owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_draft_owner_account_idSpecified
+    {
+      get { return _fantasy_draft_owner_account_id != null; }
+      set { if (value == (_fantasy_draft_owner_account_id== null)) _fantasy_draft_owner_account_id = value ? this.fantasy_draft_owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_draft_owner_account_id() { return fantasy_draft_owner_account_idSpecified; }
+    private void Resetfantasy_draft_owner_account_id() { fantasy_draft_owner_account_idSpecified = false; }
+    
 
-    private uint _fantasy_draft_player_account_id = default(uint);
+    private uint? _fantasy_draft_player_account_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"fantasy_draft_player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_draft_player_account_id
     {
-      get { return _fantasy_draft_player_account_id; }
+      get { return _fantasy_draft_player_account_id?? default(uint); }
       set { _fantasy_draft_player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_draft_player_account_idSpecified
+    {
+      get { return _fantasy_draft_player_account_id != null; }
+      set { if (value == (_fantasy_draft_player_account_id== null)) _fantasy_draft_player_account_id = value ? this.fantasy_draft_player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_draft_player_account_id() { return fantasy_draft_player_account_idSpecified; }
+    private void Resetfantasy_draft_player_account_id() { fantasy_draft_player_account_idSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private bool _suggest_invite_to_lobby = default(bool);
+    private bool? _suggest_invite_to_lobby;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"suggest_invite_to_lobby", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool suggest_invite_to_lobby
     {
-      get { return _suggest_invite_to_lobby; }
+      get { return _suggest_invite_to_lobby?? default(bool); }
       set { _suggest_invite_to_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suggest_invite_to_lobbySpecified
+    {
+      get { return _suggest_invite_to_lobby != null; }
+      set { if (value == (_suggest_invite_to_lobby== null)) _suggest_invite_to_lobby = value ? this.suggest_invite_to_lobby : (bool?)null; }
+    }
+    private bool ShouldSerializesuggest_invite_to_lobby() { return suggest_invite_to_lobbySpecified; }
+    private void Resetsuggest_invite_to_lobby() { suggest_invite_to_lobbySpecified = false; }
+    
 
-    private uint _event_points = default(uint);
+    private uint? _event_points;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"event_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_points
     {
-      get { return _event_points; }
+      get { return _event_points?? default(uint); }
       set { _event_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_pointsSpecified
+    {
+      get { return _event_points != null; }
+      set { if (value == (_event_points== null)) _event_points = value ? this.event_points : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_points() { return event_pointsSpecified; }
+    private void Resetevent_points() { event_pointsSpecified = false; }
+    
 
-    private bool _coin_flip = default(bool);
+    private bool? _coin_flip;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"coin_flip", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool coin_flip
     {
-      get { return _coin_flip; }
+      get { return _coin_flip?? default(bool); }
       set { _coin_flip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coin_flipSpecified
+    {
+      get { return _coin_flip != null; }
+      set { if (value == (_coin_flip== null)) _coin_flip = value ? this.coin_flip : (bool?)null; }
+    }
+    private bool ShouldSerializecoin_flip() { return coin_flipSpecified; }
+    private void Resetcoin_flip() { coin_flipSpecified = false; }
+    
 
-    private int _player_id = (int)-1;
+    private int? _player_id;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)-1)]
     public int player_id
     {
-      get { return _player_id; }
+      get { return _player_id?? (int)-1; }
       set { _player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_idSpecified
+    {
+      get { return _player_id != null; }
+      set { if (value == (_player_id== null)) _player_id = value ? this.player_id : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_id() { return player_idSpecified; }
+    private void Resetplayer_id() { player_idSpecified = false; }
+    
 
-    private uint _share_profile_account_id = default(uint);
+    private uint? _share_profile_account_id;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"share_profile_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint share_profile_account_id
     {
-      get { return _share_profile_account_id; }
+      get { return _share_profile_account_id?? default(uint); }
       set { _share_profile_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool share_profile_account_idSpecified
+    {
+      get { return _share_profile_account_id != null; }
+      set { if (value == (_share_profile_account_id== null)) _share_profile_account_id = value ? this.share_profile_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeshare_profile_account_id() { return share_profile_account_idSpecified; }
+    private void Resetshare_profile_account_id() { share_profile_account_idSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
     private CMsgDOTAChatMessage.DiceRoll _dice_roll = null;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"dice_roll", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -564,145 +926,280 @@ namespace SteamKit2.GC.Dota.Internal
       set { _dice_roll = value; }
     }
 
-    private ulong _share_party_id = default(ulong);
+    private ulong? _share_party_id;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"share_party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong share_party_id
     {
-      get { return _share_party_id; }
+      get { return _share_party_id?? default(ulong); }
       set { _share_party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool share_party_idSpecified
+    {
+      get { return _share_party_id != null; }
+      set { if (value == (_share_party_id== null)) _share_party_id = value ? this.share_party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeshare_party_id() { return share_party_idSpecified; }
+    private void Resetshare_party_id() { share_party_idSpecified = false; }
+    
 
-    private ulong _share_lobby_id = default(ulong);
+    private ulong? _share_lobby_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"share_lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong share_lobby_id
     {
-      get { return _share_lobby_id; }
+      get { return _share_lobby_id?? default(ulong); }
       set { _share_lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool share_lobby_idSpecified
+    {
+      get { return _share_lobby_id != null; }
+      set { if (value == (_share_lobby_id== null)) _share_lobby_id = value ? this.share_lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeshare_lobby_id() { return share_lobby_idSpecified; }
+    private void Resetshare_lobby_id() { share_lobby_idSpecified = false; }
+    
 
-    private ulong _share_lobby_custom_game_id = default(ulong);
+    private ulong? _share_lobby_custom_game_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"share_lobby_custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong share_lobby_custom_game_id
     {
-      get { return _share_lobby_custom_game_id; }
+      get { return _share_lobby_custom_game_id?? default(ulong); }
       set { _share_lobby_custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool share_lobby_custom_game_idSpecified
+    {
+      get { return _share_lobby_custom_game_id != null; }
+      set { if (value == (_share_lobby_custom_game_id== null)) _share_lobby_custom_game_id = value ? this.share_lobby_custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeshare_lobby_custom_game_id() { return share_lobby_custom_game_idSpecified; }
+    private void Resetshare_lobby_custom_game_id() { share_lobby_custom_game_idSpecified = false; }
+    
 
-    private string _share_lobby_passkey = "";
+    private string _share_lobby_passkey;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"share_lobby_passkey", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string share_lobby_passkey
     {
-      get { return _share_lobby_passkey; }
+      get { return _share_lobby_passkey?? ""; }
       set { _share_lobby_passkey = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool share_lobby_passkeySpecified
+    {
+      get { return _share_lobby_passkey != null; }
+      set { if (value == (_share_lobby_passkey== null)) _share_lobby_passkey = value ? this.share_lobby_passkey : (string)null; }
+    }
+    private bool ShouldSerializeshare_lobby_passkey() { return share_lobby_passkeySpecified; }
+    private void Resetshare_lobby_passkey() { share_lobby_passkeySpecified = false; }
+    
 
-    private uint _private_chat_channel_id = default(uint);
+    private uint? _private_chat_channel_id;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"private_chat_channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint private_chat_channel_id
     {
-      get { return _private_chat_channel_id; }
+      get { return _private_chat_channel_id?? default(uint); }
       set { _private_chat_channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_chat_channel_idSpecified
+    {
+      get { return _private_chat_channel_id != null; }
+      set { if (value == (_private_chat_channel_id== null)) _private_chat_channel_id = value ? this.private_chat_channel_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprivate_chat_channel_id() { return private_chat_channel_idSpecified; }
+    private void Resetprivate_chat_channel_id() { private_chat_channel_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private bool _legacy_battle_cup_victory = default(bool);
+    private bool? _legacy_battle_cup_victory;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"legacy_battle_cup_victory", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool legacy_battle_cup_victory
     {
-      get { return _legacy_battle_cup_victory; }
+      get { return _legacy_battle_cup_victory?? default(bool); }
       set { _legacy_battle_cup_victory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_battle_cup_victorySpecified
+    {
+      get { return _legacy_battle_cup_victory != null; }
+      set { if (value == (_legacy_battle_cup_victory== null)) _legacy_battle_cup_victory = value ? this.legacy_battle_cup_victory : (bool?)null; }
+    }
+    private bool ShouldSerializelegacy_battle_cup_victory() { return legacy_battle_cup_victorySpecified; }
+    private void Resetlegacy_battle_cup_victory() { legacy_battle_cup_victorySpecified = false; }
+    
 
-    private uint _battle_cup_streak = default(uint);
+    private uint? _battle_cup_streak;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"battle_cup_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint battle_cup_streak
     {
-      get { return _battle_cup_streak; }
+      get { return _battle_cup_streak?? default(uint); }
       set { _battle_cup_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool battle_cup_streakSpecified
+    {
+      get { return _battle_cup_streak != null; }
+      set { if (value == (_battle_cup_streak== null)) _battle_cup_streak = value ? this.battle_cup_streak : (uint?)null; }
+    }
+    private bool ShouldSerializebattle_cup_streak() { return battle_cup_streakSpecified; }
+    private void Resetbattle_cup_streak() { battle_cup_streakSpecified = false; }
+    
 
-    private uint _badge_level = default(uint);
+    private uint? _badge_level;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"badge_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_level
     {
-      get { return _badge_level; }
+      get { return _badge_level?? default(uint); }
       set { _badge_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_levelSpecified
+    {
+      get { return _badge_level != null; }
+      set { if (value == (_badge_level== null)) _badge_level = value ? this.badge_level : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_level() { return badge_levelSpecified; }
+    private void Resetbadge_level() { badge_levelSpecified = false; }
+    
 
-    private uint _suggest_pick_hero_id = default(uint);
+    private uint? _suggest_pick_hero_id;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"suggest_pick_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suggest_pick_hero_id
     {
-      get { return _suggest_pick_hero_id; }
+      get { return _suggest_pick_hero_id?? default(uint); }
       set { _suggest_pick_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suggest_pick_hero_idSpecified
+    {
+      get { return _suggest_pick_hero_id != null; }
+      set { if (value == (_suggest_pick_hero_id== null)) _suggest_pick_hero_id = value ? this.suggest_pick_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializesuggest_pick_hero_id() { return suggest_pick_hero_idSpecified; }
+    private void Resetsuggest_pick_hero_id() { suggest_pick_hero_idSpecified = false; }
+    
 
-    private string _suggest_pick_hero_role = "";
+    private string _suggest_pick_hero_role;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"suggest_pick_hero_role", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string suggest_pick_hero_role
     {
-      get { return _suggest_pick_hero_role; }
+      get { return _suggest_pick_hero_role?? ""; }
       set { _suggest_pick_hero_role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suggest_pick_hero_roleSpecified
+    {
+      get { return _suggest_pick_hero_role != null; }
+      set { if (value == (_suggest_pick_hero_role== null)) _suggest_pick_hero_role = value ? this.suggest_pick_hero_role : (string)null; }
+    }
+    private bool ShouldSerializesuggest_pick_hero_role() { return suggest_pick_hero_roleSpecified; }
+    private void Resetsuggest_pick_hero_role() { suggest_pick_hero_roleSpecified = false; }
+    
 
-    private bool _terse = default(bool);
+    private bool? _terse;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"terse", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool terse
     {
-      get { return _terse; }
+      get { return _terse?? default(bool); }
       set { _terse = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool terseSpecified
+    {
+      get { return _terse != null; }
+      set { if (value == (_terse== null)) _terse = value ? this.terse : (bool?)null; }
+    }
+    private bool ShouldSerializeterse() { return terseSpecified; }
+    private void Resetterse() { terseSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"DiceRoll")]
   public partial class DiceRoll : global::ProtoBuf.IExtensible
   {
     public DiceRoll() {}
     
 
-    private int _roll_min = default(int);
+    private int? _roll_min;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"roll_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int roll_min
     {
-      get { return _roll_min; }
+      get { return _roll_min?? default(int); }
       set { _roll_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roll_minSpecified
+    {
+      get { return _roll_min != null; }
+      set { if (value == (_roll_min== null)) _roll_min = value ? this.roll_min : (int?)null; }
+    }
+    private bool ShouldSerializeroll_min() { return roll_minSpecified; }
+    private void Resetroll_min() { roll_minSpecified = false; }
+    
 
-    private int _roll_max = default(int);
+    private int? _roll_max;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"roll_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int roll_max
     {
-      get { return _roll_max; }
+      get { return _roll_max?? default(int); }
       set { _roll_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roll_maxSpecified
+    {
+      get { return _roll_max != null; }
+      set { if (value == (_roll_max== null)) _roll_max = value ? this.roll_max : (int?)null; }
+    }
+    private bool ShouldSerializeroll_max() { return roll_maxSpecified; }
+    private void Resetroll_max() { roll_maxSpecified = false; }
+    
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -719,41 +1216,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatMember() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -765,41 +1298,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAJoinChatChannelResponse() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private uint _max_members = default(uint);
+    private uint? _max_members;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(uint); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (uint?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAChatMember> _members = new global::System.Collections.Generic.List<CMsgDOTAChatMember>();
     [global::ProtoBuf.ProtoMember(5, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAChatMember> members
@@ -808,50 +1377,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private DOTAChatChannelType_t _channel_type = DOTAChatChannelType_t.DOTAChannelType_Regional;
+    private DOTAChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAChatChannelType_t.DOTAChannelType_Regional)]
     public DOTAChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? DOTAChatChannelType_t.DOTAChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (DOTAChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
 
-    private CMsgDOTAJoinChatChannelResponse.Result _result = CMsgDOTAJoinChatChannelResponse.Result.JOIN_SUCCESS;
+    private CMsgDOTAJoinChatChannelResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAJoinChatChannelResponse.Result.JOIN_SUCCESS)]
     public CMsgDOTAJoinChatChannelResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAJoinChatChannelResponse.Result.JOIN_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAJoinChatChannelResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private bool _gc_initiated_join = default(bool);
+    private bool? _gc_initiated_join;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"gc_initiated_join", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool gc_initiated_join
     {
-      get { return _gc_initiated_join; }
+      get { return _gc_initiated_join?? default(bool); }
       set { _gc_initiated_join = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_initiated_joinSpecified
+    {
+      get { return _gc_initiated_join != null; }
+      set { if (value == (_gc_initiated_join== null)) _gc_initiated_join = value ? this.gc_initiated_join : (bool?)null; }
+    }
+    private bool ShouldSerializegc_initiated_join() { return gc_initiated_joinSpecified; }
+    private void Resetgc_initiated_join() { gc_initiated_joinSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
-    private string _welcome_message = "";
+    private string _welcome_message;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"welcome_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string welcome_message
     {
-      get { return _welcome_message; }
+      get { return _welcome_message?? ""; }
       set { _welcome_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool welcome_messageSpecified
+    {
+      get { return _welcome_message != null; }
+      set { if (value == (_welcome_message== null)) _welcome_message = value ? this.welcome_message : (string)null; }
+    }
+    private bool ShouldSerializewelcome_message() { return welcome_messageSpecified; }
+    private void Resetwelcome_message() { welcome_messageSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -910,14 +1524,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatChannelFullUpdate() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAChatMember> _members = new global::System.Collections.Generic.List<CMsgDOTAChatMember>();
     [global::ProtoBuf.ProtoMember(2, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAChatMember> members
@@ -936,50 +1559,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAOtherJoinedChatChannel() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -991,32 +1659,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAOtherLeftChatChannel() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1028,14 +1723,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatChannelMemberUpdate() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _left_steam_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"left_steam_ids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> left_steam_ids
@@ -1056,41 +1760,77 @@ namespace SteamKit2.GC.Dota.Internal
     public JoinedMember() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1129,32 +1869,59 @@ namespace SteamKit2.GC.Dota.Internal
     public ChatChannel() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private uint _num_members = default(uint);
+    private uint? _num_members;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_members
     {
-      get { return _num_members; }
+      get { return _num_members?? default(uint); }
       set { _num_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_membersSpecified
+    {
+      get { return _num_members != null; }
+      set { if (value == (_num_members== null)) _num_members = value ? this.num_members : (uint?)null; }
+    }
+    private bool ShouldSerializenum_members() { return num_membersSpecified; }
+    private void Resetnum_members() { num_membersSpecified = false; }
+    
 
-    private DOTAChatChannelType_t _channel_type = DOTAChatChannelType_t.DOTAChannelType_Regional;
+    private DOTAChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAChatChannelType_t.DOTAChannelType_Regional)]
     public DOTAChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? DOTAChatChannelType_t.DOTAChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (DOTAChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1171,14 +1938,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatGetUserList() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1190,14 +1966,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatGetUserListResponse() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAChatGetUserListResponse.Member> _members = new global::System.Collections.Generic.List<CMsgDOTAChatGetUserListResponse.Member>();
     [global::ProtoBuf.ProtoMember(2, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAChatGetUserListResponse.Member> members
@@ -1211,41 +1996,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Member() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private uint _channel_user_id = default(uint);
+    private uint? _channel_user_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_user_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_user_id
     {
-      get { return _channel_user_id; }
+      get { return _channel_user_id?? default(uint); }
       set { _channel_user_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_user_idSpecified
+    {
+      get { return _channel_user_id != null; }
+      set { if (value == (_channel_user_id== null)) _channel_user_id = value ? this.channel_user_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_user_id() { return channel_user_idSpecified; }
+    private void Resetchannel_user_id() { channel_user_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1262,23 +2083,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatGetMemberCount() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private DOTAChatChannelType_t _channel_type = DOTAChatChannelType_t.DOTAChannelType_Regional;
+    private DOTAChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAChatChannelType_t.DOTAChannelType_Regional)]
     public DOTAChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? DOTAChatChannelType_t.DOTAChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (DOTAChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1290,32 +2129,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatGetMemberCountResponse() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private DOTAChatChannelType_t _channel_type = DOTAChatChannelType_t.DOTAChannelType_Regional;
+    private DOTAChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAChatChannelType_t.DOTAChannelType_Regional)]
     public DOTAChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? DOTAChatChannelType_t.DOTAChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (DOTAChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1327,14 +2193,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChatRegionsEnabled() {}
     
 
-    private bool _enable_all_regions = default(bool);
+    private bool? _enable_all_regions;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"enable_all_regions", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool enable_all_regions
     {
-      get { return _enable_all_regions; }
+      get { return _enable_all_regions?? default(bool); }
       set { _enable_all_regions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool enable_all_regionsSpecified
+    {
+      get { return _enable_all_regions != null; }
+      set { if (value == (_enable_all_regions== null)) _enable_all_regions = value ? this.enable_all_regions : (bool?)null; }
+    }
+    private bool ShouldSerializeenable_all_regions() { return enable_all_regionsSpecified; }
+    private void Resetenable_all_regions() { enable_all_regionsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAChatRegionsEnabled.Region> _enabled_regions = new global::System.Collections.Generic.List<CMsgDOTAChatRegionsEnabled.Region>();
     [global::ProtoBuf.ProtoMember(2, Name=@"enabled_regions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAChatRegionsEnabled.Region> enabled_regions
@@ -1348,41 +2223,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Region() {}
     
 
-    private float _min_latitude = default(float);
+    private float? _min_latitude;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"min_latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float min_latitude
     {
-      get { return _min_latitude; }
+      get { return _min_latitude?? default(float); }
       set { _min_latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_latitudeSpecified
+    {
+      get { return _min_latitude != null; }
+      set { if (value == (_min_latitude== null)) _min_latitude = value ? this.min_latitude : (float?)null; }
+    }
+    private bool ShouldSerializemin_latitude() { return min_latitudeSpecified; }
+    private void Resetmin_latitude() { min_latitudeSpecified = false; }
+    
 
-    private float _max_latitude = default(float);
+    private float? _max_latitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float max_latitude
     {
-      get { return _max_latitude; }
+      get { return _max_latitude?? default(float); }
       set { _max_latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_latitudeSpecified
+    {
+      get { return _max_latitude != null; }
+      set { if (value == (_max_latitude== null)) _max_latitude = value ? this.max_latitude : (float?)null; }
+    }
+    private bool ShouldSerializemax_latitude() { return max_latitudeSpecified; }
+    private void Resetmax_latitude() { max_latitudeSpecified = false; }
+    
 
-    private float _min_longitude = default(float);
+    private float? _min_longitude;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"min_longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float min_longitude
     {
-      get { return _min_longitude; }
+      get { return _min_longitude?? default(float); }
       set { _min_longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_longitudeSpecified
+    {
+      get { return _min_longitude != null; }
+      set { if (value == (_min_longitude== null)) _min_longitude = value ? this.min_longitude : (float?)null; }
+    }
+    private bool ShouldSerializemin_longitude() { return min_longitudeSpecified; }
+    private void Resetmin_longitude() { min_longitudeSpecified = false; }
+    
 
-    private float _max_longitude = default(float);
+    private float? _max_longitude;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float max_longitude
     {
-      get { return _max_longitude; }
+      get { return _max_longitude?? default(float); }
       set { _max_longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_longitudeSpecified
+    {
+      get { return _max_longitude != null; }
+      set { if (value == (_max_longitude== null)) _max_longitude = value ? this.max_longitude : (float?)null; }
+    }
+    private bool ShouldSerializemax_longitude() { return max_longitudeSpecified; }
+    private void Resetmax_longitude() { max_longitudeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientFantasy.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientFantasy.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_fantasy.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -37,113 +39,221 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private uint _fantasy_role = default(uint);
+    private uint? _fantasy_role;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"fantasy_role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_role
     {
-      get { return _fantasy_role; }
+      get { return _fantasy_role?? default(uint); }
       set { _fantasy_role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_roleSpecified
+    {
+      get { return _fantasy_role != null; }
+      set { if (value == (_fantasy_role== null)) _fantasy_role = value ? this.fantasy_role : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_role() { return fantasy_roleSpecified; }
+    private void Resetfantasy_role() { fantasy_roleSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private string _sponsor = "";
+    private string _sponsor;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"sponsor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sponsor
     {
-      get { return _sponsor; }
+      get { return _sponsor?? ""; }
       set { _sponsor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sponsorSpecified
+    {
+      get { return _sponsor != null; }
+      set { if (value == (_sponsor== null)) _sponsor = value ? this.sponsor : (string)null; }
+    }
+    private bool ShouldSerializesponsor() { return sponsorSpecified; }
+    private void Resetsponsor() { sponsorSpecified = false; }
+    
 
-    private bool _is_locked = default(bool);
+    private bool? _is_locked;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_locked", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_locked
     {
-      get { return _is_locked; }
+      get { return _is_locked?? default(bool); }
       set { _is_locked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_lockedSpecified
+    {
+      get { return _is_locked != null; }
+      set { if (value == (_is_locked== null)) _is_locked = value ? this.is_locked : (bool?)null; }
+    }
+    private bool ShouldSerializeis_locked() { return is_lockedSpecified; }
+    private void Resetis_locked() { is_lockedSpecified = false; }
+    
 
-    private bool _is_pro = default(bool);
+    private bool? _is_pro;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_pro", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pro
     {
-      get { return _is_pro; }
+      get { return _is_pro?? default(bool); }
       set { _is_pro = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_proSpecified
+    {
+      get { return _is_pro != null; }
+      set { if (value == (_is_pro== null)) _is_pro = value ? this.is_pro : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pro() { return is_proSpecified; }
+    private void Resetis_pro() { is_proSpecified = false; }
+    
 
-    private uint _locked_until = default(uint);
+    private uint? _locked_until;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"locked_until", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint locked_until
     {
-      get { return _locked_until; }
+      get { return _locked_until?? default(uint); }
       set { _locked_until = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool locked_untilSpecified
+    {
+      get { return _locked_until != null; }
+      set { if (value == (_locked_until== null)) _locked_until = value ? this.locked_until : (uint?)null; }
+    }
+    private bool ShouldSerializelocked_until() { return locked_untilSpecified; }
+    private void Resetlocked_until() { locked_untilSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -155,14 +265,23 @@ namespace SteamKit2.GC.Dota.Internal
     public RegionLeaderboard() {}
     
 
-    private uint _division = default(uint);
+    private uint? _division;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"division", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division
     {
-      get { return _division; }
+      get { return _division?? default(uint); }
       set { _division = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool divisionSpecified
+    {
+      get { return _division != null; }
+      set { if (value == (_division== null)) _division = value ? this.division : (uint?)null; }
+    }
+    private bool ShouldSerializedivision() { return divisionSpecified; }
+    private void Resetdivision() { divisionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_ids
@@ -186,41 +305,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACreateFantasyLeagueRequest() {}
     
 
-    private string _league_name = "";
+    private string _league_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string league_name
     {
-      get { return _league_name; }
+      get { return _league_name?? ""; }
       set { _league_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_nameSpecified
+    {
+      get { return _league_name != null; }
+      set { if (value == (_league_name== null)) _league_name = value ? this.league_name : (string)null; }
+    }
+    private bool ShouldSerializeleague_name() { return league_nameSpecified; }
+    private void Resetleague_name() { league_nameSpecified = false; }
+    
 
-    private ulong _league_logo = default(ulong);
+    private ulong? _league_logo;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong league_logo
     {
-      get { return _league_logo; }
+      get { return _league_logo?? default(ulong); }
       set { _league_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_logoSpecified
+    {
+      get { return _league_logo != null; }
+      set { if (value == (_league_logo== null)) _league_logo = value ? this.league_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeleague_logo() { return league_logoSpecified; }
+    private void Resetleague_logo() { league_logoSpecified = false; }
+    
 
-    private Fantasy_Selection_Mode _selection_mode = Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID;
+    private Fantasy_Selection_Mode? _selection_mode;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"selection_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID)]
     public Fantasy_Selection_Mode selection_mode
     {
-      get { return _selection_mode; }
+      get { return _selection_mode?? Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID; }
       set { _selection_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_modeSpecified
+    {
+      get { return _selection_mode != null; }
+      set { if (value == (_selection_mode== null)) _selection_mode = value ? this.selection_mode : (Fantasy_Selection_Mode?)null; }
+    }
+    private bool ShouldSerializeselection_mode() { return selection_modeSpecified; }
+    private void Resetselection_mode() { selection_modeSpecified = false; }
+    
 
-    private uint _team_count = default(uint);
+    private uint? _team_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_count
     {
-      get { return _team_count; }
+      get { return _team_count?? default(uint); }
       set { _team_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_countSpecified
+    {
+      get { return _team_count != null; }
+      set { if (value == (_team_count== null)) _team_count = value ? this.team_count : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_count() { return team_countSpecified; }
+    private void Resetteam_count() { team_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -232,14 +387,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACreateFantasyLeagueResponse() {}
     
 
-    private CMsgDOTACreateFantasyLeagueResponse.EResult _result = CMsgDOTACreateFantasyLeagueResponse.EResult.SUCCESS;
+    private CMsgDOTACreateFantasyLeagueResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTACreateFantasyLeagueResponse.EResult.SUCCESS)]
     public CMsgDOTACreateFantasyLeagueResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTACreateFantasyLeagueResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTACreateFantasyLeagueResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -271,131 +435,257 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgFantasyLeagueScoring() {}
     
 
-    private float _level = default(float);
+    private float? _level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float level
     {
-      get { return _level; }
+      get { return _level?? default(float); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (float?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private float _kills = default(float);
+    private float? _kills;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float kills
     {
-      get { return _kills; }
+      get { return _kills?? default(float); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (float?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private float _deaths = default(float);
+    private float? _deaths;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(float); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (float?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private float _assists = default(float);
+    private float? _assists;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float assists
     {
-      get { return _assists; }
+      get { return _assists?? default(float); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (float?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private float _last_hits = default(float);
+    private float? _last_hits;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(float); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (float?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private float _denies = default(float);
+    private float? _denies;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float denies
     {
-      get { return _denies; }
+      get { return _denies?? default(float); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (float?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private float _gpm = default(float);
+    private float? _gpm;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(float); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (float?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private float _xppm = default(float);
+    private float? _xppm;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"xppm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float xppm
     {
-      get { return _xppm; }
+      get { return _xppm?? default(float); }
       set { _xppm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xppmSpecified
+    {
+      get { return _xppm != null; }
+      set { if (value == (_xppm== null)) _xppm = value ? this.xppm : (float?)null; }
+    }
+    private bool ShouldSerializexppm() { return xppmSpecified; }
+    private void Resetxppm() { xppmSpecified = false; }
+    
 
-    private float _stuns = default(float);
+    private float? _stuns;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"stuns", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float stuns
     {
-      get { return _stuns; }
+      get { return _stuns?? default(float); }
       set { _stuns = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stunsSpecified
+    {
+      get { return _stuns != null; }
+      set { if (value == (_stuns== null)) _stuns = value ? this.stuns : (float?)null; }
+    }
+    private bool ShouldSerializestuns() { return stunsSpecified; }
+    private void Resetstuns() { stunsSpecified = false; }
+    
 
-    private float _healing = default(float);
+    private float? _healing;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"healing", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float healing
     {
-      get { return _healing; }
+      get { return _healing?? default(float); }
       set { _healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healingSpecified
+    {
+      get { return _healing != null; }
+      set { if (value == (_healing== null)) _healing = value ? this.healing : (float?)null; }
+    }
+    private bool ShouldSerializehealing() { return healingSpecified; }
+    private void Resethealing() { healingSpecified = false; }
+    
 
-    private float _tower_kills = default(float);
+    private float? _tower_kills;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"tower_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float tower_kills
     {
-      get { return _tower_kills; }
+      get { return _tower_kills?? default(float); }
       set { _tower_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_killsSpecified
+    {
+      get { return _tower_kills != null; }
+      set { if (value == (_tower_kills== null)) _tower_kills = value ? this.tower_kills : (float?)null; }
+    }
+    private bool ShouldSerializetower_kills() { return tower_killsSpecified; }
+    private void Resettower_kills() { tower_killsSpecified = false; }
+    
 
-    private float _roshan_kills = default(float);
+    private float? _roshan_kills;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"roshan_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float roshan_kills
     {
-      get { return _roshan_kills; }
+      get { return _roshan_kills?? default(float); }
       set { _roshan_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roshan_killsSpecified
+    {
+      get { return _roshan_kills != null; }
+      set { if (value == (_roshan_kills== null)) _roshan_kills = value ? this.roshan_kills : (float?)null; }
+    }
+    private bool ShouldSerializeroshan_kills() { return roshan_killsSpecified; }
+    private void Resetroshan_kills() { roshan_killsSpecified = false; }
+    
 
-    private float _multiplier_premium = default(float);
+    private float? _multiplier_premium;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"multiplier_premium", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float multiplier_premium
     {
-      get { return _multiplier_premium; }
+      get { return _multiplier_premium?? default(float); }
       set { _multiplier_premium = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool multiplier_premiumSpecified
+    {
+      get { return _multiplier_premium != null; }
+      set { if (value == (_multiplier_premium== null)) _multiplier_premium = value ? this.multiplier_premium : (float?)null; }
+    }
+    private bool ShouldSerializemultiplier_premium() { return multiplier_premiumSpecified; }
+    private void Resetmultiplier_premium() { multiplier_premiumSpecified = false; }
+    
 
-    private float _multiplier_professional = default(float);
+    private float? _multiplier_professional;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"multiplier_professional", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float multiplier_professional
     {
-      get { return _multiplier_professional; }
+      get { return _multiplier_professional?? default(float); }
       set { _multiplier_professional = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool multiplier_professionalSpecified
+    {
+      get { return _multiplier_professional != null; }
+      set { if (value == (_multiplier_professional== null)) _multiplier_professional = value ? this.multiplier_professional : (float?)null; }
+    }
+    private bool ShouldSerializemultiplier_professional() { return multiplier_professionalSpecified; }
+    private void Resetmultiplier_professional() { multiplier_professionalSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -407,59 +697,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueInfo() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _commissioner_account_id = default(uint);
+    private uint? _commissioner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"commissioner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint commissioner_account_id
     {
-      get { return _commissioner_account_id; }
+      get { return _commissioner_account_id?? default(uint); }
       set { _commissioner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commissioner_account_idSpecified
+    {
+      get { return _commissioner_account_id != null; }
+      set { if (value == (_commissioner_account_id== null)) _commissioner_account_id = value ? this.commissioner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializecommissioner_account_id() { return commissioner_account_idSpecified; }
+    private void Resetcommissioner_account_id() { commissioner_account_idSpecified = false; }
+    
 
-    private string _fantasy_league_name = "";
+    private string _fantasy_league_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_league_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string fantasy_league_name
     {
-      get { return _fantasy_league_name; }
+      get { return _fantasy_league_name?? ""; }
       set { _fantasy_league_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_nameSpecified
+    {
+      get { return _fantasy_league_name != null; }
+      set { if (value == (_fantasy_league_name== null)) _fantasy_league_name = value ? this.fantasy_league_name : (string)null; }
+    }
+    private bool ShouldSerializefantasy_league_name() { return fantasy_league_nameSpecified; }
+    private void Resetfantasy_league_name() { fantasy_league_nameSpecified = false; }
+    
 
-    private Fantasy_Selection_Mode _selection_mode = Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID;
+    private Fantasy_Selection_Mode? _selection_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"selection_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID)]
     public Fantasy_Selection_Mode selection_mode
     {
-      get { return _selection_mode; }
+      get { return _selection_mode?? Fantasy_Selection_Mode.FANTASY_SELECTION_INVALID; }
       set { _selection_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_modeSpecified
+    {
+      get { return _selection_mode != null; }
+      set { if (value == (_selection_mode== null)) _selection_mode = value ? this.selection_mode : (Fantasy_Selection_Mode?)null; }
+    }
+    private bool ShouldSerializeselection_mode() { return selection_modeSpecified; }
+    private void Resetselection_mode() { selection_modeSpecified = false; }
+    
 
-    private uint _team_count = default(uint);
+    private uint? _team_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_count
     {
-      get { return _team_count; }
+      get { return _team_count?? default(uint); }
       set { _team_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_countSpecified
+    {
+      get { return _team_count != null; }
+      set { if (value == (_team_count== null)) _team_count = value ? this.team_count : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_count() { return team_countSpecified; }
+    private void Resetteam_count() { team_countSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
     private CMsgFantasyLeagueScoring _scoring = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"scoring", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -470,113 +814,221 @@ namespace SteamKit2.GC.Dota.Internal
       set { _scoring = value; }
     }
 
-    private uint _draft_time = default(uint);
+    private uint? _draft_time;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"draft_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint draft_time
     {
-      get { return _draft_time; }
+      get { return _draft_time?? default(uint); }
       set { _draft_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool draft_timeSpecified
+    {
+      get { return _draft_time != null; }
+      set { if (value == (_draft_time== null)) _draft_time = value ? this.draft_time : (uint?)null; }
+    }
+    private bool ShouldSerializedraft_time() { return draft_timeSpecified; }
+    private void Resetdraft_time() { draft_timeSpecified = false; }
+    
 
-    private uint _draft_pick_time = default(uint);
+    private uint? _draft_pick_time;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"draft_pick_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint draft_pick_time
     {
-      get { return _draft_pick_time; }
+      get { return _draft_pick_time?? default(uint); }
       set { _draft_pick_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool draft_pick_timeSpecified
+    {
+      get { return _draft_pick_time != null; }
+      set { if (value == (_draft_pick_time== null)) _draft_pick_time = value ? this.draft_pick_time : (uint?)null; }
+    }
+    private bool ShouldSerializedraft_pick_time() { return draft_pick_timeSpecified; }
+    private void Resetdraft_pick_time() { draft_pick_timeSpecified = false; }
+    
 
-    private uint _season_start = default(uint);
+    private uint? _season_start;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"season_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_start
     {
-      get { return _season_start; }
+      get { return _season_start?? default(uint); }
       set { _season_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_startSpecified
+    {
+      get { return _season_start != null; }
+      set { if (value == (_season_start== null)) _season_start = value ? this.season_start : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_start() { return season_startSpecified; }
+    private void Resetseason_start() { season_startSpecified = false; }
+    
 
-    private uint _season_length = default(uint);
+    private uint? _season_length;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"season_length", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_length
     {
-      get { return _season_length; }
+      get { return _season_length?? default(uint); }
       set { _season_length = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_lengthSpecified
+    {
+      get { return _season_length != null; }
+      set { if (value == (_season_length== null)) _season_length = value ? this.season_length : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_length() { return season_lengthSpecified; }
+    private void Resetseason_length() { season_lengthSpecified = false; }
+    
 
-    private uint _veto_votes = default(uint);
+    private uint? _veto_votes;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"veto_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint veto_votes
     {
-      get { return _veto_votes; }
+      get { return _veto_votes?? default(uint); }
       set { _veto_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool veto_votesSpecified
+    {
+      get { return _veto_votes != null; }
+      set { if (value == (_veto_votes== null)) _veto_votes = value ? this.veto_votes : (uint?)null; }
+    }
+    private bool ShouldSerializeveto_votes() { return veto_votesSpecified; }
+    private void Resetveto_votes() { veto_votesSpecified = false; }
+    
 
-    private uint _acquisitions = default(uint);
+    private uint? _acquisitions;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"acquisitions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint acquisitions
     {
-      get { return _acquisitions; }
+      get { return _acquisitions?? default(uint); }
       set { _acquisitions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acquisitionsSpecified
+    {
+      get { return _acquisitions != null; }
+      set { if (value == (_acquisitions== null)) _acquisitions = value ? this.acquisitions : (uint?)null; }
+    }
+    private bool ShouldSerializeacquisitions() { return acquisitionsSpecified; }
+    private void Resetacquisitions() { acquisitionsSpecified = false; }
+    
 
-    private uint _slot_1 = default(uint);
+    private uint? _slot_1;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"slot_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_1
     {
-      get { return _slot_1; }
+      get { return _slot_1?? default(uint); }
       set { _slot_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_1Specified
+    {
+      get { return _slot_1 != null; }
+      set { if (value == (_slot_1== null)) _slot_1 = value ? this.slot_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_1() { return slot_1Specified; }
+    private void Resetslot_1() { slot_1Specified = false; }
+    
 
-    private uint _slot_2 = default(uint);
+    private uint? _slot_2;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"slot_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_2
     {
-      get { return _slot_2; }
+      get { return _slot_2?? default(uint); }
       set { _slot_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_2Specified
+    {
+      get { return _slot_2 != null; }
+      set { if (value == (_slot_2== null)) _slot_2 = value ? this.slot_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_2() { return slot_2Specified; }
+    private void Resetslot_2() { slot_2Specified = false; }
+    
 
-    private uint _slot_3 = default(uint);
+    private uint? _slot_3;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"slot_3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_3
     {
-      get { return _slot_3; }
+      get { return _slot_3?? default(uint); }
       set { _slot_3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_3Specified
+    {
+      get { return _slot_3 != null; }
+      set { if (value == (_slot_3== null)) _slot_3 = value ? this.slot_3 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_3() { return slot_3Specified; }
+    private void Resetslot_3() { slot_3Specified = false; }
+    
 
-    private uint _slot_4 = default(uint);
+    private uint? _slot_4;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"slot_4", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_4
     {
-      get { return _slot_4; }
+      get { return _slot_4?? default(uint); }
       set { _slot_4 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_4Specified
+    {
+      get { return _slot_4 != null; }
+      set { if (value == (_slot_4== null)) _slot_4 = value ? this.slot_4 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_4() { return slot_4Specified; }
+    private void Resetslot_4() { slot_4Specified = false; }
+    
 
-    private uint _slot_5 = default(uint);
+    private uint? _slot_5;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"slot_5", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_5
     {
-      get { return _slot_5; }
+      get { return _slot_5?? default(uint); }
       set { _slot_5 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_5Specified
+    {
+      get { return _slot_5 != null; }
+      set { if (value == (_slot_5== null)) _slot_5 = value ? this.slot_5 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_5() { return slot_5Specified; }
+    private void Resetslot_5() { slot_5Specified = false; }
+    
 
-    private uint _bench_slots = default(uint);
+    private uint? _bench_slots;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"bench_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bench_slots
     {
-      get { return _bench_slots; }
+      get { return _bench_slots?? default(uint); }
       set { _bench_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bench_slotsSpecified
+    {
+      get { return _bench_slots != null; }
+      set { if (value == (_bench_slots== null)) _bench_slots = value ? this.bench_slots : (uint?)null; }
+    }
+    private bool ShouldSerializebench_slots() { return bench_slotsSpecified; }
+    private void Resetbench_slots() { bench_slotsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueInfo.OwnerInfo> _owner_info = new global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueInfo.OwnerInfo>();
     [global::ProtoBuf.ProtoMember(25, Name=@"owner_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueInfo.OwnerInfo> owner_info
@@ -592,55 +1044,100 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _time_zone = default(uint);
+    private uint? _time_zone;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"time_zone", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_zone
     {
-      get { return _time_zone; }
+      get { return _time_zone?? default(uint); }
       set { _time_zone = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_zoneSpecified
+    {
+      get { return _time_zone != null; }
+      set { if (value == (_time_zone== null)) _time_zone = value ? this.time_zone : (uint?)null; }
+    }
+    private bool ShouldSerializetime_zone() { return time_zoneSpecified; }
+    private void Resettime_zone() { time_zoneSpecified = false; }
+    
 
-    private uint _season = default(uint);
+    private uint? _season;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"season", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season
     {
-      get { return _season; }
+      get { return _season?? default(uint); }
       set { _season = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seasonSpecified
+    {
+      get { return _season != null; }
+      set { if (value == (_season== null)) _season = value ? this.season : (uint?)null; }
+    }
+    private bool ShouldSerializeseason() { return seasonSpecified; }
+    private void Resetseason() { seasonSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"OwnerInfo")]
   public partial class OwnerInfo : global::ProtoBuf.IExtensible
   {
     public OwnerInfo() {}
     
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private bool _left_league = default(bool);
+    private bool? _left_league;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"left_league", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool left_league
     {
-      get { return _left_league; }
+      get { return _left_league?? default(bool); }
       set { _left_league = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool left_leagueSpecified
+    {
+      get { return _left_league != null; }
+      set { if (value == (_left_league== null)) _left_league = value ? this.left_league : (bool?)null; }
+    }
+    private bool ShouldSerializeleft_league() { return left_leagueSpecified; }
+    private void Resetleft_league() { left_leagueSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _player_account_id = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> player_account_id
@@ -664,14 +1161,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueEditInfoRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
     private CMsgDOTAFantasyLeagueInfo _edit_info = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"edit_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -692,14 +1198,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueEditInfoResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueEditInfoResponse.EResult _result = CMsgDOTAFantasyLeagueEditInfoResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueEditInfoResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueEditInfoResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueEditInfoResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueEditInfoResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueEditInfoResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -725,23 +1240,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueFindRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -753,32 +1286,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueFindResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueFindResponse.EResult _result = CMsgDOTAFantasyLeagueFindResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueFindResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueFindResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueFindResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueFindResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueFindResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _fantasy_league_name = "";
+    private string _fantasy_league_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string fantasy_league_name
     {
-      get { return _fantasy_league_name; }
+      get { return _fantasy_league_name?? ""; }
       set { _fantasy_league_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_nameSpecified
+    {
+      get { return _fantasy_league_name != null; }
+      set { if (value == (_fantasy_league_name== null)) _fantasy_league_name = value ? this.fantasy_league_name : (string)null; }
+    }
+    private bool ShouldSerializefantasy_league_name() { return fantasy_league_nameSpecified; }
+    private void Resetfantasy_league_name() { fantasy_league_nameSpecified = false; }
+    
 
-    private string _commissioner_name = "";
+    private string _commissioner_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"commissioner_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string commissioner_name
     {
-      get { return _commissioner_name; }
+      get { return _commissioner_name?? ""; }
       set { _commissioner_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool commissioner_nameSpecified
+    {
+      get { return _commissioner_name != null; }
+      set { if (value == (_commissioner_name== null)) _commissioner_name = value ? this.commissioner_name : (string)null; }
+    }
+    private bool ShouldSerializecommissioner_name() { return commissioner_nameSpecified; }
+    private void Resetcommissioner_name() { commissioner_nameSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -816,14 +1376,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueInfoRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -835,14 +1404,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueInfoResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueInfoResponse.EResult _result = CMsgDOTAFantasyLeagueInfoResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueInfoResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueInfoResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueInfoResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueInfoResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueInfoResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -868,14 +1446,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueMatchupsRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -887,23 +1474,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueMatchupsResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueMatchupsResponse.EResult _result = CMsgDOTAFantasyLeagueMatchupsResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueMatchupsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueMatchupsResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueMatchupsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueMatchupsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueMatchupsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueMatchupsResponse.WeeklyMatchups> _weekly_matchups = new global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueMatchupsResponse.WeeklyMatchups>();
     [global::ProtoBuf.ProtoMember(3, Name=@"weekly_matchups", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueMatchupsResponse.WeeklyMatchups> weekly_matchups
@@ -917,41 +1522,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Matchup() {}
     
 
-    private uint _owner_account_id_1 = default(uint);
+    private uint? _owner_account_id_1;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_account_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id_1
     {
-      get { return _owner_account_id_1; }
+      get { return _owner_account_id_1?? default(uint); }
       set { _owner_account_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_id_1Specified
+    {
+      get { return _owner_account_id_1 != null; }
+      set { if (value == (_owner_account_id_1== null)) _owner_account_id_1 = value ? this.owner_account_id_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id_1() { return owner_account_id_1Specified; }
+    private void Resetowner_account_id_1() { owner_account_id_1Specified = false; }
+    
 
-    private uint _owner_account_id_2 = default(uint);
+    private uint? _owner_account_id_2;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id_2
     {
-      get { return _owner_account_id_2; }
+      get { return _owner_account_id_2?? default(uint); }
       set { _owner_account_id_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_id_2Specified
+    {
+      get { return _owner_account_id_2 != null; }
+      set { if (value == (_owner_account_id_2== null)) _owner_account_id_2 = value ? this.owner_account_id_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id_2() { return owner_account_id_2Specified; }
+    private void Resetowner_account_id_2() { owner_account_id_2Specified = false; }
+    
 
-    private float _score_1 = default(float);
+    private float? _score_1;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score_1", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score_1
     {
-      get { return _score_1; }
+      get { return _score_1?? default(float); }
       set { _score_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_1Specified
+    {
+      get { return _score_1 != null; }
+      set { if (value == (_score_1== null)) _score_1 = value ? this.score_1 : (float?)null; }
+    }
+    private bool ShouldSerializescore_1() { return score_1Specified; }
+    private void Resetscore_1() { score_1Specified = false; }
+    
 
-    private float _score_2 = default(float);
+    private float? _score_2;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"score_2", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score_2
     {
-      get { return _score_2; }
+      get { return _score_2?? default(float); }
       set { _score_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_2Specified
+    {
+      get { return _score_2 != null; }
+      set { if (value == (_score_2== null)) _score_2 = value ? this.score_2 : (float?)null; }
+    }
+    private bool ShouldSerializescore_2() { return score_2Specified; }
+    private void Resetscore_2() { score_2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -970,23 +1611,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _end_time = default(uint);
+    private uint? _end_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_time
     {
-      get { return _end_time; }
+      get { return _end_time?? default(uint); }
       set { _end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_timeSpecified
+    {
+      get { return _end_time != null; }
+      set { if (value == (_end_time== null)) _end_time = value ? this.end_time : (uint?)null; }
+    }
+    private bool ShouldSerializeend_time() { return end_timeSpecified; }
+    private void Resetend_time() { end_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1020,41 +1679,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAEditFantasyTeamRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1066,14 +1761,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAEditFantasyTeamResponse() {}
     
 
-    private CMsgDOTAEditFantasyTeamResponse.EResult _result = CMsgDOTAEditFantasyTeamResponse.EResult.SUCCESS;
+    private CMsgDOTAEditFantasyTeamResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAEditFantasyTeamResponse.EResult.SUCCESS)]
     public CMsgDOTAEditFantasyTeamResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAEditFantasyTeamResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAEditFantasyTeamResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -1105,14 +1809,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamInfoRequestByFantasyLeagueID() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1124,14 +1837,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamInfoRequestByOwnerAccountID() {}
     
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1160,68 +1882,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamInfo() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _fantasy_team_index = default(uint);
+    private uint? _fantasy_team_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_team_index
     {
-      get { return _fantasy_team_index; }
+      get { return _fantasy_team_index?? default(uint); }
       set { _fantasy_team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_indexSpecified
+    {
+      get { return _fantasy_team_index != null; }
+      set { if (value == (_fantasy_team_index== null)) _fantasy_team_index = value ? this.fantasy_team_index : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_team_index() { return fantasy_team_indexSpecified; }
+    private void Resetfantasy_team_index() { fantasy_team_indexSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _current_roster = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(8, Name=@"current_roster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> current_roster
@@ -1240,68 +2025,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamScoreRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _fantasy_team_index = default(uint);
+    private uint? _fantasy_team_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_team_index
     {
-      get { return _fantasy_team_index; }
+      get { return _fantasy_team_index?? default(uint); }
       set { _fantasy_team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_indexSpecified
+    {
+      get { return _fantasy_team_index != null; }
+      set { if (value == (_fantasy_team_index== null)) _fantasy_team_index = value ? this.fantasy_team_index : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_team_index() { return fantasy_team_indexSpecified; }
+    private void Resetfantasy_team_index() { fantasy_team_indexSpecified = false; }
+    
 
-    private ulong _filter_match_id = default(ulong);
+    private ulong? _filter_match_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong filter_match_id
     {
-      get { return _filter_match_id; }
+      get { return _filter_match_id?? default(ulong); }
       set { _filter_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_match_idSpecified
+    {
+      get { return _filter_match_id != null; }
+      set { if (value == (_filter_match_id== null)) _filter_match_id = value ? this.filter_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefilter_match_id() { return filter_match_idSpecified; }
+    private void Resetfilter_match_id() { filter_match_idSpecified = false; }
+    
 
-    private uint _filter_start_time = default(uint);
+    private uint? _filter_start_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"filter_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_start_time
     {
-      get { return _filter_start_time; }
+      get { return _filter_start_time?? default(uint); }
       set { _filter_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_start_timeSpecified
+    {
+      get { return _filter_start_time != null; }
+      set { if (value == (_filter_start_time== null)) _filter_start_time = value ? this.filter_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_start_time() { return filter_start_timeSpecified; }
+    private void Resetfilter_start_time() { filter_start_timeSpecified = false; }
+    
 
-    private uint _filter_end_time = default(uint);
+    private uint? _filter_end_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"filter_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_end_time
     {
-      get { return _filter_end_time; }
+      get { return _filter_end_time?? default(uint); }
       set { _filter_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_end_timeSpecified
+    {
+      get { return _filter_end_time != null; }
+      set { if (value == (_filter_end_time== null)) _filter_end_time = value ? this.filter_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_end_time() { return filter_end_timeSpecified; }
+    private void Resetfilter_end_time() { filter_end_timeSpecified = false; }
+    
 
-    private bool _include_bench = default(bool);
+    private bool? _include_bench;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"include_bench", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_bench
     {
-      get { return _include_bench; }
+      get { return _include_bench?? default(bool); }
       set { _include_bench = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_benchSpecified
+    {
+      get { return _include_bench != null; }
+      set { if (value == (_include_bench== null)) _include_bench = value ? this.include_bench : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_bench() { return include_benchSpecified; }
+    private void Resetinclude_bench() { include_benchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1313,23 +2161,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamScoreResponse() {}
     
 
-    private CMsgDOTAFantasyTeamScoreResponse.EResult _result = CMsgDOTAFantasyTeamScoreResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamScoreResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamScoreResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamScoreResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamScoreResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamScoreResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private float _fantasy_team_score = default(float);
+    private float? _fantasy_team_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_team_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float fantasy_team_score
     {
-      get { return _fantasy_team_score; }
+      get { return _fantasy_team_score?? default(float); }
       set { _fantasy_team_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_scoreSpecified
+    {
+      get { return _fantasy_team_score != null; }
+      set { if (value == (_fantasy_team_score== null)) _fantasy_team_score = value ? this.fantasy_team_score : (float?)null; }
+    }
+    private bool ShouldSerializefantasy_team_score() { return fantasy_team_scoreSpecified; }
+    private void Resetfantasy_team_score() { fantasy_team_scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyTeamScoreResponse.CMsgPlayerScore> _fantasy_player_score = new global::System.Collections.Generic.List<CMsgDOTAFantasyTeamScoreResponse.CMsgPlayerScore>();
     [global::ProtoBuf.ProtoMember(3, Name=@"fantasy_player_score", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyTeamScoreResponse.CMsgPlayerScore> fantasy_player_score
@@ -1343,23 +2209,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPlayerScore() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1393,68 +2277,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamStandingsRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private uint _filter_start_time = default(uint);
+    private uint? _filter_start_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filter_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_start_time
     {
-      get { return _filter_start_time; }
+      get { return _filter_start_time?? default(uint); }
       set { _filter_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_start_timeSpecified
+    {
+      get { return _filter_start_time != null; }
+      set { if (value == (_filter_start_time== null)) _filter_start_time = value ? this.filter_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_start_time() { return filter_start_timeSpecified; }
+    private void Resetfilter_start_time() { filter_start_timeSpecified = false; }
+    
 
-    private uint _filter_end_time = default(uint);
+    private uint? _filter_end_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_end_time
     {
-      get { return _filter_end_time; }
+      get { return _filter_end_time?? default(uint); }
       set { _filter_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_end_timeSpecified
+    {
+      get { return _filter_end_time != null; }
+      set { if (value == (_filter_end_time== null)) _filter_end_time = value ? this.filter_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_end_time() { return filter_end_timeSpecified; }
+    private void Resetfilter_end_time() { filter_end_timeSpecified = false; }
+    
 
-    private ulong _filter_match_id = default(ulong);
+    private ulong? _filter_match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"filter_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong filter_match_id
     {
-      get { return _filter_match_id; }
+      get { return _filter_match_id?? default(ulong); }
       set { _filter_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_match_idSpecified
+    {
+      get { return _filter_match_id != null; }
+      set { if (value == (_filter_match_id== null)) _filter_match_id = value ? this.filter_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefilter_match_id() { return filter_match_idSpecified; }
+    private void Resetfilter_match_id() { filter_match_idSpecified = false; }
+    
 
-    private bool _filter_last_match = default(bool);
+    private bool? _filter_last_match;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"filter_last_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool filter_last_match
     {
-      get { return _filter_last_match; }
+      get { return _filter_last_match?? default(bool); }
       set { _filter_last_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_last_matchSpecified
+    {
+      get { return _filter_last_match != null; }
+      set { if (value == (_filter_last_match== null)) _filter_last_match = value ? this.filter_last_match : (bool?)null; }
+    }
+    private bool ShouldSerializefilter_last_match() { return filter_last_matchSpecified; }
+    private void Resetfilter_last_match() { filter_last_matchSpecified = false; }
+    
 
-    private bool _filter_in_hall = default(bool);
+    private bool? _filter_in_hall;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"filter_in_hall", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool filter_in_hall
     {
-      get { return _filter_in_hall; }
+      get { return _filter_in_hall?? default(bool); }
       set { _filter_in_hall = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_in_hallSpecified
+    {
+      get { return _filter_in_hall != null; }
+      set { if (value == (_filter_in_hall== null)) _filter_in_hall = value ? this.filter_in_hall : (bool?)null; }
+    }
+    private bool ShouldSerializefilter_in_hall() { return filter_in_hallSpecified; }
+    private void Resetfilter_in_hall() { filter_in_hallSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1466,14 +2413,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamStandingsResponse() {}
     
 
-    private CMsgDOTAFantasyTeamStandingsResponse.EResult _result = CMsgDOTAFantasyTeamStandingsResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamStandingsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamStandingsResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamStandingsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamStandingsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamStandingsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyTeamStandingsResponse.CMsgTeamScore> _team_scores = new global::System.Collections.Generic.List<CMsgDOTAFantasyTeamStandingsResponse.CMsgTeamScore>();
     [global::ProtoBuf.ProtoMember(3, Name=@"team_scores", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyTeamStandingsResponse.CMsgTeamScore> team_scores
@@ -1487,104 +2443,203 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgTeamScore() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _fantasy_team_index = default(uint);
+    private uint? _fantasy_team_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_team_index
     {
-      get { return _fantasy_team_index; }
+      get { return _fantasy_team_index?? default(uint); }
       set { _fantasy_team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_indexSpecified
+    {
+      get { return _fantasy_team_index != null; }
+      set { if (value == (_fantasy_team_index== null)) _fantasy_team_index = value ? this.fantasy_team_index : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_team_index() { return fantasy_team_indexSpecified; }
+    private void Resetfantasy_team_index() { fantasy_team_indexSpecified = false; }
+    
 
-    private ulong _fantasy_team_logo = default(ulong);
+    private ulong? _fantasy_team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"fantasy_team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong fantasy_team_logo
     {
-      get { return _fantasy_team_logo; }
+      get { return _fantasy_team_logo?? default(ulong); }
       set { _fantasy_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_logoSpecified
+    {
+      get { return _fantasy_team_logo != null; }
+      set { if (value == (_fantasy_team_logo== null)) _fantasy_team_logo = value ? this.fantasy_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializefantasy_team_logo() { return fantasy_team_logoSpecified; }
+    private void Resetfantasy_team_logo() { fantasy_team_logoSpecified = false; }
+    
 
-    private string _owner_name = "";
+    private string _owner_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"owner_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string owner_name
     {
-      get { return _owner_name; }
+      get { return _owner_name?? ""; }
       set { _owner_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_nameSpecified
+    {
+      get { return _owner_name != null; }
+      set { if (value == (_owner_name== null)) _owner_name = value ? this.owner_name : (string)null; }
+    }
+    private bool ShouldSerializeowner_name() { return owner_nameSpecified; }
+    private void Resetowner_name() { owner_nameSpecified = false; }
+    
 
-    private string _fantasy_team_name = "";
+    private string _fantasy_team_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"fantasy_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string fantasy_team_name
     {
-      get { return _fantasy_team_name; }
+      get { return _fantasy_team_name?? ""; }
       set { _fantasy_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_nameSpecified
+    {
+      get { return _fantasy_team_name != null; }
+      set { if (value == (_fantasy_team_name== null)) _fantasy_team_name = value ? this.fantasy_team_name : (string)null; }
+    }
+    private bool ShouldSerializefantasy_team_name() { return fantasy_team_nameSpecified; }
+    private void Resetfantasy_team_name() { fantasy_team_nameSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private float _score_against = default(float);
+    private float? _score_against;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"score_against", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score_against
     {
-      get { return _score_against; }
+      get { return _score_against?? default(float); }
       set { _score_against = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_againstSpecified
+    {
+      get { return _score_against != null; }
+      set { if (value == (_score_against== null)) _score_against = value ? this.score_against : (float?)null; }
+    }
+    private bool ShouldSerializescore_against() { return score_againstSpecified; }
+    private void Resetscore_against() { score_againstSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
 
-    private int _streak = default(int);
+    private int? _streak;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int streak
     {
-      get { return _streak; }
+      get { return _streak?? default(int); }
       set { _streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool streakSpecified
+    {
+      get { return _streak != null; }
+      set { if (value == (_streak== null)) _streak = value ? this.streak : (int?)null; }
+    }
+    private bool ShouldSerializestreak() { return streakSpecified; }
+    private void Resetstreak() { streakSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1615,59 +2670,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerScoreRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private uint _filter_start_time = default(uint);
+    private uint? _filter_start_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filter_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_start_time
     {
-      get { return _filter_start_time; }
+      get { return _filter_start_time?? default(uint); }
       set { _filter_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_start_timeSpecified
+    {
+      get { return _filter_start_time != null; }
+      set { if (value == (_filter_start_time== null)) _filter_start_time = value ? this.filter_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_start_time() { return filter_start_timeSpecified; }
+    private void Resetfilter_start_time() { filter_start_timeSpecified = false; }
+    
 
-    private uint _filter_end_time = default(uint);
+    private uint? _filter_end_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_end_time
     {
-      get { return _filter_end_time; }
+      get { return _filter_end_time?? default(uint); }
       set { _filter_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_end_timeSpecified
+    {
+      get { return _filter_end_time != null; }
+      set { if (value == (_filter_end_time== null)) _filter_end_time = value ? this.filter_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_end_time() { return filter_end_timeSpecified; }
+    private void Resetfilter_end_time() { filter_end_timeSpecified = false; }
+    
 
-    private ulong _filter_match_id = default(ulong);
+    private ulong? _filter_match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"filter_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong filter_match_id
     {
-      get { return _filter_match_id; }
+      get { return _filter_match_id?? default(ulong); }
       set { _filter_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_match_idSpecified
+    {
+      get { return _filter_match_id != null; }
+      set { if (value == (_filter_match_id== null)) _filter_match_id = value ? this.filter_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefilter_match_id() { return filter_match_idSpecified; }
+    private void Resetfilter_match_id() { filter_match_idSpecified = false; }
+    
 
-    private bool _filter_last_match = default(bool);
+    private bool? _filter_last_match;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"filter_last_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool filter_last_match
     {
-      get { return _filter_last_match; }
+      get { return _filter_last_match?? default(bool); }
       set { _filter_last_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_last_matchSpecified
+    {
+      get { return _filter_last_match != null; }
+      set { if (value == (_filter_last_match== null)) _filter_last_match = value ? this.filter_last_match : (bool?)null; }
+    }
+    private bool ShouldSerializefilter_last_match() { return filter_last_matchSpecified; }
+    private void Resetfilter_last_match() { filter_last_matchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1679,50 +2788,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerScoreResponse() {}
     
 
-    private CMsgDOTAFantasyPlayerScoreResponse.EResult _result = CMsgDOTAFantasyPlayerScoreResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyPlayerScoreResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyPlayerScoreResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyPlayerScoreResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyPlayerScoreResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyPlayerScoreResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -1748,68 +2902,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerStandingsRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private uint _role = default(uint);
+    private uint? _role;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint role
     {
-      get { return _role; }
+      get { return _role?? default(uint); }
       set { _role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roleSpecified
+    {
+      get { return _role != null; }
+      set { if (value == (_role== null)) _role = value ? this.role : (uint?)null; }
+    }
+    private bool ShouldSerializerole() { return roleSpecified; }
+    private void Resetrole() { roleSpecified = false; }
+    
 
-    private uint _filter_start_time = default(uint);
+    private uint? _filter_start_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_start_time
     {
-      get { return _filter_start_time; }
+      get { return _filter_start_time?? default(uint); }
       set { _filter_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_start_timeSpecified
+    {
+      get { return _filter_start_time != null; }
+      set { if (value == (_filter_start_time== null)) _filter_start_time = value ? this.filter_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_start_time() { return filter_start_timeSpecified; }
+    private void Resetfilter_start_time() { filter_start_timeSpecified = false; }
+    
 
-    private uint _filter_end_time = default(uint);
+    private uint? _filter_end_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"filter_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filter_end_time
     {
-      get { return _filter_end_time; }
+      get { return _filter_end_time?? default(uint); }
       set { _filter_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_end_timeSpecified
+    {
+      get { return _filter_end_time != null; }
+      set { if (value == (_filter_end_time== null)) _filter_end_time = value ? this.filter_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializefilter_end_time() { return filter_end_timeSpecified; }
+    private void Resetfilter_end_time() { filter_end_timeSpecified = false; }
+    
 
-    private ulong _filter_match_id = default(ulong);
+    private ulong? _filter_match_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"filter_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong filter_match_id
     {
-      get { return _filter_match_id; }
+      get { return _filter_match_id?? default(ulong); }
       set { _filter_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_match_idSpecified
+    {
+      get { return _filter_match_id != null; }
+      set { if (value == (_filter_match_id== null)) _filter_match_id = value ? this.filter_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefilter_match_id() { return filter_match_idSpecified; }
+    private void Resetfilter_match_id() { filter_match_idSpecified = false; }
+    
 
-    private bool _filter_last_match = default(bool);
+    private bool? _filter_last_match;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"filter_last_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool filter_last_match
     {
-      get { return _filter_last_match; }
+      get { return _filter_last_match?? default(bool); }
       set { _filter_last_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_last_matchSpecified
+    {
+      get { return _filter_last_match != null; }
+      set { if (value == (_filter_last_match== null)) _filter_last_match = value ? this.filter_last_match : (bool?)null; }
+    }
+    private bool ShouldSerializefilter_last_match() { return filter_last_matchSpecified; }
+    private void Resetfilter_last_match() { filter_last_matchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1821,32 +3038,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerStandingsResponse() {}
     
 
-    private CMsgDOTAFantasyPlayerStandingsResponse.EResult _result = CMsgDOTAFantasyPlayerStandingsResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyPlayerStandingsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyPlayerStandingsResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyPlayerStandingsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyPlayerStandingsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyPlayerStandingsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _role = default(uint);
+    private uint? _role;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint role
     {
-      get { return _role; }
+      get { return _role?? default(uint); }
       set { _role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roleSpecified
+    {
+      get { return _role != null; }
+      set { if (value == (_role== null)) _role = value ? this.role : (uint?)null; }
+    }
+    private bool ShouldSerializerole() { return roleSpecified; }
+    private void Resetrole() { roleSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerStandingsResponse.CMsgPlayerScore> _player_scores = new global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerStandingsResponse.CMsgPlayerScore>();
     [global::ProtoBuf.ProtoMember(4, Name=@"player_scores", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerStandingsResponse.CMsgPlayerScore> player_scores
@@ -1860,32 +3104,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPlayerScore() {}
     
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1945,59 +3216,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueCreateRequest() {}
     
 
-    private uint _season_id = default(uint);
+    private uint? _season_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"season_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_id
     {
-      get { return _season_id; }
+      get { return _season_id?? default(uint); }
       set { _season_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_idSpecified
+    {
+      get { return _season_id != null; }
+      set { if (value == (_season_id== null)) _season_id = value ? this.season_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_id() { return season_idSpecified; }
+    private void Resetseason_id() { season_idSpecified = false; }
+    
 
-    private string _fantasy_league_name = "";
+    private string _fantasy_league_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string fantasy_league_name
     {
-      get { return _fantasy_league_name; }
+      get { return _fantasy_league_name?? ""; }
       set { _fantasy_league_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_nameSpecified
+    {
+      get { return _fantasy_league_name != null; }
+      set { if (value == (_fantasy_league_name== null)) _fantasy_league_name = value ? this.fantasy_league_name : (string)null; }
+    }
+    private bool ShouldSerializefantasy_league_name() { return fantasy_league_nameSpecified; }
+    private void Resetfantasy_league_name() { fantasy_league_nameSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _ticket_item_id = default(ulong);
+    private ulong? _ticket_item_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ticket_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ticket_item_id
     {
-      get { return _ticket_item_id; }
+      get { return _ticket_item_id?? default(ulong); }
       set { _ticket_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_item_idSpecified
+    {
+      get { return _ticket_item_id != null; }
+      set { if (value == (_ticket_item_id== null)) _ticket_item_id = value ? this.ticket_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeticket_item_id() { return ticket_item_idSpecified; }
+    private void Resetticket_item_id() { ticket_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2009,23 +3334,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueCreateResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueCreateResponse.EResult _result = CMsgDOTAFantasyLeagueCreateResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueCreateResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueCreateResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueCreateResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueCreateResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueCreateResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2066,50 +3409,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamCreateRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _ticket_item_id = default(ulong);
+    private ulong? _ticket_item_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ticket_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ticket_item_id
     {
-      get { return _ticket_item_id; }
+      get { return _ticket_item_id?? default(ulong); }
       set { _ticket_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_item_idSpecified
+    {
+      get { return _ticket_item_id != null; }
+      set { if (value == (_ticket_item_id== null)) _ticket_item_id = value ? this.ticket_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeticket_item_id() { return ticket_item_idSpecified; }
+    private void Resetticket_item_id() { ticket_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2121,23 +3509,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamCreateResponse() {}
     
 
-    private CMsgDOTAFantasyTeamCreateResponse.EResult _result = CMsgDOTAFantasyTeamCreateResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamCreateResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamCreateResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamCreateResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamCreateResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamCreateResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _fantasy_team_index = default(uint);
+    private uint? _fantasy_team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_team_index
     {
-      get { return _fantasy_team_index; }
+      get { return _fantasy_team_index?? default(uint); }
       set { _fantasy_team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_indexSpecified
+    {
+      get { return _fantasy_team_index != null; }
+      set { if (value == (_fantasy_team_index== null)) _fantasy_team_index = value ? this.fantasy_team_index : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_team_index() { return fantasy_team_indexSpecified; }
+    private void Resetfantasy_team_index() { fantasy_team_indexSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2187,23 +3593,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueEditInvitesRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueEditInvitesRequest.InviteChange> _invite_change = new global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueEditInvitesRequest.InviteChange>();
     [global::ProtoBuf.ProtoMember(3, Name=@"invite_change", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyLeagueEditInvitesRequest.InviteChange> invite_change
@@ -2217,23 +3641,41 @@ namespace SteamKit2.GC.Dota.Internal
     public InviteChange() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _invited = default(bool);
+    private bool? _invited;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"invited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool invited
     {
-      get { return _invited; }
+      get { return _invited?? default(bool); }
       set { _invited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invitedSpecified
+    {
+      get { return _invited != null; }
+      set { if (value == (_invited== null)) _invited = value ? this.invited : (bool?)null; }
+    }
+    private bool ShouldSerializeinvited() { return invitedSpecified; }
+    private void Resetinvited() { invitedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2250,14 +3692,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueEditInvitesResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueEditInvitesResponse.EResult _result = CMsgDOTAFantasyLeagueEditInvitesResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueEditInvitesResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueEditInvitesResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueEditInvitesResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueEditInvitesResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueEditInvitesResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2280,14 +3731,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueDraftStatusRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2299,14 +3759,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueDraftStatus() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _draft_order = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"draft_order", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> draft_order
@@ -2315,41 +3784,77 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _current_pick = default(uint);
+    private uint? _current_pick;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"current_pick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_pick
     {
-      get { return _current_pick; }
+      get { return _current_pick?? default(uint); }
       set { _current_pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_pickSpecified
+    {
+      get { return _current_pick != null; }
+      set { if (value == (_current_pick== null)) _current_pick = value ? this.current_pick : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_pick() { return current_pickSpecified; }
+    private void Resetcurrent_pick() { current_pickSpecified = false; }
+    
 
-    private uint _time_remaining = default(uint);
+    private uint? _time_remaining;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_remaining
     {
-      get { return _time_remaining; }
+      get { return _time_remaining?? default(uint); }
       set { _time_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_remainingSpecified
+    {
+      get { return _time_remaining != null; }
+      set { if (value == (_time_remaining== null)) _time_remaining = value ? this.time_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializetime_remaining() { return time_remainingSpecified; }
+    private void Resettime_remaining() { time_remainingSpecified = false; }
+    
 
-    private bool _pending_resume = default(bool);
+    private bool? _pending_resume;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"pending_resume", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pending_resume
     {
-      get { return _pending_resume; }
+      get { return _pending_resume?? default(bool); }
       set { _pending_resume = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pending_resumeSpecified
+    {
+      get { return _pending_resume != null; }
+      set { if (value == (_pending_resume== null)) _pending_resume = value ? this.pending_resume : (bool?)null; }
+    }
+    private bool ShouldSerializepending_resume() { return pending_resumeSpecified; }
+    private void Resetpending_resume() { pending_resumeSpecified = false; }
+    
 
-    private bool _completed = default(bool);
+    private bool? _completed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool completed
     {
-      get { return _completed; }
+      get { return _completed?? default(bool); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (bool?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _available_players = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"available_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> available_players
@@ -2368,32 +3873,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueDraftPlayerRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2405,14 +3937,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeagueDraftPlayerResponse() {}
     
 
-    private CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult _result = CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeagueDraftPlayerResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2456,50 +3997,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterSwapRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _slot_1 = default(uint);
+    private uint? _slot_1;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"slot_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_1
     {
-      get { return _slot_1; }
+      get { return _slot_1?? default(uint); }
       set { _slot_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_1Specified
+    {
+      get { return _slot_1 != null; }
+      set { if (value == (_slot_1== null)) _slot_1 = value ? this.slot_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_1() { return slot_1Specified; }
+    private void Resetslot_1() { slot_1Specified = false; }
+    
 
-    private uint _slot_2 = default(uint);
+    private uint? _slot_2;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"slot_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_2
     {
-      get { return _slot_2; }
+      get { return _slot_2?? default(uint); }
       set { _slot_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_2Specified
+    {
+      get { return _slot_2 != null; }
+      set { if (value == (_slot_2== null)) _slot_2 = value ? this.slot_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_2() { return slot_2Specified; }
+    private void Resetslot_2() { slot_2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2511,14 +4097,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterSwapResponse() {}
     
 
-    private CMsgDOTAFantasyTeamRosterSwapResponse.EResult _result = CMsgDOTAFantasyTeamRosterSwapResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamRosterSwapResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamRosterSwapResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamRosterSwapResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamRosterSwapResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamRosterSwapResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2550,41 +4145,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterAddDropRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
 
-    private uint _add_account_id = default(uint);
+    private uint? _add_account_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"add_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint add_account_id
     {
-      get { return _add_account_id; }
+      get { return _add_account_id?? default(uint); }
       set { _add_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool add_account_idSpecified
+    {
+      get { return _add_account_id != null; }
+      set { if (value == (_add_account_id== null)) _add_account_id = value ? this.add_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeadd_account_id() { return add_account_idSpecified; }
+    private void Resetadd_account_id() { add_account_idSpecified = false; }
+    
 
-    private uint _drop_account_id = default(uint);
+    private uint? _drop_account_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"drop_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint drop_account_id
     {
-      get { return _drop_account_id; }
+      get { return _drop_account_id?? default(uint); }
       set { _drop_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool drop_account_idSpecified
+    {
+      get { return _drop_account_id != null; }
+      set { if (value == (_drop_account_id== null)) _drop_account_id = value ? this.drop_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializedrop_account_id() { return drop_account_idSpecified; }
+    private void Resetdrop_account_id() { drop_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2596,14 +4227,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterAddDropResponse() {}
     
 
-    private CMsgDOTAFantasyTeamRosterAddDropResponse.EResult _result = CMsgDOTAFantasyTeamRosterAddDropResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamRosterAddDropResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamRosterAddDropResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamRosterAddDropResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamRosterAddDropResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamRosterAddDropResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2638,14 +4278,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamTradesRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2657,14 +4306,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamTradesResponse() {}
     
 
-    private CMsgDOTAFantasyTeamTradesResponse.EResult _result = CMsgDOTAFantasyTeamTradesResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamTradesResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamTradesResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamTradesResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamTradesResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamTradesResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyTeamTradesResponse.Trade> _trades = new global::System.Collections.Generic.List<CMsgDOTAFantasyTeamTradesResponse.Trade>();
     [global::ProtoBuf.ProtoMember(2, Name=@"trades", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyTeamTradesResponse.Trade> trades
@@ -2678,59 +4336,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Trade() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _owner_account_id_1 = default(uint);
+    private uint? _owner_account_id_1;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id_1
     {
-      get { return _owner_account_id_1; }
+      get { return _owner_account_id_1?? default(uint); }
       set { _owner_account_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_id_1Specified
+    {
+      get { return _owner_account_id_1 != null; }
+      set { if (value == (_owner_account_id_1== null)) _owner_account_id_1 = value ? this.owner_account_id_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id_1() { return owner_account_id_1Specified; }
+    private void Resetowner_account_id_1() { owner_account_id_1Specified = false; }
+    
 
-    private uint _owner_account_id_2 = default(uint);
+    private uint? _owner_account_id_2;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_account_id_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id_2
     {
-      get { return _owner_account_id_2; }
+      get { return _owner_account_id_2?? default(uint); }
       set { _owner_account_id_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_id_2Specified
+    {
+      get { return _owner_account_id_2 != null; }
+      set { if (value == (_owner_account_id_2== null)) _owner_account_id_2 = value ? this.owner_account_id_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id_2() { return owner_account_id_2Specified; }
+    private void Resetowner_account_id_2() { owner_account_id_2Specified = false; }
+    
 
-    private uint _player_account_id_1 = default(uint);
+    private uint? _player_account_id_1;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"player_account_id_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id_1
     {
-      get { return _player_account_id_1; }
+      get { return _player_account_id_1?? default(uint); }
       set { _player_account_id_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_id_1Specified
+    {
+      get { return _player_account_id_1 != null; }
+      set { if (value == (_player_account_id_1== null)) _player_account_id_1 = value ? this.player_account_id_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id_1() { return player_account_id_1Specified; }
+    private void Resetplayer_account_id_1() { player_account_id_1Specified = false; }
+    
 
-    private uint _player_account_id_2 = default(uint);
+    private uint? _player_account_id_2;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"player_account_id_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id_2
     {
-      get { return _player_account_id_2; }
+      get { return _player_account_id_2?? default(uint); }
       set { _player_account_id_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_id_2Specified
+    {
+      get { return _player_account_id_2 != null; }
+      set { if (value == (_player_account_id_2== null)) _player_account_id_2 = value ? this.player_account_id_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id_2() { return player_account_id_2Specified; }
+    private void Resetplayer_account_id_2() { player_account_id_2Specified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2761,41 +4473,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamTradeCancelRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index_1 = default(uint);
+    private uint? _team_index_1;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_index_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index_1
     {
-      get { return _team_index_1; }
+      get { return _team_index_1?? default(uint); }
       set { _team_index_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_index_1Specified
+    {
+      get { return _team_index_1 != null; }
+      set { if (value == (_team_index_1== null)) _team_index_1 = value ? this.team_index_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index_1() { return team_index_1Specified; }
+    private void Resetteam_index_1() { team_index_1Specified = false; }
+    
 
-    private uint _owner_account_id_2 = default(uint);
+    private uint? _owner_account_id_2;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_account_id_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id_2
     {
-      get { return _owner_account_id_2; }
+      get { return _owner_account_id_2?? default(uint); }
       set { _owner_account_id_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_id_2Specified
+    {
+      get { return _owner_account_id_2 != null; }
+      set { if (value == (_owner_account_id_2== null)) _owner_account_id_2 = value ? this.owner_account_id_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id_2() { return owner_account_id_2Specified; }
+    private void Resetowner_account_id_2() { owner_account_id_2Specified = false; }
+    
 
-    private uint _team_index_2 = default(uint);
+    private uint? _team_index_2;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_index_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index_2
     {
-      get { return _team_index_2; }
+      get { return _team_index_2?? default(uint); }
       set { _team_index_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_index_2Specified
+    {
+      get { return _team_index_2 != null; }
+      set { if (value == (_team_index_2== null)) _team_index_2 = value ? this.team_index_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index_2() { return team_index_2Specified; }
+    private void Resetteam_index_2() { team_index_2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2807,14 +4555,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamTradeCancelResponse() {}
     
 
-    private CMsgDOTAFantasyTeamTradeCancelResponse.EResult _result = CMsgDOTAFantasyTeamTradeCancelResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamTradeCancelResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamTradeCancelResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamTradeCancelResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamTradeCancelResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamTradeCancelResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2843,41 +4600,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2889,14 +4682,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyTeamRosterResponse() {}
     
 
-    private CMsgDOTAFantasyTeamRosterResponse.EResult _result = CMsgDOTAFantasyTeamRosterResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyTeamRosterResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyTeamRosterResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyTeamRosterResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyTeamRosterResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyTeamRosterResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _player_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> player_account_ids
@@ -2939,14 +4741,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerHisoricalStatsRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2958,14 +4769,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerHisoricalStatsResponse() {}
     
 
-    private CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult _result = CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyPlayerHisoricalStatsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerHisoricalStatsResponse.PlayerStats> _stats = new global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerHisoricalStatsResponse.PlayerStats>();
     [global::ProtoBuf.ProtoMember(2, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerHisoricalStatsResponse.PlayerStats> stats
@@ -2979,131 +4799,257 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerScoreAccumulator() {}
     
 
-    private uint _matches = default(uint);
+    private uint? _matches;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matches
     {
-      get { return _matches; }
+      get { return _matches?? default(uint); }
       set { _matches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchesSpecified
+    {
+      get { return _matches != null; }
+      set { if (value == (_matches== null)) _matches = value ? this.matches : (uint?)null; }
+    }
+    private bool ShouldSerializematches() { return matchesSpecified; }
+    private void Resetmatches() { matchesSpecified = false; }
+    
 
-    private float _levels = default(float);
+    private float? _levels;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"levels", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float levels
     {
-      get { return _levels; }
+      get { return _levels?? default(float); }
       set { _levels = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelsSpecified
+    {
+      get { return _levels != null; }
+      set { if (value == (_levels== null)) _levels = value ? this.levels : (float?)null; }
+    }
+    private bool ShouldSerializelevels() { return levelsSpecified; }
+    private void Resetlevels() { levelsSpecified = false; }
+    
 
-    private float _kills = default(float);
+    private float? _kills;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float kills
     {
-      get { return _kills; }
+      get { return _kills?? default(float); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (float?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private float _deaths = default(float);
+    private float? _deaths;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(float); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (float?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private float _assists = default(float);
+    private float? _assists;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float assists
     {
-      get { return _assists; }
+      get { return _assists?? default(float); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (float?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private float _last_hits = default(float);
+    private float? _last_hits;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(float); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (float?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private float _denies = default(float);
+    private float? _denies;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float denies
     {
-      get { return _denies; }
+      get { return _denies?? default(float); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (float?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private float _gpm = default(float);
+    private float? _gpm;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(float); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (float?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private float _xppm = default(float);
+    private float? _xppm;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"xppm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float xppm
     {
-      get { return _xppm; }
+      get { return _xppm?? default(float); }
       set { _xppm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xppmSpecified
+    {
+      get { return _xppm != null; }
+      set { if (value == (_xppm== null)) _xppm = value ? this.xppm : (float?)null; }
+    }
+    private bool ShouldSerializexppm() { return xppmSpecified; }
+    private void Resetxppm() { xppmSpecified = false; }
+    
 
-    private float _stuns = default(float);
+    private float? _stuns;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"stuns", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float stuns
     {
-      get { return _stuns; }
+      get { return _stuns?? default(float); }
       set { _stuns = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stunsSpecified
+    {
+      get { return _stuns != null; }
+      set { if (value == (_stuns== null)) _stuns = value ? this.stuns : (float?)null; }
+    }
+    private bool ShouldSerializestuns() { return stunsSpecified; }
+    private void Resetstuns() { stunsSpecified = false; }
+    
 
-    private float _healing = default(float);
+    private float? _healing;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"healing", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float healing
     {
-      get { return _healing; }
+      get { return _healing?? default(float); }
       set { _healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healingSpecified
+    {
+      get { return _healing != null; }
+      set { if (value == (_healing== null)) _healing = value ? this.healing : (float?)null; }
+    }
+    private bool ShouldSerializehealing() { return healingSpecified; }
+    private void Resethealing() { healingSpecified = false; }
+    
 
-    private float _tower_kills = default(float);
+    private float? _tower_kills;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"tower_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float tower_kills
     {
-      get { return _tower_kills; }
+      get { return _tower_kills?? default(float); }
       set { _tower_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_killsSpecified
+    {
+      get { return _tower_kills != null; }
+      set { if (value == (_tower_kills== null)) _tower_kills = value ? this.tower_kills : (float?)null; }
+    }
+    private bool ShouldSerializetower_kills() { return tower_killsSpecified; }
+    private void Resettower_kills() { tower_killsSpecified = false; }
+    
 
-    private float _roshan_kills = default(float);
+    private float? _roshan_kills;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"roshan_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float roshan_kills
     {
-      get { return _roshan_kills; }
+      get { return _roshan_kills?? default(float); }
       set { _roshan_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roshan_killsSpecified
+    {
+      get { return _roshan_kills != null; }
+      set { if (value == (_roshan_kills== null)) _roshan_kills = value ? this.roshan_kills : (float?)null; }
+    }
+    private bool ShouldSerializeroshan_kills() { return roshan_killsSpecified; }
+    private void Resetroshan_kills() { roshan_killsSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3115,23 +5061,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerStats() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _weeks = default(uint);
+    private uint? _weeks;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"weeks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weeks
     {
-      get { return _weeks; }
+      get { return _weeks?? default(uint); }
       set { _weeks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weeksSpecified
+    {
+      get { return _weeks != null; }
+      set { if (value == (_weeks== null)) _weeks = value ? this.weeks : (uint?)null; }
+    }
+    private bool ShouldSerializeweeks() { return weeksSpecified; }
+    private void Resetweeks() { weeksSpecified = false; }
+    
 
     private CMsgDOTAFantasyPlayerHisoricalStatsResponse.PlayerScoreAccumulator _stats_premium = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"stats_premium", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3180,23 +5144,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyMessageAdd() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3208,32 +5190,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyMessagesRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _start_message = default(uint);
+    private uint? _start_message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_message", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_message
     {
-      get { return _start_message; }
+      get { return _start_message?? default(uint); }
       set { _start_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_messageSpecified
+    {
+      get { return _start_message != null; }
+      set { if (value == (_start_message== null)) _start_message = value ? this.start_message : (uint?)null; }
+    }
+    private bool ShouldSerializestart_message() { return start_messageSpecified; }
+    private void Resetstart_message() { start_messageSpecified = false; }
+    
 
-    private uint _end_message = default(uint);
+    private uint? _end_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"end_message", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_message
     {
-      get { return _end_message; }
+      get { return _end_message?? default(uint); }
       set { _end_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_messageSpecified
+    {
+      get { return _end_message != null; }
+      set { if (value == (_end_message== null)) _end_message = value ? this.end_message : (uint?)null; }
+    }
+    private bool ShouldSerializeend_message() { return end_messageSpecified; }
+    private void Resetend_message() { end_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3245,14 +5254,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyMessagesResponse() {}
     
 
-    private CMsgDOTAFantasyMessagesResponse.EResult _result = CMsgDOTAFantasyMessagesResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyMessagesResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyMessagesResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyMessagesResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyMessagesResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyMessagesResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyMessagesResponse.Message> _messages = new global::System.Collections.Generic.List<CMsgDOTAFantasyMessagesResponse.Message>();
     [global::ProtoBuf.ProtoMember(2, Name=@"messages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyMessagesResponse.Message> messages
@@ -3261,55 +5279,100 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _num_total_messages = default(uint);
+    private uint? _num_total_messages;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_total_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_total_messages
     {
-      get { return _num_total_messages; }
+      get { return _num_total_messages?? default(uint); }
       set { _num_total_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_total_messagesSpecified
+    {
+      get { return _num_total_messages != null; }
+      set { if (value == (_num_total_messages== null)) _num_total_messages = value ? this.num_total_messages : (uint?)null; }
+    }
+    private bool ShouldSerializenum_total_messages() { return num_total_messagesSpecified; }
+    private void Resetnum_total_messages() { num_total_messagesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Message")]
   public partial class Message : global::ProtoBuf.IExtensible
   {
     public Message() {}
     
 
-    private uint _message_id = default(uint);
+    private uint? _message_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint message_id
     {
-      get { return _message_id; }
+      get { return _message_id?? default(uint); }
       set { _message_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_idSpecified
+    {
+      get { return _message_id != null; }
+      set { if (value == (_message_id== null)) _message_id = value ? this.message_id : (uint?)null; }
+    }
+    private bool ShouldSerializemessage_id() { return message_idSpecified; }
+    private void Resetmessage_id() { message_idSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _author_account_id = default(uint);
+    private uint? _author_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"author_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint author_account_id
     {
-      get { return _author_account_id; }
+      get { return _author_account_id?? default(uint); }
       set { _author_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool author_account_idSpecified
+    {
+      get { return _author_account_id != null; }
+      set { if (value == (_author_account_id== null)) _author_account_id = value ? this.author_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeauthor_account_id() { return author_account_idSpecified; }
+    private void Resetauthor_account_id() { author_account_idSpecified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3340,32 +5403,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyRemoveOwner() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _team_index = default(uint);
+    private uint? _team_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_index
     {
-      get { return _team_index; }
+      get { return _team_index?? default(uint); }
       set { _team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_indexSpecified
+    {
+      get { return _team_index != null; }
+      set { if (value == (_team_index== null)) _team_index = value ? this.team_index : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_index() { return team_indexSpecified; }
+    private void Resetteam_index() { team_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3377,14 +5467,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyRemoveOwnerResponse() {}
     
 
-    private CMsgDOTAFantasyRemoveOwnerResponse.EResult _result = CMsgDOTAFantasyRemoveOwnerResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyRemoveOwnerResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyRemoveOwnerResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyRemoveOwnerResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyRemoveOwnerResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyRemoveOwnerResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -3416,14 +5515,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyScheduledMatchesRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3435,14 +5543,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyScheduledMatchesResponse() {}
     
 
-    private CMsgDOTAFantasyScheduledMatchesResponse.EResult _result = CMsgDOTAFantasyScheduledMatchesResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyScheduledMatchesResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyScheduledMatchesResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyScheduledMatchesResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyScheduledMatchesResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyScheduledMatchesResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyScheduledMatchesResponse.ScheduledMatchDays> _scheduled_match_days = new global::System.Collections.Generic.List<CMsgDOTAFantasyScheduledMatchesResponse.ScheduledMatchDays>();
     [global::ProtoBuf.ProtoMember(2, Name=@"scheduled_match_days", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyScheduledMatchesResponse.ScheduledMatchDays> scheduled_match_days
@@ -3456,14 +5573,23 @@ namespace SteamKit2.GC.Dota.Internal
     public ScheduledMatchDays() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _team_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"team_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> team_ids
@@ -3505,23 +5631,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeaveLeagueRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _fantasy_team_index = default(uint);
+    private uint? _fantasy_team_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fantasy_team_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_team_index
     {
-      get { return _fantasy_team_index; }
+      get { return _fantasy_team_index?? default(uint); }
       set { _fantasy_team_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_team_indexSpecified
+    {
+      get { return _fantasy_team_index != null; }
+      set { if (value == (_fantasy_team_index== null)) _fantasy_team_index = value ? this.fantasy_team_index : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_team_index() { return fantasy_team_indexSpecified; }
+    private void Resetfantasy_team_index() { fantasy_team_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3533,14 +5677,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyLeaveLeagueResponse() {}
     
 
-    private CMsgDOTAFantasyLeaveLeagueResponse.EResult _result = CMsgDOTAFantasyLeaveLeagueResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyLeaveLeagueResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyLeaveLeagueResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyLeaveLeagueResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyLeaveLeagueResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyLeaveLeagueResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -3572,41 +5725,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerScoreDetailsRequest() {}
     
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _end_time = default(uint);
+    private uint? _end_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_time
     {
-      get { return _end_time; }
+      get { return _end_time?? default(uint); }
       set { _end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_timeSpecified
+    {
+      get { return _end_time != null; }
+      set { if (value == (_end_time== null)) _end_time = value ? this.end_time : (uint?)null; }
+    }
+    private bool ShouldSerializeend_time() { return end_timeSpecified; }
+    private void Resetend_time() { end_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3618,14 +5807,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerScoreDetailsResponse() {}
     
 
-    private CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult _result = CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult.SUCCESS;
+    private CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult.SUCCESS)]
     public CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAFantasyPlayerScoreDetailsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerScoreDetailsResponse.PlayerMatchData> _data = new global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerScoreDetailsResponse.PlayerMatchData>();
     [global::ProtoBuf.ProtoMember(2, Name=@"data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFantasyPlayerScoreDetailsResponse.PlayerMatchData> data
@@ -3639,104 +5837,203 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerMatchData() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _series_num = default(uint);
+    private uint? _series_num;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"series_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_num
     {
-      get { return _series_num; }
+      get { return _series_num?? default(uint); }
       set { _series_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_numSpecified
+    {
+      get { return _series_num != null; }
+      set { if (value == (_series_num== null)) _series_num = value ? this.series_num : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_num() { return series_numSpecified; }
+    private void Resetseries_num() { series_numSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _league_tier = default(uint);
+    private uint? _league_tier;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"league_tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_tier
     {
-      get { return _league_tier; }
+      get { return _league_tier?? default(uint); }
       set { _league_tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_tierSpecified
+    {
+      get { return _league_tier != null; }
+      set { if (value == (_league_tier== null)) _league_tier = value ? this.league_tier : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_tier() { return league_tierSpecified; }
+    private void Resetleague_tier() { league_tierSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _opposing_team_id = default(uint);
+    private uint? _opposing_team_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"opposing_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint opposing_team_id
     {
-      get { return _opposing_team_id; }
+      get { return _opposing_team_id?? default(uint); }
       set { _opposing_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opposing_team_idSpecified
+    {
+      get { return _opposing_team_id != null; }
+      set { if (value == (_opposing_team_id== null)) _opposing_team_id = value ? this.opposing_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeopposing_team_id() { return opposing_team_idSpecified; }
+    private void Resetopposing_team_id() { opposing_team_idSpecified = false; }
+    
 
-    private ulong _opposing_team_logo = default(ulong);
+    private ulong? _opposing_team_logo;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"opposing_team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong opposing_team_logo
     {
-      get { return _opposing_team_logo; }
+      get { return _opposing_team_logo?? default(ulong); }
       set { _opposing_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opposing_team_logoSpecified
+    {
+      get { return _opposing_team_logo != null; }
+      set { if (value == (_opposing_team_logo== null)) _opposing_team_logo = value ? this.opposing_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeopposing_team_logo() { return opposing_team_logoSpecified; }
+    private void Resetopposing_team_logo() { opposing_team_logoSpecified = false; }
+    
 
-    private string _opposing_team_name = "";
+    private string _opposing_team_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"opposing_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string opposing_team_name
     {
-      get { return _opposing_team_name; }
+      get { return _opposing_team_name?? ""; }
       set { _opposing_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opposing_team_nameSpecified
+    {
+      get { return _opposing_team_name != null; }
+      set { if (value == (_opposing_team_name== null)) _opposing_team_name = value ? this.opposing_team_name : (string)null; }
+    }
+    private bool ShouldSerializeopposing_team_name() { return opposing_team_nameSpecified; }
+    private void Resetopposing_team_name() { opposing_team_nameSpecified = false; }
+    
 
-    private uint _owned_by = default(uint);
+    private uint? _owned_by;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"owned_by", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owned_by
     {
-      get { return _owned_by; }
+      get { return _owned_by?? default(uint); }
       set { _owned_by = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owned_bySpecified
+    {
+      get { return _owned_by != null; }
+      set { if (value == (_owned_by== null)) _owned_by = value ? this.owned_by : (uint?)null; }
+    }
+    private bool ShouldSerializeowned_by() { return owned_bySpecified; }
+    private void Resetowned_by() { owned_bySpecified = false; }
+    
 
-    private bool _benched = default(bool);
+    private bool? _benched;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"benched", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool benched
     {
-      get { return _benched; }
+      get { return _benched?? default(bool); }
       set { _benched = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool benchedSpecified
+    {
+      get { return _benched != null; }
+      set { if (value == (_benched== null)) _benched = value ? this.benched : (bool?)null; }
+    }
+    private bool ShouldSerializebenched() { return benchedSpecified; }
+    private void Resetbenched() { benchedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3767,32 +6064,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPassportVoteTeamGuess() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _winner_id = default(uint);
+    private uint? _winner_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"winner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint winner_id
     {
-      get { return _winner_id; }
+      get { return _winner_id?? default(uint); }
       set { _winner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winner_idSpecified
+    {
+      get { return _winner_id != null; }
+      set { if (value == (_winner_id== null)) _winner_id = value ? this.winner_id : (uint?)null; }
+    }
+    private bool ShouldSerializewinner_id() { return winner_idSpecified; }
+    private void Resetwinner_id() { winner_idSpecified = false; }
+    
 
-    private uint _runnerup_id = default(uint);
+    private uint? _runnerup_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"runnerup_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint runnerup_id
     {
-      get { return _runnerup_id; }
+      get { return _runnerup_id?? default(uint); }
       set { _runnerup_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool runnerup_idSpecified
+    {
+      get { return _runnerup_id != null; }
+      set { if (value == (_runnerup_id== null)) _runnerup_id = value ? this.runnerup_id : (uint?)null; }
+    }
+    private bool ShouldSerializerunnerup_id() { return runnerup_idSpecified; }
+    private void Resetrunnerup_id() { runnerup_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3804,23 +6128,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPassportVoteGenericSelection() {}
     
 
-    private DOTA_2013PassportSelectionIndices _selection_index = DOTA_2013PassportSelectionIndices.PP13_SEL_ALLSTAR_PLAYER_0;
+    private DOTA_2013PassportSelectionIndices? _selection_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"selection_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_2013PassportSelectionIndices.PP13_SEL_ALLSTAR_PLAYER_0)]
     public DOTA_2013PassportSelectionIndices selection_index
     {
-      get { return _selection_index; }
+      get { return _selection_index?? DOTA_2013PassportSelectionIndices.PP13_SEL_ALLSTAR_PLAYER_0; }
       set { _selection_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_indexSpecified
+    {
+      get { return _selection_index != null; }
+      set { if (value == (_selection_index== null)) _selection_index = value ? this.selection_index : (DOTA_2013PassportSelectionIndices?)null; }
+    }
+    private bool ShouldSerializeselection_index() { return selection_indexSpecified; }
+    private void Resetselection_index() { selection_indexSpecified = false; }
+    
 
-    private uint _selection = default(uint);
+    private uint? _selection;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"selection", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection
     {
-      get { return _selection; }
+      get { return _selection?? default(uint); }
       set { _selection = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selectionSpecified
+    {
+      get { return _selection != null; }
+      set { if (value == (_selection== null)) _selection = value ? this.selection : (uint?)null; }
+    }
+    private bool ShouldSerializeselection() { return selectionSpecified; }
+    private void Resetselection() { selectionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3832,23 +6174,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPassportStampedPlayer() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _stamp_level = default(uint);
+    private uint? _stamp_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stamp_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stamp_level
     {
-      get { return _stamp_level; }
+      get { return _stamp_level?? default(uint); }
       set { _stamp_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stamp_levelSpecified
+    {
+      get { return _stamp_level != null; }
+      set { if (value == (_stamp_level== null)) _stamp_level = value ? this.stamp_level : (uint?)null; }
+    }
+    private bool ShouldSerializestamp_level() { return stamp_levelSpecified; }
+    private void Resetstamp_level() { stamp_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3860,14 +6220,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPassportPlayerCardChallenge() {}
     
 
-    private uint _challenge_id = default(uint);
+    private uint? _challenge_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"challenge_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_id
     {
-      get { return _challenge_id; }
+      get { return _challenge_id?? default(uint); }
       set { _challenge_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_idSpecified
+    {
+      get { return _challenge_id != null; }
+      set { if (value == (_challenge_id== null)) _challenge_id = value ? this.challenge_id : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_id() { return challenge_idSpecified; }
+    private void Resetchallenge_id() { challenge_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3917,23 +6286,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetPlayerCardRosterRequest() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3945,14 +6332,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetPlayerCardRosterResponse() {}
     
 
-    private CMsgClientToGCGetPlayerCardRosterResponse.Result _result = CMsgClientToGCGetPlayerCardRosterResponse.Result.SUCCESS;
+    private CMsgClientToGCGetPlayerCardRosterResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCGetPlayerCardRosterResponse.Result.SUCCESS)]
     public CMsgClientToGCGetPlayerCardRosterResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCGetPlayerCardRosterResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCGetPlayerCardRosterResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _player_card_item_id = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_card_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> player_card_item_id
@@ -3961,32 +6357,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private bool _finalized = default(bool);
+    private bool? _finalized;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"finalized", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool finalized
     {
-      get { return _finalized; }
+      get { return _finalized?? default(bool); }
       set { _finalized = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool finalizedSpecified
+    {
+      get { return _finalized != null; }
+      set { if (value == (_finalized== null)) _finalized = value ? this.finalized : (bool?)null; }
+    }
+    private bool ShouldSerializefinalized() { return finalizedSpecified; }
+    private void Resetfinalized() { finalizedSpecified = false; }
+    
 
-    private float _percentile = default(float);
+    private float? _percentile;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"percentile", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float percentile
     {
-      get { return _percentile; }
+      get { return _percentile?? default(float); }
       set { _percentile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool percentileSpecified
+    {
+      get { return _percentile != null; }
+      set { if (value == (_percentile== null)) _percentile = value ? this.percentile : (float?)null; }
+    }
+    private bool ShouldSerializepercentile() { return percentileSpecified; }
+    private void Resetpercentile() { percentileSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -4015,41 +6438,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSetPlayerCardRosterRequest() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _slot = default(uint);
+    private uint? _slot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot
     {
-      get { return _slot; }
+      get { return _slot?? default(uint); }
       set { _slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slotSpecified
+    {
+      get { return _slot != null; }
+      set { if (value == (_slot== null)) _slot = value ? this.slot : (uint?)null; }
+    }
+    private bool ShouldSerializeslot() { return slotSpecified; }
+    private void Resetslot() { slotSpecified = false; }
+    
 
-    private ulong _player_card_item_id = default(ulong);
+    private ulong? _player_card_item_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"player_card_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_card_item_id
     {
-      get { return _player_card_item_id; }
+      get { return _player_card_item_id?? default(ulong); }
       set { _player_card_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_card_item_idSpecified
+    {
+      get { return _player_card_item_id != null; }
+      set { if (value == (_player_card_item_id== null)) _player_card_item_id = value ? this.player_card_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_card_item_id() { return player_card_item_idSpecified; }
+    private void Resetplayer_card_item_id() { player_card_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4061,14 +6520,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSetPlayerCardRosterResponse() {}
     
 
-    private CMsgClientToGCSetPlayerCardRosterResponse.Result _result = CMsgClientToGCSetPlayerCardRosterResponse.Result.SUCCESS;
+    private CMsgClientToGCSetPlayerCardRosterResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCSetPlayerCardRosterResponse.Result.SUCCESS)]
     public CMsgClientToGCSetPlayerCardRosterResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgClientToGCSetPlayerCardRosterResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgClientToGCSetPlayerCardRosterResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientGuild.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientGuild.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_guild.proto
 namespace SteamKit2.GC.Dota.Internal
 {
@@ -17,77 +19,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildSDO() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _time_disbanded = default(uint);
+    private uint? _time_disbanded;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_disbanded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_disbanded
     {
-      get { return _time_disbanded; }
+      get { return _time_disbanded?? default(uint); }
       set { _time_disbanded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_disbandedSpecified
+    {
+      get { return _time_disbanded != null; }
+      set { if (value == (_time_disbanded== null)) _time_disbanded = value ? this.time_disbanded : (uint?)null; }
+    }
+    private bool ShouldSerializetime_disbanded() { return time_disbandedSpecified; }
+    private void Resettime_disbanded() { time_disbandedSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAGuildSDO.Member> _members = new global::System.Collections.Generic.List<CMsgDOTAGuildSDO.Member>();
     [global::ProtoBuf.ProtoMember(9, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAGuildSDO.Member> members
@@ -103,55 +177,100 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private bool _incremental = default(bool);
+    private bool? _incremental;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"incremental", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool incremental
     {
-      get { return _incremental; }
+      get { return _incremental?? default(bool); }
       set { _incremental = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incrementalSpecified
+    {
+      get { return _incremental != null; }
+      set { if (value == (_incremental== null)) _incremental = value ? this.incremental : (bool?)null; }
+    }
+    private bool ShouldSerializeincremental() { return incrementalSpecified; }
+    private void Resetincremental() { incrementalSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Member")]
   public partial class Member : global::ProtoBuf.IExtensible
   {
     public Member() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _time_joined = default(uint);
+    private uint? _time_joined;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_joined", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_joined
     {
-      get { return _time_joined; }
+      get { return _time_joined?? default(uint); }
       set { _time_joined = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_joinedSpecified
+    {
+      get { return _time_joined != null; }
+      set { if (value == (_time_joined== null)) _time_joined = value ? this.time_joined : (uint?)null; }
+    }
+    private bool ShouldSerializetime_joined() { return time_joinedSpecified; }
+    private void Resettime_joined() { time_joinedSpecified = false; }
+    
 
-    private uint _role = default(uint);
+    private uint? _role;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint role
     {
-      get { return _role; }
+      get { return _role?? default(uint); }
       set { _role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roleSpecified
+    {
+      get { return _role != null; }
+      set { if (value == (_role== null)) _role = value ? this.role : (uint?)null; }
+    }
+    private bool ShouldSerializerole() { return roleSpecified; }
+    private void Resetrole() { roleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -163,32 +282,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Invitation() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _time_sent = default(uint);
+    private uint? _time_sent;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_sent
     {
-      get { return _time_sent; }
+      get { return _time_sent?? default(uint); }
       set { _time_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_sentSpecified
+    {
+      get { return _time_sent != null; }
+      set { if (value == (_time_sent== null)) _time_sent = value ? this.time_sent : (uint?)null; }
+    }
+    private bool ShouldSerializetime_sent() { return time_sentSpecified; }
+    private void Resettime_sent() { time_sentSpecified = false; }
+    
 
-    private uint _account_id_sender = default(uint);
+    private uint? _account_id_sender;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_id_sender", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_sender
     {
-      get { return _account_id_sender; }
+      get { return _account_id_sender?? default(uint); }
       set { _account_id_sender = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_senderSpecified
+    {
+      get { return _account_id_sender != null; }
+      set { if (value == (_account_id_sender== null)) _account_id_sender = value ? this.account_id_sender : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_sender() { return account_id_senderSpecified; }
+    private void Resetaccount_id_sender() { account_id_senderSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -205,14 +351,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildAuditSDO() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAGuildAuditSDO.Entry> _entries = new global::System.Collections.Generic.List<CMsgDOTAGuildAuditSDO.Entry>();
     [global::ProtoBuf.ProtoMember(2, Name=@"entries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAGuildAuditSDO.Entry> entries
@@ -226,68 +381,131 @@ namespace SteamKit2.GC.Dota.Internal
     public Entry() {}
     
 
-    private uint _event_index = default(uint);
+    private uint? _event_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_index
     {
-      get { return _event_index; }
+      get { return _event_index?? default(uint); }
       set { _event_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_indexSpecified
+    {
+      get { return _event_index != null; }
+      set { if (value == (_event_index== null)) _event_index = value ? this.event_index : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_index() { return event_indexSpecified; }
+    private void Resetevent_index() { event_indexSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _action = default(uint);
+    private uint? _action;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action
     {
-      get { return _action; }
+      get { return _action?? default(uint); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (uint?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
 
-    private uint _account_id_requestor = default(uint);
+    private uint? _account_id_requestor;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"account_id_requestor", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_requestor
     {
-      get { return _account_id_requestor; }
+      get { return _account_id_requestor?? default(uint); }
       set { _account_id_requestor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_requestorSpecified
+    {
+      get { return _account_id_requestor != null; }
+      set { if (value == (_account_id_requestor== null)) _account_id_requestor = value ? this.account_id_requestor : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_requestor() { return account_id_requestorSpecified; }
+    private void Resetaccount_id_requestor() { account_id_requestorSpecified = false; }
+    
 
-    private uint _account_id_target = default(uint);
+    private uint? _account_id_target;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"account_id_target", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_target
     {
-      get { return _account_id_target; }
+      get { return _account_id_target?? default(uint); }
       set { _account_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_targetSpecified
+    {
+      get { return _account_id_target != null; }
+      set { if (value == (_account_id_target== null)) _account_id_target = value ? this.account_id_target : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_target() { return account_id_targetSpecified; }
+    private void Resetaccount_id_target() { account_id_targetSpecified = false; }
+    
 
-    private uint _reference_data_a = default(uint);
+    private uint? _reference_data_a;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"reference_data_a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_data_a
     {
-      get { return _reference_data_a; }
+      get { return _reference_data_a?? default(uint); }
       set { _reference_data_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_data_aSpecified
+    {
+      get { return _reference_data_a != null; }
+      set { if (value == (_reference_data_a== null)) _reference_data_a = value ? this.reference_data_a : (uint?)null; }
+    }
+    private bool ShouldSerializereference_data_a() { return reference_data_aSpecified; }
+    private void Resetreference_data_a() { reference_data_aSpecified = false; }
+    
 
-    private uint _reference_data_b = default(uint);
+    private uint? _reference_data_b;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"reference_data_b", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_data_b
     {
-      get { return _reference_data_b; }
+      get { return _reference_data_b?? default(uint); }
       set { _reference_data_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_data_bSpecified
+    {
+      get { return _reference_data_b != null; }
+      set { if (value == (_reference_data_b== null)) _reference_data_b = value ? this.reference_data_b : (uint?)null; }
+    }
+    private bool ShouldSerializereference_data_b() { return reference_data_bSpecified; }
+    private void Resetreference_data_b() { reference_data_bSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -304,14 +522,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAAccountGuildMembershipsSDO() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAAccountGuildMembershipsSDO.Membership> _memberships = new global::System.Collections.Generic.List<CMsgDOTAAccountGuildMembershipsSDO.Membership>();
     [global::ProtoBuf.ProtoMember(2, Name=@"memberships", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAAccountGuildMembershipsSDO.Membership> memberships
@@ -332,23 +559,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Membership() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private uint _role = default(uint);
+    private uint? _role;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint role
     {
-      get { return _role; }
+      get { return _role?? default(uint); }
       set { _role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roleSpecified
+    {
+      get { return _role != null; }
+      set { if (value == (_role== null)) _role = value ? this.role : (uint?)null; }
+    }
+    private bool ShouldSerializerole() { return roleSpecified; }
+    private void Resetrole() { roleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -360,32 +605,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Invitation() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private uint _time_sent = default(uint);
+    private uint? _time_sent;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_sent
     {
-      get { return _time_sent; }
+      get { return _time_sent?? default(uint); }
       set { _time_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_sentSpecified
+    {
+      get { return _time_sent != null; }
+      set { if (value == (_time_sent== null)) _time_sent = value ? this.time_sent : (uint?)null; }
+    }
+    private bool ShouldSerializetime_sent() { return time_sentSpecified; }
+    private void Resettime_sent() { time_sentSpecified = false; }
+    
 
-    private uint _account_id_sender = default(uint);
+    private uint? _account_id_sender;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_id_sender", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_sender
     {
-      get { return _account_id_sender; }
+      get { return _account_id_sender?? default(uint); }
       set { _account_id_sender = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_senderSpecified
+    {
+      get { return _account_id_sender != null; }
+      set { if (value == (_account_id_sender== null)) _account_id_sender = value ? this.account_id_sender : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_sender() { return account_id_senderSpecified; }
+    private void Resetaccount_id_sender() { account_id_senderSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -402,50 +674,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildCreateRequest() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -457,14 +774,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildCreateResponse() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAGuildCreateResponse.EError> _errors = new global::System.Collections.Generic.List<CMsgDOTAGuildCreateResponse.EError>();
     [global::ProtoBuf.ProtoMember(2, Name=@"errors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<CMsgDOTAGuildCreateResponse.EError> errors
@@ -518,32 +844,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildSetAccountRoleRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
 
-    private uint _target_role = default(uint);
+    private uint? _target_role;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"target_role", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_role
     {
-      get { return _target_role; }
+      get { return _target_role?? default(uint); }
       set { _target_role = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_roleSpecified
+    {
+      get { return _target_role != null; }
+      set { if (value == (_target_role== null)) _target_role = value ? this.target_role : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_role() { return target_roleSpecified; }
+    private void Resettarget_role() { target_roleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -555,14 +908,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildSetAccountRoleResponse() {}
     
 
-    private CMsgDOTAGuildSetAccountRoleResponse.EResult _result = CMsgDOTAGuildSetAccountRoleResponse.EResult.SUCCESS;
+    private CMsgDOTAGuildSetAccountRoleResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAGuildSetAccountRoleResponse.EResult.SUCCESS)]
     public CMsgDOTAGuildSetAccountRoleResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAGuildSetAccountRoleResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAGuildSetAccountRoleResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -597,23 +959,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildInviteAccountRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -625,14 +1005,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildInviteAccountResponse() {}
     
 
-    private CMsgDOTAGuildInviteAccountResponse.EResult _result = CMsgDOTAGuildInviteAccountResponse.EResult.SUCCESS;
+    private CMsgDOTAGuildInviteAccountResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAGuildInviteAccountResponse.EResult.SUCCESS)]
     public CMsgDOTAGuildInviteAccountResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAGuildInviteAccountResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAGuildInviteAccountResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -673,23 +1062,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildCancelInviteRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private uint _target_account_id = default(uint);
+    private uint? _target_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_account_id
     {
-      get { return _target_account_id; }
+      get { return _target_account_id?? default(uint); }
       set { _target_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_account_idSpecified
+    {
+      get { return _target_account_id != null; }
+      set { if (value == (_target_account_id== null)) _target_account_id = value ? this.target_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_account_id() { return target_account_idSpecified; }
+    private void Resettarget_account_id() { target_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -701,14 +1108,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildCancelInviteResponse() {}
     
 
-    private CMsgDOTAGuildCancelInviteResponse.EResult _result = CMsgDOTAGuildCancelInviteResponse.EResult.SUCCESS;
+    private CMsgDOTAGuildCancelInviteResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAGuildCancelInviteResponse.EResult.SUCCESS)]
     public CMsgDOTAGuildCancelInviteResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAGuildCancelInviteResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAGuildCancelInviteResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -734,41 +1150,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildUpdateDetailsRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -780,14 +1232,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildUpdateDetailsResponse() {}
     
 
-    private CMsgDOTAGuildUpdateDetailsResponse.EResult _result = CMsgDOTAGuildUpdateDetailsResponse.EResult.SUCCESS;
+    private CMsgDOTAGuildUpdateDetailsResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAGuildUpdateDetailsResponse.EResult.SUCCESS)]
     public CMsgDOTAGuildUpdateDetailsResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAGuildUpdateDetailsResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAGuildUpdateDetailsResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -813,23 +1274,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGCToGCUpdateOpenGuildPartyRequest() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _member_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"member_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> member_account_ids
@@ -838,14 +1317,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -857,14 +1345,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGCToGCUpdateOpenGuildPartyResponse() {}
     
 
-    private bool _maintain_association = default(bool);
+    private bool? _maintain_association;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"maintain_association", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool maintain_association
     {
-      get { return _maintain_association; }
+      get { return _maintain_association?? default(bool); }
       set { _maintain_association = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maintain_associationSpecified
+    {
+      get { return _maintain_association != null; }
+      set { if (value == (_maintain_association== null)) _maintain_association = value ? this.maintain_association : (bool?)null; }
+    }
+    private bool ShouldSerializemaintain_association() { return maintain_associationSpecified; }
+    private void Resetmaintain_association() { maintain_associationSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -876,23 +1373,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGCToGCDestroyOpenGuildPartyRequest() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -914,23 +1429,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPartySetOpenGuildRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -942,14 +1475,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPartySetOpenGuildResponse() {}
     
 
-    private CMsgDOTAPartySetOpenGuildResponse.EResult _result = CMsgDOTAPartySetOpenGuildResponse.EResult.SUCCESS;
+    private CMsgDOTAPartySetOpenGuildResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAPartySetOpenGuildResponse.EResult.SUCCESS)]
     public CMsgDOTAPartySetOpenGuildResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAPartySetOpenGuildResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAPartySetOpenGuildResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -972,14 +1514,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAJoinOpenGuildPartyRequest() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -991,14 +1542,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAJoinOpenGuildPartyResponse() {}
     
 
-    private CMsgDOTAJoinOpenGuildPartyResponse.EResult _result = CMsgDOTAJoinOpenGuildPartyResponse.EResult.SUCCESS;
+    private CMsgDOTAJoinOpenGuildPartyResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAJoinOpenGuildPartyResponse.EResult.SUCCESS)]
     public CMsgDOTAJoinOpenGuildPartyResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAJoinOpenGuildPartyResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAJoinOpenGuildPartyResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -1021,14 +1581,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildOpenPartyRefresh() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAGuildOpenPartyRefresh.OpenParty> _open_parties = new global::System.Collections.Generic.List<CMsgDOTAGuildOpenPartyRefresh.OpenParty>();
     [global::ProtoBuf.ProtoMember(2, Name=@"open_parties", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAGuildOpenPartyRefresh.OpenParty> open_parties
@@ -1042,14 +1611,23 @@ namespace SteamKit2.GC.Dota.Internal
     public OpenParty() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _member_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"member_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> member_account_ids
@@ -1058,23 +1636,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1101,77 +1697,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildInviteData() {}
     
 
-    private bool _invited_to_guild = default(bool);
+    private bool? _invited_to_guild;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"invited_to_guild", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool invited_to_guild
     {
-      get { return _invited_to_guild; }
+      get { return _invited_to_guild?? default(bool); }
       set { _invited_to_guild = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invited_to_guildSpecified
+    {
+      get { return _invited_to_guild != null; }
+      set { if (value == (_invited_to_guild== null)) _invited_to_guild = value ? this.invited_to_guild : (bool?)null; }
+    }
+    private bool ShouldSerializeinvited_to_guild() { return invited_to_guildSpecified; }
+    private void Resetinvited_to_guild() { invited_to_guildSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private string _guild_name = "";
+    private string _guild_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"guild_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string guild_name
     {
-      get { return _guild_name; }
+      get { return _guild_name?? ""; }
       set { _guild_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_nameSpecified
+    {
+      get { return _guild_name != null; }
+      set { if (value == (_guild_name== null)) _guild_name = value ? this.guild_name : (string)null; }
+    }
+    private bool ShouldSerializeguild_name() { return guild_nameSpecified; }
+    private void Resetguild_name() { guild_nameSpecified = false; }
+    
 
-    private string _guild_tag = "";
+    private string _guild_tag;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"guild_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string guild_tag
     {
-      get { return _guild_tag; }
+      get { return _guild_tag?? ""; }
       set { _guild_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_tagSpecified
+    {
+      get { return _guild_tag != null; }
+      set { if (value == (_guild_tag== null)) _guild_tag = value ? this.guild_tag : (string)null; }
+    }
+    private bool ShouldSerializeguild_tag() { return guild_tagSpecified; }
+    private void Resetguild_tag() { guild_tagSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private uint _inviter = default(uint);
+    private uint? _inviter;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"inviter", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inviter
     {
-      get { return _inviter; }
+      get { return _inviter?? default(uint); }
       set { _inviter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inviterSpecified
+    {
+      get { return _inviter != null; }
+      set { if (value == (_inviter== null)) _inviter = value ? this.inviter : (uint?)null; }
+    }
+    private bool ShouldSerializeinviter() { return inviterSpecified; }
+    private void Resetinviter() { inviterSpecified = false; }
+    
 
-    private string _inviter_name = "";
+    private string _inviter_name;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"inviter_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string inviter_name
     {
-      get { return _inviter_name; }
+      get { return _inviter_name?? ""; }
       set { _inviter_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inviter_nameSpecified
+    {
+      get { return _inviter_name != null; }
+      set { if (value == (_inviter_name== null)) _inviter_name = value ? this.inviter_name : (string)null; }
+    }
+    private bool ShouldSerializeinviter_name() { return inviter_nameSpecified; }
+    private void Resetinviter_name() { inviter_nameSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1183,23 +1851,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildUpdateMessage() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1211,23 +1897,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildEditLogoRequest() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1239,23 +1943,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGuildEditLogoResponse() {}
     
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private CMsgDOTAGuildEditLogoResponse.EResult _result = CMsgDOTAGuildEditLogoResponse.EResult.SUCCESS;
+    private CMsgDOTAGuildEditLogoResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAGuildEditLogoResponse.EResult.SUCCESS)]
     public CMsgDOTAGuildEditLogoResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAGuildEditLogoResponse.EResult.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAGuildEditLogoResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientMatchMgmt.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientMatchMgmt.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_match_management.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
@@ -22,104 +24,203 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgStartFindingMatch() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private uint _matchgroups = (uint)4294967295;
+    private uint? _matchgroups;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matchgroups", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4294967295)]
     public uint matchgroups
     {
-      get { return _matchgroups; }
+      get { return _matchgroups?? (uint)4294967295; }
       set { _matchgroups = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroupsSpecified
+    {
+      get { return _matchgroups != null; }
+      set { if (value == (_matchgroups== null)) _matchgroups = value ? this.matchgroups : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroups() { return matchgroupsSpecified; }
+    private void Resetmatchgroups() { matchgroupsSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _game_modes = (uint)4294967295;
+    private uint? _game_modes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_modes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4294967295)]
     public uint game_modes
     {
-      get { return _game_modes; }
+      get { return _game_modes?? (uint)4294967295; }
       set { _game_modes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modesSpecified
+    {
+      get { return _game_modes != null; }
+      set { if (value == (_game_modes== null)) _game_modes = value ? this.game_modes : (uint?)null; }
+    }
+    private bool ShouldSerializegame_modes() { return game_modesSpecified; }
+    private void Resetgame_modes() { game_modesSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty = DOTABotDifficulty.BOT_DIFFICULTY_HARD;
+    private DOTABotDifficulty? _bot_difficulty;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"bot_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_HARD)]
     public DOTABotDifficulty bot_difficulty
     {
-      get { return _bot_difficulty; }
+      get { return _bot_difficulty?? DOTABotDifficulty.BOT_DIFFICULTY_HARD; }
       set { _bot_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficultySpecified
+    {
+      get { return _bot_difficulty != null; }
+      set { if (value == (_bot_difficulty== null)) _bot_difficulty = value ? this.bot_difficulty : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty() { return bot_difficultySpecified; }
+    private void Resetbot_difficulty() { bot_difficultySpecified = false; }
+    
 
-    private MatchType _match_type = MatchType.MATCH_TYPE_CASUAL;
+    private MatchType? _match_type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"match_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchType.MATCH_TYPE_CASUAL)]
     public MatchType match_type
     {
-      get { return _match_type; }
+      get { return _match_type?? MatchType.MATCH_TYPE_CASUAL; }
       set { _match_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_typeSpecified
+    {
+      get { return _match_type != null; }
+      set { if (value == (_match_type== null)) _match_type = value ? this.match_type : (MatchType?)null; }
+    }
+    private bool ShouldSerializematch_type() { return match_typeSpecified; }
+    private void Resetmatch_type() { match_typeSpecified = false; }
+    
 
-    private uint _matchlanguages = (uint)4294967295;
+    private uint? _matchlanguages;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"matchlanguages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4294967295)]
     public uint matchlanguages
     {
-      get { return _matchlanguages; }
+      get { return _matchlanguages?? (uint)4294967295; }
       set { _matchlanguages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchlanguagesSpecified
+    {
+      get { return _matchlanguages != null; }
+      set { if (value == (_matchlanguages== null)) _matchlanguages = value ? this.matchlanguages : (uint?)null; }
+    }
+    private bool ShouldSerializematchlanguages() { return matchlanguagesSpecified; }
+    private void Resetmatchlanguages() { matchlanguagesSpecified = false; }
+    
 
-    private uint _map_preference = default(uint);
+    private uint? _map_preference;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"map_preference", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint map_preference
     {
-      get { return _map_preference; }
+      get { return _map_preference?? default(uint); }
       set { _map_preference = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_preferenceSpecified
+    {
+      get { return _map_preference != null; }
+      set { if (value == (_map_preference== null)) _map_preference = value ? this.map_preference : (uint?)null; }
+    }
+    private bool ShouldSerializemap_preference() { return map_preferenceSpecified; }
+    private void Resetmap_preference() { map_preferenceSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private MatchLanguages _game_language_enum = MatchLanguages.MATCH_LANGUAGE_INVALID;
+    private MatchLanguages? _game_language_enum;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"game_language_enum", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchLanguages.MATCH_LANGUAGE_INVALID)]
     public MatchLanguages game_language_enum
     {
-      get { return _game_language_enum; }
+      get { return _game_language_enum?? MatchLanguages.MATCH_LANGUAGE_INVALID; }
       set { _game_language_enum = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_language_enumSpecified
+    {
+      get { return _game_language_enum != null; }
+      set { if (value == (_game_language_enum== null)) _game_language_enum = value ? this.game_language_enum : (MatchLanguages?)null; }
+    }
+    private bool ShouldSerializegame_language_enum() { return game_language_enumSpecified; }
+    private void Resetgame_language_enum() { game_language_enumSpecified = false; }
+    
 
-    private string _game_language_name = "";
+    private string _game_language_name;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"game_language_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_language_name
     {
-      get { return _game_language_name; }
+      get { return _game_language_name?? ""; }
       set { _game_language_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_language_nameSpecified
+    {
+      get { return _game_language_name != null; }
+      set { if (value == (_game_language_name== null)) _game_language_name = value ? this.game_language_name : (string)null; }
+    }
+    private bool ShouldSerializegame_language_name() { return game_language_nameSpecified; }
+    private void Resetgame_language_name() { game_language_nameSpecified = false; }
+    
 
     private CMsgClientPingData _ping_data = null;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"ping_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -130,14 +231,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _ping_data = value; }
     }
 
-    private uint _region_select_flags = default(uint);
+    private uint? _region_select_flags;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"region_select_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_select_flags
     {
-      get { return _region_select_flags; }
+      get { return _region_select_flags?? default(uint); }
       set { _region_select_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_select_flagsSpecified
+    {
+      get { return _region_select_flags != null; }
+      set { if (value == (_region_select_flags== null)) _region_select_flags = value ? this.region_select_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_select_flags() { return region_select_flagsSpecified; }
+    private void Resetregion_select_flags() { region_select_flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -149,41 +259,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgStartFindingMatchResult() {}
     
 
-    private uint _legacy_generic_eresult = (uint)2;
+    private uint? _legacy_generic_eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"legacy_generic_eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint legacy_generic_eresult
     {
-      get { return _legacy_generic_eresult; }
+      get { return _legacy_generic_eresult?? (uint)2; }
       set { _legacy_generic_eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_generic_eresultSpecified
+    {
+      get { return _legacy_generic_eresult != null; }
+      set { if (value == (_legacy_generic_eresult== null)) _legacy_generic_eresult = value ? this.legacy_generic_eresult : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_generic_eresult() { return legacy_generic_eresultSpecified; }
+    private void Resetlegacy_generic_eresult() { legacy_generic_eresultSpecified = false; }
+    
 
-    private EStartFindingMatchResult _result = EStartFindingMatchResult.k_EStartFindingMatchResult_Invalid;
+    private EStartFindingMatchResult? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EStartFindingMatchResult.k_EStartFindingMatchResult_Invalid)]
     public EStartFindingMatchResult result
     {
-      get { return _result; }
+      get { return _result?? EStartFindingMatchResult.k_EStartFindingMatchResult_Invalid; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (EStartFindingMatchResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _error_token = "";
+    private string _error_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"error_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_token
     {
-      get { return _error_token; }
+      get { return _error_token?? ""; }
       set { _error_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_tokenSpecified
+    {
+      get { return _error_token != null; }
+      set { if (value == (_error_token== null)) _error_token = value ? this.error_token : (string)null; }
+    }
+    private bool ShouldSerializeerror_token() { return error_tokenSpecified; }
+    private void Reseterror_token() { error_tokenSpecified = false; }
+    
 
-    private string _debug_message = "";
+    private string _debug_message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"debug_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string debug_message
     {
-      get { return _debug_message; }
+      get { return _debug_message?? ""; }
       set { _debug_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool debug_messageSpecified
+    {
+      get { return _debug_message != null; }
+      set { if (value == (_debug_message== null)) _debug_message = value ? this.debug_message : (string)null; }
+    }
+    private bool ShouldSerializedebug_message() { return debug_messageSpecified; }
+    private void Resetdebug_message() { debug_messageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _responsible_party_members = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(5, Name=@"responsible_party_members", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> responsible_party_members
@@ -212,50 +358,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPartyBuilderOptions() {}
     
 
-    private uint _additional_slots = default(uint);
+    private uint? _additional_slots;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"additional_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint additional_slots
     {
-      get { return _additional_slots; }
+      get { return _additional_slots?? default(uint); }
       set { _additional_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool additional_slotsSpecified
+    {
+      get { return _additional_slots != null; }
+      set { if (value == (_additional_slots== null)) _additional_slots = value ? this.additional_slots : (uint?)null; }
+    }
+    private bool ShouldSerializeadditional_slots() { return additional_slotsSpecified; }
+    private void Resetadditional_slots() { additional_slotsSpecified = false; }
+    
 
-    private MatchType _match_type = MatchType.MATCH_TYPE_CASUAL;
+    private MatchType? _match_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchType.MATCH_TYPE_CASUAL)]
     public MatchType match_type
     {
-      get { return _match_type; }
+      get { return _match_type?? MatchType.MATCH_TYPE_CASUAL; }
       set { _match_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_typeSpecified
+    {
+      get { return _match_type != null; }
+      set { if (value == (_match_type== null)) _match_type = value ? this.match_type : (MatchType?)null; }
+    }
+    private bool ShouldSerializematch_type() { return match_typeSpecified; }
+    private void Resetmatch_type() { match_typeSpecified = false; }
+    
 
-    private uint _matchgroups = default(uint);
+    private uint? _matchgroups;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"matchgroups", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchgroups
     {
-      get { return _matchgroups; }
+      get { return _matchgroups?? default(uint); }
       set { _matchgroups = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroupsSpecified
+    {
+      get { return _matchgroups != null; }
+      set { if (value == (_matchgroups== null)) _matchgroups = value ? this.matchgroups : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroups() { return matchgroupsSpecified; }
+    private void Resetmatchgroups() { matchgroupsSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private MatchLanguages _language = MatchLanguages.MATCH_LANGUAGE_INVALID;
+    private MatchLanguages? _language;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchLanguages.MATCH_LANGUAGE_INVALID)]
     public MatchLanguages language
     {
-      get { return _language; }
+      get { return _language?? MatchLanguages.MATCH_LANGUAGE_INVALID; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (MatchLanguages?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -267,23 +458,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgReadyUp() {}
     
 
-    private DOTALobbyReadyState _state = DOTALobbyReadyState.DOTALobbyReadyState_UNDECLARED;
+    private DOTALobbyReadyState? _state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTALobbyReadyState.DOTALobbyReadyState_UNDECLARED)]
     public DOTALobbyReadyState state
     {
-      get { return _state; }
+      get { return _state?? DOTALobbyReadyState.DOTALobbyReadyState_UNDECLARED; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (DOTALobbyReadyState?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private ulong _ready_up_key = default(ulong);
+    private ulong? _ready_up_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ready_up_key", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ready_up_key
     {
-      get { return _ready_up_key; }
+      get { return _ready_up_key?? default(ulong); }
       set { _ready_up_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ready_up_keySpecified
+    {
+      get { return _ready_up_key != null; }
+      set { if (value == (_ready_up_key== null)) _ready_up_key = value ? this.ready_up_key : (ulong?)null; }
+    }
+    private bool ShouldSerializeready_up_key() { return ready_up_keySpecified; }
+    private void Resetready_up_key() { ready_up_keySpecified = false; }
+    
 
     private CDOTAClientHardwareSpecs _hardware_specs = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hardware_specs", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -304,14 +513,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgReadyUpStatus() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _accepted_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"accepted_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> accepted_ids
@@ -347,23 +565,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbySetDetails() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private string _game_name = "";
+    private string _game_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_name
     {
-      get { return _game_name; }
+      get { return _game_name?? ""; }
       set { _game_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_nameSpecified
+    {
+      get { return _game_name != null; }
+      set { if (value == (_game_name== null)) _game_name = value ? this.game_name : (string)null; }
+    }
+    private bool ShouldSerializegame_name() { return game_nameSpecified; }
+    private void Resetgame_name() { game_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CLobbyTeamDetails> _team_details = new global::System.Collections.Generic.List<CLobbyTeamDetails>();
     [global::ProtoBuf.ProtoMember(3, Name=@"team_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CLobbyTeamDetails> team_details
@@ -372,365 +608,725 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private DOTA_CM_PICK _cm_pick = DOTA_CM_PICK.DOTA_CM_RANDOM;
+    private DOTA_CM_PICK? _cm_pick;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"cm_pick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_CM_PICK.DOTA_CM_RANDOM)]
     public DOTA_CM_PICK cm_pick
     {
-      get { return _cm_pick; }
+      get { return _cm_pick?? DOTA_CM_PICK.DOTA_CM_RANDOM; }
       set { _cm_pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cm_pickSpecified
+    {
+      get { return _cm_pick != null; }
+      set { if (value == (_cm_pick== null)) _cm_pick = value ? this.cm_pick : (DOTA_CM_PICK?)null; }
+    }
+    private bool ShouldSerializecm_pick() { return cm_pickSpecified; }
+    private void Resetcm_pick() { cm_pickSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_radiant = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty_radiant;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"bot_difficulty_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty_radiant
     {
-      get { return _bot_difficulty_radiant; }
+      get { return _bot_difficulty_radiant?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_radiantSpecified
+    {
+      get { return _bot_difficulty_radiant != null; }
+      set { if (value == (_bot_difficulty_radiant== null)) _bot_difficulty_radiant = value ? this.bot_difficulty_radiant : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_radiant() { return bot_difficulty_radiantSpecified; }
+    private void Resetbot_difficulty_radiant() { bot_difficulty_radiantSpecified = false; }
+    
 
-    private bool _allow_cheats = default(bool);
+    private bool? _allow_cheats;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"allow_cheats", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_cheats
     {
-      get { return _allow_cheats; }
+      get { return _allow_cheats?? default(bool); }
       set { _allow_cheats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_cheatsSpecified
+    {
+      get { return _allow_cheats != null; }
+      set { if (value == (_allow_cheats== null)) _allow_cheats = value ? this.allow_cheats : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_cheats() { return allow_cheatsSpecified; }
+    private void Resetallow_cheats() { allow_cheatsSpecified = false; }
+    
 
-    private bool _fill_with_bots = default(bool);
+    private bool? _fill_with_bots;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"fill_with_bots", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool fill_with_bots
     {
-      get { return _fill_with_bots; }
+      get { return _fill_with_bots?? default(bool); }
       set { _fill_with_bots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fill_with_botsSpecified
+    {
+      get { return _fill_with_bots != null; }
+      set { if (value == (_fill_with_bots== null)) _fill_with_bots = value ? this.fill_with_bots : (bool?)null; }
+    }
+    private bool ShouldSerializefill_with_bots() { return fill_with_botsSpecified; }
+    private void Resetfill_with_bots() { fill_with_botsSpecified = false; }
+    
 
-    private bool _intro_mode = default(bool);
+    private bool? _intro_mode;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"intro_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool intro_mode
     {
-      get { return _intro_mode; }
+      get { return _intro_mode?? default(bool); }
       set { _intro_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool intro_modeSpecified
+    {
+      get { return _intro_mode != null; }
+      set { if (value == (_intro_mode== null)) _intro_mode = value ? this.intro_mode : (bool?)null; }
+    }
+    private bool ShouldSerializeintro_mode() { return intro_modeSpecified; }
+    private void Resetintro_mode() { intro_modeSpecified = false; }
+    
 
-    private bool _allow_spectating = default(bool);
+    private bool? _allow_spectating;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"allow_spectating", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_spectating
     {
-      get { return _allow_spectating; }
+      get { return _allow_spectating?? default(bool); }
       set { _allow_spectating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_spectatingSpecified
+    {
+      get { return _allow_spectating != null; }
+      set { if (value == (_allow_spectating== null)) _allow_spectating = value ? this.allow_spectating : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_spectating() { return allow_spectatingSpecified; }
+    private void Resetallow_spectating() { allow_spectatingSpecified = false; }
+    
 
-    private DOTAGameVersion _game_version = DOTAGameVersion.GAME_VERSION_CURRENT;
+    private DOTAGameVersion? _game_version;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"game_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAGameVersion.GAME_VERSION_CURRENT)]
     public DOTAGameVersion game_version
     {
-      get { return _game_version; }
+      get { return _game_version?? DOTAGameVersion.GAME_VERSION_CURRENT; }
       set { _game_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_versionSpecified
+    {
+      get { return _game_version != null; }
+      set { if (value == (_game_version== null)) _game_version = value ? this.game_version : (DOTAGameVersion?)null; }
+    }
+    private bool ShouldSerializegame_version() { return game_versionSpecified; }
+    private void Resetgame_version() { game_versionSpecified = false; }
+    
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
 
-    private uint _penalty_level_radiant = default(uint);
+    private uint? _penalty_level_radiant;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"penalty_level_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_level_radiant
     {
-      get { return _penalty_level_radiant; }
+      get { return _penalty_level_radiant?? default(uint); }
       set { _penalty_level_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_level_radiantSpecified
+    {
+      get { return _penalty_level_radiant != null; }
+      set { if (value == (_penalty_level_radiant== null)) _penalty_level_radiant = value ? this.penalty_level_radiant : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_level_radiant() { return penalty_level_radiantSpecified; }
+    private void Resetpenalty_level_radiant() { penalty_level_radiantSpecified = false; }
+    
 
-    private uint _penalty_level_dire = default(uint);
+    private uint? _penalty_level_dire;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"penalty_level_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint penalty_level_dire
     {
-      get { return _penalty_level_dire; }
+      get { return _penalty_level_dire?? default(uint); }
       set { _penalty_level_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_level_direSpecified
+    {
+      get { return _penalty_level_dire != null; }
+      set { if (value == (_penalty_level_dire== null)) _penalty_level_dire = value ? this.penalty_level_dire : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_level_dire() { return penalty_level_direSpecified; }
+    private void Resetpenalty_level_dire() { penalty_level_direSpecified = false; }
+    
 
-    private uint _load_game_id = default(uint);
+    private uint? _load_game_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"load_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint load_game_id
     {
-      get { return _load_game_id; }
+      get { return _load_game_id?? default(uint); }
       set { _load_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool load_game_idSpecified
+    {
+      get { return _load_game_id != null; }
+      set { if (value == (_load_game_id== null)) _load_game_id = value ? this.load_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializeload_game_id() { return load_game_idSpecified; }
+    private void Resetload_game_id() { load_game_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _radiant_series_wins = default(uint);
+    private uint? _radiant_series_wins;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"radiant_series_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_series_wins
     {
-      get { return _radiant_series_wins; }
+      get { return _radiant_series_wins?? default(uint); }
       set { _radiant_series_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_series_winsSpecified
+    {
+      get { return _radiant_series_wins != null; }
+      set { if (value == (_radiant_series_wins== null)) _radiant_series_wins = value ? this.radiant_series_wins : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_series_wins() { return radiant_series_winsSpecified; }
+    private void Resetradiant_series_wins() { radiant_series_winsSpecified = false; }
+    
 
-    private uint _dire_series_wins = default(uint);
+    private uint? _dire_series_wins;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"dire_series_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_series_wins
     {
-      get { return _dire_series_wins; }
+      get { return _dire_series_wins?? default(uint); }
       set { _dire_series_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_series_winsSpecified
+    {
+      get { return _dire_series_wins != null; }
+      set { if (value == (_dire_series_wins== null)) _dire_series_wins = value ? this.dire_series_wins : (uint?)null; }
+    }
+    private bool ShouldSerializedire_series_wins() { return dire_series_winsSpecified; }
+    private void Resetdire_series_wins() { dire_series_winsSpecified = false; }
+    
 
-    private bool _allchat = (bool)false;
+    private bool? _allchat;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"allchat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool allchat
     {
-      get { return _allchat; }
+      get { return _allchat?? (bool)false; }
       set { _allchat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allchatSpecified
+    {
+      get { return _allchat != null; }
+      set { if (value == (_allchat== null)) _allchat = value ? this.allchat : (bool?)null; }
+    }
+    private bool ShouldSerializeallchat() { return allchatSpecified; }
+    private void Resetallchat() { allchatSpecified = false; }
+    
 
-    private LobbyDotaTVDelay _dota_tv_delay = LobbyDotaTVDelay.LobbyDotaTV_120;
+    private LobbyDotaTVDelay? _dota_tv_delay;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"dota_tv_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(LobbyDotaTVDelay.LobbyDotaTV_120)]
     public LobbyDotaTVDelay dota_tv_delay
     {
-      get { return _dota_tv_delay; }
+      get { return _dota_tv_delay?? LobbyDotaTVDelay.LobbyDotaTV_120; }
       set { _dota_tv_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dota_tv_delaySpecified
+    {
+      get { return _dota_tv_delay != null; }
+      set { if (value == (_dota_tv_delay== null)) _dota_tv_delay = value ? this.dota_tv_delay : (LobbyDotaTVDelay?)null; }
+    }
+    private bool ShouldSerializedota_tv_delay() { return dota_tv_delaySpecified; }
+    private void Resetdota_tv_delay() { dota_tv_delaySpecified = false; }
+    
 
-    private bool _lan = default(bool);
+    private bool? _lan;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"lan", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool lan
     {
-      get { return _lan; }
+      get { return _lan?? default(bool); }
       set { _lan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lanSpecified
+    {
+      get { return _lan != null; }
+      set { if (value == (_lan== null)) _lan = value ? this.lan : (bool?)null; }
+    }
+    private bool ShouldSerializelan() { return lanSpecified; }
+    private void Resetlan() { lanSpecified = false; }
+    
 
-    private string _custom_game_mode = "";
+    private string _custom_game_mode;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"custom_game_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_game_mode
     {
-      get { return _custom_game_mode; }
+      get { return _custom_game_mode?? ""; }
       set { _custom_game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_modeSpecified
+    {
+      get { return _custom_game_mode != null; }
+      set { if (value == (_custom_game_mode== null)) _custom_game_mode = value ? this.custom_game_mode : (string)null; }
+    }
+    private bool ShouldSerializecustom_game_mode() { return custom_game_modeSpecified; }
+    private void Resetcustom_game_mode() { custom_game_modeSpecified = false; }
+    
 
-    private string _custom_map_name = "";
+    private string _custom_map_name;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"custom_map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_map_name
     {
-      get { return _custom_map_name; }
+      get { return _custom_map_name?? ""; }
       set { _custom_map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_map_nameSpecified
+    {
+      get { return _custom_map_name != null; }
+      set { if (value == (_custom_map_name== null)) _custom_map_name = value ? this.custom_map_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_map_name() { return custom_map_nameSpecified; }
+    private void Resetcustom_map_name() { custom_map_nameSpecified = false; }
+    
 
-    private uint _custom_difficulty = default(uint);
+    private uint? _custom_difficulty;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"custom_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_difficulty
     {
-      get { return _custom_difficulty; }
+      get { return _custom_difficulty?? default(uint); }
       set { _custom_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_difficultySpecified
+    {
+      get { return _custom_difficulty != null; }
+      set { if (value == (_custom_difficulty== null)) _custom_difficulty = value ? this.custom_difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_difficulty() { return custom_difficultySpecified; }
+    private void Resetcustom_difficulty() { custom_difficultySpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private uint _custom_min_players = default(uint);
+    private uint? _custom_min_players;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"custom_min_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_min_players
     {
-      get { return _custom_min_players; }
+      get { return _custom_min_players?? default(uint); }
       set { _custom_min_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_min_playersSpecified
+    {
+      get { return _custom_min_players != null; }
+      set { if (value == (_custom_min_players== null)) _custom_min_players = value ? this.custom_min_players : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_min_players() { return custom_min_playersSpecified; }
+    private void Resetcustom_min_players() { custom_min_playersSpecified = false; }
+    
 
-    private uint _custom_max_players = default(uint);
+    private uint? _custom_max_players;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"custom_max_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_max_players
     {
-      get { return _custom_max_players; }
+      get { return _custom_max_players?? default(uint); }
       set { _custom_max_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_max_playersSpecified
+    {
+      get { return _custom_max_players != null; }
+      set { if (value == (_custom_max_players== null)) _custom_max_players = value ? this.custom_max_players : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_max_players() { return custom_max_playersSpecified; }
+    private void Resetcustom_max_players() { custom_max_playersSpecified = false; }
+    
 
-    private uint _lan_host_ping_to_server_region = default(uint);
+    private uint? _lan_host_ping_to_server_region;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"lan_host_ping_to_server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lan_host_ping_to_server_region
     {
-      get { return _lan_host_ping_to_server_region; }
+      get { return _lan_host_ping_to_server_region?? default(uint); }
       set { _lan_host_ping_to_server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lan_host_ping_to_server_regionSpecified
+    {
+      get { return _lan_host_ping_to_server_region != null; }
+      set { if (value == (_lan_host_ping_to_server_region== null)) _lan_host_ping_to_server_region = value ? this.lan_host_ping_to_server_region : (uint?)null; }
+    }
+    private bool ShouldSerializelan_host_ping_to_server_region() { return lan_host_ping_to_server_regionSpecified; }
+    private void Resetlan_host_ping_to_server_region() { lan_host_ping_to_server_regionSpecified = false; }
+    
 
-    private DOTALobbyVisibility _visibility = DOTALobbyVisibility.DOTALobbyVisibility_Public;
+    private DOTALobbyVisibility? _visibility;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTALobbyVisibility.DOTALobbyVisibility_Public)]
     public DOTALobbyVisibility visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? DOTALobbyVisibility.DOTALobbyVisibility_Public; }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (DOTALobbyVisibility?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private ulong _custom_game_crc = default(ulong);
+    private ulong? _custom_game_crc;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"custom_game_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_crc
     {
-      get { return _custom_game_crc; }
+      get { return _custom_game_crc?? default(ulong); }
       set { _custom_game_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_crcSpecified
+    {
+      get { return _custom_game_crc != null; }
+      set { if (value == (_custom_game_crc== null)) _custom_game_crc = value ? this.custom_game_crc : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_crc() { return custom_game_crcSpecified; }
+    private void Resetcustom_game_crc() { custom_game_crcSpecified = false; }
+    
 
-    private uint _league_series_id = default(uint);
+    private uint? _league_series_id;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"league_series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_series_id
     {
-      get { return _league_series_id; }
+      get { return _league_series_id?? default(uint); }
       set { _league_series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_series_idSpecified
+    {
+      get { return _league_series_id != null; }
+      set { if (value == (_league_series_id== null)) _league_series_id = value ? this.league_series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_series_id() { return league_series_idSpecified; }
+    private void Resetleague_series_id() { league_series_idSpecified = false; }
+    
 
-    private uint _league_game_id = default(uint);
+    private uint? _league_game_id;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"league_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_game_id
     {
-      get { return _league_game_id; }
+      get { return _league_game_id?? default(uint); }
       set { _league_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_game_idSpecified
+    {
+      get { return _league_game_id != null; }
+      set { if (value == (_league_game_id== null)) _league_game_id = value ? this.league_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_game_id() { return league_game_idSpecified; }
+    private void Resetleague_game_id() { league_game_idSpecified = false; }
+    
 
-    private uint _custom_game_timestamp = default(uint);
+    private uint? _custom_game_timestamp;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"custom_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_game_timestamp
     {
-      get { return _custom_game_timestamp; }
+      get { return _custom_game_timestamp?? default(uint); }
       set { _custom_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_timestampSpecified
+    {
+      get { return _custom_game_timestamp != null; }
+      set { if (value == (_custom_game_timestamp== null)) _custom_game_timestamp = value ? this.custom_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_game_timestamp() { return custom_game_timestampSpecified; }
+    private void Resetcustom_game_timestamp() { custom_game_timestampSpecified = false; }
+    
 
-    private ulong _previous_match_override = default(ulong);
+    private ulong? _previous_match_override;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"previous_match_override", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong previous_match_override
     {
-      get { return _previous_match_override; }
+      get { return _previous_match_override?? default(ulong); }
       set { _previous_match_override = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool previous_match_overrideSpecified
+    {
+      get { return _previous_match_override != null; }
+      set { if (value == (_previous_match_override== null)) _previous_match_override = value ? this.previous_match_override : (ulong?)null; }
+    }
+    private bool ShouldSerializeprevious_match_override() { return previous_match_overrideSpecified; }
+    private void Resetprevious_match_override() { previous_match_overrideSpecified = false; }
+    
 
-    private uint _league_selection_priority_team = default(uint);
+    private uint? _league_selection_priority_team;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"league_selection_priority_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_selection_priority_team
     {
-      get { return _league_selection_priority_team; }
+      get { return _league_selection_priority_team?? default(uint); }
       set { _league_selection_priority_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_selection_priority_teamSpecified
+    {
+      get { return _league_selection_priority_team != null; }
+      set { if (value == (_league_selection_priority_team== null)) _league_selection_priority_team = value ? this.league_selection_priority_team : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_selection_priority_team() { return league_selection_priority_teamSpecified; }
+    private void Resetleague_selection_priority_team() { league_selection_priority_teamSpecified = false; }
+    
 
-    private SelectionPriorityType _league_selection_priority_choice = SelectionPriorityType.UNDEFINED;
+    private SelectionPriorityType? _league_selection_priority_choice;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"league_selection_priority_choice", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SelectionPriorityType.UNDEFINED)]
     public SelectionPriorityType league_selection_priority_choice
     {
-      get { return _league_selection_priority_choice; }
+      get { return _league_selection_priority_choice?? SelectionPriorityType.UNDEFINED; }
       set { _league_selection_priority_choice = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_selection_priority_choiceSpecified
+    {
+      get { return _league_selection_priority_choice != null; }
+      set { if (value == (_league_selection_priority_choice== null)) _league_selection_priority_choice = value ? this.league_selection_priority_choice : (SelectionPriorityType?)null; }
+    }
+    private bool ShouldSerializeleague_selection_priority_choice() { return league_selection_priority_choiceSpecified; }
+    private void Resetleague_selection_priority_choice() { league_selection_priority_choiceSpecified = false; }
+    
 
-    private SelectionPriorityType _league_non_selection_priority_choice = SelectionPriorityType.UNDEFINED;
+    private SelectionPriorityType? _league_non_selection_priority_choice;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"league_non_selection_priority_choice", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SelectionPriorityType.UNDEFINED)]
     public SelectionPriorityType league_non_selection_priority_choice
     {
-      get { return _league_non_selection_priority_choice; }
+      get { return _league_non_selection_priority_choice?? SelectionPriorityType.UNDEFINED; }
       set { _league_non_selection_priority_choice = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_non_selection_priority_choiceSpecified
+    {
+      get { return _league_non_selection_priority_choice != null; }
+      set { if (value == (_league_non_selection_priority_choice== null)) _league_non_selection_priority_choice = value ? this.league_non_selection_priority_choice : (SelectionPriorityType?)null; }
+    }
+    private bool ShouldSerializeleague_non_selection_priority_choice() { return league_non_selection_priority_choiceSpecified; }
+    private void Resetleague_non_selection_priority_choice() { league_non_selection_priority_choiceSpecified = false; }
+    
 
-    private LobbyDotaPauseSetting _pause_setting = LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited;
+    private LobbyDotaPauseSetting? _pause_setting;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"pause_setting", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited)]
     public LobbyDotaPauseSetting pause_setting
     {
-      get { return _pause_setting; }
+      get { return _pause_setting?? LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited; }
       set { _pause_setting = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pause_settingSpecified
+    {
+      get { return _pause_setting != null; }
+      set { if (value == (_pause_setting== null)) _pause_setting = value ? this.pause_setting : (LobbyDotaPauseSetting?)null; }
+    }
+    private bool ShouldSerializepause_setting() { return pause_settingSpecified; }
+    private void Resetpause_setting() { pause_settingSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_dire = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty_dire;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"bot_difficulty_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty_dire
     {
-      get { return _bot_difficulty_dire; }
+      get { return _bot_difficulty_dire?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_direSpecified
+    {
+      get { return _bot_difficulty_dire != null; }
+      set { if (value == (_bot_difficulty_dire== null)) _bot_difficulty_dire = value ? this.bot_difficulty_dire : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_dire() { return bot_difficulty_direSpecified; }
+    private void Resetbot_difficulty_dire() { bot_difficulty_direSpecified = false; }
+    
 
-    private ulong _bot_radiant = default(ulong);
+    private ulong? _bot_radiant;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"bot_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bot_radiant
     {
-      get { return _bot_radiant; }
+      get { return _bot_radiant?? default(ulong); }
       set { _bot_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_radiantSpecified
+    {
+      get { return _bot_radiant != null; }
+      set { if (value == (_bot_radiant== null)) _bot_radiant = value ? this.bot_radiant : (ulong?)null; }
+    }
+    private bool ShouldSerializebot_radiant() { return bot_radiantSpecified; }
+    private void Resetbot_radiant() { bot_radiantSpecified = false; }
+    
 
-    private ulong _bot_dire = default(ulong);
+    private ulong? _bot_dire;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"bot_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bot_dire
     {
-      get { return _bot_dire; }
+      get { return _bot_dire?? default(ulong); }
       set { _bot_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_direSpecified
+    {
+      get { return _bot_dire != null; }
+      set { if (value == (_bot_dire== null)) _bot_dire = value ? this.bot_dire : (ulong?)null; }
+    }
+    private bool ShouldSerializebot_dire() { return bot_direSpecified; }
+    private void Resetbot_dire() { bot_direSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -742,32 +1338,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyCreate() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
     private CMsgPracticeLobbySetDetails _lobby_details = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"lobby_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -792,41 +1415,77 @@ namespace SteamKit2.GC.Dota.Internal
     public SaveGame() {}
     
 
-    private byte[] _data = null;
+    private byte[] _data;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] data
     {
-      get { return _data; }
+      get { return _data?? null; }
       set { _data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dataSpecified
+    {
+      get { return _data != null; }
+      set { if (value == (_data== null)) _data = value ? this.data : (byte[])null; }
+    }
+    private bool ShouldSerializedata() { return dataSpecified; }
+    private void Resetdata() { dataSpecified = false; }
+    
 
-    private int _version = default(int);
+    private int? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int version
     {
-      get { return _version; }
+      get { return _version?? default(int); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (int?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _signature = default(ulong);
+    private ulong? _signature;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong signature
     {
-      get { return _signature; }
+      get { return _signature?? default(ulong); }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (ulong?)null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -843,32 +1502,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbySetTeamSlot() {}
     
 
-    private DOTA_GC_TEAM _team = DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    private DOTA_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS)]
     public DOTA_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _slot = default(uint);
+    private uint? _slot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot
     {
-      get { return _slot; }
+      get { return _slot?? default(uint); }
       set { _slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slotSpecified
+    {
+      get { return _slot != null; }
+      set { if (value == (_slot== null)) _slot = value ? this.slot : (uint?)null; }
+    }
+    private bool ShouldSerializeslot() { return slotSpecified; }
+    private void Resetslot() { slotSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bot_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty
     {
-      get { return _bot_difficulty; }
+      get { return _bot_difficulty?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficultySpecified
+    {
+      get { return _bot_difficulty != null; }
+      set { if (value == (_bot_difficulty== null)) _bot_difficulty = value ? this.bot_difficulty : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty() { return bot_difficultySpecified; }
+    private void Resetbot_difficulty() { bot_difficultySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -880,14 +1566,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbySetCoach() {}
     
 
-    private DOTA_GC_TEAM _team = DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    private DOTA_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS)]
     public DOTA_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -899,41 +1594,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyJoinBroadcastChannel() {}
     
 
-    private uint _channel = default(uint);
+    private uint? _channel;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel
     {
-      get { return _channel; }
+      get { return _channel?? default(uint); }
       set { _channel = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channelSpecified
+    {
+      get { return _channel != null; }
+      set { if (value == (_channel== null)) _channel = value ? this.channel : (uint?)null; }
+    }
+    private bool ShouldSerializechannel() { return channelSpecified; }
+    private void Resetchannel() { channelSpecified = false; }
+    
 
-    private string _preferred_description = "";
+    private string _preferred_description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"preferred_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preferred_description
     {
-      get { return _preferred_description; }
+      get { return _preferred_description?? ""; }
       set { _preferred_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preferred_descriptionSpecified
+    {
+      get { return _preferred_description != null; }
+      set { if (value == (_preferred_description== null)) _preferred_description = value ? this.preferred_description : (string)null; }
+    }
+    private bool ShouldSerializepreferred_description() { return preferred_descriptionSpecified; }
+    private void Resetpreferred_description() { preferred_descriptionSpecified = false; }
+    
 
-    private string _preferred_country_code = "";
+    private string _preferred_country_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"preferred_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preferred_country_code
     {
-      get { return _preferred_country_code; }
+      get { return _preferred_country_code?? ""; }
       set { _preferred_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preferred_country_codeSpecified
+    {
+      get { return _preferred_country_code != null; }
+      set { if (value == (_preferred_country_code== null)) _preferred_country_code = value ? this.preferred_country_code : (string)null; }
+    }
+    private bool ShouldSerializepreferred_country_code() { return preferred_country_codeSpecified; }
+    private void Resetpreferred_country_code() { preferred_country_codeSpecified = false; }
+    
 
-    private string _preferred_language_code = "";
+    private string _preferred_language_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"preferred_language_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preferred_language_code
     {
-      get { return _preferred_language_code; }
+      get { return _preferred_language_code?? ""; }
       set { _preferred_language_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preferred_language_codeSpecified
+    {
+      get { return _preferred_language_code != null; }
+      set { if (value == (_preferred_language_code== null)) _preferred_language_code = value ? this.preferred_language_code : (string)null; }
+    }
+    private bool ShouldSerializepreferred_language_code() { return preferred_language_codeSpecified; }
+    private void Resetpreferred_language_code() { preferred_language_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -945,14 +1676,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyCloseBroadcastChannel() {}
     
 
-    private uint _channel = default(uint);
+    private uint? _channel;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel
     {
-      get { return _channel; }
+      get { return _channel?? default(uint); }
       set { _channel = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channelSpecified
+    {
+      get { return _channel != null; }
+      set { if (value == (_channel== null)) _channel = value ? this.channel : (uint?)null; }
+    }
+    private bool ShouldSerializechannel() { return channelSpecified; }
+    private void Resetchannel() { channelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -974,14 +1714,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyKick() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -993,14 +1742,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyKickFromTeam() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1022,14 +1780,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyLaunch() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1041,14 +1808,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgApplyTeamToPracticeLobby() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1070,41 +1846,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyList() {}
     
 
-    private bool _tournament_games = default(bool);
+    private bool? _tournament_games;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tournament_games
     {
-      get { return _tournament_games; }
+      get { return _tournament_games?? default(bool); }
       set { _tournament_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_gamesSpecified
+    {
+      get { return _tournament_games != null; }
+      set { if (value == (_tournament_games== null)) _tournament_games = value ? this.tournament_games : (bool?)null; }
+    }
+    private bool ShouldSerializetournament_games() { return tournament_gamesSpecified; }
+    private void Resettournament_games() { tournament_gamesSpecified = false; }
+    
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
-    private uint _region = default(uint);
+    private uint? _region;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region
     {
-      get { return _region; }
+      get { return _region?? default(uint); }
       set { _region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool regionSpecified
+    {
+      get { return _region != null; }
+      set { if (value == (_region== null)) _region = value ? this.region : (uint?)null; }
+    }
+    private bool ShouldSerializeregion() { return regionSpecified; }
+    private void Resetregion() { regionSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1116,32 +1928,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyListResponseEntry() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _tournament_game_id = default(uint);
+    private uint? _tournament_game_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tournament_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_game_id
     {
-      get { return _tournament_game_id; }
+      get { return _tournament_game_id?? default(uint); }
       set { _tournament_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_game_idSpecified
+    {
+      get { return _tournament_game_id != null; }
+      set { if (value == (_tournament_game_id== null)) _tournament_game_id = value ? this.tournament_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_game_id() { return tournament_game_idSpecified; }
+    private void Resettournament_game_id() { tournament_game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry.CLobbyMember> _members = new global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry.CLobbyMember>();
     [global::ProtoBuf.ProtoMember(5, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry.CLobbyMember> members
@@ -1150,154 +1989,298 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _requires_pass_key = default(bool);
+    private bool? _requires_pass_key;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"requires_pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_pass_key
     {
-      get { return _requires_pass_key; }
+      get { return _requires_pass_key?? default(bool); }
       set { _requires_pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_pass_keySpecified
+    {
+      get { return _requires_pass_key != null; }
+      set { if (value == (_requires_pass_key== null)) _requires_pass_key = value ? this.requires_pass_key : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_pass_key() { return requires_pass_keySpecified; }
+    private void Resetrequires_pass_key() { requires_pass_keySpecified = false; }
+    
 
-    private uint _leader_account_id = default(uint);
+    private uint? _leader_account_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"leader_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leader_account_id
     {
-      get { return _leader_account_id; }
+      get { return _leader_account_id?? default(uint); }
       set { _leader_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_account_idSpecified
+    {
+      get { return _leader_account_id != null; }
+      set { if (value == (_leader_account_id== null)) _leader_account_id = value ? this.leader_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleader_account_id() { return leader_account_idSpecified; }
+    private void Resetleader_account_id() { leader_account_idSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private ulong _guild_logo = default(ulong);
+    private ulong? _guild_logo;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"guild_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong guild_logo
     {
-      get { return _guild_logo; }
+      get { return _guild_logo?? default(ulong); }
       set { _guild_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_logoSpecified
+    {
+      get { return _guild_logo != null; }
+      set { if (value == (_guild_logo== null)) _guild_logo = value ? this.guild_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeguild_logo() { return guild_logoSpecified; }
+    private void Resetguild_logo() { guild_logoSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _custom_game_mode = "";
+    private string _custom_game_mode;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"custom_game_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_game_mode
     {
-      get { return _custom_game_mode; }
+      get { return _custom_game_mode?? ""; }
       set { _custom_game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_modeSpecified
+    {
+      get { return _custom_game_mode != null; }
+      set { if (value == (_custom_game_mode== null)) _custom_game_mode = value ? this.custom_game_mode : (string)null; }
+    }
+    private bool ShouldSerializecustom_game_mode() { return custom_game_modeSpecified; }
+    private void Resetcustom_game_mode() { custom_game_modeSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private bool _friend_present = default(bool);
+    private bool? _friend_present;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"friend_present", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool friend_present
     {
-      get { return _friend_present; }
+      get { return _friend_present?? default(bool); }
       set { _friend_present = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_presentSpecified
+    {
+      get { return _friend_present != null; }
+      set { if (value == (_friend_present== null)) _friend_present = value ? this.friend_present : (bool?)null; }
+    }
+    private bool ShouldSerializefriend_present() { return friend_presentSpecified; }
+    private void Resetfriend_present() { friend_presentSpecified = false; }
+    
 
-    private uint _players = default(uint);
+    private uint? _players;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players
     {
-      get { return _players; }
+      get { return _players?? default(uint); }
       set { _players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playersSpecified
+    {
+      get { return _players != null; }
+      set { if (value == (_players== null)) _players = value ? this.players : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers() { return playersSpecified; }
+    private void Resetplayers() { playersSpecified = false; }
+    
 
-    private string _custom_map_name = "";
+    private string _custom_map_name;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"custom_map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_map_name
     {
-      get { return _custom_map_name; }
+      get { return _custom_map_name?? ""; }
       set { _custom_map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_map_nameSpecified
+    {
+      get { return _custom_map_name != null; }
+      set { if (value == (_custom_map_name== null)) _custom_map_name = value ? this.custom_map_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_map_name() { return custom_map_nameSpecified; }
+    private void Resetcustom_map_name() { custom_map_nameSpecified = false; }
+    
 
-    private uint _max_player_count = default(uint);
+    private uint? _max_player_count;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"max_player_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_player_count
     {
-      get { return _max_player_count; }
+      get { return _max_player_count?? default(uint); }
       set { _max_player_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_player_countSpecified
+    {
+      get { return _max_player_count != null; }
+      set { if (value == (_max_player_count== null)) _max_player_count = value ? this.max_player_count : (uint?)null; }
+    }
+    private bool ShouldSerializemax_player_count() { return max_player_countSpecified; }
+    private void Resetmax_player_count() { max_player_countSpecified = false; }
+    
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private uint _lan_host_ping_to_server_region = default(uint);
+    private uint? _lan_host_ping_to_server_region;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"lan_host_ping_to_server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lan_host_ping_to_server_region
     {
-      get { return _lan_host_ping_to_server_region; }
+      get { return _lan_host_ping_to_server_region?? default(uint); }
       set { _lan_host_ping_to_server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lan_host_ping_to_server_regionSpecified
+    {
+      get { return _lan_host_ping_to_server_region != null; }
+      set { if (value == (_lan_host_ping_to_server_region== null)) _lan_host_ping_to_server_region = value ? this.lan_host_ping_to_server_region : (uint?)null; }
+    }
+    private bool ShouldSerializelan_host_ping_to_server_region() { return lan_host_ping_to_server_regionSpecified; }
+    private void Resetlan_host_ping_to_server_region() { lan_host_ping_to_server_regionSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CLobbyMember")]
   public partial class CLobbyMember : global::ProtoBuf.IExtensible
   {
     public CLobbyMember() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1314,14 +2297,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyListResponse() {}
     
 
-    private bool _tournament_games = default(bool);
+    private bool? _tournament_games;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tournament_games
     {
-      get { return _tournament_games; }
+      get { return _tournament_games?? default(bool); }
       set { _tournament_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_gamesSpecified
+    {
+      get { return _tournament_games != null; }
+      set { if (value == (_tournament_games== null)) _tournament_games = value ? this.tournament_games : (bool?)null; }
+    }
+    private bool ShouldSerializetournament_games() { return tournament_gamesSpecified; }
+    private void Resettournament_games() { tournament_gamesSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry> _lobbies = new global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry>();
     [global::ProtoBuf.ProtoMember(2, Name=@"lobbies", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPracticeLobbyListResponseEntry> lobbies
@@ -1340,23 +2332,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLobbyList() {}
     
 
-    private uint _server_region = (uint)0;
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? (uint)0; }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1385,50 +2395,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyJoin() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
-    private ulong _custom_game_crc = default(ulong);
+    private ulong? _custom_game_crc;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"custom_game_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_crc
     {
-      get { return _custom_game_crc; }
+      get { return _custom_game_crc?? default(ulong); }
       set { _custom_game_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_crcSpecified
+    {
+      get { return _custom_game_crc != null; }
+      set { if (value == (_custom_game_crc== null)) _custom_game_crc = value ? this.custom_game_crc : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_crc() { return custom_game_crcSpecified; }
+    private void Resetcustom_game_crc() { custom_game_crcSpecified = false; }
+    
 
-    private uint _custom_game_timestamp = default(uint);
+    private uint? _custom_game_timestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"custom_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_game_timestamp
     {
-      get { return _custom_game_timestamp; }
+      get { return _custom_game_timestamp?? default(uint); }
       set { _custom_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_timestampSpecified
+    {
+      get { return _custom_game_timestamp != null; }
+      set { if (value == (_custom_game_timestamp== null)) _custom_game_timestamp = value ? this.custom_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_game_timestamp() { return custom_game_timestampSpecified; }
+    private void Resetcustom_game_timestamp() { custom_game_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1440,14 +2495,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPracticeLobbyJoinResponse() {}
     
 
-    private DOTAJoinLobbyResult _result = DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS;
+    private DOTAJoinLobbyResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS)]
     public DOTAJoinLobbyResult result
     {
-      get { return _result; }
+      get { return _result?? DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (DOTAJoinLobbyResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1527,14 +2591,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgJoinableCustomGameModesRequest() {}
     
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1546,32 +2619,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgJoinableCustomGameModesResponseEntry() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private uint _lobby_count = default(uint);
+    private uint? _lobby_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_count
     {
-      get { return _lobby_count; }
+      get { return _lobby_count?? default(uint); }
       set { _lobby_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_countSpecified
+    {
+      get { return _lobby_count != null; }
+      set { if (value == (_lobby_count== null)) _lobby_count = value ? this.lobby_count : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_count() { return lobby_countSpecified; }
+    private void Resetlobby_count() { lobby_countSpecified = false; }
+    
 
-    private uint _player_count = default(uint);
+    private uint? _player_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"player_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_count
     {
-      get { return _player_count; }
+      get { return _player_count?? default(uint); }
       set { _player_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_countSpecified
+    {
+      get { return _player_count != null; }
+      set { if (value == (_player_count== null)) _player_count = value ? this.player_count : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_count() { return player_countSpecified; }
+    private void Resetplayer_count() { player_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1600,23 +2700,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgJoinableCustomLobbiesRequest() {}
     
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1628,104 +2746,203 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgJoinableCustomLobbiesResponseEntry() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private string _lobby_name = "";
+    private string _lobby_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string lobby_name
     {
-      get { return _lobby_name; }
+      get { return _lobby_name?? ""; }
       set { _lobby_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_nameSpecified
+    {
+      get { return _lobby_name != null; }
+      set { if (value == (_lobby_name== null)) _lobby_name = value ? this.lobby_name : (string)null; }
+    }
+    private bool ShouldSerializelobby_name() { return lobby_nameSpecified; }
+    private void Resetlobby_name() { lobby_nameSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
 
-    private uint _leader_account_id = default(uint);
+    private uint? _leader_account_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"leader_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leader_account_id
     {
-      get { return _leader_account_id; }
+      get { return _leader_account_id?? default(uint); }
       set { _leader_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_account_idSpecified
+    {
+      get { return _leader_account_id != null; }
+      set { if (value == (_leader_account_id== null)) _leader_account_id = value ? this.leader_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleader_account_id() { return leader_account_idSpecified; }
+    private void Resetleader_account_id() { leader_account_idSpecified = false; }
+    
 
-    private string _leader_name = "";
+    private string _leader_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"leader_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string leader_name
     {
-      get { return _leader_name; }
+      get { return _leader_name?? ""; }
       set { _leader_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_nameSpecified
+    {
+      get { return _leader_name != null; }
+      set { if (value == (_leader_name== null)) _leader_name = value ? this.leader_name : (string)null; }
+    }
+    private bool ShouldSerializeleader_name() { return leader_nameSpecified; }
+    private void Resetleader_name() { leader_nameSpecified = false; }
+    
 
-    private string _custom_map_name = "";
+    private string _custom_map_name;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_map_name
     {
-      get { return _custom_map_name; }
+      get { return _custom_map_name?? ""; }
       set { _custom_map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_map_nameSpecified
+    {
+      get { return _custom_map_name != null; }
+      set { if (value == (_custom_map_name== null)) _custom_map_name = value ? this.custom_map_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_map_name() { return custom_map_nameSpecified; }
+    private void Resetcustom_map_name() { custom_map_nameSpecified = false; }
+    
 
-    private uint _max_player_count = default(uint);
+    private uint? _max_player_count;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"max_player_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_player_count
     {
-      get { return _max_player_count; }
+      get { return _max_player_count?? default(uint); }
       set { _max_player_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_player_countSpecified
+    {
+      get { return _max_player_count != null; }
+      set { if (value == (_max_player_count== null)) _max_player_count = value ? this.max_player_count : (uint?)null; }
+    }
+    private bool ShouldSerializemax_player_count() { return max_player_countSpecified; }
+    private void Resetmax_player_count() { max_player_countSpecified = false; }
+    
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private uint _lan_host_ping_to_server_region = default(uint);
+    private uint? _lan_host_ping_to_server_region;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"lan_host_ping_to_server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lan_host_ping_to_server_region
     {
-      get { return _lan_host_ping_to_server_region; }
+      get { return _lan_host_ping_to_server_region?? default(uint); }
       set { _lan_host_ping_to_server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lan_host_ping_to_server_regionSpecified
+    {
+      get { return _lan_host_ping_to_server_region != null; }
+      set { if (value == (_lan_host_ping_to_server_region== null)) _lan_host_ping_to_server_region = value ? this.lan_host_ping_to_server_region : (uint?)null; }
+    }
+    private bool ShouldSerializelan_host_ping_to_server_region() { return lan_host_ping_to_server_regionSpecified; }
+    private void Resetlan_host_ping_to_server_region() { lan_host_ping_to_server_regionSpecified = false; }
+    
 
-    private bool _has_pass_key = default(bool);
+    private bool? _has_pass_key;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"has_pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_pass_key
     {
-      get { return _has_pass_key; }
+      get { return _has_pass_key?? default(bool); }
       set { _has_pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_pass_keySpecified
+    {
+      get { return _has_pass_key != null; }
+      set { if (value == (_has_pass_key== null)) _has_pass_key = value ? this.has_pass_key : (bool?)null; }
+    }
+    private bool ShouldSerializehas_pass_key() { return has_pass_keySpecified; }
+    private void Resethas_pass_key() { has_pass_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1754,32 +2971,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgQuickJoinCustomLobby() {}
     
 
-    private uint _legacy_server_region = default(uint);
+    private uint? _legacy_server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"legacy_server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint legacy_server_region
     {
-      get { return _legacy_server_region; }
+      get { return _legacy_server_region?? default(uint); }
       set { _legacy_server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_server_regionSpecified
+    {
+      get { return _legacy_server_region != null; }
+      set { if (value == (_legacy_server_region== null)) _legacy_server_region = value ? this.legacy_server_region : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_server_region() { return legacy_server_regionSpecified; }
+    private void Resetlegacy_server_region() { legacy_server_regionSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
     private CMsgPracticeLobbySetDetails _create_lobby_details = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"create_lobby_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1790,14 +3034,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _create_lobby_details = value; }
     }
 
-    private bool _allow_any_map = default(bool);
+    private bool? _allow_any_map;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"allow_any_map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_any_map
     {
-      get { return _allow_any_map; }
+      get { return _allow_any_map?? default(bool); }
       set { _allow_any_map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_any_mapSpecified
+    {
+      get { return _allow_any_map != null; }
+      set { if (value == (_allow_any_map== null)) _allow_any_map = value ? this.allow_any_map : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_any_map() { return allow_any_mapSpecified; }
+    private void Resetallow_any_map() { allow_any_mapSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgQuickJoinCustomLobby.LegacyRegionPing> _legacy_region_pings = new global::System.Collections.Generic.List<CMsgQuickJoinCustomLobby.LegacyRegionPing>();
     [global::ProtoBuf.ProtoMember(6, Name=@"legacy_region_pings", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgQuickJoinCustomLobby.LegacyRegionPing> legacy_region_pings
@@ -1820,32 +3073,59 @@ namespace SteamKit2.GC.Dota.Internal
     public LegacyRegionPing() {}
     
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private uint _ping = default(uint);
+    private uint? _ping;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ping", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ping
     {
-      get { return _ping; }
+      get { return _ping?? default(uint); }
       set { _ping = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingSpecified
+    {
+      get { return _ping != null; }
+      set { if (value == (_ping== null)) _ping = value ? this.ping : (uint?)null; }
+    }
+    private bool ShouldSerializeping() { return pingSpecified; }
+    private void Resetping() { pingSpecified = false; }
+    
 
-    private uint _region_code = default(uint);
+    private uint? _region_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"region_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_code
     {
-      get { return _region_code; }
+      get { return _region_code?? default(uint); }
       set { _region_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_codeSpecified
+    {
+      get { return _region_code != null; }
+      set { if (value == (_region_code== null)) _region_code = value ? this.region_code : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_code() { return region_codeSpecified; }
+    private void Resetregion_code() { region_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1862,14 +3142,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgQuickJoinCustomLobbyResponse() {}
     
 
-    private DOTAJoinLobbyResult _result = DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS;
+    private DOTAJoinLobbyResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS)]
     public DOTAJoinLobbyResult result
     {
-      get { return _result; }
+      get { return _result?? DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (DOTAJoinLobbyResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1881,59 +3170,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgBotGameCreate() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private DOTABotDifficulty _difficulty_radiant = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _difficulty_radiant;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"difficulty_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty difficulty_radiant
     {
-      get { return _difficulty_radiant; }
+      get { return _difficulty_radiant?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _difficulty_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool difficulty_radiantSpecified
+    {
+      get { return _difficulty_radiant != null; }
+      set { if (value == (_difficulty_radiant== null)) _difficulty_radiant = value ? this.difficulty_radiant : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializedifficulty_radiant() { return difficulty_radiantSpecified; }
+    private void Resetdifficulty_radiant() { difficulty_radiantSpecified = false; }
+    
 
-    private DOTA_GC_TEAM _team = DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    private DOTA_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS)]
     public DOTA_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private DOTABotDifficulty _difficulty_dire = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _difficulty_dire;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"difficulty_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty difficulty_dire
     {
-      get { return _difficulty_dire; }
+      get { return _difficulty_dire?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _difficulty_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool difficulty_direSpecified
+    {
+      get { return _difficulty_dire != null; }
+      set { if (value == (_difficulty_dire== null)) _difficulty_dire = value ? this.difficulty_dire : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializedifficulty_dire() { return difficulty_direSpecified; }
+    private void Resetdifficulty_dire() { difficulty_direSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1945,59 +3288,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgCustomGameCreate() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _difficulty = default(uint);
+    private uint? _difficulty;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint difficulty
     {
-      get { return _difficulty; }
+      get { return _difficulty?? default(uint); }
       set { _difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool difficultySpecified
+    {
+      get { return _difficulty != null; }
+      set { if (value == (_difficulty== null)) _difficulty = value ? this.difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializedifficulty() { return difficultySpecified; }
+    private void Resetdifficulty() { difficultySpecified = false; }
+    
 
-    private string _game_mode = "";
+    private string _game_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? ""; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (string)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2009,59 +3406,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgEventGameCreate() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _difficulty = default(uint);
+    private uint? _difficulty;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint difficulty
     {
-      get { return _difficulty; }
+      get { return _difficulty?? default(uint); }
       set { _difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool difficultySpecified
+    {
+      get { return _difficulty != null; }
+      set { if (value == (_difficulty== null)) _difficulty = value ? this.difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializedifficulty() { return difficultySpecified; }
+    private void Resetdifficulty() { difficultySpecified = false; }
+    
 
-    private string _game_mode = "";
+    private string _game_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? ""; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (string)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2073,14 +3524,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAPartyMemberSetCoach() {}
     
 
-    private bool _wants_coach = default(bool);
+    private bool? _wants_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"wants_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool wants_coach
     {
-      get { return _wants_coach; }
+      get { return _wants_coach?? default(bool); }
       set { _wants_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wants_coachSpecified
+    {
+      get { return _wants_coach != null; }
+      set { if (value == (_wants_coach== null)) _wants_coach = value ? this.wants_coach : (bool?)null; }
+    }
+    private bool ShouldSerializewants_coach() { return wants_coachSpecified; }
+    private void Resetwants_coach() { wants_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2092,14 +3552,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetGroupLeader() {}
     
 
-    private ulong _new_leader_steamid = default(ulong);
+    private ulong? _new_leader_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_leader_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong new_leader_steamid
     {
-      get { return _new_leader_steamid; }
+      get { return _new_leader_steamid?? default(ulong); }
       set { _new_leader_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_leader_steamidSpecified
+    {
+      get { return _new_leader_steamid != null; }
+      set { if (value == (_new_leader_steamid== null)) _new_leader_steamid = value ? this.new_leader_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializenew_leader_steamid() { return new_leader_steamidSpecified; }
+    private void Resetnew_leader_steamid() { new_leader_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2135,14 +3604,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASetGroupOpenStatus() {}
     
 
-    private bool _open = default(bool);
+    private bool? _open;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"open", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool open
     {
-      get { return _open; }
+      get { return _open?? default(bool); }
       set { _open = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool openSpecified
+    {
+      get { return _open != null; }
+      set { if (value == (_open== null)) _open = value ? this.open : (bool?)null; }
+    }
+    private bool ShouldSerializeopen() { return openSpecified; }
+    private void Resetopen() { openSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2154,14 +3632,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGroupMergeInvite() {}
     
 
-    private ulong _other_group_id = default(ulong);
+    private ulong? _other_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"other_group_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong other_group_id
     {
-      get { return _other_group_id; }
+      get { return _other_group_id?? default(ulong); }
       set { _other_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_group_idSpecified
+    {
+      get { return _other_group_id != null; }
+      set { if (value == (_other_group_id== null)) _other_group_id = value ? this.other_group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeother_group_id() { return other_group_idSpecified; }
+    private void Resetother_group_id() { other_group_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2173,23 +3660,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGroupMergeResponse() {}
     
 
-    private ulong _initiator_group_id = default(ulong);
+    private ulong? _initiator_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"initiator_group_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong initiator_group_id
     {
-      get { return _initiator_group_id; }
+      get { return _initiator_group_id?? default(ulong); }
       set { _initiator_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiator_group_idSpecified
+    {
+      get { return _initiator_group_id != null; }
+      set { if (value == (_initiator_group_id== null)) _initiator_group_id = value ? this.initiator_group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeinitiator_group_id() { return initiator_group_idSpecified; }
+    private void Resetinitiator_group_id() { initiator_group_idSpecified = false; }
+    
 
-    private bool _accept = default(bool);
+    private bool? _accept;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accept", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept
     {
-      get { return _accept; }
+      get { return _accept?? default(bool); }
       set { _accept = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptSpecified
+    {
+      get { return _accept != null; }
+      set { if (value == (_accept== null)) _accept = value ? this.accept : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept() { return acceptSpecified; }
+    private void Resetaccept() { acceptSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2201,14 +3706,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGroupMergeReply() {}
     
 
-    private EDOTAGroupMergeResult _result = EDOTAGroupMergeResult.k_EDOTAGroupMergeResult_OK;
+    private EDOTAGroupMergeResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EDOTAGroupMergeResult.k_EDOTAGroupMergeResult_OK)]
     public EDOTAGroupMergeResult result
     {
-      get { return _result; }
+      get { return _result?? EDOTAGroupMergeResult.k_EDOTAGroupMergeResult_OK; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (EDOTAGroupMergeResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2220,77 +3734,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSpectatorLobbyGameDetails() {}
     
 
-    private uint _language = default(uint);
+    private uint? _language;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint language
     {
-      get { return _language; }
+      get { return _language?? default(uint); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (uint?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private string _stream_url = "";
+    private string _stream_url;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"stream_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string stream_url
     {
-      get { return _stream_url; }
+      get { return _stream_url?? ""; }
       set { _stream_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stream_urlSpecified
+    {
+      get { return _stream_url != null; }
+      set { if (value == (_stream_url== null)) _stream_url = value ? this.stream_url : (string)null; }
+    }
+    private bool ShouldSerializestream_url() { return stream_urlSpecified; }
+    private void Resetstream_url() { stream_urlSpecified = false; }
+    
 
-    private string _stream_name = "";
+    private string _stream_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"stream_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string stream_name
     {
-      get { return _stream_name; }
+      get { return _stream_name?? ""; }
       set { _stream_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stream_nameSpecified
+    {
+      get { return _stream_name != null; }
+      set { if (value == (_stream_name== null)) _stream_name = value ? this.stream_name : (string)null; }
+    }
+    private bool ShouldSerializestream_name() { return stream_nameSpecified; }
+    private void Resetstream_name() { stream_nameSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _series_game = default(uint);
+    private uint? _series_game;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"series_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_game
     {
-      get { return _series_game; }
+      get { return _series_game?? default(uint); }
       set { _series_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_gameSpecified
+    {
+      get { return _series_game != null; }
+      set { if (value == (_series_game== null)) _series_game = value ? this.series_game : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_game() { return series_gameSpecified; }
+    private void Resetseries_game() { series_gameSpecified = false; }
+    
 
     private CMsgSpectatorLobbyGameDetails.Team _radiant_team = null;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"radiant_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2315,32 +3901,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Team() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2357,32 +3970,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSetSpectatorLobbyDetails() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private string _lobby_name = "";
+    private string _lobby_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string lobby_name
     {
-      get { return _lobby_name; }
+      get { return _lobby_name?? ""; }
       set { _lobby_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_nameSpecified
+    {
+      get { return _lobby_name != null; }
+      set { if (value == (_lobby_name== null)) _lobby_name = value ? this.lobby_name : (string)null; }
+    }
+    private bool ShouldSerializelobby_name() { return lobby_nameSpecified; }
+    private void Resetlobby_name() { lobby_nameSpecified = false; }
+    
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
     private CMsgSpectatorLobbyGameDetails _game_details = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2403,14 +4043,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgCreateSpectatorLobby() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
     private CMsgSetSpectatorLobbyDetails _details = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2453,50 +4102,95 @@ namespace SteamKit2.GC.Dota.Internal
     public SpectatorLobby() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private string _game_name = "";
+    private string _game_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_name
     {
-      get { return _game_name; }
+      get { return _game_name?? ""; }
       set { _game_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_nameSpecified
+    {
+      get { return _game_name != null; }
+      set { if (value == (_game_name== null)) _game_name = value ? this.game_name : (string)null; }
+    }
+    private bool ShouldSerializegame_name() { return game_nameSpecified; }
+    private void Resetgame_name() { game_nameSpecified = false; }
+    
 
-    private bool _requires_pass_key = default(bool);
+    private bool? _requires_pass_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"requires_pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_pass_key
     {
-      get { return _requires_pass_key; }
+      get { return _requires_pass_key?? default(bool); }
       set { _requires_pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_pass_keySpecified
+    {
+      get { return _requires_pass_key != null; }
+      set { if (value == (_requires_pass_key== null)) _requires_pass_key = value ? this.requires_pass_key : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_pass_key() { return requires_pass_keySpecified; }
+    private void Resetrequires_pass_key() { requires_pass_keySpecified = false; }
+    
 
-    private uint _leader_account_id = default(uint);
+    private uint? _leader_account_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"leader_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leader_account_id
     {
-      get { return _leader_account_id; }
+      get { return _leader_account_id?? default(uint); }
       set { _leader_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_account_idSpecified
+    {
+      get { return _leader_account_id != null; }
+      set { if (value == (_leader_account_id== null)) _leader_account_id = value ? this.leader_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleader_account_id() { return leader_account_idSpecified; }
+    private void Resetleader_account_id() { leader_account_idSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
 
     private CMsgSpectatorLobbyGameDetails _game_details = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2522,14 +4216,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestSteamDatagramTicket() {}
     
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2541,23 +4244,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRequestSteamDatagramTicketResponse() {}
     
 
-    private string _serialized_ticket = "";
+    private string _serialized_ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serialized_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serialized_ticket
     {
-      get { return _serialized_ticket; }
+      get { return _serialized_ticket?? ""; }
       set { _serialized_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_ticketSpecified
+    {
+      get { return _serialized_ticket != null; }
+      set { if (value == (_serialized_ticket== null)) _serialized_ticket = value ? this.serialized_ticket : (string)null; }
+    }
+    private bool ShouldSerializeserialized_ticket() { return serialized_ticketSpecified; }
+    private void Resetserialized_ticket() { serialized_ticketSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientTeam.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientTeam.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_team.proto
 namespace SteamKit2.GC.Dota.Internal
 {
@@ -17,14 +19,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamMemberSDO() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _team_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"team_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> team_ids
@@ -33,14 +44,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _profile_team_id = default(uint);
+    private uint? _profile_team_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"profile_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint profile_team_id
     {
-      get { return _profile_team_id; }
+      get { return _profile_team_id?? default(uint); }
       set { _profile_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool profile_team_idSpecified
+    {
+      get { return _profile_team_id != null; }
+      set { if (value == (_profile_team_id== null)) _profile_team_id = value ? this.profile_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprofile_team_id() { return profile_team_idSpecified; }
+    private void Resetprofile_team_id() { profile_team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -52,14 +72,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamAdminSDO() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _team_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"team_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> team_ids
@@ -78,23 +107,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamMember() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _time_joined = default(uint);
+    private uint? _time_joined;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_joined", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_joined
     {
-      get { return _time_joined; }
+      get { return _time_joined?? default(uint); }
       set { _time_joined = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_joinedSpecified
+    {
+      get { return _time_joined != null; }
+      set { if (value == (_time_joined== null)) _time_joined = value ? this.time_joined : (uint?)null; }
+    }
+    private bool ShouldSerializetime_joined() { return time_joinedSpecified; }
+    private void Resettime_joined() { time_joinedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -113,158 +160,311 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private uint _admin_id = default(uint);
+    private uint? _admin_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"admin_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint admin_id
     {
-      get { return _admin_id; }
+      get { return _admin_id?? default(uint); }
       set { _admin_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool admin_idSpecified
+    {
+      get { return _admin_id != null; }
+      set { if (value == (_admin_id== null)) _admin_id = value ? this.admin_id : (uint?)null; }
+    }
+    private bool ShouldSerializeadmin_id() { return admin_idSpecified; }
+    private void Resetadmin_id() { admin_idSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private bool _disbanded = default(bool);
+    private bool? _disbanded;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"disbanded", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool disbanded
     {
-      get { return _disbanded; }
+      get { return _disbanded?? default(bool); }
       set { _disbanded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool disbandedSpecified
+    {
+      get { return _disbanded != null; }
+      set { if (value == (_disbanded== null)) _disbanded = value ? this.disbanded : (bool?)null; }
+    }
+    private bool ShouldSerializedisbanded() { return disbandedSpecified; }
+    private void Resetdisbanded() { disbandedSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _calibration_games_remaining = default(uint);
+    private uint? _calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint calibration_games_remaining
     {
-      get { return _calibration_games_remaining; }
+      get { return _calibration_games_remaining?? default(uint); }
       set { _calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool calibration_games_remainingSpecified
+    {
+      get { return _calibration_games_remaining != null; }
+      set { if (value == (_calibration_games_remaining== null)) _calibration_games_remaining = value ? this.calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializecalibration_games_remaining() { return calibration_games_remainingSpecified; }
+    private void Resetcalibration_games_remaining() { calibration_games_remainingSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
 
-    private ulong _sponsor_logo = default(ulong);
+    private ulong? _sponsor_logo;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"sponsor_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sponsor_logo
     {
-      get { return _sponsor_logo; }
+      get { return _sponsor_logo?? default(ulong); }
       set { _sponsor_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sponsor_logoSpecified
+    {
+      get { return _sponsor_logo != null; }
+      set { if (value == (_sponsor_logo== null)) _sponsor_logo = value ? this.sponsor_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializesponsor_logo() { return sponsor_logoSpecified; }
+    private void Resetsponsor_logo() { sponsor_logoSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _fullgamesplayed = default(uint);
+    private uint? _fullgamesplayed;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"fullgamesplayed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fullgamesplayed
     {
-      get { return _fullgamesplayed; }
+      get { return _fullgamesplayed?? default(uint); }
       set { _fullgamesplayed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fullgamesplayedSpecified
+    {
+      get { return _fullgamesplayed != null; }
+      set { if (value == (_fullgamesplayed== null)) _fullgamesplayed = value ? this.fullgamesplayed : (uint?)null; }
+    }
+    private bool ShouldSerializefullgamesplayed() { return fullgamesplayedSpecified; }
+    private void Resetfullgamesplayed() { fullgamesplayedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _leagues = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(18, Name=@"leagues", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> leagues
@@ -273,50 +473,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _gamesplayed = default(uint);
+    private uint? _gamesplayed;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"gamesplayed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gamesplayed
     {
-      get { return _gamesplayed; }
+      get { return _gamesplayed?? default(uint); }
       set { _gamesplayed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamesplayedSpecified
+    {
+      get { return _gamesplayed != null; }
+      set { if (value == (_gamesplayed== null)) _gamesplayed = value ? this.gamesplayed : (uint?)null; }
+    }
+    private bool ShouldSerializegamesplayed() { return gamesplayedSpecified; }
+    private void Resetgamesplayed() { gamesplayedSpecified = false; }
+    
 
-    private uint _gamesplayedwithcurrentroster = default(uint);
+    private uint? _gamesplayedwithcurrentroster;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"gamesplayedwithcurrentroster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gamesplayedwithcurrentroster
     {
-      get { return _gamesplayedwithcurrentroster; }
+      get { return _gamesplayedwithcurrentroster?? default(uint); }
       set { _gamesplayedwithcurrentroster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamesplayedwithcurrentrosterSpecified
+    {
+      get { return _gamesplayedwithcurrentroster != null; }
+      set { if (value == (_gamesplayedwithcurrentroster== null)) _gamesplayedwithcurrentroster = value ? this.gamesplayedwithcurrentroster : (uint?)null; }
+    }
+    private bool ShouldSerializegamesplayedwithcurrentroster() { return gamesplayedwithcurrentrosterSpecified; }
+    private void Resetgamesplayedwithcurrentroster() { gamesplayedwithcurrentrosterSpecified = false; }
+    
 
-    private uint _teammatchmakinggamesplayed = default(uint);
+    private uint? _teammatchmakinggamesplayed;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"teammatchmakinggamesplayed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teammatchmakinggamesplayed
     {
-      get { return _teammatchmakinggamesplayed; }
+      get { return _teammatchmakinggamesplayed?? default(uint); }
       set { _teammatchmakinggamesplayed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teammatchmakinggamesplayedSpecified
+    {
+      get { return _teammatchmakinggamesplayed != null; }
+      set { if (value == (_teammatchmakinggamesplayed== null)) _teammatchmakinggamesplayed = value ? this.teammatchmakinggamesplayed : (uint?)null; }
+    }
+    private bool ShouldSerializeteammatchmakinggamesplayed() { return teammatchmakinggamesplayedSpecified; }
+    private void Resetteammatchmakinggamesplayed() { teammatchmakinggamesplayedSpecified = false; }
+    
 
-    private uint _lastplayedgametime = default(uint);
+    private uint? _lastplayedgametime;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"lastplayedgametime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lastplayedgametime
     {
-      get { return _lastplayedgametime; }
+      get { return _lastplayedgametime?? default(uint); }
       set { _lastplayedgametime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lastplayedgametimeSpecified
+    {
+      get { return _lastplayedgametime != null; }
+      set { if (value == (_lastplayedgametime== null)) _lastplayedgametime = value ? this.lastplayedgametime : (uint?)null; }
+    }
+    private bool ShouldSerializelastplayedgametime() { return lastplayedgametimeSpecified; }
+    private void Resetlastplayedgametime() { lastplayedgametimeSpecified = false; }
+    
 
-    private uint _lastrenametime = default(uint);
+    private uint? _lastrenametime;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"lastrenametime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lastrenametime
     {
-      get { return _lastrenametime; }
+      get { return _lastrenametime?? default(uint); }
       set { _lastrenametime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lastrenametimeSpecified
+    {
+      get { return _lastrenametime != null; }
+      set { if (value == (_lastrenametime== null)) _lastrenametime = value ? this.lastrenametime : (uint?)null; }
+    }
+    private bool ShouldSerializelastrenametime() { return lastrenametimeSpecified; }
+    private void Resetlastrenametime() { lastrenametimeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _recent_match_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(25, Name=@"recent_match_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> recent_match_ids
@@ -332,14 +577,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _pickup_team = default(bool);
+    private bool? _pickup_team;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"pickup_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pickup_team
     {
-      get { return _pickup_team; }
+      get { return _pickup_team?? default(bool); }
       set { _pickup_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickup_teamSpecified
+    {
+      get { return _pickup_team != null; }
+      set { if (value == (_pickup_team== null)) _pickup_team = value ? this.pickup_team : (bool?)null; }
+    }
+    private bool ShouldSerializepickup_team() { return pickup_teamSpecified; }
+    private void Resetpickup_team() { pickup_teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -358,176 +612,347 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private bool _pro = default(bool);
+    private bool? _pro;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"pro", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pro
     {
-      get { return _pro; }
+      get { return _pro?? default(bool); }
       set { _pro = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool proSpecified
+    {
+      get { return _pro != null; }
+      set { if (value == (_pro== null)) _pro = value ? this.pro : (bool?)null; }
+    }
+    private bool ShouldSerializepro() { return proSpecified; }
+    private void Resetpro() { proSpecified = false; }
+    
 
-    private bool _locked = default(bool);
+    private bool? _locked;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"locked", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool locked
     {
-      get { return _locked; }
+      get { return _locked?? default(bool); }
       set { _locked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lockedSpecified
+    {
+      get { return _locked != null; }
+      set { if (value == (_locked== null)) _locked = value ? this.locked : (bool?)null; }
+    }
+    private bool ShouldSerializelocked() { return lockedSpecified; }
+    private void Resetlocked() { lockedSpecified = false; }
+    
 
-    private bool _pickup_team = default(bool);
+    private bool? _pickup_team;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"pickup_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pickup_team
     {
-      get { return _pickup_team; }
+      get { return _pickup_team?? default(bool); }
       set { _pickup_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickup_teamSpecified
+    {
+      get { return _pickup_team != null; }
+      set { if (value == (_pickup_team== null)) _pickup_team = value ? this.pickup_team : (bool?)null; }
+    }
+    private bool ShouldSerializepickup_team() { return pickup_teamSpecified; }
+    private void Resetpickup_team() { pickup_teamSpecified = false; }
+    
 
-    private ulong _ugc_logo = default(ulong);
+    private ulong? _ugc_logo;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"ugc_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_logo
     {
-      get { return _ugc_logo; }
+      get { return _ugc_logo?? default(ulong); }
       set { _ugc_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_logoSpecified
+    {
+      get { return _ugc_logo != null; }
+      set { if (value == (_ugc_logo== null)) _ugc_logo = value ? this.ugc_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_logo() { return ugc_logoSpecified; }
+    private void Resetugc_logo() { ugc_logoSpecified = false; }
+    
 
-    private ulong _ugc_base_logo = default(ulong);
+    private ulong? _ugc_base_logo;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"ugc_base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_base_logo
     {
-      get { return _ugc_base_logo; }
+      get { return _ugc_base_logo?? default(ulong); }
       set { _ugc_base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_base_logoSpecified
+    {
+      get { return _ugc_base_logo != null; }
+      set { if (value == (_ugc_base_logo== null)) _ugc_base_logo = value ? this.ugc_base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_base_logo() { return ugc_base_logoSpecified; }
+    private void Resetugc_base_logo() { ugc_base_logoSpecified = false; }
+    
 
-    private ulong _ugc_banner_logo = default(ulong);
+    private ulong? _ugc_banner_logo;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"ugc_banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_banner_logo
     {
-      get { return _ugc_banner_logo; }
+      get { return _ugc_banner_logo?? default(ulong); }
       set { _ugc_banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_banner_logoSpecified
+    {
+      get { return _ugc_banner_logo != null; }
+      set { if (value == (_ugc_banner_logo== null)) _ugc_banner_logo = value ? this.ugc_banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_banner_logo() { return ugc_banner_logoSpecified; }
+    private void Resetugc_banner_logo() { ugc_banner_logoSpecified = false; }
+    
 
-    private ulong _ugc_sponsor_logo = default(ulong);
+    private ulong? _ugc_sponsor_logo;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"ugc_sponsor_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_sponsor_logo
     {
-      get { return _ugc_sponsor_logo; }
+      get { return _ugc_sponsor_logo?? default(ulong); }
       set { _ugc_sponsor_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_sponsor_logoSpecified
+    {
+      get { return _ugc_sponsor_logo != null; }
+      set { if (value == (_ugc_sponsor_logo== null)) _ugc_sponsor_logo = value ? this.ugc_sponsor_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_sponsor_logo() { return ugc_sponsor_logoSpecified; }
+    private void Resetugc_sponsor_logo() { ugc_sponsor_logoSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _calibration_games_remaining = default(uint);
+    private uint? _calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint calibration_games_remaining
     {
-      get { return _calibration_games_remaining; }
+      get { return _calibration_games_remaining?? default(uint); }
       set { _calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool calibration_games_remainingSpecified
+    {
+      get { return _calibration_games_remaining != null; }
+      set { if (value == (_calibration_games_remaining== null)) _calibration_games_remaining = value ? this.calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializecalibration_games_remaining() { return calibration_games_remainingSpecified; }
+    private void Resetcalibration_games_remaining() { calibration_games_remainingSpecified = false; }
+    
 
-    private uint _games_played_total = default(uint);
+    private uint? _games_played_total;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"games_played_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games_played_total
     {
-      get { return _games_played_total; }
+      get { return _games_played_total?? default(uint); }
       set { _games_played_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool games_played_totalSpecified
+    {
+      get { return _games_played_total != null; }
+      set { if (value == (_games_played_total== null)) _games_played_total = value ? this.games_played_total : (uint?)null; }
+    }
+    private bool ShouldSerializegames_played_total() { return games_played_totalSpecified; }
+    private void Resetgames_played_total() { games_played_totalSpecified = false; }
+    
 
-    private uint _games_played_matchmaking = default(uint);
+    private uint? _games_played_matchmaking;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"games_played_matchmaking", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games_played_matchmaking
     {
-      get { return _games_played_matchmaking; }
+      get { return _games_played_matchmaking?? default(uint); }
       set { _games_played_matchmaking = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool games_played_matchmakingSpecified
+    {
+      get { return _games_played_matchmaking != null; }
+      set { if (value == (_games_played_matchmaking== null)) _games_played_matchmaking = value ? this.games_played_matchmaking : (uint?)null; }
+    }
+    private bool ShouldSerializegames_played_matchmaking() { return games_played_matchmakingSpecified; }
+    private void Resetgames_played_matchmaking() { games_played_matchmakingSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _leagues_participated = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(21, Name=@"leagues_participated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> leagues_participated
@@ -555,41 +980,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Member() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _time_joined = default(uint);
+    private uint? _time_joined;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_joined", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_joined
     {
-      get { return _time_joined; }
+      get { return _time_joined?? default(uint); }
       set { _time_joined = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_joinedSpecified
+    {
+      get { return _time_joined != null; }
+      set { if (value == (_time_joined== null)) _time_joined = value ? this.time_joined : (uint?)null; }
+    }
+    private bool ShouldSerializetime_joined() { return time_joinedSpecified; }
+    private void Resettime_joined() { time_joinedSpecified = false; }
+    
 
-    private bool _admin = default(bool);
+    private bool? _admin;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"admin", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool admin
     {
-      get { return _admin; }
+      get { return _admin?? default(bool); }
       set { _admin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool adminSpecified
+    {
+      get { return _admin != null; }
+      set { if (value == (_admin== null)) _admin = value ? this.admin : (bool?)null; }
+    }
+    private bool ShouldSerializeadmin() { return adminSpecified; }
+    private void Resetadmin() { adminSpecified = false; }
+    
 
-    private bool _sub = default(bool);
+    private bool? _sub;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sub", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sub
     {
-      get { return _sub; }
+      get { return _sub?? default(bool); }
       set { _sub = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subSpecified
+    {
+      get { return _sub != null; }
+      set { if (value == (_sub== null)) _sub = value ? this.sub : (bool?)null; }
+    }
+    private bool ShouldSerializesub() { return subSpecified; }
+    private void Resetsub() { subSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -606,14 +1067,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamsInfo() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTATeamInfo> _teams = new global::System.Collections.Generic.List<CMsgDOTATeamInfo>();
     [global::ProtoBuf.ProtoMember(2, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTATeamInfo> teams
@@ -642,86 +1112,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACreateTeam() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
 
-    private ulong _sponsor_logo = default(ulong);
+    private ulong? _sponsor_logo;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sponsor_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sponsor_logo
     {
-      get { return _sponsor_logo; }
+      get { return _sponsor_logo?? default(ulong); }
       set { _sponsor_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sponsor_logoSpecified
+    {
+      get { return _sponsor_logo != null; }
+      set { if (value == (_sponsor_logo== null)) _sponsor_logo = value ? this.sponsor_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializesponsor_logo() { return sponsor_logoSpecified; }
+    private void Resetsponsor_logo() { sponsor_logoSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private bool _pickup_team = default(bool);
+    private bool? _pickup_team;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"pickup_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pickup_team
     {
-      get { return _pickup_team; }
+      get { return _pickup_team?? default(bool); }
       set { _pickup_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickup_teamSpecified
+    {
+      get { return _pickup_team != null; }
+      set { if (value == (_pickup_team== null)) _pickup_team = value ? this.pickup_team : (bool?)null; }
+    }
+    private bool ShouldSerializepickup_team() { return pickup_teamSpecified; }
+    private void Resetpickup_team() { pickup_teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -733,23 +1284,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACreateTeamResponse() {}
     
 
-    private CMsgDOTACreateTeamResponse.Result _result = CMsgDOTACreateTeamResponse.Result.INVALID;
+    private CMsgDOTACreateTeamResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTACreateTeamResponse.Result.INVALID)]
     public CMsgDOTACreateTeamResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTACreateTeamResponse.Result.INVALID; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTACreateTeamResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -823,95 +1392,185 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAEditTeamDetails() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private ulong _base_logo = default(ulong);
+    private ulong? _base_logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong base_logo
     {
-      get { return _base_logo; }
+      get { return _base_logo?? default(ulong); }
       set { _base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_logoSpecified
+    {
+      get { return _base_logo != null; }
+      set { if (value == (_base_logo== null)) _base_logo = value ? this.base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebase_logo() { return base_logoSpecified; }
+    private void Resetbase_logo() { base_logoSpecified = false; }
+    
 
-    private ulong _banner_logo = default(ulong);
+    private ulong? _banner_logo;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner_logo
     {
-      get { return _banner_logo; }
+      get { return _banner_logo?? default(ulong); }
       set { _banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool banner_logoSpecified
+    {
+      get { return _banner_logo != null; }
+      set { if (value == (_banner_logo== null)) _banner_logo = value ? this.banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner_logo() { return banner_logoSpecified; }
+    private void Resetbanner_logo() { banner_logoSpecified = false; }
+    
 
-    private ulong _sponsor_logo = default(ulong);
+    private ulong? _sponsor_logo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sponsor_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sponsor_logo
     {
-      get { return _sponsor_logo; }
+      get { return _sponsor_logo?? default(ulong); }
       set { _sponsor_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sponsor_logoSpecified
+    {
+      get { return _sponsor_logo != null; }
+      set { if (value == (_sponsor_logo== null)) _sponsor_logo = value ? this.sponsor_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializesponsor_logo() { return sponsor_logoSpecified; }
+    private void Resetsponsor_logo() { sponsor_logoSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private bool _in_use_by_party = default(bool);
+    private bool? _in_use_by_party;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"in_use_by_party", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_use_by_party
     {
-      get { return _in_use_by_party; }
+      get { return _in_use_by_party?? default(bool); }
       set { _in_use_by_party = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_use_by_partySpecified
+    {
+      get { return _in_use_by_party != null; }
+      set { if (value == (_in_use_by_party== null)) _in_use_by_party = value ? this.in_use_by_party : (bool?)null; }
+    }
+    private bool ShouldSerializein_use_by_party() { return in_use_by_partySpecified; }
+    private void Resetin_use_by_party() { in_use_by_partySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -923,14 +1582,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAEditTeamDetailsResponse() {}
     
 
-    private CMsgDOTAEditTeamDetailsResponse.Result _result = CMsgDOTAEditTeamDetailsResponse.Result.SUCCESS;
+    private CMsgDOTAEditTeamDetailsResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAEditTeamDetailsResponse.Result.SUCCESS)]
     public CMsgDOTAEditTeamDetailsResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAEditTeamDetailsResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAEditTeamDetailsResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -962,14 +1630,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamProfileResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
     private CMsgDOTATeam _team = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1007,73 +1684,136 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"TeamEntry")]
   public partial class TeamEntry : global::ProtoBuf.IExtensible
   {
     public TeamEntry() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private uint _member_count = default(uint);
+    private uint? _member_count;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"member_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_count
     {
-      get { return _member_count; }
+      get { return _member_count?? default(uint); }
       set { _member_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_countSpecified
+    {
+      get { return _member_count != null; }
+      set { if (value == (_member_count== null)) _member_count = value ? this.member_count : (uint?)null; }
+    }
+    private bool ShouldSerializemember_count() { return member_countSpecified; }
+    private void Resetmember_count() { member_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1090,23 +1830,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_InviterToGC() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1118,32 +1876,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_GCImmediateResponseToInviter() {}
     
 
-    private ETeamInviteResult _result = ETeamInviteResult.TEAM_INVITE_SUCCESS;
+    private ETeamInviteResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETeamInviteResult.TEAM_INVITE_SUCCESS)]
     public ETeamInviteResult result
     {
-      get { return _result; }
+      get { return _result?? ETeamInviteResult.TEAM_INVITE_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (ETeamInviteResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _invitee_name = "";
+    private string _invitee_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"invitee_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string invitee_name
     {
-      get { return _invitee_name; }
+      get { return _invitee_name?? ""; }
       set { _invitee_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invitee_nameSpecified
+    {
+      get { return _invitee_name != null; }
+      set { if (value == (_invitee_name== null)) _invitee_name = value ? this.invitee_name : (string)null; }
+    }
+    private bool ShouldSerializeinvitee_name() { return invitee_nameSpecified; }
+    private void Resetinvitee_name() { invitee_nameSpecified = false; }
+    
 
-    private uint _required_badge_level = default(uint);
+    private uint? _required_badge_level;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"required_badge_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint required_badge_level
     {
-      get { return _required_badge_level; }
+      get { return _required_badge_level?? default(uint); }
       set { _required_badge_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool required_badge_levelSpecified
+    {
+      get { return _required_badge_level != null; }
+      set { if (value == (_required_badge_level== null)) _required_badge_level = value ? this.required_badge_level : (uint?)null; }
+    }
+    private bool ShouldSerializerequired_badge_level() { return required_badge_levelSpecified; }
+    private void Resetrequired_badge_level() { required_badge_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1155,41 +1940,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_GCRequestToInvitee() {}
     
 
-    private uint _inviter_account_id = default(uint);
+    private uint? _inviter_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"inviter_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inviter_account_id
     {
-      get { return _inviter_account_id; }
+      get { return _inviter_account_id?? default(uint); }
       set { _inviter_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inviter_account_idSpecified
+    {
+      get { return _inviter_account_id != null; }
+      set { if (value == (_inviter_account_id== null)) _inviter_account_id = value ? this.inviter_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeinviter_account_id() { return inviter_account_idSpecified; }
+    private void Resetinviter_account_id() { inviter_account_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private ulong _logo = default(ulong);
+    private ulong? _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong logo
     {
-      get { return _logo; }
+      get { return _logo?? default(ulong); }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (ulong?)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1201,14 +2022,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_InviteeResponseToGC() {}
     
 
-    private ETeamInviteResult _result = ETeamInviteResult.TEAM_INVITE_SUCCESS;
+    private ETeamInviteResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETeamInviteResult.TEAM_INVITE_SUCCESS)]
     public ETeamInviteResult result
     {
-      get { return _result; }
+      get { return _result?? ETeamInviteResult.TEAM_INVITE_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (ETeamInviteResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1220,23 +2050,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_GCResponseToInviter() {}
     
 
-    private ETeamInviteResult _result = ETeamInviteResult.TEAM_INVITE_SUCCESS;
+    private ETeamInviteResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETeamInviteResult.TEAM_INVITE_SUCCESS)]
     public ETeamInviteResult result
     {
-      get { return _result; }
+      get { return _result?? ETeamInviteResult.TEAM_INVITE_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (ETeamInviteResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _invitee_name = "";
+    private string _invitee_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"invitee_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string invitee_name
     {
-      get { return _invitee_name; }
+      get { return _invitee_name?? ""; }
       set { _invitee_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invitee_nameSpecified
+    {
+      get { return _invitee_name != null; }
+      set { if (value == (_invitee_name== null)) _invitee_name = value ? this.invitee_name : (string)null; }
+    }
+    private bool ShouldSerializeinvitee_name() { return invitee_nameSpecified; }
+    private void Resetinvitee_name() { invitee_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1248,23 +2096,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATeamInvite_GCResponseToInvitee() {}
     
 
-    private ETeamInviteResult _result = ETeamInviteResult.TEAM_INVITE_SUCCESS;
+    private ETeamInviteResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETeamInviteResult.TEAM_INVITE_SUCCESS)]
     public ETeamInviteResult result
     {
-      get { return _result; }
+      get { return _result?? ETeamInviteResult.TEAM_INVITE_SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (ETeamInviteResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1276,23 +2142,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAKickTeamMember() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1304,14 +2188,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAKickTeamMemberResponse() {}
     
 
-    private CMsgDOTAKickTeamMemberResponse.Result _result = CMsgDOTAKickTeamMemberResponse.Result.SUCCESS;
+    private CMsgDOTAKickTeamMemberResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAKickTeamMemberResponse.Result.SUCCESS)]
     public CMsgDOTAKickTeamMemberResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAKickTeamMemberResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAKickTeamMemberResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -1346,23 +2239,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATransferTeamAdmin() {}
     
 
-    private uint _new_admin_account_id = default(uint);
+    private uint? _new_admin_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_admin_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_admin_account_id
     {
-      get { return _new_admin_account_id; }
+      get { return _new_admin_account_id?? default(uint); }
       set { _new_admin_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_admin_account_idSpecified
+    {
+      get { return _new_admin_account_id != null; }
+      set { if (value == (_new_admin_account_id== null)) _new_admin_account_id = value ? this.new_admin_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializenew_admin_account_id() { return new_admin_account_idSpecified; }
+    private void Resetnew_admin_account_id() { new_admin_account_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1374,14 +2285,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATransferTeamAdminResponse() {}
     
 
-    private CMsgDOTATransferTeamAdminResponse.Result _result = CMsgDOTATransferTeamAdminResponse.Result.SUCCESS;
+    private CMsgDOTATransferTeamAdminResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTATransferTeamAdminResponse.Result.SUCCESS)]
     public CMsgDOTATransferTeamAdminResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTATransferTeamAdminResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTATransferTeamAdminResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -1416,32 +2336,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChangeTeamSub() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private uint _member_account_id = default(uint);
+    private uint? _member_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"member_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint member_account_id
     {
-      get { return _member_account_id; }
+      get { return _member_account_id?? default(uint); }
       set { _member_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_account_idSpecified
+    {
+      get { return _member_account_id != null; }
+      set { if (value == (_member_account_id== null)) _member_account_id = value ? this.member_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializemember_account_id() { return member_account_idSpecified; }
+    private void Resetmember_account_id() { member_account_idSpecified = false; }
+    
 
-    private uint _sub_account_id = default(uint);
+    private uint? _sub_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sub_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sub_account_id
     {
-      get { return _sub_account_id; }
+      get { return _sub_account_id?? default(uint); }
       set { _sub_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sub_account_idSpecified
+    {
+      get { return _sub_account_id != null; }
+      set { if (value == (_sub_account_id== null)) _sub_account_id = value ? this.sub_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializesub_account_id() { return sub_account_idSpecified; }
+    private void Resetsub_account_id() { sub_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1453,14 +2400,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAChangeTeamSubResponse() {}
     
 
-    private CMsgDOTAChangeTeamSubResponse.Result _result = CMsgDOTAChangeTeamSubResponse.Result.SUCCESS;
+    private CMsgDOTAChangeTeamSubResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAChangeTeamSubResponse.Result.SUCCESS)]
     public CMsgDOTAChangeTeamSubResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTAChangeTeamSubResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTAChangeTeamSubResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -1501,14 +2457,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeaveTeam() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1520,14 +2485,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALeaveTeamResponse() {}
     
 
-    private CMsgDOTALeaveTeamResponse.Result _result = CMsgDOTALeaveTeamResponse.Result.SUCCESS;
+    private CMsgDOTALeaveTeamResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTALeaveTeamResponse.Result.SUCCESS)]
     public CMsgDOTALeaveTeamResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgDOTALeaveTeamResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgDOTALeaveTeamResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -1556,14 +2530,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTABetaParticipation() {}
     
 
-    private uint _access_rights = default(uint);
+    private uint? _access_rights;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"access_rights", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint access_rights
     {
-      get { return _access_rights; }
+      get { return _access_rights?? default(uint); }
       set { _access_rights = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_rightsSpecified
+    {
+      get { return _access_rights != null; }
+      set { if (value == (_access_rights== null)) _access_rights = value ? this.access_rights : (uint?)null; }
+    }
+    private bool ShouldSerializeaccess_rights() { return access_rightsSpecified; }
+    private void Resetaccess_rights() { access_rightsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientTournament.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientTournament.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_tournament.proto
 // Note: requires additional types generated from: dota_client_enums.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATournamentInfo() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTATournamentInfo.Phase> _phase_list = new global::System.Collections.Generic.List<CMsgDOTATournamentInfo.Phase>();
     [global::ProtoBuf.ProtoMember(2, Name=@"phase_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTATournamentInfo.Phase> phase_list
@@ -60,23 +71,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PhaseGroup() {}
     
 
-    private uint _group_id = default(uint);
+    private uint? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(uint); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (uint?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private string _group_name = "";
+    private string _group_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"group_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string group_name
     {
-      get { return _group_name; }
+      get { return _group_name?? ""; }
       set { _group_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_nameSpecified
+    {
+      get { return _group_name != null; }
+      set { if (value == (_group_name== null)) _group_name = value ? this.group_name : (string)null; }
+    }
+    private bool ShouldSerializegroup_name() { return group_nameSpecified; }
+    private void Resetgroup_name() { group_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -88,59 +117,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Phase() {}
     
 
-    private uint _phase_id = default(uint);
+    private uint? _phase_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"phase_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phase_id
     {
-      get { return _phase_id; }
+      get { return _phase_id?? default(uint); }
       set { _phase_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phase_idSpecified
+    {
+      get { return _phase_id != null; }
+      set { if (value == (_phase_id== null)) _phase_id = value ? this.phase_id : (uint?)null; }
+    }
+    private bool ShouldSerializephase_id() { return phase_idSpecified; }
+    private void Resetphase_id() { phase_idSpecified = false; }
+    
 
-    private string _phase_name = "";
+    private string _phase_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"phase_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string phase_name
     {
-      get { return _phase_name; }
+      get { return _phase_name?? ""; }
       set { _phase_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phase_nameSpecified
+    {
+      get { return _phase_name != null; }
+      set { if (value == (_phase_name== null)) _phase_name = value ? this.phase_name : (string)null; }
+    }
+    private bool ShouldSerializephase_name() { return phase_nameSpecified; }
+    private void Resetphase_name() { phase_nameSpecified = false; }
+    
 
-    private uint _type_id = default(uint);
+    private uint? _type_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(uint); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (uint?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private uint _iterations = default(uint);
+    private uint? _iterations;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"iterations", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint iterations
     {
-      get { return _iterations; }
+      get { return _iterations?? default(uint); }
       set { _iterations = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool iterationsSpecified
+    {
+      get { return _iterations != null; }
+      set { if (value == (_iterations== null)) _iterations = value ? this.iterations : (uint?)null; }
+    }
+    private bool ShouldSerializeiterations() { return iterationsSpecified; }
+    private void Resetiterations() { iterationsSpecified = false; }
+    
 
-    private uint _min_start_time = default(uint);
+    private uint? _min_start_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"min_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint min_start_time
     {
-      get { return _min_start_time; }
+      get { return _min_start_time?? default(uint); }
       set { _min_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_start_timeSpecified
+    {
+      get { return _min_start_time != null; }
+      set { if (value == (_min_start_time== null)) _min_start_time = value ? this.min_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializemin_start_time() { return min_start_timeSpecified; }
+    private void Resetmin_start_time() { min_start_timeSpecified = false; }
+    
 
-    private uint _max_start_time = default(uint);
+    private uint? _max_start_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"max_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_start_time
     {
-      get { return _max_start_time; }
+      get { return _max_start_time?? default(uint); }
       set { _max_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_start_timeSpecified
+    {
+      get { return _max_start_time != null; }
+      set { if (value == (_max_start_time== null)) _max_start_time = value ? this.max_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializemax_start_time() { return max_start_timeSpecified; }
+    private void Resetmax_start_time() { max_start_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTATournamentInfo.PhaseGroup> _group_list = new global::System.Collections.Generic.List<CMsgDOTATournamentInfo.PhaseGroup>();
     [global::ProtoBuf.ProtoMember(7, Name=@"group_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTATournamentInfo.PhaseGroup> group_list
@@ -159,50 +242,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Team() {}
     
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
-    private bool _eliminated = default(bool);
+    private bool? _eliminated;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"eliminated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool eliminated
     {
-      get { return _eliminated; }
+      get { return _eliminated?? default(bool); }
       set { _eliminated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eliminatedSpecified
+    {
+      get { return _eliminated != null; }
+      set { if (value == (_eliminated== null)) _eliminated = value ? this.eliminated : (bool?)null; }
+    }
+    private bool ShouldSerializeeliminated() { return eliminatedSpecified; }
+    private void Reseteliminated() { eliminatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -214,239 +342,473 @@ namespace SteamKit2.GC.Dota.Internal
     public UpcomingMatch() {}
     
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _team1_id = default(uint);
+    private uint? _team1_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team1_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_id
     {
-      get { return _team1_id; }
+      get { return _team1_id?? default(uint); }
       set { _team1_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_idSpecified
+    {
+      get { return _team1_id != null; }
+      set { if (value == (_team1_id== null)) _team1_id = value ? this.team1_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_id() { return team1_idSpecified; }
+    private void Resetteam1_id() { team1_idSpecified = false; }
+    
 
-    private uint _team2_id = default(uint);
+    private uint? _team2_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team2_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_id
     {
-      get { return _team2_id; }
+      get { return _team2_id?? default(uint); }
       set { _team2_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_idSpecified
+    {
+      get { return _team2_id != null; }
+      set { if (value == (_team2_id== null)) _team2_id = value ? this.team2_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_id() { return team2_idSpecified; }
+    private void Resetteam2_id() { team2_idSpecified = false; }
+    
 
-    private uint _bo = default(uint);
+    private uint? _bo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bo
     {
-      get { return _bo; }
+      get { return _bo?? default(uint); }
       set { _bo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boSpecified
+    {
+      get { return _bo != null; }
+      set { if (value == (_bo== null)) _bo = value ? this.bo : (uint?)null; }
+    }
+    private bool ShouldSerializebo() { return boSpecified; }
+    private void Resetbo() { boSpecified = false; }
+    
 
-    private string _stage_name = "";
+    private string _stage_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"stage_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string stage_name
     {
-      get { return _stage_name; }
+      get { return _stage_name?? ""; }
       set { _stage_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stage_nameSpecified
+    {
+      get { return _stage_name != null; }
+      set { if (value == (_stage_name== null)) _stage_name = value ? this.stage_name : (string)null; }
+    }
+    private bool ShouldSerializestage_name() { return stage_nameSpecified; }
+    private void Resetstage_name() { stage_nameSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private string _winner_stage = "";
+    private string _winner_stage;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"winner_stage", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string winner_stage
     {
-      get { return _winner_stage; }
+      get { return _winner_stage?? ""; }
       set { _winner_stage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winner_stageSpecified
+    {
+      get { return _winner_stage != null; }
+      set { if (value == (_winner_stage== null)) _winner_stage = value ? this.winner_stage : (string)null; }
+    }
+    private bool ShouldSerializewinner_stage() { return winner_stageSpecified; }
+    private void Resetwinner_stage() { winner_stageSpecified = false; }
+    
 
-    private string _loser_stage = "";
+    private string _loser_stage;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"loser_stage", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loser_stage
     {
-      get { return _loser_stage; }
+      get { return _loser_stage?? ""; }
       set { _loser_stage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loser_stageSpecified
+    {
+      get { return _loser_stage != null; }
+      set { if (value == (_loser_stage== null)) _loser_stage = value ? this.loser_stage : (string)null; }
+    }
+    private bool ShouldSerializeloser_stage() { return loser_stageSpecified; }
+    private void Resetloser_stage() { loser_stageSpecified = false; }
+    
 
-    private string _team1_tag = "";
+    private string _team1_tag;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"team1_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team1_tag
     {
-      get { return _team1_tag; }
+      get { return _team1_tag?? ""; }
       set { _team1_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_tagSpecified
+    {
+      get { return _team1_tag != null; }
+      set { if (value == (_team1_tag== null)) _team1_tag = value ? this.team1_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam1_tag() { return team1_tagSpecified; }
+    private void Resetteam1_tag() { team1_tagSpecified = false; }
+    
 
-    private string _team2_tag = "";
+    private string _team2_tag;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"team2_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team2_tag
     {
-      get { return _team2_tag; }
+      get { return _team2_tag?? ""; }
       set { _team2_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_tagSpecified
+    {
+      get { return _team2_tag != null; }
+      set { if (value == (_team2_tag== null)) _team2_tag = value ? this.team2_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam2_tag() { return team2_tagSpecified; }
+    private void Resetteam2_tag() { team2_tagSpecified = false; }
+    
 
-    private string _team1_prev_opponent_tag = "";
+    private string _team1_prev_opponent_tag;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"team1_prev_opponent_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team1_prev_opponent_tag
     {
-      get { return _team1_prev_opponent_tag; }
+      get { return _team1_prev_opponent_tag?? ""; }
       set { _team1_prev_opponent_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_prev_opponent_tagSpecified
+    {
+      get { return _team1_prev_opponent_tag != null; }
+      set { if (value == (_team1_prev_opponent_tag== null)) _team1_prev_opponent_tag = value ? this.team1_prev_opponent_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam1_prev_opponent_tag() { return team1_prev_opponent_tagSpecified; }
+    private void Resetteam1_prev_opponent_tag() { team1_prev_opponent_tagSpecified = false; }
+    
 
-    private string _team2_prev_opponent_tag = "";
+    private string _team2_prev_opponent_tag;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"team2_prev_opponent_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team2_prev_opponent_tag
     {
-      get { return _team2_prev_opponent_tag; }
+      get { return _team2_prev_opponent_tag?? ""; }
       set { _team2_prev_opponent_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_prev_opponent_tagSpecified
+    {
+      get { return _team2_prev_opponent_tag != null; }
+      set { if (value == (_team2_prev_opponent_tag== null)) _team2_prev_opponent_tag = value ? this.team2_prev_opponent_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam2_prev_opponent_tag() { return team2_prev_opponent_tagSpecified; }
+    private void Resetteam2_prev_opponent_tag() { team2_prev_opponent_tagSpecified = false; }
+    
 
-    private ulong _team1_logo = default(ulong);
+    private ulong? _team1_logo;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"team1_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team1_logo
     {
-      get { return _team1_logo; }
+      get { return _team1_logo?? default(ulong); }
       set { _team1_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_logoSpecified
+    {
+      get { return _team1_logo != null; }
+      set { if (value == (_team1_logo== null)) _team1_logo = value ? this.team1_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam1_logo() { return team1_logoSpecified; }
+    private void Resetteam1_logo() { team1_logoSpecified = false; }
+    
 
-    private ulong _team2_logo = default(ulong);
+    private ulong? _team2_logo;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"team2_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team2_logo
     {
-      get { return _team2_logo; }
+      get { return _team2_logo?? default(ulong); }
       set { _team2_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_logoSpecified
+    {
+      get { return _team2_logo != null; }
+      set { if (value == (_team2_logo== null)) _team2_logo = value ? this.team2_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam2_logo() { return team2_logoSpecified; }
+    private void Resetteam2_logo() { team2_logoSpecified = false; }
+    
 
-    private ulong _team1_prev_opponent_logo = default(ulong);
+    private ulong? _team1_prev_opponent_logo;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"team1_prev_opponent_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team1_prev_opponent_logo
     {
-      get { return _team1_prev_opponent_logo; }
+      get { return _team1_prev_opponent_logo?? default(ulong); }
       set { _team1_prev_opponent_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_prev_opponent_logoSpecified
+    {
+      get { return _team1_prev_opponent_logo != null; }
+      set { if (value == (_team1_prev_opponent_logo== null)) _team1_prev_opponent_logo = value ? this.team1_prev_opponent_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam1_prev_opponent_logo() { return team1_prev_opponent_logoSpecified; }
+    private void Resetteam1_prev_opponent_logo() { team1_prev_opponent_logoSpecified = false; }
+    
 
-    private ulong _team2_prev_opponent_logo = default(ulong);
+    private ulong? _team2_prev_opponent_logo;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"team2_prev_opponent_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team2_prev_opponent_logo
     {
-      get { return _team2_prev_opponent_logo; }
+      get { return _team2_prev_opponent_logo?? default(ulong); }
       set { _team2_prev_opponent_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_prev_opponent_logoSpecified
+    {
+      get { return _team2_prev_opponent_logo != null; }
+      set { if (value == (_team2_prev_opponent_logo== null)) _team2_prev_opponent_logo = value ? this.team2_prev_opponent_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam2_prev_opponent_logo() { return team2_prev_opponent_logoSpecified; }
+    private void Resetteam2_prev_opponent_logo() { team2_prev_opponent_logoSpecified = false; }
+    
 
-    private uint _team1_prev_opponent_id = default(uint);
+    private uint? _team1_prev_opponent_id;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"team1_prev_opponent_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_prev_opponent_id
     {
-      get { return _team1_prev_opponent_id; }
+      get { return _team1_prev_opponent_id?? default(uint); }
       set { _team1_prev_opponent_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_prev_opponent_idSpecified
+    {
+      get { return _team1_prev_opponent_id != null; }
+      set { if (value == (_team1_prev_opponent_id== null)) _team1_prev_opponent_id = value ? this.team1_prev_opponent_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_prev_opponent_id() { return team1_prev_opponent_idSpecified; }
+    private void Resetteam1_prev_opponent_id() { team1_prev_opponent_idSpecified = false; }
+    
 
-    private uint _team2_prev_opponent_id = default(uint);
+    private uint? _team2_prev_opponent_id;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"team2_prev_opponent_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_prev_opponent_id
     {
-      get { return _team2_prev_opponent_id; }
+      get { return _team2_prev_opponent_id?? default(uint); }
       set { _team2_prev_opponent_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_prev_opponent_idSpecified
+    {
+      get { return _team2_prev_opponent_id != null; }
+      set { if (value == (_team2_prev_opponent_id== null)) _team2_prev_opponent_id = value ? this.team2_prev_opponent_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_prev_opponent_id() { return team2_prev_opponent_idSpecified; }
+    private void Resetteam2_prev_opponent_id() { team2_prev_opponent_idSpecified = false; }
+    
 
-    private uint _team1_prev_match_score = default(uint);
+    private uint? _team1_prev_match_score;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"team1_prev_match_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_prev_match_score
     {
-      get { return _team1_prev_match_score; }
+      get { return _team1_prev_match_score?? default(uint); }
       set { _team1_prev_match_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_prev_match_scoreSpecified
+    {
+      get { return _team1_prev_match_score != null; }
+      set { if (value == (_team1_prev_match_score== null)) _team1_prev_match_score = value ? this.team1_prev_match_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_prev_match_score() { return team1_prev_match_scoreSpecified; }
+    private void Resetteam1_prev_match_score() { team1_prev_match_scoreSpecified = false; }
+    
 
-    private uint _team1_prev_match_opponent_score = default(uint);
+    private uint? _team1_prev_match_opponent_score;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"team1_prev_match_opponent_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_prev_match_opponent_score
     {
-      get { return _team1_prev_match_opponent_score; }
+      get { return _team1_prev_match_opponent_score?? default(uint); }
       set { _team1_prev_match_opponent_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_prev_match_opponent_scoreSpecified
+    {
+      get { return _team1_prev_match_opponent_score != null; }
+      set { if (value == (_team1_prev_match_opponent_score== null)) _team1_prev_match_opponent_score = value ? this.team1_prev_match_opponent_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_prev_match_opponent_score() { return team1_prev_match_opponent_scoreSpecified; }
+    private void Resetteam1_prev_match_opponent_score() { team1_prev_match_opponent_scoreSpecified = false; }
+    
 
-    private uint _team2_prev_match_score = default(uint);
+    private uint? _team2_prev_match_score;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"team2_prev_match_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_prev_match_score
     {
-      get { return _team2_prev_match_score; }
+      get { return _team2_prev_match_score?? default(uint); }
       set { _team2_prev_match_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_prev_match_scoreSpecified
+    {
+      get { return _team2_prev_match_score != null; }
+      set { if (value == (_team2_prev_match_score== null)) _team2_prev_match_score = value ? this.team2_prev_match_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_prev_match_score() { return team2_prev_match_scoreSpecified; }
+    private void Resetteam2_prev_match_score() { team2_prev_match_scoreSpecified = false; }
+    
 
-    private uint _team2_prev_match_opponent_score = default(uint);
+    private uint? _team2_prev_match_opponent_score;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"team2_prev_match_opponent_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_prev_match_opponent_score
     {
-      get { return _team2_prev_match_opponent_score; }
+      get { return _team2_prev_match_opponent_score?? default(uint); }
       set { _team2_prev_match_opponent_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_prev_match_opponent_scoreSpecified
+    {
+      get { return _team2_prev_match_opponent_score != null; }
+      set { if (value == (_team2_prev_match_opponent_score== null)) _team2_prev_match_opponent_score = value ? this.team2_prev_match_opponent_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_prev_match_opponent_score() { return team2_prev_match_opponent_scoreSpecified; }
+    private void Resetteam2_prev_match_opponent_score() { team2_prev_match_opponent_scoreSpecified = false; }
+    
 
-    private uint _phase_type = default(uint);
+    private uint? _phase_type;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"phase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phase_type
     {
-      get { return _phase_type; }
+      get { return _phase_type?? default(uint); }
       set { _phase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phase_typeSpecified
+    {
+      get { return _phase_type != null; }
+      set { if (value == (_phase_type== null)) _phase_type = value ? this.phase_type : (uint?)null; }
+    }
+    private bool ShouldSerializephase_type() { return phase_typeSpecified; }
+    private void Resetphase_type() { phase_typeSpecified = false; }
+    
 
-    private uint _team1_score = default(uint);
+    private uint? _team1_score;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"team1_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_score
     {
-      get { return _team1_score; }
+      get { return _team1_score?? default(uint); }
       set { _team1_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_scoreSpecified
+    {
+      get { return _team1_score != null; }
+      set { if (value == (_team1_score== null)) _team1_score = value ? this.team1_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_score() { return team1_scoreSpecified; }
+    private void Resetteam1_score() { team1_scoreSpecified = false; }
+    
 
-    private uint _team2_score = default(uint);
+    private uint? _team2_score;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"team2_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_score
     {
-      get { return _team2_score; }
+      get { return _team2_score?? default(uint); }
       set { _team2_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_scoreSpecified
+    {
+      get { return _team2_score != null; }
+      set { if (value == (_team2_score== null)) _team2_score = value ? this.team2_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_score() { return team2_scoreSpecified; }
+    private void Resetteam2_score() { team2_scoreSpecified = false; }
+    
 
-    private uint _phase_id = default(uint);
+    private uint? _phase_id;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"phase_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phase_id
     {
-      get { return _phase_id; }
+      get { return _phase_id?? default(uint); }
       set { _phase_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phase_idSpecified
+    {
+      get { return _phase_id != null; }
+      set { if (value == (_phase_id== null)) _phase_id = value ? this.phase_id : (uint?)null; }
+    }
+    private bool ShouldSerializephase_id() { return phase_idSpecified; }
+    private void Resetphase_id() { phase_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -458,41 +820,77 @@ namespace SteamKit2.GC.Dota.Internal
     public News() {}
     
 
-    private string _link = "";
+    private string _link;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"link", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string link
     {
-      get { return _link; }
+      get { return _link?? ""; }
       set { _link = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool linkSpecified
+    {
+      get { return _link != null; }
+      set { if (value == (_link== null)) _link = value ? this.link : (string)null; }
+    }
+    private bool ShouldSerializelink() { return linkSpecified; }
+    private void Resetlink() { linkSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _image = "";
+    private string _image;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"image", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string image
     {
-      get { return _image; }
+      get { return _image?? ""; }
       set { _image = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool imageSpecified
+    {
+      get { return _image != null; }
+      set { if (value == (_image== null)) _image = value ? this.image : (string)null; }
+    }
+    private bool ShouldSerializeimage() { return imageSpecified; }
+    private void Resetimage() { imageSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -531,50 +929,95 @@ namespace SteamKit2.GC.Dota.Internal
     public Division() {}
     
 
-    private uint _division_code = default(uint);
+    private uint? _division_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"division_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division_code
     {
-      get { return _division_code; }
+      get { return _division_code?? default(uint); }
       set { _division_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool division_codeSpecified
+    {
+      get { return _division_code != null; }
+      set { if (value == (_division_code== null)) _division_code = value ? this.division_code : (uint?)null; }
+    }
+    private bool ShouldSerializedivision_code() { return division_codeSpecified; }
+    private void Resetdivision_code() { division_codeSpecified = false; }
+    
 
-    private uint _time_window_open = default(uint);
+    private uint? _time_window_open;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_window_open", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_window_open
     {
-      get { return _time_window_open; }
+      get { return _time_window_open?? default(uint); }
       set { _time_window_open = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_window_openSpecified
+    {
+      get { return _time_window_open != null; }
+      set { if (value == (_time_window_open== null)) _time_window_open = value ? this.time_window_open : (uint?)null; }
+    }
+    private bool ShouldSerializetime_window_open() { return time_window_openSpecified; }
+    private void Resettime_window_open() { time_window_openSpecified = false; }
+    
 
-    private uint _time_window_close = default(uint);
+    private uint? _time_window_close;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_window_close", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_window_close
     {
-      get { return _time_window_close; }
+      get { return _time_window_close?? default(uint); }
       set { _time_window_close = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_window_closeSpecified
+    {
+      get { return _time_window_close != null; }
+      set { if (value == (_time_window_close== null)) _time_window_close = value ? this.time_window_close : (uint?)null; }
+    }
+    private bool ShouldSerializetime_window_close() { return time_window_closeSpecified; }
+    private void Resettime_window_close() { time_window_closeSpecified = false; }
+    
 
-    private uint _time_window_open_next = default(uint);
+    private uint? _time_window_open_next;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_window_open_next", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_window_open_next
     {
-      get { return _time_window_open_next; }
+      get { return _time_window_open_next?? default(uint); }
       set { _time_window_open_next = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_window_open_nextSpecified
+    {
+      get { return _time_window_open_next != null; }
+      set { if (value == (_time_window_open_next== null)) _time_window_open_next = value ? this.time_window_open_next : (uint?)null; }
+    }
+    private bool ShouldSerializetime_window_open_next() { return time_window_open_nextSpecified; }
+    private void Resettime_window_open_next() { time_window_open_nextSpecified = false; }
+    
 
-    private uint _trophy_id = default(uint);
+    private uint? _trophy_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_id
     {
-      get { return _trophy_id; }
+      get { return _trophy_id?? default(uint); }
       set { _trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_idSpecified
+    {
+      get { return _trophy_id != null; }
+      set { if (value == (_trophy_id== null)) _trophy_id = value ? this.trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_id() { return trophy_idSpecified; }
+    private void Resettrophy_id() { trophy_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -591,77 +1034,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgWeekendTourneyOpts() {}
     
 
-    private bool _participating = default(bool);
+    private bool? _participating;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"participating", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool participating
     {
-      get { return _participating; }
+      get { return _participating?? default(bool); }
       set { _participating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool participatingSpecified
+    {
+      get { return _participating != null; }
+      set { if (value == (_participating== null)) _participating = value ? this.participating : (bool?)null; }
+    }
+    private bool ShouldSerializeparticipating() { return participatingSpecified; }
+    private void Resetparticipating() { participatingSpecified = false; }
+    
 
-    private uint _division_id = default(uint);
+    private uint? _division_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division_id
     {
-      get { return _division_id; }
+      get { return _division_id?? default(uint); }
       set { _division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool division_idSpecified
+    {
+      get { return _division_id != null; }
+      set { if (value == (_division_id== null)) _division_id = value ? this.division_id : (uint?)null; }
+    }
+    private bool ShouldSerializedivision_id() { return division_idSpecified; }
+    private void Resetdivision_id() { division_idSpecified = false; }
+    
 
-    private uint _buyin = default(uint);
+    private uint? _buyin;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"buyin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint buyin
     {
-      get { return _buyin; }
+      get { return _buyin?? default(uint); }
       set { _buyin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool buyinSpecified
+    {
+      get { return _buyin != null; }
+      set { if (value == (_buyin== null)) _buyin = value ? this.buyin : (uint?)null; }
+    }
+    private bool ShouldSerializebuyin() { return buyinSpecified; }
+    private void Resetbuyin() { buyinSpecified = false; }
+    
 
-    private uint _skill_level = default(uint);
+    private uint? _skill_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_level
     {
-      get { return _skill_level; }
+      get { return _skill_level?? default(uint); }
       set { _skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_levelSpecified
+    {
+      get { return _skill_level != null; }
+      set { if (value == (_skill_level== null)) _skill_level = value ? this.skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_level() { return skill_levelSpecified; }
+    private void Resetskill_level() { skill_levelSpecified = false; }
+    
 
-    private uint _match_groups = default(uint);
+    private uint? _match_groups;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"match_groups", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_groups
     {
-      get { return _match_groups; }
+      get { return _match_groups?? default(uint); }
       set { _match_groups = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupsSpecified
+    {
+      get { return _match_groups != null; }
+      set { if (value == (_match_groups== null)) _match_groups = value ? this.match_groups : (uint?)null; }
+    }
+    private bool ShouldSerializematch_groups() { return match_groupsSpecified; }
+    private void Resetmatch_groups() { match_groupsSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _pickup_team_name = "";
+    private string _pickup_team_name;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"pickup_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pickup_team_name
     {
-      get { return _pickup_team_name; }
+      get { return _pickup_team_name?? ""; }
       set { _pickup_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickup_team_nameSpecified
+    {
+      get { return _pickup_team_name != null; }
+      set { if (value == (_pickup_team_name== null)) _pickup_team_name = value ? this.pickup_team_name : (string)null; }
+    }
+    private bool ShouldSerializepickup_team_name() { return pickup_team_nameSpecified; }
+    private void Resetpickup_team_name() { pickup_team_nameSpecified = false; }
+    
 
-    private ulong _pickup_team_logo = default(ulong);
+    private ulong? _pickup_team_logo;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"pickup_team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pickup_team_logo
     {
-      get { return _pickup_team_logo; }
+      get { return _pickup_team_logo?? default(ulong); }
       set { _pickup_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pickup_team_logoSpecified
+    {
+      get { return _pickup_team_logo != null; }
+      set { if (value == (_pickup_team_logo== null)) _pickup_team_logo = value ? this.pickup_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializepickup_team_logo() { return pickup_team_logoSpecified; }
+    private void Resetpickup_team_logo() { pickup_team_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -683,77 +1198,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATournament() {}
     
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _division_id = default(uint);
+    private uint? _division_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division_id
     {
-      get { return _division_id; }
+      get { return _division_id?? default(uint); }
       set { _division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool division_idSpecified
+    {
+      get { return _division_id != null; }
+      set { if (value == (_division_id== null)) _division_id = value ? this.division_id : (uint?)null; }
+    }
+    private bool ShouldSerializedivision_id() { return division_idSpecified; }
+    private void Resetdivision_id() { division_idSpecified = false; }
+    
 
-    private uint _schedule_time = default(uint);
+    private uint? _schedule_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"schedule_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint schedule_time
     {
-      get { return _schedule_time; }
+      get { return _schedule_time?? default(uint); }
       set { _schedule_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schedule_timeSpecified
+    {
+      get { return _schedule_time != null; }
+      set { if (value == (_schedule_time== null)) _schedule_time = value ? this.schedule_time : (uint?)null; }
+    }
+    private bool ShouldSerializeschedule_time() { return schedule_timeSpecified; }
+    private void Resetschedule_time() { schedule_timeSpecified = false; }
+    
 
-    private uint _skill_level = default(uint);
+    private uint? _skill_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_level
     {
-      get { return _skill_level; }
+      get { return _skill_level?? default(uint); }
       set { _skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_levelSpecified
+    {
+      get { return _skill_level != null; }
+      set { if (value == (_skill_level== null)) _skill_level = value ? this.skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_level() { return skill_levelSpecified; }
+    private void Resetskill_level() { skill_levelSpecified = false; }
+    
 
-    private ETournamentTemplate _tournament_template = ETournamentTemplate.k_ETournamentTemplate_None;
+    private ETournamentTemplate? _tournament_template;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tournament_template", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentTemplate.k_ETournamentTemplate_None)]
     public ETournamentTemplate tournament_template
     {
-      get { return _tournament_template; }
+      get { return _tournament_template?? ETournamentTemplate.k_ETournamentTemplate_None; }
       set { _tournament_template = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_templateSpecified
+    {
+      get { return _tournament_template != null; }
+      set { if (value == (_tournament_template== null)) _tournament_template = value ? this.tournament_template : (ETournamentTemplate?)null; }
+    }
+    private bool ShouldSerializetournament_template() { return tournament_templateSpecified; }
+    private void Resettournament_template() { tournament_templateSpecified = false; }
+    
 
-    private ETournamentState _state = ETournamentState.k_ETournamentState_Unknown;
+    private ETournamentState? _state;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentState.k_ETournamentState_Unknown)]
     public ETournamentState state
     {
-      get { return _state; }
+      get { return _state?? ETournamentState.k_ETournamentState_Unknown; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (ETournamentState?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private uint _state_seq_num = default(uint);
+    private uint? _state_seq_num;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"state_seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint state_seq_num
     {
-      get { return _state_seq_num; }
+      get { return _state_seq_num?? default(uint); }
       set { _state_seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool state_seq_numSpecified
+    {
+      get { return _state_seq_num != null; }
+      set { if (value == (_state_seq_num== null)) _state_seq_num = value ? this.state_seq_num : (uint?)null; }
+    }
+    private bool ShouldSerializestate_seq_num() { return state_seq_numSpecified; }
+    private void Resetstate_seq_num() { state_seq_numSpecified = false; }
+    
 
-    private uint _season_trophy_id = default(uint);
+    private uint? _season_trophy_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_trophy_id
     {
-      get { return _season_trophy_id; }
+      get { return _season_trophy_id?? default(uint); }
       set { _season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_trophy_idSpecified
+    {
+      get { return _season_trophy_id != null; }
+      set { if (value == (_season_trophy_id== null)) _season_trophy_id = value ? this.season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_trophy_id() { return season_trophy_idSpecified; }
+    private void Resetseason_trophy_id() { season_trophy_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTATournament.Team> _teams = new global::System.Collections.Generic.List<CMsgDOTATournament.Team>();
     [global::ProtoBuf.ProtoMember(7, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTATournament.Team> teams
@@ -781,23 +1368,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Team() {}
     
 
-    private ulong _team_gid = default(ulong);
+    private ulong? _team_gid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_gid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_gid
     {
-      get { return _team_gid; }
+      get { return _team_gid?? default(ulong); }
       set { _team_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_gidSpecified
+    {
+      get { return _team_gid != null; }
+      set { if (value == (_team_gid== null)) _team_gid = value ? this.team_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_gid() { return team_gidSpecified; }
+    private void Resetteam_gid() { team_gidSpecified = false; }
+    
 
-    private uint _node_or_state = default(uint);
+    private uint? _node_or_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"node_or_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint node_or_state
     {
-      get { return _node_or_state; }
+      get { return _node_or_state?? default(uint); }
       set { _node_or_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool node_or_stateSpecified
+    {
+      get { return _node_or_state != null; }
+      set { if (value == (_node_or_state== null)) _node_or_state = value ? this.node_or_state : (uint?)null; }
+    }
+    private bool ShouldSerializenode_or_state() { return node_or_stateSpecified; }
+    private void Resetnode_or_state() { node_or_stateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _players = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement, Options = global::ProtoBuf.MemberSerializationOptions.Packed)]
     public global::System.Collections.Generic.List<uint> players
@@ -820,59 +1425,113 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _match_group_mask = default(uint);
+    private uint? _match_group_mask;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"match_group_mask", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_group_mask
     {
-      get { return _match_group_mask; }
+      get { return _match_group_mask?? default(uint); }
       set { _match_group_mask = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_group_maskSpecified
+    {
+      get { return _match_group_mask != null; }
+      set { if (value == (_match_group_mask== null)) _match_group_mask = value ? this.match_group_mask : (uint?)null; }
+    }
+    private bool ShouldSerializematch_group_mask() { return match_group_maskSpecified; }
+    private void Resetmatch_group_mask() { match_group_maskSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_base_logo = default(ulong);
+    private ulong? _team_base_logo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_base_logo
     {
-      get { return _team_base_logo; }
+      get { return _team_base_logo?? default(ulong); }
       set { _team_base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_base_logoSpecified
+    {
+      get { return _team_base_logo != null; }
+      set { if (value == (_team_base_logo== null)) _team_base_logo = value ? this.team_base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_base_logo() { return team_base_logoSpecified; }
+    private void Resetteam_base_logo() { team_base_logoSpecified = false; }
+    
 
-    private ulong _team_ui_logo = default(ulong);
+    private ulong? _team_ui_logo;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_ui_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_ui_logo
     {
-      get { return _team_ui_logo; }
+      get { return _team_ui_logo?? default(ulong); }
       set { _team_ui_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_ui_logoSpecified
+    {
+      get { return _team_ui_logo != null; }
+      set { if (value == (_team_ui_logo== null)) _team_ui_logo = value ? this.team_ui_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_ui_logo() { return team_ui_logoSpecified; }
+    private void Resetteam_ui_logo() { team_ui_logoSpecified = false; }
+    
 
-    private uint _team_date = default(uint);
+    private uint? _team_date;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"team_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_date
     {
-      get { return _team_date; }
+      get { return _team_date?? default(uint); }
       set { _team_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_dateSpecified
+    {
+      get { return _team_date != null; }
+      set { if (value == (_team_date== null)) _team_date = value ? this.team_date : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_date() { return team_dateSpecified; }
+    private void Resetteam_date() { team_dateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -884,59 +1543,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Game() {}
     
 
-    private uint _node_idx = default(uint);
+    private uint? _node_idx;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"node_idx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint node_idx
     {
-      get { return _node_idx; }
+      get { return _node_idx?? default(uint); }
       set { _node_idx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool node_idxSpecified
+    {
+      get { return _node_idx != null; }
+      set { if (value == (_node_idx== null)) _node_idx = value ? this.node_idx : (uint?)null; }
+    }
+    private bool ShouldSerializenode_idx() { return node_idxSpecified; }
+    private void Resetnode_idx() { node_idxSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private bool _team_a_good = default(bool);
+    private bool? _team_a_good;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_a_good", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool team_a_good
     {
-      get { return _team_a_good; }
+      get { return _team_a_good?? default(bool); }
       set { _team_a_good = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_a_goodSpecified
+    {
+      get { return _team_a_good != null; }
+      set { if (value == (_team_a_good== null)) _team_a_good = value ? this.team_a_good : (bool?)null; }
+    }
+    private bool ShouldSerializeteam_a_good() { return team_a_goodSpecified; }
+    private void Resetteam_a_good() { team_a_goodSpecified = false; }
+    
 
-    private ETournamentGameState _state = ETournamentGameState.k_ETournamentGameState_Unknown;
+    private ETournamentGameState? _state;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentGameState.k_ETournamentGameState_Unknown)]
     public ETournamentGameState state
     {
-      get { return _state; }
+      get { return _state?? ETournamentGameState.k_ETournamentGameState_Unknown; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (ETournamentGameState?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -948,41 +1661,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Node() {}
     
 
-    private uint _node_id = default(uint);
+    private uint? _node_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"node_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint node_id
     {
-      get { return _node_id; }
+      get { return _node_id?? default(uint); }
       set { _node_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool node_idSpecified
+    {
+      get { return _node_id != null; }
+      set { if (value == (_node_id== null)) _node_id = value ? this.node_id : (uint?)null; }
+    }
+    private bool ShouldSerializenode_id() { return node_idSpecified; }
+    private void Resetnode_id() { node_idSpecified = false; }
+    
 
-    private uint _team_idx_a = default(uint);
+    private uint? _team_idx_a;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_idx_a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_idx_a
     {
-      get { return _team_idx_a; }
+      get { return _team_idx_a?? default(uint); }
       set { _team_idx_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idx_aSpecified
+    {
+      get { return _team_idx_a != null; }
+      set { if (value == (_team_idx_a== null)) _team_idx_a = value ? this.team_idx_a : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_idx_a() { return team_idx_aSpecified; }
+    private void Resetteam_idx_a() { team_idx_aSpecified = false; }
+    
 
-    private uint _team_idx_b = default(uint);
+    private uint? _team_idx_b;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_idx_b", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_idx_b
     {
-      get { return _team_idx_b; }
+      get { return _team_idx_b?? default(uint); }
       set { _team_idx_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idx_bSpecified
+    {
+      get { return _team_idx_b != null; }
+      set { if (value == (_team_idx_b== null)) _team_idx_b = value ? this.team_idx_b : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_idx_b() { return team_idx_bSpecified; }
+    private void Resetteam_idx_b() { team_idx_bSpecified = false; }
+    
 
-    private ETournamentNodeState _node_state = ETournamentNodeState.k_ETournamentNodeState_Unknown;
+    private ETournamentNodeState? _node_state;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"node_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentNodeState.k_ETournamentNodeState_Unknown)]
     public ETournamentNodeState node_state
     {
-      get { return _node_state; }
+      get { return _node_state?? ETournamentNodeState.k_ETournamentNodeState_Unknown; }
       set { _node_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool node_stateSpecified
+    {
+      get { return _node_state != null; }
+      set { if (value == (_node_state== null)) _node_state = value ? this.node_state : (ETournamentNodeState?)null; }
+    }
+    private bool ShouldSerializenode_state() { return node_stateSpecified; }
+    private void Resetnode_state() { node_stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -999,32 +1748,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATournamentStateChange() {}
     
 
-    private uint _new_tournament_id = default(uint);
+    private uint? _new_tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_tournament_id
     {
-      get { return _new_tournament_id; }
+      get { return _new_tournament_id?? default(uint); }
       set { _new_tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_tournament_idSpecified
+    {
+      get { return _new_tournament_id != null; }
+      set { if (value == (_new_tournament_id== null)) _new_tournament_id = value ? this.new_tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializenew_tournament_id() { return new_tournament_idSpecified; }
+    private void Resetnew_tournament_id() { new_tournament_idSpecified = false; }
+    
 
-    private ETournamentEvent _event = ETournamentEvent.k_ETournamentEvent_None;
+    private ETournamentEvent? _event;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentEvent.k_ETournamentEvent_None)]
     public ETournamentEvent @event
     {
-      get { return _event; }
+      get { return _event?? ETournamentEvent.k_ETournamentEvent_None; }
       set { _event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventSpecified
+    {
+      get { return _event != null; }
+      set { if (value == (_event== null)) _event = value ? this.@event : (ETournamentEvent?)null; }
+    }
+    private bool ShouldSerializeevent() { return eventSpecified; }
+    private void Resetevent() { eventSpecified = false; }
+    
 
-    private ETournamentState _new_tournament_state = ETournamentState.k_ETournamentState_Unknown;
+    private ETournamentState? _new_tournament_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"new_tournament_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentState.k_ETournamentState_Unknown)]
     public ETournamentState new_tournament_state
     {
-      get { return _new_tournament_state; }
+      get { return _new_tournament_state?? ETournamentState.k_ETournamentState_Unknown; }
       set { _new_tournament_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_tournament_stateSpecified
+    {
+      get { return _new_tournament_state != null; }
+      set { if (value == (_new_tournament_state== null)) _new_tournament_state = value ? this.new_tournament_state : (ETournamentState?)null; }
+    }
+    private bool ShouldSerializenew_tournament_state() { return new_tournament_stateSpecified; }
+    private void Resetnew_tournament_state() { new_tournament_stateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTATournamentStateChange.GameChange> _game_changes = new global::System.Collections.Generic.List<CMsgDOTATournamentStateChange.GameChange>();
     [global::ProtoBuf.ProtoMember(4, Name=@"game_changes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTATournamentStateChange.GameChange> game_changes
@@ -1047,37 +1823,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _state_seq_num = default(uint);
+    private uint? _state_seq_num;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"state_seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint state_seq_num
     {
-      get { return _state_seq_num; }
+      get { return _state_seq_num?? default(uint); }
       set { _state_seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool state_seq_numSpecified
+    {
+      get { return _state_seq_num != null; }
+      set { if (value == (_state_seq_num== null)) _state_seq_num = value ? this.state_seq_num : (uint?)null; }
+    }
+    private bool ShouldSerializestate_seq_num() { return state_seq_numSpecified; }
+    private void Resetstate_seq_num() { state_seq_numSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"GameChange")]
   public partial class GameChange : global::ProtoBuf.IExtensible
   {
     public GameChange() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private ETournamentGameState _new_state = ETournamentGameState.k_ETournamentGameState_Unknown;
+    private ETournamentGameState? _new_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETournamentGameState.k_ETournamentGameState_Unknown)]
     public ETournamentGameState new_state
     {
-      get { return _new_state; }
+      get { return _new_state?? ETournamentGameState.k_ETournamentGameState_Unknown; }
       set { _new_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_stateSpecified
+    {
+      get { return _new_state != null; }
+      set { if (value == (_new_state== null)) _new_state = value ? this.new_state : (ETournamentGameState?)null; }
+    }
+    private bool ShouldSerializenew_state() { return new_stateSpecified; }
+    private void Resetnew_state() { new_stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1089,32 +1892,59 @@ namespace SteamKit2.GC.Dota.Internal
     public TeamChange() {}
     
 
-    private ulong _team_gid = default(ulong);
+    private ulong? _team_gid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_gid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_gid
     {
-      get { return _team_gid; }
+      get { return _team_gid?? default(ulong); }
       set { _team_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_gidSpecified
+    {
+      get { return _team_gid != null; }
+      set { if (value == (_team_gid== null)) _team_gid = value ? this.team_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_gid() { return team_gidSpecified; }
+    private void Resetteam_gid() { team_gidSpecified = false; }
+    
 
-    private uint _new_node_or_state = default(uint);
+    private uint? _new_node_or_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_node_or_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_node_or_state
     {
-      get { return _new_node_or_state; }
+      get { return _new_node_or_state?? default(uint); }
       set { _new_node_or_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_node_or_stateSpecified
+    {
+      get { return _new_node_or_state != null; }
+      set { if (value == (_new_node_or_state== null)) _new_node_or_state = value ? this.new_node_or_state : (uint?)null; }
+    }
+    private bool ShouldSerializenew_node_or_state() { return new_node_or_stateSpecified; }
+    private void Resetnew_node_or_state() { new_node_or_stateSpecified = false; }
+    
 
-    private uint _old_node_or_state = default(uint);
+    private uint? _old_node_or_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"old_node_or_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint old_node_or_state
     {
-      get { return _old_node_or_state; }
+      get { return _old_node_or_state?? default(uint); }
       set { _old_node_or_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool old_node_or_stateSpecified
+    {
+      get { return _old_node_or_state != null; }
+      set { if (value == (_old_node_or_state== null)) _old_node_or_state = value ? this.old_node_or_state : (uint?)null; }
+    }
+    private bool ShouldSerializeold_node_or_state() { return old_node_or_stateSpecified; }
+    private void Resetold_node_or_state() { old_node_or_stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1131,23 +1961,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATournamentRequest() {}
     
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private ulong _client_tournament_gid = default(ulong);
+    private ulong? _client_tournament_gid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_tournament_gid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_tournament_gid
     {
-      get { return _client_tournament_gid; }
+      get { return _client_tournament_gid?? default(ulong); }
       set { _client_tournament_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_tournament_gidSpecified
+    {
+      get { return _client_tournament_gid != null; }
+      set { if (value == (_client_tournament_gid== null)) _client_tournament_gid = value ? this.client_tournament_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_tournament_gid() { return client_tournament_gidSpecified; }
+    private void Resetclient_tournament_gid() { client_tournament_gidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1159,14 +2007,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTATournamentResponse() {}
     
 
-    private uint _result = (uint)2;
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? (uint)2; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
     private CMsgDOTATournament _tournament = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tournament", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1187,23 +2044,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAClearTournamentGame() {}
     
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _game_id = default(uint);
+    private uint? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(uint); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1215,86 +2090,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWeekendTourneyPlayerSkillLevelStats() {}
     
 
-    private uint _skill_level = default(uint);
+    private uint? _skill_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_level
     {
-      get { return _skill_level; }
+      get { return _skill_level?? default(uint); }
       set { _skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_levelSpecified
+    {
+      get { return _skill_level != null; }
+      set { if (value == (_skill_level== null)) _skill_level = value ? this.skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_level() { return skill_levelSpecified; }
+    private void Resetskill_level() { skill_levelSpecified = false; }
+    
 
-    private uint _times_won_0 = default(uint);
+    private uint? _times_won_0;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"times_won_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_won_0
     {
-      get { return _times_won_0; }
+      get { return _times_won_0?? default(uint); }
       set { _times_won_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_won_0Specified
+    {
+      get { return _times_won_0 != null; }
+      set { if (value == (_times_won_0== null)) _times_won_0 = value ? this.times_won_0 : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_won_0() { return times_won_0Specified; }
+    private void Resettimes_won_0() { times_won_0Specified = false; }
+    
 
-    private uint _times_won_1 = default(uint);
+    private uint? _times_won_1;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"times_won_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_won_1
     {
-      get { return _times_won_1; }
+      get { return _times_won_1?? default(uint); }
       set { _times_won_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_won_1Specified
+    {
+      get { return _times_won_1 != null; }
+      set { if (value == (_times_won_1== null)) _times_won_1 = value ? this.times_won_1 : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_won_1() { return times_won_1Specified; }
+    private void Resettimes_won_1() { times_won_1Specified = false; }
+    
 
-    private uint _times_won_2 = default(uint);
+    private uint? _times_won_2;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"times_won_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_won_2
     {
-      get { return _times_won_2; }
+      get { return _times_won_2?? default(uint); }
       set { _times_won_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_won_2Specified
+    {
+      get { return _times_won_2 != null; }
+      set { if (value == (_times_won_2== null)) _times_won_2 = value ? this.times_won_2 : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_won_2() { return times_won_2Specified; }
+    private void Resettimes_won_2() { times_won_2Specified = false; }
+    
 
-    private uint _times_won_3 = default(uint);
+    private uint? _times_won_3;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"times_won_3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_won_3
     {
-      get { return _times_won_3; }
+      get { return _times_won_3?? default(uint); }
       set { _times_won_3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_won_3Specified
+    {
+      get { return _times_won_3 != null; }
+      set { if (value == (_times_won_3== null)) _times_won_3 = value ? this.times_won_3 : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_won_3() { return times_won_3Specified; }
+    private void Resettimes_won_3() { times_won_3Specified = false; }
+    
 
-    private uint _times_bye_and_lost = default(uint);
+    private uint? _times_bye_and_lost;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"times_bye_and_lost", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_bye_and_lost
     {
-      get { return _times_bye_and_lost; }
+      get { return _times_bye_and_lost?? default(uint); }
       set { _times_bye_and_lost = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_bye_and_lostSpecified
+    {
+      get { return _times_bye_and_lost != null; }
+      set { if (value == (_times_bye_and_lost== null)) _times_bye_and_lost = value ? this.times_bye_and_lost : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_bye_and_lost() { return times_bye_and_lostSpecified; }
+    private void Resettimes_bye_and_lost() { times_bye_and_lostSpecified = false; }
+    
 
-    private uint _times_bye_and_won = default(uint);
+    private uint? _times_bye_and_won;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"times_bye_and_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint times_bye_and_won
     {
-      get { return _times_bye_and_won; }
+      get { return _times_bye_and_won?? default(uint); }
       set { _times_bye_and_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool times_bye_and_wonSpecified
+    {
+      get { return _times_bye_and_won != null; }
+      set { if (value == (_times_bye_and_won== null)) _times_bye_and_won = value ? this.times_bye_and_won : (uint?)null; }
+    }
+    private bool ShouldSerializetimes_bye_and_won() { return times_bye_and_wonSpecified; }
+    private void Resettimes_bye_and_won() { times_bye_and_wonSpecified = false; }
+    
 
-    private uint _total_games_won = default(uint);
+    private uint? _total_games_won;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"total_games_won", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_games_won
     {
-      get { return _total_games_won; }
+      get { return _total_games_won?? default(uint); }
       set { _total_games_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_games_wonSpecified
+    {
+      get { return _total_games_won != null; }
+      set { if (value == (_total_games_won== null)) _total_games_won = value ? this.total_games_won : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_games_won() { return total_games_wonSpecified; }
+    private void Resettotal_games_won() { total_games_wonSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1306,23 +2262,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWeekendTourneyPlayerStats() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _season_trophy_id = default(uint);
+    private uint? _season_trophy_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_trophy_id
     {
-      get { return _season_trophy_id; }
+      get { return _season_trophy_id?? default(uint); }
       set { _season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_trophy_idSpecified
+    {
+      get { return _season_trophy_id != null; }
+      set { if (value == (_season_trophy_id== null)) _season_trophy_id = value ? this.season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_trophy_id() { return season_trophy_idSpecified; }
+    private void Resetseason_trophy_id() { season_trophy_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerSkillLevelStats> _skill_levels = new global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerSkillLevelStats>();
     [global::ProtoBuf.ProtoMember(3, Name=@"skill_levels", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerSkillLevelStats> skill_levels
@@ -1331,14 +2305,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _current_tier = default(uint);
+    private uint? _current_tier;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"current_tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_tier
     {
-      get { return _current_tier; }
+      get { return _current_tier?? default(uint); }
       set { _current_tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_tierSpecified
+    {
+      get { return _current_tier != null; }
+      set { if (value == (_current_tier== null)) _current_tier = value ? this.current_tier : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_tier() { return current_tierSpecified; }
+    private void Resetcurrent_tier() { current_tierSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1350,23 +2333,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWeekendTourneyPlayerStatsRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _season_trophy_id = default(uint);
+    private uint? _season_trophy_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_trophy_id
     {
-      get { return _season_trophy_id; }
+      get { return _season_trophy_id?? default(uint); }
       set { _season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_trophy_idSpecified
+    {
+      get { return _season_trophy_id != null; }
+      set { if (value == (_season_trophy_id== null)) _season_trophy_id = value ? this.season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_trophy_id() { return season_trophy_idSpecified; }
+    private void Resetseason_trophy_id() { season_trophy_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1378,23 +2379,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWeekendTourneyPlayerHistoryRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _season_trophy_id = default(uint);
+    private uint? _season_trophy_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_trophy_id
     {
-      get { return _season_trophy_id; }
+      get { return _season_trophy_id?? default(uint); }
       set { _season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_trophy_idSpecified
+    {
+      get { return _season_trophy_id != null; }
+      set { if (value == (_season_trophy_id== null)) _season_trophy_id = value ? this.season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_trophy_id() { return season_trophy_idSpecified; }
+    private void Resetseason_trophy_id() { season_trophy_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1406,14 +2425,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAWeekendTourneyPlayerHistory() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerHistory.Tournament> _tournaments = new global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerHistory.Tournament>();
     [global::ProtoBuf.ProtoMember(3, Name=@"tournaments", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyPlayerHistory.Tournament> tournaments
@@ -1427,59 +2455,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Tournament() {}
     
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _tournament_tier = default(uint);
+    private uint? _tournament_tier;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tournament_tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_tier
     {
-      get { return _tournament_tier; }
+      get { return _tournament_tier?? default(uint); }
       set { _tournament_tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_tierSpecified
+    {
+      get { return _tournament_tier != null; }
+      set { if (value == (_tournament_tier== null)) _tournament_tier = value ? this.tournament_tier : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_tier() { return tournament_tierSpecified; }
+    private void Resettournament_tier() { tournament_tierSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private uint _team_date = default(uint);
+    private uint? _team_date;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_date
     {
-      get { return _team_date; }
+      get { return _team_date?? default(uint); }
       set { _team_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_dateSpecified
+    {
+      get { return _team_date != null; }
+      set { if (value == (_team_date== null)) _team_date = value ? this.team_date : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_date() { return team_dateSpecified; }
+    private void Resetteam_date() { team_dateSpecified = false; }
+    
 
-    private uint _team_result = default(uint);
+    private uint? _team_result;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_result
     {
-      get { return _team_result; }
+      get { return _team_result?? default(uint); }
       set { _team_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_resultSpecified
+    {
+      get { return _team_result != null; }
+      set { if (value == (_team_result== null)) _team_result = value ? this.team_result : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_result() { return team_resultSpecified; }
+    private void Resetteam_result() { team_resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_id = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_id
@@ -1488,23 +2570,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private uint _season_trophy_id = default(uint);
+    private uint? _season_trophy_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_trophy_id
     {
-      get { return _season_trophy_id; }
+      get { return _season_trophy_id?? default(uint); }
       set { _season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_trophy_idSpecified
+    {
+      get { return _season_trophy_id != null; }
+      set { if (value == (_season_trophy_id== null)) _season_trophy_id = value ? this.season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_trophy_id() { return season_trophy_idSpecified; }
+    private void Resetseason_trophy_id() { season_trophy_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1533,77 +2633,149 @@ namespace SteamKit2.GC.Dota.Internal
     public Tier() {}
     
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
 
-    private uint _players = default(uint);
+    private uint? _players;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players
     {
-      get { return _players; }
+      get { return _players?? default(uint); }
       set { _players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playersSpecified
+    {
+      get { return _players != null; }
+      set { if (value == (_players== null)) _players = value ? this.players : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers() { return playersSpecified; }
+    private void Resetplayers() { playersSpecified = false; }
+    
 
-    private uint _teams = default(uint);
+    private uint? _teams;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"teams", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teams
     {
-      get { return _teams; }
+      get { return _teams?? default(uint); }
       set { _teams = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamsSpecified
+    {
+      get { return _teams != null; }
+      set { if (value == (_teams== null)) _teams = value ? this.teams : (uint?)null; }
+    }
+    private bool ShouldSerializeteams() { return teamsSpecified; }
+    private void Resetteams() { teamsSpecified = false; }
+    
 
-    private uint _winning_teams = default(uint);
+    private uint? _winning_teams;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"winning_teams", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint winning_teams
     {
-      get { return _winning_teams; }
+      get { return _winning_teams?? default(uint); }
       set { _winning_teams = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winning_teamsSpecified
+    {
+      get { return _winning_teams != null; }
+      set { if (value == (_winning_teams== null)) _winning_teams = value ? this.winning_teams : (uint?)null; }
+    }
+    private bool ShouldSerializewinning_teams() { return winning_teamsSpecified; }
+    private void Resetwinning_teams() { winning_teamsSpecified = false; }
+    
 
-    private uint _players_streak_2 = default(uint);
+    private uint? _players_streak_2;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"players_streak_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_streak_2
     {
-      get { return _players_streak_2; }
+      get { return _players_streak_2?? default(uint); }
       set { _players_streak_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_streak_2Specified
+    {
+      get { return _players_streak_2 != null; }
+      set { if (value == (_players_streak_2== null)) _players_streak_2 = value ? this.players_streak_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_streak_2() { return players_streak_2Specified; }
+    private void Resetplayers_streak_2() { players_streak_2Specified = false; }
+    
 
-    private uint _players_streak_3 = default(uint);
+    private uint? _players_streak_3;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"players_streak_3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_streak_3
     {
-      get { return _players_streak_3; }
+      get { return _players_streak_3?? default(uint); }
       set { _players_streak_3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_streak_3Specified
+    {
+      get { return _players_streak_3 != null; }
+      set { if (value == (_players_streak_3== null)) _players_streak_3 = value ? this.players_streak_3 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_streak_3() { return players_streak_3Specified; }
+    private void Resetplayers_streak_3() { players_streak_3Specified = false; }
+    
 
-    private uint _players_streak_4 = default(uint);
+    private uint? _players_streak_4;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"players_streak_4", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_streak_4
     {
-      get { return _players_streak_4; }
+      get { return _players_streak_4?? default(uint); }
       set { _players_streak_4 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_streak_4Specified
+    {
+      get { return _players_streak_4 != null; }
+      set { if (value == (_players_streak_4== null)) _players_streak_4 = value ? this.players_streak_4 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_streak_4() { return players_streak_4Specified; }
+    private void Resetplayers_streak_4() { players_streak_4Specified = false; }
+    
 
-    private uint _players_streak_5 = default(uint);
+    private uint? _players_streak_5;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"players_streak_5", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_streak_5
     {
-      get { return _players_streak_5; }
+      get { return _players_streak_5?? default(uint); }
       set { _players_streak_5 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_streak_5Specified
+    {
+      get { return _players_streak_5 != null; }
+      set { if (value == (_players_streak_5== null)) _players_streak_5 = value ? this.players_streak_5 : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_streak_5() { return players_streak_5Specified; }
+    private void Resetplayers_streak_5() { players_streak_5Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1615,23 +2787,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Division() {}
     
 
-    private uint _division_id = default(uint);
+    private uint? _division_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division_id
     {
-      get { return _division_id; }
+      get { return _division_id?? default(uint); }
       set { _division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool division_idSpecified
+    {
+      get { return _division_id != null; }
+      set { if (value == (_division_id== null)) _division_id = value ? this.division_id : (uint?)null; }
+    }
+    private bool ShouldSerializedivision_id() { return division_idSpecified; }
+    private void Resetdivision_id() { division_idSpecified = false; }
+    
 
-    private uint _schedule_time = default(uint);
+    private uint? _schedule_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"schedule_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint schedule_time
     {
-      get { return _schedule_time; }
+      get { return _schedule_time?? default(uint); }
       set { _schedule_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schedule_timeSpecified
+    {
+      get { return _schedule_time != null; }
+      set { if (value == (_schedule_time== null)) _schedule_time = value ? this.schedule_time : (uint?)null; }
+    }
+    private bool ShouldSerializeschedule_time() { return schedule_timeSpecified; }
+    private void Resetschedule_time() { schedule_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyParticipationDetails.Tier> _tiers = new global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyParticipationDetails.Tier>();
     [global::ProtoBuf.ProtoMember(3, Name=@"tiers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAWeekendTourneyParticipationDetails.Tier> tiers

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientWatch.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCClientWatch.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_client_watch.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
 // Note: requires additional types generated from: dota_gcmessages_common.proto
@@ -19,185 +21,365 @@ namespace SteamKit2.GC.Dota.Internal
     public CSourceTVGameSmall() {}
     
 
-    private uint _activate_time = default(uint);
+    private uint? _activate_time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"activate_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint activate_time
     {
-      get { return _activate_time; }
+      get { return _activate_time?? default(uint); }
       set { _activate_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activate_timeSpecified
+    {
+      get { return _activate_time != null; }
+      set { if (value == (_activate_time== null)) _activate_time = value ? this.activate_time : (uint?)null; }
+    }
+    private bool ShouldSerializeactivate_time() { return activate_timeSpecified; }
+    private void Resetactivate_time() { activate_timeSpecified = false; }
+    
 
-    private uint _deactivate_time = default(uint);
+    private uint? _deactivate_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"deactivate_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deactivate_time
     {
-      get { return _deactivate_time; }
+      get { return _deactivate_time?? default(uint); }
       set { _deactivate_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deactivate_timeSpecified
+    {
+      get { return _deactivate_time != null; }
+      set { if (value == (_deactivate_time== null)) _deactivate_time = value ? this.deactivate_time : (uint?)null; }
+    }
+    private bool ShouldSerializedeactivate_time() { return deactivate_timeSpecified; }
+    private void Resetdeactivate_time() { deactivate_timeSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _lobby_type = default(uint);
+    private uint? _lobby_type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(uint); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _game_time = default(int);
+    private int? _game_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(int); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (int?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private uint _delay = default(uint);
+    private uint? _delay;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint delay
     {
-      get { return _delay; }
+      get { return _delay?? default(uint); }
       set { _delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delaySpecified
+    {
+      get { return _delay != null; }
+      set { if (value == (_delay== null)) _delay = value ? this.delay : (uint?)null; }
+    }
+    private bool ShouldSerializedelay() { return delaySpecified; }
+    private void Resetdelay() { delaySpecified = false; }
+    
 
-    private uint _spectators = default(uint);
+    private uint? _spectators;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spectators
     {
-      get { return _spectators; }
+      get { return _spectators?? default(uint); }
       set { _spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectatorsSpecified
+    {
+      get { return _spectators != null; }
+      set { if (value == (_spectators== null)) _spectators = value ? this.spectators : (uint?)null; }
+    }
+    private bool ShouldSerializespectators() { return spectatorsSpecified; }
+    private void Resetspectators() { spectatorsSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _average_mmr = default(uint);
+    private uint? _average_mmr;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"average_mmr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint average_mmr
     {
-      get { return _average_mmr; }
+      get { return _average_mmr?? default(uint); }
       set { _average_mmr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_mmrSpecified
+    {
+      get { return _average_mmr != null; }
+      set { if (value == (_average_mmr== null)) _average_mmr = value ? this.average_mmr : (uint?)null; }
+    }
+    private bool ShouldSerializeaverage_mmr() { return average_mmrSpecified; }
+    private void Resetaverage_mmr() { average_mmrSpecified = false; }
+    
 
-    private string _team_name_radiant = "";
+    private string _team_name_radiant;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"team_name_radiant", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name_radiant
     {
-      get { return _team_name_radiant; }
+      get { return _team_name_radiant?? ""; }
       set { _team_name_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_name_radiantSpecified
+    {
+      get { return _team_name_radiant != null; }
+      set { if (value == (_team_name_radiant== null)) _team_name_radiant = value ? this.team_name_radiant : (string)null; }
+    }
+    private bool ShouldSerializeteam_name_radiant() { return team_name_radiantSpecified; }
+    private void Resetteam_name_radiant() { team_name_radiantSpecified = false; }
+    
 
-    private string _team_name_dire = "";
+    private string _team_name_dire;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"team_name_dire", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name_dire
     {
-      get { return _team_name_dire; }
+      get { return _team_name_dire?? ""; }
       set { _team_name_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_name_direSpecified
+    {
+      get { return _team_name_dire != null; }
+      set { if (value == (_team_name_dire== null)) _team_name_dire = value ? this.team_name_dire : (string)null; }
+    }
+    private bool ShouldSerializeteam_name_dire() { return team_name_direSpecified; }
+    private void Resetteam_name_dire() { team_name_direSpecified = false; }
+    
 
-    private ulong _team_logo_radiant = default(ulong);
+    private ulong? _team_logo_radiant;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"team_logo_radiant", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo_radiant
     {
-      get { return _team_logo_radiant; }
+      get { return _team_logo_radiant?? default(ulong); }
       set { _team_logo_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logo_radiantSpecified
+    {
+      get { return _team_logo_radiant != null; }
+      set { if (value == (_team_logo_radiant== null)) _team_logo_radiant = value ? this.team_logo_radiant : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo_radiant() { return team_logo_radiantSpecified; }
+    private void Resetteam_logo_radiant() { team_logo_radiantSpecified = false; }
+    
 
-    private ulong _team_logo_dire = default(ulong);
+    private ulong? _team_logo_dire;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"team_logo_dire", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo_dire
     {
-      get { return _team_logo_dire; }
+      get { return _team_logo_dire?? default(ulong); }
       set { _team_logo_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logo_direSpecified
+    {
+      get { return _team_logo_dire != null; }
+      set { if (value == (_team_logo_dire== null)) _team_logo_dire = value ? this.team_logo_dire : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo_dire() { return team_logo_direSpecified; }
+    private void Resetteam_logo_dire() { team_logo_direSpecified = false; }
+    
 
-    private uint _sort_score = default(uint);
+    private uint? _sort_score;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"sort_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_score
     {
-      get { return _sort_score; }
+      get { return _sort_score?? default(uint); }
       set { _sort_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_scoreSpecified
+    {
+      get { return _sort_score != null; }
+      set { if (value == (_sort_score== null)) _sort_score = value ? this.sort_score : (uint?)null; }
+    }
+    private bool ShouldSerializesort_score() { return sort_scoreSpecified; }
+    private void Resetsort_score() { sort_scoreSpecified = false; }
+    
 
-    private float _last_update_time = default(float);
+    private float? _last_update_time;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"last_update_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float last_update_time
     {
-      get { return _last_update_time; }
+      get { return _last_update_time?? default(float); }
       set { _last_update_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_update_timeSpecified
+    {
+      get { return _last_update_time != null; }
+      set { if (value == (_last_update_time== null)) _last_update_time = value ? this.last_update_time : (float?)null; }
+    }
+    private bool ShouldSerializelast_update_time() { return last_update_timeSpecified; }
+    private void Resetlast_update_time() { last_update_timeSpecified = false; }
+    
 
-    private int _radiant_lead = default(int);
+    private int? _radiant_lead;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"radiant_lead", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int radiant_lead
     {
-      get { return _radiant_lead; }
+      get { return _radiant_lead?? default(int); }
       set { _radiant_lead = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_leadSpecified
+    {
+      get { return _radiant_lead != null; }
+      set { if (value == (_radiant_lead== null)) _radiant_lead = value ? this.radiant_lead : (int?)null; }
+    }
+    private bool ShouldSerializeradiant_lead() { return radiant_leadSpecified; }
+    private void Resetradiant_lead() { radiant_leadSpecified = false; }
+    
 
-    private uint _radiant_score = default(uint);
+    private uint? _radiant_score;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"radiant_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_score
     {
-      get { return _radiant_score; }
+      get { return _radiant_score?? default(uint); }
       set { _radiant_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_scoreSpecified
+    {
+      get { return _radiant_score != null; }
+      set { if (value == (_radiant_score== null)) _radiant_score = value ? this.radiant_score : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_score() { return radiant_scoreSpecified; }
+    private void Resetradiant_score() { radiant_scoreSpecified = false; }
+    
 
-    private uint _dire_score = default(uint);
+    private uint? _dire_score;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"dire_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_score
     {
-      get { return _dire_score; }
+      get { return _dire_score?? default(uint); }
       set { _dire_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_scoreSpecified
+    {
+      get { return _dire_score != null; }
+      set { if (value == (_dire_score== null)) _dire_score = value ? this.dire_score : (uint?)null; }
+    }
+    private bool ShouldSerializedire_score() { return dire_scoreSpecified; }
+    private void Resetdire_score() { dire_scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSourceTVGameSmall.Player> _players = new global::System.Collections.Generic.List<CSourceTVGameSmall.Player>();
     [global::ProtoBuf.ProtoMember(22, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSourceTVGameSmall.Player> players
@@ -206,73 +388,136 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _building_state = default(uint);
+    private uint? _building_state;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"building_state", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint building_state
     {
-      get { return _building_state; }
+      get { return _building_state?? default(uint); }
       set { _building_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool building_stateSpecified
+    {
+      get { return _building_state != null; }
+      set { if (value == (_building_state== null)) _building_state = value ? this.building_state : (uint?)null; }
+    }
+    private bool ShouldSerializebuilding_state() { return building_stateSpecified; }
+    private void Resetbuilding_state() { building_stateSpecified = false; }
+    
 
-    private uint _weekend_tourney_tournament_id = default(uint);
+    private uint? _weekend_tourney_tournament_id;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"weekend_tourney_tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_tournament_id
     {
-      get { return _weekend_tourney_tournament_id; }
+      get { return _weekend_tourney_tournament_id?? default(uint); }
       set { _weekend_tourney_tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_tournament_idSpecified
+    {
+      get { return _weekend_tourney_tournament_id != null; }
+      set { if (value == (_weekend_tourney_tournament_id== null)) _weekend_tourney_tournament_id = value ? this.weekend_tourney_tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_tournament_id() { return weekend_tourney_tournament_idSpecified; }
+    private void Resetweekend_tourney_tournament_id() { weekend_tourney_tournament_idSpecified = false; }
+    
 
-    private uint _weekend_tourney_division = default(uint);
+    private uint? _weekend_tourney_division;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"weekend_tourney_division", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_division
     {
-      get { return _weekend_tourney_division; }
+      get { return _weekend_tourney_division?? default(uint); }
       set { _weekend_tourney_division = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_divisionSpecified
+    {
+      get { return _weekend_tourney_division != null; }
+      set { if (value == (_weekend_tourney_division== null)) _weekend_tourney_division = value ? this.weekend_tourney_division : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_division() { return weekend_tourney_divisionSpecified; }
+    private void Resetweekend_tourney_division() { weekend_tourney_divisionSpecified = false; }
+    
 
-    private uint _weekend_tourney_skill_level = default(uint);
+    private uint? _weekend_tourney_skill_level;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"weekend_tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_skill_level
     {
-      get { return _weekend_tourney_skill_level; }
+      get { return _weekend_tourney_skill_level?? default(uint); }
       set { _weekend_tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_skill_levelSpecified
+    {
+      get { return _weekend_tourney_skill_level != null; }
+      set { if (value == (_weekend_tourney_skill_level== null)) _weekend_tourney_skill_level = value ? this.weekend_tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_skill_level() { return weekend_tourney_skill_levelSpecified; }
+    private void Resetweekend_tourney_skill_level() { weekend_tourney_skill_levelSpecified = false; }
+    
 
-    private uint _weekend_tourney_bracket_round = default(uint);
+    private uint? _weekend_tourney_bracket_round;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"weekend_tourney_bracket_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_bracket_round
     {
-      get { return _weekend_tourney_bracket_round; }
+      get { return _weekend_tourney_bracket_round?? default(uint); }
       set { _weekend_tourney_bracket_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_bracket_roundSpecified
+    {
+      get { return _weekend_tourney_bracket_round != null; }
+      set { if (value == (_weekend_tourney_bracket_round== null)) _weekend_tourney_bracket_round = value ? this.weekend_tourney_bracket_round : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_bracket_round() { return weekend_tourney_bracket_roundSpecified; }
+    private void Resetweekend_tourney_bracket_round() { weekend_tourney_bracket_roundSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -289,50 +534,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCFindTopSourceTVGames() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _start_game = default(uint);
+    private uint? _start_game;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_game
     {
-      get { return _start_game; }
+      get { return _start_game?? default(uint); }
       set { _start_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_gameSpecified
+    {
+      get { return _start_game != null; }
+      set { if (value == (_start_game== null)) _start_game = value ? this.start_game : (uint?)null; }
+    }
+    private bool ShouldSerializestart_game() { return start_gameSpecified; }
+    private void Resetstart_game() { start_gameSpecified = false; }
+    
 
-    private uint _game_list_index = default(uint);
+    private uint? _game_list_index;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_list_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_list_index
     {
-      get { return _game_list_index; }
+      get { return _game_list_index?? default(uint); }
       set { _game_list_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_list_indexSpecified
+    {
+      get { return _game_list_index != null; }
+      set { if (value == (_game_list_index== null)) _game_list_index = value ? this.game_list_index : (uint?)null; }
+    }
+    private bool ShouldSerializegame_list_index() { return game_list_indexSpecified; }
+    private void Resetgame_list_index() { game_list_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _lobby_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(6, Name=@"lobby_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> lobby_ids
@@ -351,59 +641,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientFindTopSourceTVGamesResponse() {}
     
 
-    private string _search_key = "";
+    private string _search_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_key
     {
-      get { return _search_key; }
+      get { return _search_key?? ""; }
       set { _search_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_keySpecified
+    {
+      get { return _search_key != null; }
+      set { if (value == (_search_key== null)) _search_key = value ? this.search_key : (string)null; }
+    }
+    private bool ShouldSerializesearch_key() { return search_keySpecified; }
+    private void Resetsearch_key() { search_keySpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _start_game = default(uint);
+    private uint? _start_game;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_game
     {
-      get { return _start_game; }
+      get { return _start_game?? default(uint); }
       set { _start_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_gameSpecified
+    {
+      get { return _start_game != null; }
+      set { if (value == (_start_game== null)) _start_game = value ? this.start_game : (uint?)null; }
+    }
+    private bool ShouldSerializestart_game() { return start_gameSpecified; }
+    private void Resetstart_game() { start_gameSpecified = false; }
+    
 
-    private uint _num_games = default(uint);
+    private uint? _num_games;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"num_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_games
     {
-      get { return _num_games; }
+      get { return _num_games?? default(uint); }
       set { _num_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_gamesSpecified
+    {
+      get { return _num_games != null; }
+      set { if (value == (_num_games== null)) _num_games = value ? this.num_games : (uint?)null; }
+    }
+    private bool ShouldSerializenum_games() { return num_gamesSpecified; }
+    private void Resetnum_games() { num_gamesSpecified = false; }
+    
 
-    private uint _game_list_index = default(uint);
+    private uint? _game_list_index;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_list_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_list_index
     {
-      get { return _game_list_index; }
+      get { return _game_list_index?? default(uint); }
       set { _game_list_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_list_indexSpecified
+    {
+      get { return _game_list_index != null; }
+      set { if (value == (_game_list_index== null)) _game_list_index = value ? this.game_list_index : (uint?)null; }
+    }
+    private bool ShouldSerializegame_list_index() { return game_list_indexSpecified; }
+    private void Resetgame_list_index() { game_list_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSourceTVGameSmall> _game_list = new global::System.Collections.Generic.List<CSourceTVGameSmall>();
     [global::ProtoBuf.ProtoMember(7, Name=@"game_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSourceTVGameSmall> game_list
@@ -412,14 +756,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _specific_games = default(bool);
+    private bool? _specific_games;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"specific_games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool specific_games
     {
-      get { return _specific_games; }
+      get { return _specific_games?? default(bool); }
       set { _specific_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool specific_gamesSpecified
+    {
+      get { return _specific_games != null; }
+      set { if (value == (_specific_games== null)) _specific_games = value ? this.specific_games : (bool?)null; }
+    }
+    private bool ShouldSerializespecific_games() { return specific_gamesSpecified; }
+    private void Resetspecific_games() { specific_gamesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -448,32 +801,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCTopMatchesRequest() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -529,14 +909,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _last_match = default(bool);
+    private bool? _last_match;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_match", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool last_match
     {
-      get { return _last_match; }
+      get { return _last_match?? default(bool); }
       set { _last_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_matchSpecified
+    {
+      get { return _last_match != null; }
+      set { if (value == (_last_match== null)) _last_match = value ? this.last_match : (bool?)null; }
+    }
+    private bool ShouldSerializelast_match() { return last_matchSpecified; }
+    private void Resetlast_match() { last_matchSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -582,59 +971,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCFindTopMatches() {}
     
 
-    private uint _start_game = default(uint);
+    private uint? _start_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"start_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_game
     {
-      get { return _start_game; }
+      get { return _start_game?? default(uint); }
       set { _start_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_gameSpecified
+    {
+      get { return _start_game != null; }
+      set { if (value == (_start_game== null)) _start_game = value ? this.start_game : (uint?)null; }
+    }
+    private bool ShouldSerializestart_game() { return start_gameSpecified; }
+    private void Resetstart_game() { start_gameSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _friend_id = default(uint);
+    private uint? _friend_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"friend_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friend_id
     {
-      get { return _friend_id; }
+      get { return _friend_id?? default(uint); }
       set { _friend_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_idSpecified
+    {
+      get { return _friend_id != null; }
+      set { if (value == (_friend_id== null)) _friend_id = value ? this.friend_id : (uint?)null; }
+    }
+    private bool ShouldSerializefriend_id() { return friend_idSpecified; }
+    private void Resetfriend_id() { friend_idSpecified = false; }
+    
 
-    private bool _friend_list = default(bool);
+    private bool? _friend_list;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"friend_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool friend_list
     {
-      get { return _friend_list; }
+      get { return _friend_list?? default(bool); }
       set { _friend_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_listSpecified
+    {
+      get { return _friend_list != null; }
+      set { if (value == (_friend_list== null)) _friend_list = value ? this.friend_list : (bool?)null; }
+    }
+    private bool ShouldSerializefriend_list() { return friend_listSpecified; }
+    private void Resetfriend_list() { friend_listSpecified = false; }
+    
 
-    private bool _league_list = default(bool);
+    private bool? _league_list;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"league_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool league_list
     {
-      get { return _league_list; }
+      get { return _league_list?? default(bool); }
       set { _league_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_listSpecified
+    {
+      get { return _league_list != null; }
+      set { if (value == (_league_list== null)) _league_list = value ? this.league_list : (bool?)null; }
+    }
+    private bool ShouldSerializeleague_list() { return league_listSpecified; }
+    private void Resetleague_list() { league_listSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -646,32 +1089,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientFindTopLeagueMatchesResponse() {}
     
 
-    private uint _start_game = default(uint);
+    private uint? _start_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"start_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_game
     {
-      get { return _start_game; }
+      get { return _start_game?? default(uint); }
       set { _start_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_gameSpecified
+    {
+      get { return _start_game != null; }
+      set { if (value == (_start_game== null)) _start_game = value ? this.start_game : (uint?)null; }
+    }
+    private bool ShouldSerializestart_game() { return start_gameSpecified; }
+    private void Resetstart_game() { start_gameSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _match_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"match_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> match_ids
@@ -697,14 +1167,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSpectateFriendGame() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -716,14 +1195,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSpectateFriendGameResponse() {}
     
 
-    private ulong _server_steamid = default(ulong);
+    private ulong? _server_steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steamid
     {
-      get { return _server_steamid; }
+      get { return _server_steamid?? default(ulong); }
       set { _server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steamidSpecified
+    {
+      get { return _server_steamid != null; }
+      set { if (value == (_server_steamid== null)) _server_steamid = value ? this.server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steamid() { return server_steamidSpecified; }
+    private void Resetserver_steamid() { server_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -735,41 +1223,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAMatchMinimal() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAMatchMinimal.Player> _players = new global::System.Collections.Generic.List<CMsgDOTAMatchMinimal.Player>();
     [global::ProtoBuf.ProtoMember(6, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAMatchMinimal.Player> players
@@ -787,64 +1311,118 @@ namespace SteamKit2.GC.Dota.Internal
       set { _tourney = value; }
     }
 
-    private EMatchOutcome _match_outcome = EMatchOutcome.k_EMatchOutcome_Unknown;
+    private EMatchOutcome? _match_outcome;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_outcome", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EMatchOutcome.k_EMatchOutcome_Unknown)]
     public EMatchOutcome match_outcome
     {
-      get { return _match_outcome; }
+      get { return _match_outcome?? EMatchOutcome.k_EMatchOutcome_Unknown; }
       set { _match_outcome = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_outcomeSpecified
+    {
+      get { return _match_outcome != null; }
+      set { if (value == (_match_outcome== null)) _match_outcome = value ? this.match_outcome : (EMatchOutcome?)null; }
+    }
+    private bool ShouldSerializematch_outcome() { return match_outcomeSpecified; }
+    private void Resetmatch_outcome() { match_outcomeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _items = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> items
@@ -853,14 +1431,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _player_slot = default(uint);
+    private uint? _player_slot;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"player_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_slot
     {
-      get { return _player_slot; }
+      get { return _player_slot?? default(uint); }
       set { _player_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_slotSpecified
+    {
+      get { return _player_slot != null; }
+      set { if (value == (_player_slot== null)) _player_slot = value ? this.player_slot : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_slot() { return player_slotSpecified; }
+    private void Resetplayer_slot() { player_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -872,122 +1459,239 @@ namespace SteamKit2.GC.Dota.Internal
     public Tourney() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _series_game = default(uint);
+    private uint? _series_game;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"series_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_game
     {
-      get { return _series_game; }
+      get { return _series_game?? default(uint); }
       set { _series_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_gameSpecified
+    {
+      get { return _series_game != null; }
+      set { if (value == (_series_game== null)) _series_game = value ? this.series_game : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_game() { return series_gameSpecified; }
+    private void Resetseries_game() { series_gameSpecified = false; }
+    
 
-    private uint _weekend_tourney_tournament_id = default(uint);
+    private uint? _weekend_tourney_tournament_id;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"weekend_tourney_tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_tournament_id
     {
-      get { return _weekend_tourney_tournament_id; }
+      get { return _weekend_tourney_tournament_id?? default(uint); }
       set { _weekend_tourney_tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_tournament_idSpecified
+    {
+      get { return _weekend_tourney_tournament_id != null; }
+      set { if (value == (_weekend_tourney_tournament_id== null)) _weekend_tourney_tournament_id = value ? this.weekend_tourney_tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_tournament_id() { return weekend_tourney_tournament_idSpecified; }
+    private void Resetweekend_tourney_tournament_id() { weekend_tourney_tournament_idSpecified = false; }
+    
 
-    private uint _weekend_tourney_season_trophy_id = default(uint);
+    private uint? _weekend_tourney_season_trophy_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"weekend_tourney_season_trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_season_trophy_id
     {
-      get { return _weekend_tourney_season_trophy_id; }
+      get { return _weekend_tourney_season_trophy_id?? default(uint); }
       set { _weekend_tourney_season_trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_season_trophy_idSpecified
+    {
+      get { return _weekend_tourney_season_trophy_id != null; }
+      set { if (value == (_weekend_tourney_season_trophy_id== null)) _weekend_tourney_season_trophy_id = value ? this.weekend_tourney_season_trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_season_trophy_id() { return weekend_tourney_season_trophy_idSpecified; }
+    private void Resetweekend_tourney_season_trophy_id() { weekend_tourney_season_trophy_idSpecified = false; }
+    
 
-    private uint _weekend_tourney_division = default(uint);
+    private uint? _weekend_tourney_division;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"weekend_tourney_division", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_division
     {
-      get { return _weekend_tourney_division; }
+      get { return _weekend_tourney_division?? default(uint); }
       set { _weekend_tourney_division = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_divisionSpecified
+    {
+      get { return _weekend_tourney_division != null; }
+      set { if (value == (_weekend_tourney_division== null)) _weekend_tourney_division = value ? this.weekend_tourney_division : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_division() { return weekend_tourney_divisionSpecified; }
+    private void Resetweekend_tourney_division() { weekend_tourney_divisionSpecified = false; }
+    
 
-    private uint _weekend_tourney_skill_level = default(uint);
+    private uint? _weekend_tourney_skill_level;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"weekend_tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_skill_level
     {
-      get { return _weekend_tourney_skill_level; }
+      get { return _weekend_tourney_skill_level?? default(uint); }
       set { _weekend_tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_skill_levelSpecified
+    {
+      get { return _weekend_tourney_skill_level != null; }
+      set { if (value == (_weekend_tourney_skill_level== null)) _weekend_tourney_skill_level = value ? this.weekend_tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_skill_level() { return weekend_tourney_skill_levelSpecified; }
+    private void Resetweekend_tourney_skill_level() { weekend_tourney_skill_levelSpecified = false; }
+    
 
-    private uint _radiant_team_id = default(uint);
+    private uint? _radiant_team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"radiant_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_team_id
     {
-      get { return _radiant_team_id; }
+      get { return _radiant_team_id?? default(uint); }
       set { _radiant_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_idSpecified
+    {
+      get { return _radiant_team_id != null; }
+      set { if (value == (_radiant_team_id== null)) _radiant_team_id = value ? this.radiant_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_team_id() { return radiant_team_idSpecified; }
+    private void Resetradiant_team_id() { radiant_team_idSpecified = false; }
+    
 
-    private string _radiant_team_name = "";
+    private string _radiant_team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"radiant_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string radiant_team_name
     {
-      get { return _radiant_team_name; }
+      get { return _radiant_team_name?? ""; }
       set { _radiant_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_nameSpecified
+    {
+      get { return _radiant_team_name != null; }
+      set { if (value == (_radiant_team_name== null)) _radiant_team_name = value ? this.radiant_team_name : (string)null; }
+    }
+    private bool ShouldSerializeradiant_team_name() { return radiant_team_nameSpecified; }
+    private void Resetradiant_team_name() { radiant_team_nameSpecified = false; }
+    
 
-    private ulong _radiant_team_logo = default(ulong);
+    private ulong? _radiant_team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"radiant_team_logo", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong radiant_team_logo
     {
-      get { return _radiant_team_logo; }
+      get { return _radiant_team_logo?? default(ulong); }
       set { _radiant_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_logoSpecified
+    {
+      get { return _radiant_team_logo != null; }
+      set { if (value == (_radiant_team_logo== null)) _radiant_team_logo = value ? this.radiant_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeradiant_team_logo() { return radiant_team_logoSpecified; }
+    private void Resetradiant_team_logo() { radiant_team_logoSpecified = false; }
+    
 
-    private uint _dire_team_id = default(uint);
+    private uint? _dire_team_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"dire_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_team_id
     {
-      get { return _dire_team_id; }
+      get { return _dire_team_id?? default(uint); }
       set { _dire_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_idSpecified
+    {
+      get { return _dire_team_id != null; }
+      set { if (value == (_dire_team_id== null)) _dire_team_id = value ? this.dire_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializedire_team_id() { return dire_team_idSpecified; }
+    private void Resetdire_team_id() { dire_team_idSpecified = false; }
+    
 
-    private string _dire_team_name = "";
+    private string _dire_team_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"dire_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string dire_team_name
     {
-      get { return _dire_team_name; }
+      get { return _dire_team_name?? ""; }
       set { _dire_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_nameSpecified
+    {
+      get { return _dire_team_name != null; }
+      set { if (value == (_dire_team_name== null)) _dire_team_name = value ? this.dire_team_name : (string)null; }
+    }
+    private bool ShouldSerializedire_team_name() { return dire_team_nameSpecified; }
+    private void Resetdire_team_name() { dire_team_nameSpecified = false; }
+    
 
-    private ulong _dire_team_logo = default(ulong);
+    private ulong? _dire_team_logo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"dire_team_logo", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong dire_team_logo
     {
-      get { return _dire_team_logo; }
+      get { return _dire_team_logo?? default(ulong); }
       set { _dire_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_logoSpecified
+    {
+      get { return _dire_team_logo != null; }
+      set { if (value == (_dire_team_logo== null)) _dire_team_logo = value ? this.dire_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializedire_team_logo() { return dire_team_logoSpecified; }
+    private void Resetdire_team_logo() { dire_team_logoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1013,32 +1717,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _match = value; }
     }
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private uint _size = default(uint);
+    private uint? _size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint size
     {
-      get { return _size; }
+      get { return _size?? default(uint); }
       set { _size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sizeSpecified
+    {
+      get { return _size != null; }
+      set { if (value == (_size== null)) _size = value ? this.size : (uint?)null; }
+    }
+    private bool ShouldSerializesize() { return sizeSpecified; }
+    private void Resetsize() { sizeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(5, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -1047,37 +1778,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _exists_on_disk = default(bool);
+    private bool? _exists_on_disk;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"exists_on_disk", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool exists_on_disk
     {
-      get { return _exists_on_disk; }
+      get { return _exists_on_disk?? default(bool); }
       set { _exists_on_disk = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool exists_on_diskSpecified
+    {
+      get { return _exists_on_disk != null; }
+      set { if (value == (_exists_on_disk== null)) _exists_on_disk = value ? this.exists_on_disk : (bool?)null; }
+    }
+    private bool ShouldSerializeexists_on_disk() { return exists_on_diskSpecified; }
+    private void Resetexists_on_disk() { exists_on_diskSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Highlight")]
   public partial class Highlight : global::ProtoBuf.IExtensible
   {
     public Highlight() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1094,41 +1852,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgWatchGame() {}
     
 
-    private ulong _server_steamid = default(ulong);
+    private ulong? _server_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steamid
     {
-      get { return _server_steamid; }
+      get { return _server_steamid?? default(ulong); }
       set { _server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steamidSpecified
+    {
+      get { return _server_steamid != null; }
+      set { if (value == (_server_steamid== null)) _server_steamid = value ? this.server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steamid() { return server_steamidSpecified; }
+    private void Resetserver_steamid() { server_steamidSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private ulong _watch_server_steamid = default(ulong);
+    private ulong? _watch_server_steamid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"watch_server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong watch_server_steamid
     {
-      get { return _watch_server_steamid; }
+      get { return _watch_server_steamid?? default(ulong); }
       set { _watch_server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watch_server_steamidSpecified
+    {
+      get { return _watch_server_steamid != null; }
+      set { if (value == (_watch_server_steamid== null)) _watch_server_steamid = value ? this.watch_server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializewatch_server_steamid() { return watch_server_steamidSpecified; }
+    private void Resetwatch_server_steamid() { watch_server_steamidSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _regions = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"regions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> regions
@@ -1157,68 +1951,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgWatchGameResponse() {}
     
 
-    private CMsgWatchGameResponse.WatchGameResult _watch_game_result = CMsgWatchGameResponse.WatchGameResult.PENDING;
+    private CMsgWatchGameResponse.WatchGameResult? _watch_game_result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"watch_game_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgWatchGameResponse.WatchGameResult.PENDING)]
     public CMsgWatchGameResponse.WatchGameResult watch_game_result
     {
-      get { return _watch_game_result; }
+      get { return _watch_game_result?? CMsgWatchGameResponse.WatchGameResult.PENDING; }
       set { _watch_game_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watch_game_resultSpecified
+    {
+      get { return _watch_game_result != null; }
+      set { if (value == (_watch_game_result== null)) _watch_game_result = value ? this.watch_game_result : (CMsgWatchGameResponse.WatchGameResult?)null; }
+    }
+    private bool ShouldSerializewatch_game_result() { return watch_game_resultSpecified; }
+    private void Resetwatch_game_result() { watch_game_resultSpecified = false; }
+    
 
-    private uint _source_tv_public_addr = default(uint);
+    private uint? _source_tv_public_addr;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"source_tv_public_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_public_addr
     {
-      get { return _source_tv_public_addr; }
+      get { return _source_tv_public_addr?? default(uint); }
       set { _source_tv_public_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_public_addrSpecified
+    {
+      get { return _source_tv_public_addr != null; }
+      set { if (value == (_source_tv_public_addr== null)) _source_tv_public_addr = value ? this.source_tv_public_addr : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_public_addr() { return source_tv_public_addrSpecified; }
+    private void Resetsource_tv_public_addr() { source_tv_public_addrSpecified = false; }
+    
 
-    private uint _source_tv_private_addr = default(uint);
+    private uint? _source_tv_private_addr;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_tv_private_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_private_addr
     {
-      get { return _source_tv_private_addr; }
+      get { return _source_tv_private_addr?? default(uint); }
       set { _source_tv_private_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_private_addrSpecified
+    {
+      get { return _source_tv_private_addr != null; }
+      set { if (value == (_source_tv_private_addr== null)) _source_tv_private_addr = value ? this.source_tv_private_addr : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_private_addr() { return source_tv_private_addrSpecified; }
+    private void Resetsource_tv_private_addr() { source_tv_private_addrSpecified = false; }
+    
 
-    private uint _source_tv_port = default(uint);
+    private uint? _source_tv_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"source_tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_port
     {
-      get { return _source_tv_port; }
+      get { return _source_tv_port?? default(uint); }
       set { _source_tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_portSpecified
+    {
+      get { return _source_tv_port != null; }
+      set { if (value == (_source_tv_port== null)) _source_tv_port = value ? this.source_tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_port() { return source_tv_portSpecified; }
+    private void Resetsource_tv_port() { source_tv_portSpecified = false; }
+    
 
-    private ulong _game_server_steamid = default(ulong);
+    private ulong? _game_server_steamid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_server_steamid
     {
-      get { return _game_server_steamid; }
+      get { return _game_server_steamid?? default(ulong); }
       set { _game_server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_steamidSpecified
+    {
+      get { return _game_server_steamid != null; }
+      set { if (value == (_game_server_steamid== null)) _game_server_steamid = value ? this.game_server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_server_steamid() { return game_server_steamidSpecified; }
+    private void Resetgame_server_steamid() { game_server_steamidSpecified = false; }
+    
 
-    private ulong _watch_server_steamid = default(ulong);
+    private ulong? _watch_server_steamid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"watch_server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong watch_server_steamid
     {
-      get { return _watch_server_steamid; }
+      get { return _watch_server_steamid?? default(ulong); }
       set { _watch_server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watch_server_steamidSpecified
+    {
+      get { return _watch_server_steamid != null; }
+      set { if (value == (_watch_server_steamid== null)) _watch_server_steamid = value ? this.watch_server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializewatch_server_steamid() { return watch_server_steamidSpecified; }
+    private void Resetwatch_server_steamid() { watch_server_steamidSpecified = false; }
+    
 
-    private ulong _watch_tv_unique_secret_code = default(ulong);
+    private ulong? _watch_tv_unique_secret_code;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"watch_tv_unique_secret_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong watch_tv_unique_secret_code
     {
-      get { return _watch_tv_unique_secret_code; }
+      get { return _watch_tv_unique_secret_code?? default(ulong); }
       set { _watch_tv_unique_secret_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watch_tv_unique_secret_codeSpecified
+    {
+      get { return _watch_tv_unique_secret_code != null; }
+      set { if (value == (_watch_tv_unique_secret_code== null)) _watch_tv_unique_secret_code = value ? this.watch_tv_unique_secret_code : (ulong?)null; }
+    }
+    private bool ShouldSerializewatch_tv_unique_secret_code() { return watch_tv_unique_secret_codeSpecified; }
+    private void Resetwatch_tv_unique_secret_code() { watch_tv_unique_secret_codeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"WatchGameResult", EnumPassthru=true)]
     public enum WatchGameResult
     {
@@ -1259,14 +2116,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPartyLeaderWatchGamePrompt() {}
     
 
-    private ulong _game_server_steamid = default(ulong);
+    private ulong? _game_server_steamid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_server_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_server_steamid
     {
-      get { return _game_server_steamid; }
+      get { return _game_server_steamid?? default(ulong); }
       set { _game_server_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_steamidSpecified
+    {
+      get { return _game_server_steamid != null; }
+      set { if (value == (_game_server_steamid== null)) _game_server_steamid = value ? this.game_server_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_server_steamid() { return game_server_steamidSpecified; }
+    private void Resetgame_server_steamid() { game_server_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1278,95 +2144,185 @@ namespace SteamKit2.GC.Dota.Internal
     public CDOTABroadcasterInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private bool _live = default(bool);
+    private bool? _live;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"live", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool live
     {
-      get { return _live; }
+      get { return _live?? default(bool); }
       set { _live = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool liveSpecified
+    {
+      get { return _live != null; }
+      set { if (value == (_live== null)) _live = value ? this.live : (bool?)null; }
+    }
+    private bool ShouldSerializelive() { return liveSpecified; }
+    private void Resetlive() { liveSpecified = false; }
+    
 
-    private string _team_name_radiant = "";
+    private string _team_name_radiant;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_name_radiant", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name_radiant
     {
-      get { return _team_name_radiant; }
+      get { return _team_name_radiant?? ""; }
       set { _team_name_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_name_radiantSpecified
+    {
+      get { return _team_name_radiant != null; }
+      set { if (value == (_team_name_radiant== null)) _team_name_radiant = value ? this.team_name_radiant : (string)null; }
+    }
+    private bool ShouldSerializeteam_name_radiant() { return team_name_radiantSpecified; }
+    private void Resetteam_name_radiant() { team_name_radiantSpecified = false; }
+    
 
-    private string _team_name_dire = "";
+    private string _team_name_dire;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_name_dire", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name_dire
     {
-      get { return _team_name_dire; }
+      get { return _team_name_dire?? ""; }
       set { _team_name_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_name_direSpecified
+    {
+      get { return _team_name_dire != null; }
+      set { if (value == (_team_name_dire== null)) _team_name_dire = value ? this.team_name_dire : (string)null; }
+    }
+    private bool ShouldSerializeteam_name_dire() { return team_name_direSpecified; }
+    private void Resetteam_name_dire() { team_name_direSpecified = false; }
+    
 
-    private string _stage_name = "";
+    private string _stage_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"stage_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string stage_name
     {
-      get { return _stage_name; }
+      get { return _stage_name?? ""; }
       set { _stage_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stage_nameSpecified
+    {
+      get { return _stage_name != null; }
+      set { if (value == (_stage_name== null)) _stage_name = value ? this.stage_name : (string)null; }
+    }
+    private bool ShouldSerializestage_name() { return stage_nameSpecified; }
+    private void Resetstage_name() { stage_nameSpecified = false; }
+    
 
-    private uint _series_game = default(uint);
+    private uint? _series_game;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"series_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_game
     {
-      get { return _series_game; }
+      get { return _series_game?? default(uint); }
       set { _series_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_gameSpecified
+    {
+      get { return _series_game != null; }
+      set { if (value == (_series_game== null)) _series_game = value ? this.series_game : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_game() { return series_gameSpecified; }
+    private void Resetseries_game() { series_gameSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _upcoming_broadcast_timestamp = default(uint);
+    private uint? _upcoming_broadcast_timestamp;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"upcoming_broadcast_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint upcoming_broadcast_timestamp
     {
-      get { return _upcoming_broadcast_timestamp; }
+      get { return _upcoming_broadcast_timestamp?? default(uint); }
       set { _upcoming_broadcast_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upcoming_broadcast_timestampSpecified
+    {
+      get { return _upcoming_broadcast_timestamp != null; }
+      set { if (value == (_upcoming_broadcast_timestamp== null)) _upcoming_broadcast_timestamp = value ? this.upcoming_broadcast_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializeupcoming_broadcast_timestamp() { return upcoming_broadcast_timestampSpecified; }
+    private void Resetupcoming_broadcast_timestamp() { upcoming_broadcast_timestampSpecified = false; }
+    
 
-    private bool _allow_live_video = default(bool);
+    private bool? _allow_live_video;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"allow_live_video", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_live_video
     {
-      get { return _allow_live_video; }
+      get { return _allow_live_video?? default(bool); }
       set { _allow_live_video = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_live_videoSpecified
+    {
+      get { return _allow_live_video != null; }
+      set { if (value == (_allow_live_video== null)) _allow_live_video = value ? this.allow_live_video : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_live_video() { return allow_live_videoSpecified; }
+    private void Resetallow_live_video() { allow_live_videoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCCommon.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCCommon.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_common.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: gcsdk_gcmessages.proto
@@ -20,554 +22,1103 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAGameAccountClient() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _wins = default(uint);
+    private uint? _wins;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wins
     {
-      get { return _wins; }
+      get { return _wins?? default(uint); }
       set { _wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winsSpecified
+    {
+      get { return _wins != null; }
+      set { if (value == (_wins== null)) _wins = value ? this.wins : (uint?)null; }
+    }
+    private bool ShouldSerializewins() { return winsSpecified; }
+    private void Resetwins() { winsSpecified = false; }
+    
 
-    private uint _losses = default(uint);
+    private uint? _losses;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint losses
     {
-      get { return _losses; }
+      get { return _losses?? default(uint); }
       set { _losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lossesSpecified
+    {
+      get { return _losses != null; }
+      set { if (value == (_losses== null)) _losses = value ? this.losses : (uint?)null; }
+    }
+    private bool ShouldSerializelosses() { return lossesSpecified; }
+    private void Resetlosses() { lossesSpecified = false; }
+    
 
-    private uint _xp = default(uint);
+    private uint? _xp;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"xp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp
     {
-      get { return _xp; }
+      get { return _xp?? default(uint); }
       set { _xp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xpSpecified
+    {
+      get { return _xp != null; }
+      set { if (value == (_xp== null)) _xp = value ? this.xp : (uint?)null; }
+    }
+    private bool ShouldSerializexp() { return xpSpecified; }
+    private void Resetxp() { xpSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _initial_skill = default(uint);
+    private uint? _initial_skill;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"initial_skill", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_skill
     {
-      get { return _initial_skill; }
+      get { return _initial_skill?? default(uint); }
       set { _initial_skill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_skillSpecified
+    {
+      get { return _initial_skill != null; }
+      set { if (value == (_initial_skill== null)) _initial_skill = value ? this.initial_skill : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_skill() { return initial_skillSpecified; }
+    private void Resetinitial_skill() { initial_skillSpecified = false; }
+    
 
-    private uint _leaver_count = default(uint);
+    private uint? _leaver_count;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"leaver_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leaver_count
     {
-      get { return _leaver_count; }
+      get { return _leaver_count?? default(uint); }
       set { _leaver_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_countSpecified
+    {
+      get { return _leaver_count != null; }
+      set { if (value == (_leaver_count== null)) _leaver_count = value ? this.leaver_count : (uint?)null; }
+    }
+    private bool ShouldSerializeleaver_count() { return leaver_countSpecified; }
+    private void Resetleaver_count() { leaver_countSpecified = false; }
+    
 
-    private uint _secondary_leaver_count = default(uint);
+    private uint? _secondary_leaver_count;
     [global::ProtoBuf.ProtoMember(58, IsRequired = false, Name=@"secondary_leaver_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint secondary_leaver_count
     {
-      get { return _secondary_leaver_count; }
+      get { return _secondary_leaver_count?? default(uint); }
       set { _secondary_leaver_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secondary_leaver_countSpecified
+    {
+      get { return _secondary_leaver_count != null; }
+      set { if (value == (_secondary_leaver_count== null)) _secondary_leaver_count = value ? this.secondary_leaver_count : (uint?)null; }
+    }
+    private bool ShouldSerializesecondary_leaver_count() { return secondary_leaver_countSpecified; }
+    private void Resetsecondary_leaver_count() { secondary_leaver_countSpecified = false; }
+    
 
-    private uint _low_priority_until_date = default(uint);
+    private uint? _low_priority_until_date;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"low_priority_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint low_priority_until_date
     {
-      get { return _low_priority_until_date; }
+      get { return _low_priority_until_date?? default(uint); }
       set { _low_priority_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_priority_until_dateSpecified
+    {
+      get { return _low_priority_until_date != null; }
+      set { if (value == (_low_priority_until_date== null)) _low_priority_until_date = value ? this.low_priority_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializelow_priority_until_date() { return low_priority_until_dateSpecified; }
+    private void Resetlow_priority_until_date() { low_priority_until_dateSpecified = false; }
+    
 
-    private uint _prevent_text_chat_until_date = default(uint);
+    private uint? _prevent_text_chat_until_date;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"prevent_text_chat_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prevent_text_chat_until_date
     {
-      get { return _prevent_text_chat_until_date; }
+      get { return _prevent_text_chat_until_date?? default(uint); }
       set { _prevent_text_chat_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_text_chat_until_dateSpecified
+    {
+      get { return _prevent_text_chat_until_date != null; }
+      set { if (value == (_prevent_text_chat_until_date== null)) _prevent_text_chat_until_date = value ? this.prevent_text_chat_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializeprevent_text_chat_until_date() { return prevent_text_chat_until_dateSpecified; }
+    private void Resetprevent_text_chat_until_date() { prevent_text_chat_until_dateSpecified = false; }
+    
 
-    private uint _prevent_voice_until_date = default(uint);
+    private uint? _prevent_voice_until_date;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"prevent_voice_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prevent_voice_until_date
     {
-      get { return _prevent_voice_until_date; }
+      get { return _prevent_voice_until_date?? default(uint); }
       set { _prevent_voice_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_voice_until_dateSpecified
+    {
+      get { return _prevent_voice_until_date != null; }
+      set { if (value == (_prevent_voice_until_date== null)) _prevent_voice_until_date = value ? this.prevent_voice_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializeprevent_voice_until_date() { return prevent_voice_until_dateSpecified; }
+    private void Resetprevent_voice_until_date() { prevent_voice_until_dateSpecified = false; }
+    
 
-    private uint _prevent_public_text_chat_until_date = default(uint);
+    private uint? _prevent_public_text_chat_until_date;
     [global::ProtoBuf.ProtoMember(86, IsRequired = false, Name=@"prevent_public_text_chat_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prevent_public_text_chat_until_date
     {
-      get { return _prevent_public_text_chat_until_date; }
+      get { return _prevent_public_text_chat_until_date?? default(uint); }
       set { _prevent_public_text_chat_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_public_text_chat_until_dateSpecified
+    {
+      get { return _prevent_public_text_chat_until_date != null; }
+      set { if (value == (_prevent_public_text_chat_until_date== null)) _prevent_public_text_chat_until_date = value ? this.prevent_public_text_chat_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializeprevent_public_text_chat_until_date() { return prevent_public_text_chat_until_dateSpecified; }
+    private void Resetprevent_public_text_chat_until_date() { prevent_public_text_chat_until_dateSpecified = false; }
+    
 
-    private uint _last_abandoned_game_date = default(uint);
+    private uint? _last_abandoned_game_date;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"last_abandoned_game_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_abandoned_game_date
     {
-      get { return _last_abandoned_game_date; }
+      get { return _last_abandoned_game_date?? default(uint); }
       set { _last_abandoned_game_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_abandoned_game_dateSpecified
+    {
+      get { return _last_abandoned_game_date != null; }
+      set { if (value == (_last_abandoned_game_date== null)) _last_abandoned_game_date = value ? this.last_abandoned_game_date : (uint?)null; }
+    }
+    private bool ShouldSerializelast_abandoned_game_date() { return last_abandoned_game_dateSpecified; }
+    private void Resetlast_abandoned_game_date() { last_abandoned_game_dateSpecified = false; }
+    
 
-    private uint _last_secondary_abandoned_game_date = default(uint);
+    private uint? _last_secondary_abandoned_game_date;
     [global::ProtoBuf.ProtoMember(59, IsRequired = false, Name=@"last_secondary_abandoned_game_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_secondary_abandoned_game_date
     {
-      get { return _last_secondary_abandoned_game_date; }
+      get { return _last_secondary_abandoned_game_date?? default(uint); }
       set { _last_secondary_abandoned_game_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_secondary_abandoned_game_dateSpecified
+    {
+      get { return _last_secondary_abandoned_game_date != null; }
+      set { if (value == (_last_secondary_abandoned_game_date== null)) _last_secondary_abandoned_game_date = value ? this.last_secondary_abandoned_game_date : (uint?)null; }
+    }
+    private bool ShouldSerializelast_secondary_abandoned_game_date() { return last_secondary_abandoned_game_dateSpecified; }
+    private void Resetlast_secondary_abandoned_game_date() { last_secondary_abandoned_game_dateSpecified = false; }
+    
 
-    private uint _leaver_penalty_count = default(uint);
+    private uint? _leaver_penalty_count;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"leaver_penalty_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leaver_penalty_count
     {
-      get { return _leaver_penalty_count; }
+      get { return _leaver_penalty_count?? default(uint); }
       set { _leaver_penalty_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_penalty_countSpecified
+    {
+      get { return _leaver_penalty_count != null; }
+      set { if (value == (_leaver_penalty_count== null)) _leaver_penalty_count = value ? this.leaver_penalty_count : (uint?)null; }
+    }
+    private bool ShouldSerializeleaver_penalty_count() { return leaver_penalty_countSpecified; }
+    private void Resetleaver_penalty_count() { leaver_penalty_countSpecified = false; }
+    
 
-    private uint _completed_game_streak = default(uint);
+    private uint? _completed_game_streak;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"completed_game_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint completed_game_streak
     {
-      get { return _completed_game_streak; }
+      get { return _completed_game_streak?? default(uint); }
       set { _completed_game_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completed_game_streakSpecified
+    {
+      get { return _completed_game_streak != null; }
+      set { if (value == (_completed_game_streak== null)) _completed_game_streak = value ? this.completed_game_streak : (uint?)null; }
+    }
+    private bool ShouldSerializecompleted_game_streak() { return completed_game_streakSpecified; }
+    private void Resetcompleted_game_streak() { completed_game_streakSpecified = false; }
+    
 
-    private uint _teaching = default(uint);
+    private uint? _teaching;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"teaching", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teaching
     {
-      get { return _teaching; }
+      get { return _teaching?? default(uint); }
       set { _teaching = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teachingSpecified
+    {
+      get { return _teaching != null; }
+      set { if (value == (_teaching== null)) _teaching = value ? this.teaching : (uint?)null; }
+    }
+    private bool ShouldSerializeteaching() { return teachingSpecified; }
+    private void Resetteaching() { teachingSpecified = false; }
+    
 
-    private uint _leadership = default(uint);
+    private uint? _leadership;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"leadership", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leadership
     {
-      get { return _leadership; }
+      get { return _leadership?? default(uint); }
       set { _leadership = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leadershipSpecified
+    {
+      get { return _leadership != null; }
+      set { if (value == (_leadership== null)) _leadership = value ? this.leadership : (uint?)null; }
+    }
+    private bool ShouldSerializeleadership() { return leadershipSpecified; }
+    private void Resetleadership() { leadershipSpecified = false; }
+    
 
-    private uint _friendly = default(uint);
+    private uint? _friendly;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"friendly", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friendly
     {
-      get { return _friendly; }
+      get { return _friendly?? default(uint); }
       set { _friendly = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendlySpecified
+    {
+      get { return _friendly != null; }
+      set { if (value == (_friendly== null)) _friendly = value ? this.friendly : (uint?)null; }
+    }
+    private bool ShouldSerializefriendly() { return friendlySpecified; }
+    private void Resetfriendly() { friendlySpecified = false; }
+    
 
-    private uint _forgiving = default(uint);
+    private uint? _forgiving;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"forgiving", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint forgiving
     {
-      get { return _forgiving; }
+      get { return _forgiving?? default(uint); }
       set { _forgiving = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool forgivingSpecified
+    {
+      get { return _forgiving != null; }
+      set { if (value == (_forgiving== null)) _forgiving = value ? this.forgiving : (uint?)null; }
+    }
+    private bool ShouldSerializeforgiving() { return forgivingSpecified; }
+    private void Resetforgiving() { forgivingSpecified = false; }
+    
 
-    private uint _account_disabled_until_date = default(uint);
+    private uint? _account_disabled_until_date;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"account_disabled_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_disabled_until_date
     {
-      get { return _account_disabled_until_date; }
+      get { return _account_disabled_until_date?? default(uint); }
       set { _account_disabled_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_disabled_until_dateSpecified
+    {
+      get { return _account_disabled_until_date != null; }
+      set { if (value == (_account_disabled_until_date== null)) _account_disabled_until_date = value ? this.account_disabled_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_disabled_until_date() { return account_disabled_until_dateSpecified; }
+    private void Resetaccount_disabled_until_date() { account_disabled_until_dateSpecified = false; }
+    
 
-    private uint _account_disabled_count = default(uint);
+    private uint? _account_disabled_count;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"account_disabled_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_disabled_count
     {
-      get { return _account_disabled_count; }
+      get { return _account_disabled_count?? default(uint); }
       set { _account_disabled_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_disabled_countSpecified
+    {
+      get { return _account_disabled_count != null; }
+      set { if (value == (_account_disabled_count== null)) _account_disabled_count = value ? this.account_disabled_count : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_disabled_count() { return account_disabled_countSpecified; }
+    private void Resetaccount_disabled_count() { account_disabled_countSpecified = false; }
+    
 
-    private uint _showcase_hero_id = default(uint);
+    private uint? _showcase_hero_id;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"showcase_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint showcase_hero_id
     {
-      get { return _showcase_hero_id; }
+      get { return _showcase_hero_id?? default(uint); }
       set { _showcase_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool showcase_hero_idSpecified
+    {
+      get { return _showcase_hero_id != null; }
+      set { if (value == (_showcase_hero_id== null)) _showcase_hero_id = value ? this.showcase_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializeshowcase_hero_id() { return showcase_hero_idSpecified; }
+    private void Resetshowcase_hero_id() { showcase_hero_idSpecified = false; }
+    
 
-    private uint _match_disabled_until_date = default(uint);
+    private uint? _match_disabled_until_date;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"match_disabled_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_disabled_until_date
     {
-      get { return _match_disabled_until_date; }
+      get { return _match_disabled_until_date?? default(uint); }
       set { _match_disabled_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_disabled_until_dateSpecified
+    {
+      get { return _match_disabled_until_date != null; }
+      set { if (value == (_match_disabled_until_date== null)) _match_disabled_until_date = value ? this.match_disabled_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializematch_disabled_until_date() { return match_disabled_until_dateSpecified; }
+    private void Resetmatch_disabled_until_date() { match_disabled_until_dateSpecified = false; }
+    
 
-    private uint _match_disabled_count = default(uint);
+    private uint? _match_disabled_count;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"match_disabled_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_disabled_count
     {
-      get { return _match_disabled_count; }
+      get { return _match_disabled_count?? default(uint); }
       set { _match_disabled_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_disabled_countSpecified
+    {
+      get { return _match_disabled_count != null; }
+      set { if (value == (_match_disabled_count== null)) _match_disabled_count = value ? this.match_disabled_count : (uint?)null; }
+    }
+    private bool ShouldSerializematch_disabled_count() { return match_disabled_countSpecified; }
+    private void Resetmatch_disabled_count() { match_disabled_countSpecified = false; }
+    
 
-    private PartnerAccountType _partner_account_type = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _partner_account_type;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"partner_account_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType partner_account_type
     {
-      get { return _partner_account_type; }
+      get { return _partner_account_type?? PartnerAccountType.PARTNER_NONE; }
       set { _partner_account_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_account_typeSpecified
+    {
+      get { return _partner_account_type != null; }
+      set { if (value == (_partner_account_type== null)) _partner_account_type = value ? this.partner_account_type : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializepartner_account_type() { return partner_account_typeSpecified; }
+    private void Resetpartner_account_type() { partner_account_typeSpecified = false; }
+    
 
-    private uint _partner_account_state = default(uint);
+    private uint? _partner_account_state;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"partner_account_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint partner_account_state
     {
-      get { return _partner_account_state; }
+      get { return _partner_account_state?? default(uint); }
       set { _partner_account_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_account_stateSpecified
+    {
+      get { return _partner_account_state != null; }
+      set { if (value == (_partner_account_state== null)) _partner_account_state = value ? this.partner_account_state : (uint?)null; }
+    }
+    private bool ShouldSerializepartner_account_state() { return partner_account_stateSpecified; }
+    private void Resetpartner_account_state() { partner_account_stateSpecified = false; }
+    
 
-    private uint _shutdownlawterminatetimestamp = default(uint);
+    private uint? _shutdownlawterminatetimestamp;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"shutdownlawterminatetimestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint shutdownlawterminatetimestamp
     {
-      get { return _shutdownlawterminatetimestamp; }
+      get { return _shutdownlawterminatetimestamp?? default(uint); }
       set { _shutdownlawterminatetimestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shutdownlawterminatetimestampSpecified
+    {
+      get { return _shutdownlawterminatetimestamp != null; }
+      set { if (value == (_shutdownlawterminatetimestamp== null)) _shutdownlawterminatetimestamp = value ? this.shutdownlawterminatetimestamp : (uint?)null; }
+    }
+    private bool ShouldSerializeshutdownlawterminatetimestamp() { return shutdownlawterminatetimestampSpecified; }
+    private void Resetshutdownlawterminatetimestamp() { shutdownlawterminatetimestampSpecified = false; }
+    
 
-    private uint _low_priority_games_remaining = default(uint);
+    private uint? _low_priority_games_remaining;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"low_priority_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint low_priority_games_remaining
     {
-      get { return _low_priority_games_remaining; }
+      get { return _low_priority_games_remaining?? default(uint); }
       set { _low_priority_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_priority_games_remainingSpecified
+    {
+      get { return _low_priority_games_remaining != null; }
+      set { if (value == (_low_priority_games_remaining== null)) _low_priority_games_remaining = value ? this.low_priority_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializelow_priority_games_remaining() { return low_priority_games_remainingSpecified; }
+    private void Resetlow_priority_games_remaining() { low_priority_games_remainingSpecified = false; }
+    
 
-    private uint _competitive_rank = default(uint);
+    private uint? _competitive_rank;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"competitive_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint competitive_rank
     {
-      get { return _competitive_rank; }
+      get { return _competitive_rank?? default(uint); }
       set { _competitive_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool competitive_rankSpecified
+    {
+      get { return _competitive_rank != null; }
+      set { if (value == (_competitive_rank== null)) _competitive_rank = value ? this.competitive_rank : (uint?)null; }
+    }
+    private bool ShouldSerializecompetitive_rank() { return competitive_rankSpecified; }
+    private void Resetcompetitive_rank() { competitive_rankSpecified = false; }
+    
 
-    private uint _calibration_games_remaining = default(uint);
+    private uint? _calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint calibration_games_remaining
     {
-      get { return _calibration_games_remaining; }
+      get { return _calibration_games_remaining?? default(uint); }
       set { _calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool calibration_games_remainingSpecified
+    {
+      get { return _calibration_games_remaining != null; }
+      set { if (value == (_calibration_games_remaining== null)) _calibration_games_remaining = value ? this.calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializecalibration_games_remaining() { return calibration_games_remainingSpecified; }
+    private void Resetcalibration_games_remaining() { calibration_games_remainingSpecified = false; }
+    
 
-    private uint _solo_competitive_rank = default(uint);
+    private uint? _solo_competitive_rank;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"solo_competitive_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_competitive_rank
     {
-      get { return _solo_competitive_rank; }
+      get { return _solo_competitive_rank?? default(uint); }
       set { _solo_competitive_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_competitive_rankSpecified
+    {
+      get { return _solo_competitive_rank != null; }
+      set { if (value == (_solo_competitive_rank== null)) _solo_competitive_rank = value ? this.solo_competitive_rank : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_competitive_rank() { return solo_competitive_rankSpecified; }
+    private void Resetsolo_competitive_rank() { solo_competitive_rankSpecified = false; }
+    
 
-    private uint _solo_calibration_games_remaining = default(uint);
+    private uint? _solo_calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(54, IsRequired = false, Name=@"solo_calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_calibration_games_remaining
     {
-      get { return _solo_calibration_games_remaining; }
+      get { return _solo_calibration_games_remaining?? default(uint); }
       set { _solo_calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_calibration_games_remainingSpecified
+    {
+      get { return _solo_calibration_games_remaining != null; }
+      set { if (value == (_solo_calibration_games_remaining== null)) _solo_calibration_games_remaining = value ? this.solo_calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_calibration_games_remaining() { return solo_calibration_games_remainingSpecified; }
+    private void Resetsolo_calibration_games_remaining() { solo_calibration_games_remainingSpecified = false; }
+    
 
-    private uint _general_seasonal_ranked_rank = default(uint);
+    private uint? _general_seasonal_ranked_rank;
     [global::ProtoBuf.ProtoMember(75, IsRequired = false, Name=@"general_seasonal_ranked_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint general_seasonal_ranked_rank
     {
-      get { return _general_seasonal_ranked_rank; }
+      get { return _general_seasonal_ranked_rank?? default(uint); }
       set { _general_seasonal_ranked_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool general_seasonal_ranked_rankSpecified
+    {
+      get { return _general_seasonal_ranked_rank != null; }
+      set { if (value == (_general_seasonal_ranked_rank== null)) _general_seasonal_ranked_rank = value ? this.general_seasonal_ranked_rank : (uint?)null; }
+    }
+    private bool ShouldSerializegeneral_seasonal_ranked_rank() { return general_seasonal_ranked_rankSpecified; }
+    private void Resetgeneral_seasonal_ranked_rank() { general_seasonal_ranked_rankSpecified = false; }
+    
 
-    private uint _general_seasonal_ranked_calibration_games_remaining = default(uint);
+    private uint? _general_seasonal_ranked_calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(76, IsRequired = false, Name=@"general_seasonal_ranked_calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint general_seasonal_ranked_calibration_games_remaining
     {
-      get { return _general_seasonal_ranked_calibration_games_remaining; }
+      get { return _general_seasonal_ranked_calibration_games_remaining?? default(uint); }
       set { _general_seasonal_ranked_calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool general_seasonal_ranked_calibration_games_remainingSpecified
+    {
+      get { return _general_seasonal_ranked_calibration_games_remaining != null; }
+      set { if (value == (_general_seasonal_ranked_calibration_games_remaining== null)) _general_seasonal_ranked_calibration_games_remaining = value ? this.general_seasonal_ranked_calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializegeneral_seasonal_ranked_calibration_games_remaining() { return general_seasonal_ranked_calibration_games_remainingSpecified; }
+    private void Resetgeneral_seasonal_ranked_calibration_games_remaining() { general_seasonal_ranked_calibration_games_remainingSpecified = false; }
+    
 
-    private uint _general_seasonal_ranked_games_played = default(uint);
+    private uint? _general_seasonal_ranked_games_played;
     [global::ProtoBuf.ProtoMember(80, IsRequired = false, Name=@"general_seasonal_ranked_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint general_seasonal_ranked_games_played
     {
-      get { return _general_seasonal_ranked_games_played; }
+      get { return _general_seasonal_ranked_games_played?? default(uint); }
       set { _general_seasonal_ranked_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool general_seasonal_ranked_games_playedSpecified
+    {
+      get { return _general_seasonal_ranked_games_played != null; }
+      set { if (value == (_general_seasonal_ranked_games_played== null)) _general_seasonal_ranked_games_played = value ? this.general_seasonal_ranked_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializegeneral_seasonal_ranked_games_played() { return general_seasonal_ranked_games_playedSpecified; }
+    private void Resetgeneral_seasonal_ranked_games_played() { general_seasonal_ranked_games_playedSpecified = false; }
+    
 
-    private uint _general_seasonal_ranked_rank_peak = default(uint);
+    private uint? _general_seasonal_ranked_rank_peak;
     [global::ProtoBuf.ProtoMember(81, IsRequired = false, Name=@"general_seasonal_ranked_rank_peak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint general_seasonal_ranked_rank_peak
     {
-      get { return _general_seasonal_ranked_rank_peak; }
+      get { return _general_seasonal_ranked_rank_peak?? default(uint); }
       set { _general_seasonal_ranked_rank_peak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool general_seasonal_ranked_rank_peakSpecified
+    {
+      get { return _general_seasonal_ranked_rank_peak != null; }
+      set { if (value == (_general_seasonal_ranked_rank_peak== null)) _general_seasonal_ranked_rank_peak = value ? this.general_seasonal_ranked_rank_peak : (uint?)null; }
+    }
+    private bool ShouldSerializegeneral_seasonal_ranked_rank_peak() { return general_seasonal_ranked_rank_peakSpecified; }
+    private void Resetgeneral_seasonal_ranked_rank_peak() { general_seasonal_ranked_rank_peakSpecified = false; }
+    
 
-    private bool _general_seasonal_rank_transferred = default(bool);
+    private bool? _general_seasonal_rank_transferred;
     [global::ProtoBuf.ProtoMember(83, IsRequired = false, Name=@"general_seasonal_rank_transferred", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool general_seasonal_rank_transferred
     {
-      get { return _general_seasonal_rank_transferred; }
+      get { return _general_seasonal_rank_transferred?? default(bool); }
       set { _general_seasonal_rank_transferred = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool general_seasonal_rank_transferredSpecified
+    {
+      get { return _general_seasonal_rank_transferred != null; }
+      set { if (value == (_general_seasonal_rank_transferred== null)) _general_seasonal_rank_transferred = value ? this.general_seasonal_rank_transferred : (bool?)null; }
+    }
+    private bool ShouldSerializegeneral_seasonal_rank_transferred() { return general_seasonal_rank_transferredSpecified; }
+    private void Resetgeneral_seasonal_rank_transferred() { general_seasonal_rank_transferredSpecified = false; }
+    
 
-    private uint _solo_seasonal_ranked_rank = default(uint);
+    private uint? _solo_seasonal_ranked_rank;
     [global::ProtoBuf.ProtoMember(77, IsRequired = false, Name=@"solo_seasonal_ranked_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_seasonal_ranked_rank
     {
-      get { return _solo_seasonal_ranked_rank; }
+      get { return _solo_seasonal_ranked_rank?? default(uint); }
       set { _solo_seasonal_ranked_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_seasonal_ranked_rankSpecified
+    {
+      get { return _solo_seasonal_ranked_rank != null; }
+      set { if (value == (_solo_seasonal_ranked_rank== null)) _solo_seasonal_ranked_rank = value ? this.solo_seasonal_ranked_rank : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_seasonal_ranked_rank() { return solo_seasonal_ranked_rankSpecified; }
+    private void Resetsolo_seasonal_ranked_rank() { solo_seasonal_ranked_rankSpecified = false; }
+    
 
-    private uint _solo_seasonal_ranked_calibration_games_remaining = default(uint);
+    private uint? _solo_seasonal_ranked_calibration_games_remaining;
     [global::ProtoBuf.ProtoMember(78, IsRequired = false, Name=@"solo_seasonal_ranked_calibration_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_seasonal_ranked_calibration_games_remaining
     {
-      get { return _solo_seasonal_ranked_calibration_games_remaining; }
+      get { return _solo_seasonal_ranked_calibration_games_remaining?? default(uint); }
       set { _solo_seasonal_ranked_calibration_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_seasonal_ranked_calibration_games_remainingSpecified
+    {
+      get { return _solo_seasonal_ranked_calibration_games_remaining != null; }
+      set { if (value == (_solo_seasonal_ranked_calibration_games_remaining== null)) _solo_seasonal_ranked_calibration_games_remaining = value ? this.solo_seasonal_ranked_calibration_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_seasonal_ranked_calibration_games_remaining() { return solo_seasonal_ranked_calibration_games_remainingSpecified; }
+    private void Resetsolo_seasonal_ranked_calibration_games_remaining() { solo_seasonal_ranked_calibration_games_remainingSpecified = false; }
+    
 
-    private uint _solo_seasonal_ranked_games_played = default(uint);
+    private uint? _solo_seasonal_ranked_games_played;
     [global::ProtoBuf.ProtoMember(79, IsRequired = false, Name=@"solo_seasonal_ranked_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_seasonal_ranked_games_played
     {
-      get { return _solo_seasonal_ranked_games_played; }
+      get { return _solo_seasonal_ranked_games_played?? default(uint); }
       set { _solo_seasonal_ranked_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_seasonal_ranked_games_playedSpecified
+    {
+      get { return _solo_seasonal_ranked_games_played != null; }
+      set { if (value == (_solo_seasonal_ranked_games_played== null)) _solo_seasonal_ranked_games_played = value ? this.solo_seasonal_ranked_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_seasonal_ranked_games_played() { return solo_seasonal_ranked_games_playedSpecified; }
+    private void Resetsolo_seasonal_ranked_games_played() { solo_seasonal_ranked_games_playedSpecified = false; }
+    
 
-    private uint _solo_seasonal_ranked_rank_peak = default(uint);
+    private uint? _solo_seasonal_ranked_rank_peak;
     [global::ProtoBuf.ProtoMember(82, IsRequired = false, Name=@"solo_seasonal_ranked_rank_peak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_seasonal_ranked_rank_peak
     {
-      get { return _solo_seasonal_ranked_rank_peak; }
+      get { return _solo_seasonal_ranked_rank_peak?? default(uint); }
       set { _solo_seasonal_ranked_rank_peak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_seasonal_ranked_rank_peakSpecified
+    {
+      get { return _solo_seasonal_ranked_rank_peak != null; }
+      set { if (value == (_solo_seasonal_ranked_rank_peak== null)) _solo_seasonal_ranked_rank_peak = value ? this.solo_seasonal_ranked_rank_peak : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_seasonal_ranked_rank_peak() { return solo_seasonal_ranked_rank_peakSpecified; }
+    private void Resetsolo_seasonal_ranked_rank_peak() { solo_seasonal_ranked_rank_peakSpecified = false; }
+    
 
-    private bool _solo_seasonal_rank_transferred = default(bool);
+    private bool? _solo_seasonal_rank_transferred;
     [global::ProtoBuf.ProtoMember(84, IsRequired = false, Name=@"solo_seasonal_rank_transferred", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool solo_seasonal_rank_transferred
     {
-      get { return _solo_seasonal_rank_transferred; }
+      get { return _solo_seasonal_rank_transferred?? default(bool); }
       set { _solo_seasonal_rank_transferred = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_seasonal_rank_transferredSpecified
+    {
+      get { return _solo_seasonal_rank_transferred != null; }
+      set { if (value == (_solo_seasonal_rank_transferred== null)) _solo_seasonal_rank_transferred = value ? this.solo_seasonal_rank_transferred : (bool?)null; }
+    }
+    private bool ShouldSerializesolo_seasonal_rank_transferred() { return solo_seasonal_rank_transferredSpecified; }
+    private void Resetsolo_seasonal_rank_transferred() { solo_seasonal_rank_transferredSpecified = false; }
+    
 
-    private uint _recruitment_level = default(uint);
+    private uint? _recruitment_level;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"recruitment_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recruitment_level
     {
-      get { return _recruitment_level; }
+      get { return _recruitment_level?? default(uint); }
       set { _recruitment_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recruitment_levelSpecified
+    {
+      get { return _recruitment_level != null; }
+      set { if (value == (_recruitment_level== null)) _recruitment_level = value ? this.recruitment_level : (uint?)null; }
+    }
+    private bool ShouldSerializerecruitment_level() { return recruitment_levelSpecified; }
+    private void Resetrecruitment_level() { recruitment_levelSpecified = false; }
+    
 
-    private bool _has_new_notifications = default(bool);
+    private bool? _has_new_notifications;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"has_new_notifications", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_new_notifications
     {
-      get { return _has_new_notifications; }
+      get { return _has_new_notifications?? default(bool); }
       set { _has_new_notifications = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_new_notificationsSpecified
+    {
+      get { return _has_new_notifications != null; }
+      set { if (value == (_has_new_notifications== null)) _has_new_notifications = value ? this.has_new_notifications : (bool?)null; }
+    }
+    private bool ShouldSerializehas_new_notifications() { return has_new_notificationsSpecified; }
+    private void Resethas_new_notifications() { has_new_notificationsSpecified = false; }
+    
 
-    private bool _is_league_admin = default(bool);
+    private bool? _is_league_admin;
     [global::ProtoBuf.ProtoMember(57, IsRequired = false, Name=@"is_league_admin", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_league_admin
     {
-      get { return _is_league_admin; }
+      get { return _is_league_admin?? default(bool); }
       set { _is_league_admin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_league_adminSpecified
+    {
+      get { return _is_league_admin != null; }
+      set { if (value == (_is_league_admin== null)) _is_league_admin = value ? this.is_league_admin : (bool?)null; }
+    }
+    private bool ShouldSerializeis_league_admin() { return is_league_adminSpecified; }
+    private void Resetis_league_admin() { is_league_adminSpecified = false; }
+    
 
-    private uint _casual_games_played = default(uint);
+    private uint? _casual_games_played;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"casual_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint casual_games_played
     {
-      get { return _casual_games_played; }
+      get { return _casual_games_played?? default(uint); }
       set { _casual_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool casual_games_playedSpecified
+    {
+      get { return _casual_games_played != null; }
+      set { if (value == (_casual_games_played== null)) _casual_games_played = value ? this.casual_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializecasual_games_played() { return casual_games_playedSpecified; }
+    private void Resetcasual_games_played() { casual_games_playedSpecified = false; }
+    
 
-    private uint _solo_competitive_games_played = default(uint);
+    private uint? _solo_competitive_games_played;
     [global::ProtoBuf.ProtoMember(61, IsRequired = false, Name=@"solo_competitive_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solo_competitive_games_played
     {
-      get { return _solo_competitive_games_played; }
+      get { return _solo_competitive_games_played?? default(uint); }
       set { _solo_competitive_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_competitive_games_playedSpecified
+    {
+      get { return _solo_competitive_games_played != null; }
+      set { if (value == (_solo_competitive_games_played== null)) _solo_competitive_games_played = value ? this.solo_competitive_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializesolo_competitive_games_played() { return solo_competitive_games_playedSpecified; }
+    private void Resetsolo_competitive_games_played() { solo_competitive_games_playedSpecified = false; }
+    
 
-    private uint _party_competitive_games_played = default(uint);
+    private uint? _party_competitive_games_played;
     [global::ProtoBuf.ProtoMember(62, IsRequired = false, Name=@"party_competitive_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint party_competitive_games_played
     {
-      get { return _party_competitive_games_played; }
+      get { return _party_competitive_games_played?? default(uint); }
       set { _party_competitive_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_competitive_games_playedSpecified
+    {
+      get { return _party_competitive_games_played != null; }
+      set { if (value == (_party_competitive_games_played== null)) _party_competitive_games_played = value ? this.party_competitive_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializeparty_competitive_games_played() { return party_competitive_games_playedSpecified; }
+    private void Resetparty_competitive_games_played() { party_competitive_games_playedSpecified = false; }
+    
 
-    private uint _casual_1v1_games_played = default(uint);
+    private uint? _casual_1v1_games_played;
     [global::ProtoBuf.ProtoMember(65, IsRequired = false, Name=@"casual_1v1_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint casual_1v1_games_played
     {
-      get { return _casual_1v1_games_played; }
+      get { return _casual_1v1_games_played?? default(uint); }
       set { _casual_1v1_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool casual_1v1_games_playedSpecified
+    {
+      get { return _casual_1v1_games_played != null; }
+      set { if (value == (_casual_1v1_games_played== null)) _casual_1v1_games_played = value ? this.casual_1v1_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializecasual_1v1_games_played() { return casual_1v1_games_playedSpecified; }
+    private void Resetcasual_1v1_games_played() { casual_1v1_games_playedSpecified = false; }
+    
 
-    private uint _competitive_team_games_played = default(uint);
+    private uint? _competitive_team_games_played;
     [global::ProtoBuf.ProtoMember(66, IsRequired = false, Name=@"competitive_team_games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint competitive_team_games_played
     {
-      get { return _competitive_team_games_played; }
+      get { return _competitive_team_games_played?? default(uint); }
       set { _competitive_team_games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool competitive_team_games_playedSpecified
+    {
+      get { return _competitive_team_games_played != null; }
+      set { if (value == (_competitive_team_games_played== null)) _competitive_team_games_played = value ? this.competitive_team_games_played : (uint?)null; }
+    }
+    private bool ShouldSerializecompetitive_team_games_played() { return competitive_team_games_playedSpecified; }
+    private void Resetcompetitive_team_games_played() { competitive_team_games_playedSpecified = false; }
+    
 
-    private uint _curr_all_hero_challenge_id = default(uint);
+    private uint? _curr_all_hero_challenge_id;
     [global::ProtoBuf.ProtoMember(67, IsRequired = false, Name=@"curr_all_hero_challenge_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint curr_all_hero_challenge_id
     {
-      get { return _curr_all_hero_challenge_id; }
+      get { return _curr_all_hero_challenge_id?? default(uint); }
       set { _curr_all_hero_challenge_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_all_hero_challenge_idSpecified
+    {
+      get { return _curr_all_hero_challenge_id != null; }
+      set { if (value == (_curr_all_hero_challenge_id== null)) _curr_all_hero_challenge_id = value ? this.curr_all_hero_challenge_id : (uint?)null; }
+    }
+    private bool ShouldSerializecurr_all_hero_challenge_id() { return curr_all_hero_challenge_idSpecified; }
+    private void Resetcurr_all_hero_challenge_id() { curr_all_hero_challenge_idSpecified = false; }
+    
 
-    private uint _play_time_points = default(uint);
+    private uint? _play_time_points;
     [global::ProtoBuf.ProtoMember(68, IsRequired = false, Name=@"play_time_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint play_time_points
     {
-      get { return _play_time_points; }
+      get { return _play_time_points?? default(uint); }
       set { _play_time_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool play_time_pointsSpecified
+    {
+      get { return _play_time_points != null; }
+      set { if (value == (_play_time_points== null)) _play_time_points = value ? this.play_time_points : (uint?)null; }
+    }
+    private bool ShouldSerializeplay_time_points() { return play_time_pointsSpecified; }
+    private void Resetplay_time_points() { play_time_pointsSpecified = false; }
+    
 
-    private uint _account_flags = default(uint);
+    private uint? _account_flags;
     [global::ProtoBuf.ProtoMember(69, IsRequired = false, Name=@"account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_flags
     {
-      get { return _account_flags; }
+      get { return _account_flags?? default(uint); }
       set { _account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_flagsSpecified
+    {
+      get { return _account_flags != null; }
+      set { if (value == (_account_flags== null)) _account_flags = value ? this.account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_flags() { return account_flagsSpecified; }
+    private void Resetaccount_flags() { account_flagsSpecified = false; }
+    
 
-    private uint _play_time_level = default(uint);
+    private uint? _play_time_level;
     [global::ProtoBuf.ProtoMember(70, IsRequired = false, Name=@"play_time_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint play_time_level
     {
-      get { return _play_time_level; }
+      get { return _play_time_level?? default(uint); }
       set { _play_time_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool play_time_levelSpecified
+    {
+      get { return _play_time_level != null; }
+      set { if (value == (_play_time_level== null)) _play_time_level = value ? this.play_time_level : (uint?)null; }
+    }
+    private bool ShouldSerializeplay_time_level() { return play_time_levelSpecified; }
+    private void Resetplay_time_level() { play_time_levelSpecified = false; }
+    
 
-    private uint _player_behavior_seq_num_last_report = default(uint);
+    private uint? _player_behavior_seq_num_last_report;
     [global::ProtoBuf.ProtoMember(71, IsRequired = false, Name=@"player_behavior_seq_num_last_report", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_behavior_seq_num_last_report
     {
-      get { return _player_behavior_seq_num_last_report; }
+      get { return _player_behavior_seq_num_last_report?? default(uint); }
       set { _player_behavior_seq_num_last_report = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_behavior_seq_num_last_reportSpecified
+    {
+      get { return _player_behavior_seq_num_last_report != null; }
+      set { if (value == (_player_behavior_seq_num_last_report== null)) _player_behavior_seq_num_last_report = value ? this.player_behavior_seq_num_last_report : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_behavior_seq_num_last_report() { return player_behavior_seq_num_last_reportSpecified; }
+    private void Resetplayer_behavior_seq_num_last_report() { player_behavior_seq_num_last_reportSpecified = false; }
+    
 
-    private uint _player_behavior_score_last_report = default(uint);
+    private uint? _player_behavior_score_last_report;
     [global::ProtoBuf.ProtoMember(72, IsRequired = false, Name=@"player_behavior_score_last_report", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_behavior_score_last_report
     {
-      get { return _player_behavior_score_last_report; }
+      get { return _player_behavior_score_last_report?? default(uint); }
       set { _player_behavior_score_last_report = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_behavior_score_last_reportSpecified
+    {
+      get { return _player_behavior_score_last_report != null; }
+      set { if (value == (_player_behavior_score_last_report== null)) _player_behavior_score_last_report = value ? this.player_behavior_score_last_report : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_behavior_score_last_report() { return player_behavior_score_last_reportSpecified; }
+    private void Resetplayer_behavior_score_last_report() { player_behavior_score_last_reportSpecified = false; }
+    
 
-    private bool _player_behavior_report_old_data = default(bool);
+    private bool? _player_behavior_report_old_data;
     [global::ProtoBuf.ProtoMember(73, IsRequired = false, Name=@"player_behavior_report_old_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool player_behavior_report_old_data
     {
-      get { return _player_behavior_report_old_data; }
+      get { return _player_behavior_report_old_data?? default(bool); }
       set { _player_behavior_report_old_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_behavior_report_old_dataSpecified
+    {
+      get { return _player_behavior_report_old_data != null; }
+      set { if (value == (_player_behavior_report_old_data== null)) _player_behavior_report_old_data = value ? this.player_behavior_report_old_data : (bool?)null; }
+    }
+    private bool ShouldSerializeplayer_behavior_report_old_data() { return player_behavior_report_old_dataSpecified; }
+    private void Resetplayer_behavior_report_old_data() { player_behavior_report_old_dataSpecified = false; }
+    
 
-    private uint _tourney_skill_level = default(uint);
+    private uint? _tourney_skill_level;
     [global::ProtoBuf.ProtoMember(74, IsRequired = false, Name=@"tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_skill_level
     {
-      get { return _tourney_skill_level; }
+      get { return _tourney_skill_level?? default(uint); }
       set { _tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_skill_levelSpecified
+    {
+      get { return _tourney_skill_level != null; }
+      set { if (value == (_tourney_skill_level== null)) _tourney_skill_level = value ? this.tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_skill_level() { return tourney_skill_levelSpecified; }
+    private void Resettourney_skill_level() { tourney_skill_levelSpecified = false; }
+    
 
-    private uint _tourney_recent_participation_date = default(uint);
+    private uint? _tourney_recent_participation_date;
     [global::ProtoBuf.ProtoMember(85, IsRequired = false, Name=@"tourney_recent_participation_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_recent_participation_date
     {
-      get { return _tourney_recent_participation_date; }
+      get { return _tourney_recent_participation_date?? default(uint); }
       set { _tourney_recent_participation_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_recent_participation_dateSpecified
+    {
+      get { return _tourney_recent_participation_date != null; }
+      set { if (value == (_tourney_recent_participation_date== null)) _tourney_recent_participation_date = value ? this.tourney_recent_participation_date : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_recent_participation_date() { return tourney_recent_participation_dateSpecified; }
+    private void Resettourney_recent_participation_date() { tourney_recent_participation_dateSpecified = false; }
+    
 
-    private uint _favorite_team = default(uint);
+    private uint? _favorite_team;
     [global::ProtoBuf.ProtoMember(87, IsRequired = false, Name=@"favorite_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorite_team
     {
-      get { return _favorite_team; }
+      get { return _favorite_team?? default(uint); }
       set { _favorite_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favorite_teamSpecified
+    {
+      get { return _favorite_team != null; }
+      set { if (value == (_favorite_team== null)) _favorite_team = value ? this.favorite_team : (uint?)null; }
+    }
+    private bool ShouldSerializefavorite_team() { return favorite_teamSpecified; }
+    private void Resetfavorite_team() { favorite_teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -579,14 +1130,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLobbyEventPoints() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgLobbyEventPoints.AccountPoints> _account_points = new global::System.Collections.Generic.List<CMsgLobbyEventPoints.AccountPoints>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_points", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgLobbyEventPoints.AccountPoints> account_points
@@ -600,113 +1160,221 @@ namespace SteamKit2.GC.Dota.Internal
     public AccountPoints() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _normal_points = default(uint);
+    private uint? _normal_points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"normal_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint normal_points
     {
-      get { return _normal_points; }
+      get { return _normal_points?? default(uint); }
       set { _normal_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool normal_pointsSpecified
+    {
+      get { return _normal_points != null; }
+      set { if (value == (_normal_points== null)) _normal_points = value ? this.normal_points : (uint?)null; }
+    }
+    private bool ShouldSerializenormal_points() { return normal_pointsSpecified; }
+    private void Resetnormal_points() { normal_pointsSpecified = false; }
+    
 
-    private uint _premium_points = default(uint);
+    private uint? _premium_points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"premium_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint premium_points
     {
-      get { return _premium_points; }
+      get { return _premium_points?? default(uint); }
       set { _premium_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool premium_pointsSpecified
+    {
+      get { return _premium_points != null; }
+      set { if (value == (_premium_points== null)) _premium_points = value ? this.premium_points : (uint?)null; }
+    }
+    private bool ShouldSerializepremium_points() { return premium_pointsSpecified; }
+    private void Resetpremium_points() { premium_pointsSpecified = false; }
+    
 
-    private bool _owned = default(bool);
+    private bool? _owned;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool owned
     {
-      get { return _owned; }
+      get { return _owned?? default(bool); }
       set { _owned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownedSpecified
+    {
+      get { return _owned != null; }
+      set { if (value == (_owned== null)) _owned = value ? this.owned : (bool?)null; }
+    }
+    private bool ShouldSerializeowned() { return ownedSpecified; }
+    private void Resetowned() { ownedSpecified = false; }
+    
 
-    private uint _favorite_team = default(uint);
+    private uint? _favorite_team;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"favorite_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorite_team
     {
-      get { return _favorite_team; }
+      get { return _favorite_team?? default(uint); }
       set { _favorite_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favorite_teamSpecified
+    {
+      get { return _favorite_team != null; }
+      set { if (value == (_favorite_team== null)) _favorite_team = value ? this.favorite_team : (uint?)null; }
+    }
+    private bool ShouldSerializefavorite_team() { return favorite_teamSpecified; }
+    private void Resetfavorite_team() { favorite_teamSpecified = false; }
+    
 
-    private uint _favorite_team_level = default(uint);
+    private uint? _favorite_team_level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"favorite_team_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorite_team_level
     {
-      get { return _favorite_team_level; }
+      get { return _favorite_team_level?? default(uint); }
       set { _favorite_team_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favorite_team_levelSpecified
+    {
+      get { return _favorite_team_level != null; }
+      set { if (value == (_favorite_team_level== null)) _favorite_team_level = value ? this.favorite_team_level : (uint?)null; }
+    }
+    private bool ShouldSerializefavorite_team_level() { return favorite_team_levelSpecified; }
+    private void Resetfavorite_team_level() { favorite_team_levelSpecified = false; }
+    
 
-    private uint _points_held = default(uint);
+    private uint? _points_held;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"points_held", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_held
     {
-      get { return _points_held; }
+      get { return _points_held?? default(uint); }
       set { _points_held = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_heldSpecified
+    {
+      get { return _points_held != null; }
+      set { if (value == (_points_held== null)) _points_held = value ? this.points_held : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_held() { return points_heldSpecified; }
+    private void Resetpoints_held() { points_heldSpecified = false; }
+    
 
-    private uint _premium_points_held = default(uint);
+    private uint? _premium_points_held;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"premium_points_held", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint premium_points_held
     {
-      get { return _premium_points_held; }
+      get { return _premium_points_held?? default(uint); }
       set { _premium_points_held = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool premium_points_heldSpecified
+    {
+      get { return _premium_points_held != null; }
+      set { if (value == (_premium_points_held== null)) _premium_points_held = value ? this.premium_points_held : (uint?)null; }
+    }
+    private bool ShouldSerializepremium_points_held() { return premium_points_heldSpecified; }
+    private void Resetpremium_points_held() { premium_points_heldSpecified = false; }
+    
 
-    private uint _favorite_team_foil_level = default(uint);
+    private uint? _favorite_team_foil_level;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"favorite_team_foil_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorite_team_foil_level
     {
-      get { return _favorite_team_foil_level; }
+      get { return _favorite_team_foil_level?? default(uint); }
       set { _favorite_team_foil_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favorite_team_foil_levelSpecified
+    {
+      get { return _favorite_team_foil_level != null; }
+      set { if (value == (_favorite_team_foil_level== null)) _favorite_team_foil_level = value ? this.favorite_team_foil_level : (uint?)null; }
+    }
+    private bool ShouldSerializefavorite_team_foil_level() { return favorite_team_foil_levelSpecified; }
+    private void Resetfavorite_team_foil_level() { favorite_team_foil_levelSpecified = false; }
+    
 
-    private uint _wager_tokens_remaining = default(uint);
+    private uint? _wager_tokens_remaining;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"wager_tokens_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wager_tokens_remaining
     {
-      get { return _wager_tokens_remaining; }
+      get { return _wager_tokens_remaining?? default(uint); }
       set { _wager_tokens_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wager_tokens_remainingSpecified
+    {
+      get { return _wager_tokens_remaining != null; }
+      set { if (value == (_wager_tokens_remaining== null)) _wager_tokens_remaining = value ? this.wager_tokens_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializewager_tokens_remaining() { return wager_tokens_remainingSpecified; }
+    private void Resetwager_tokens_remaining() { wager_tokens_remainingSpecified = false; }
+    
 
-    private uint _wager_tokens_max = default(uint);
+    private uint? _wager_tokens_max;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"wager_tokens_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wager_tokens_max
     {
-      get { return _wager_tokens_max; }
+      get { return _wager_tokens_max?? default(uint); }
       set { _wager_tokens_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wager_tokens_maxSpecified
+    {
+      get { return _wager_tokens_max != null; }
+      set { if (value == (_wager_tokens_max== null)) _wager_tokens_max = value ? this.wager_tokens_max : (uint?)null; }
+    }
+    private bool ShouldSerializewager_tokens_max() { return wager_tokens_maxSpecified; }
+    private void Resetwager_tokens_max() { wager_tokens_maxSpecified = false; }
+    
 
-    private ulong _active_effects_mask = default(ulong);
+    private ulong? _active_effects_mask;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"active_effects_mask", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong active_effects_mask
     {
-      get { return _active_effects_mask; }
+      get { return _active_effects_mask?? default(ulong); }
       set { _active_effects_mask = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_effects_maskSpecified
+    {
+      get { return _active_effects_mask != null; }
+      set { if (value == (_active_effects_mask== null)) _active_effects_mask = value ? this.active_effects_mask : (ulong?)null; }
+    }
+    private bool ShouldSerializeactive_effects_mask() { return active_effects_maskSpecified; }
+    private void Resetactive_effects_mask() { active_effects_maskSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -723,86 +1391,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgBattleCupVictory() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _win_date = default(uint);
+    private uint? _win_date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"win_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint win_date
     {
-      get { return _win_date; }
+      get { return _win_date?? default(uint); }
       set { _win_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool win_dateSpecified
+    {
+      get { return _win_date != null; }
+      set { if (value == (_win_date== null)) _win_date = value ? this.win_date : (uint?)null; }
+    }
+    private bool ShouldSerializewin_date() { return win_dateSpecified; }
+    private void Resetwin_date() { win_dateSpecified = false; }
+    
 
-    private uint _valid_until = default(uint);
+    private uint? _valid_until;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"valid_until", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint valid_until
     {
-      get { return _valid_until; }
+      get { return _valid_until?? default(uint); }
       set { _valid_until = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valid_untilSpecified
+    {
+      get { return _valid_until != null; }
+      set { if (value == (_valid_until== null)) _valid_until = value ? this.valid_until : (uint?)null; }
+    }
+    private bool ShouldSerializevalid_until() { return valid_untilSpecified; }
+    private void Resetvalid_until() { valid_untilSpecified = false; }
+    
 
-    private uint _skill_level = default(uint);
+    private uint? _skill_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_level
     {
-      get { return _skill_level; }
+      get { return _skill_level?? default(uint); }
       set { _skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_levelSpecified
+    {
+      get { return _skill_level != null; }
+      set { if (value == (_skill_level== null)) _skill_level = value ? this.skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_level() { return skill_levelSpecified; }
+    private void Resetskill_level() { skill_levelSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _division_id = default(uint);
+    private uint? _division_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint division_id
     {
-      get { return _division_id; }
+      get { return _division_id?? default(uint); }
       set { _division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool division_idSpecified
+    {
+      get { return _division_id != null; }
+      set { if (value == (_division_id== null)) _division_id = value ? this.division_id : (uint?)null; }
+    }
+    private bool ShouldSerializedivision_id() { return division_idSpecified; }
+    private void Resetdivision_id() { division_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private uint _streak = default(uint);
+    private uint? _streak;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint streak
     {
-      get { return _streak; }
+      get { return _streak?? default(uint); }
       set { _streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool streakSpecified
+    {
+      get { return _streak != null; }
+      set { if (value == (_streak== null)) _streak = value ? this.streak : (uint?)null; }
+    }
+    private bool ShouldSerializestreak() { return streakSpecified; }
+    private void Resetstreak() { streakSpecified = false; }
+    
 
-    private uint _trophy_id = default(uint);
+    private uint? _trophy_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_id
     {
-      get { return _trophy_id; }
+      get { return _trophy_id?? default(uint); }
       set { _trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_idSpecified
+    {
+      get { return _trophy_id != null; }
+      set { if (value == (_trophy_id== null)) _trophy_id = value ? this.trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_id() { return trophy_idSpecified; }
+    private void Resettrophy_id() { trophy_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -831,14 +1580,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTABroadcastNotification() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -850,41 +1608,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CProtoItemHeroStatue() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _status_effect_index = default(uint);
+    private uint? _status_effect_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"status_effect_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_effect_index
     {
-      get { return _status_effect_index; }
+      get { return _status_effect_index?? default(uint); }
       set { _status_effect_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_effect_indexSpecified
+    {
+      get { return _status_effect_index != null; }
+      set { if (value == (_status_effect_index== null)) _status_effect_index = value ? this.status_effect_index : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_effect_index() { return status_effect_indexSpecified; }
+    private void Resetstatus_effect_index() { status_effect_indexSpecified = false; }
+    
 
-    private string _sequence_name = "";
+    private string _sequence_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sequence_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sequence_name
     {
-      get { return _sequence_name; }
+      get { return _sequence_name?? ""; }
       set { _sequence_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_nameSpecified
+    {
+      get { return _sequence_name != null; }
+      set { if (value == (_sequence_name== null)) _sequence_name = value ? this.sequence_name : (string)null; }
+    }
+    private bool ShouldSerializesequence_name() { return sequence_nameSpecified; }
+    private void Resetsequence_name() { sequence_nameSpecified = false; }
+    
 
-    private float _cycle = default(float);
+    private float? _cycle;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cycle", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cycle
     {
-      get { return _cycle; }
+      get { return _cycle?? default(float); }
       set { _cycle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cycleSpecified
+    {
+      get { return _cycle != null; }
+      set { if (value == (_cycle== null)) _cycle = value ? this.cycle : (float?)null; }
+    }
+    private bool ShouldSerializecycle() { return cycleSpecified; }
+    private void Resetcycle() { cycleSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _wearable = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"wearable", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> wearable
@@ -893,14 +1687,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _inscription = "";
+    private string _inscription;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"inscription", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string inscription
     {
-      get { return _inscription; }
+      get { return _inscription?? ""; }
       set { _inscription = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inscriptionSpecified
+    {
+      get { return _inscription != null; }
+      set { if (value == (_inscription== null)) _inscription = value ? this.inscription : (string)null; }
+    }
+    private bool ShouldSerializeinscription() { return inscriptionSpecified; }
+    private void Resetinscription() { inscriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _style = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"style", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> style
@@ -909,14 +1712,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _tournament_drop = default(bool);
+    private bool? _tournament_drop;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"tournament_drop", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tournament_drop
     {
-      get { return _tournament_drop; }
+      get { return _tournament_drop?? default(bool); }
       set { _tournament_drop = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_dropSpecified
+    {
+      get { return _tournament_drop != null; }
+      set { if (value == (_tournament_drop== null)) _tournament_drop = value ? this.tournament_drop : (bool?)null; }
+    }
+    private bool ShouldSerializetournament_drop() { return tournament_dropSpecified; }
+    private void Resettournament_drop() { tournament_dropSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -928,41 +1740,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CProtoItemTeamShowcase() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _status_effect_index = default(uint);
+    private uint? _status_effect_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"status_effect_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_effect_index
     {
-      get { return _status_effect_index; }
+      get { return _status_effect_index?? default(uint); }
       set { _status_effect_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_effect_indexSpecified
+    {
+      get { return _status_effect_index != null; }
+      set { if (value == (_status_effect_index== null)) _status_effect_index = value ? this.status_effect_index : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_effect_index() { return status_effect_indexSpecified; }
+    private void Resetstatus_effect_index() { status_effect_indexSpecified = false; }
+    
 
-    private string _sequence_name = "";
+    private string _sequence_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sequence_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sequence_name
     {
-      get { return _sequence_name; }
+      get { return _sequence_name?? ""; }
       set { _sequence_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_nameSpecified
+    {
+      get { return _sequence_name != null; }
+      set { if (value == (_sequence_name== null)) _sequence_name = value ? this.sequence_name : (string)null; }
+    }
+    private bool ShouldSerializesequence_name() { return sequence_nameSpecified; }
+    private void Resetsequence_name() { sequence_nameSpecified = false; }
+    
 
-    private float _cycle = default(float);
+    private float? _cycle;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cycle", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cycle
     {
-      get { return _cycle; }
+      get { return _cycle?? default(float); }
       set { _cycle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cycleSpecified
+    {
+      get { return _cycle != null; }
+      set { if (value == (_cycle== null)) _cycle = value ? this.cycle : (float?)null; }
+    }
+    private bool ShouldSerializecycle() { return cycleSpecified; }
+    private void Resetcycle() { cycleSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _wearable = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"wearable", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> wearable
@@ -971,14 +1819,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _inscription = "";
+    private string _inscription;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"inscription", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string inscription
     {
-      get { return _inscription; }
+      get { return _inscription?? ""; }
       set { _inscription = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inscriptionSpecified
+    {
+      get { return _inscription != null; }
+      set { if (value == (_inscription== null)) _inscription = value ? this.inscription : (string)null; }
+    }
+    private bool ShouldSerializeinscription() { return inscriptionSpecified; }
+    private void Resetinscription() { inscriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _style = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(7, Name=@"style", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> style
@@ -997,23 +1854,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMatchPlayerAbilityUpgrade() {}
     
 
-    private uint _ability = default(uint);
+    private uint? _ability;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ability", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ability
     {
-      get { return _ability; }
+      get { return _ability?? default(uint); }
       set { _ability = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abilitySpecified
+    {
+      get { return _ability != null; }
+      set { if (value == (_ability== null)) _ability = value ? this.ability : (uint?)null; }
+    }
+    private bool ShouldSerializeability() { return abilitySpecified; }
+    private void Resetability() { abilitySpecified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1025,14 +1900,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMatchAdditionalUnitInventory() {}
     
 
-    private string _unit_name = "";
+    private string _unit_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"unit_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string unit_name
     {
-      get { return _unit_name; }
+      get { return _unit_name?? ""; }
       set { _unit_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unit_nameSpecified
+    {
+      get { return _unit_name != null; }
+      set { if (value == (_unit_name== null)) _unit_name = value ? this.unit_name : (string)null; }
+    }
+    private bool ShouldSerializeunit_name() { return unit_nameSpecified; }
+    private void Resetunit_name() { unit_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _items = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> items
@@ -1051,23 +1935,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMatchPlayerPermanentBuff() {}
     
 
-    private uint _permanent_buff = default(uint);
+    private uint? _permanent_buff;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"permanent_buff", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint permanent_buff
     {
-      get { return _permanent_buff; }
+      get { return _permanent_buff?? default(uint); }
       set { _permanent_buff = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permanent_buffSpecified
+    {
+      get { return _permanent_buff != null; }
+      set { if (value == (_permanent_buff== null)) _permanent_buff = value ? this.permanent_buff : (uint?)null; }
+    }
+    private bool ShouldSerializepermanent_buff() { return permanent_buffSpecified; }
+    private void Resetpermanent_buff() { permanent_buffSpecified = false; }
+    
 
-    private uint _stack_count = default(uint);
+    private uint? _stack_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stack_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stack_count
     {
-      get { return _stack_count; }
+      get { return _stack_count?? default(uint); }
       set { _stack_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stack_countSpecified
+    {
+      get { return _stack_count != null; }
+      set { if (value == (_stack_count== null)) _stack_count = value ? this.stack_count : (uint?)null; }
+    }
+    private bool ShouldSerializestack_count() { return stack_countSpecified; }
+    private void Resetstack_count() { stack_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1079,32 +1981,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMatchHeroSelectEvent() {}
     
 
-    private bool _is_pick = default(bool);
+    private bool? _is_pick;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_pick", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pick
     {
-      get { return _is_pick; }
+      get { return _is_pick?? default(bool); }
       set { _is_pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_pickSpecified
+    {
+      get { return _is_pick != null; }
+      set { if (value == (_is_pick== null)) _is_pick = value ? this.is_pick : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pick() { return is_pickSpecified; }
+    private void Resetis_pick() { is_pickSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1116,50 +2045,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAProcessFantasyScheduledEvent() {}
     
 
-    private uint _event = default(uint);
+    private uint? _event;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint @event
     {
-      get { return _event; }
+      get { return _event?? default(uint); }
       set { _event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventSpecified
+    {
+      get { return _event != null; }
+      set { if (value == (_event== null)) _event = value ? this.@event : (uint?)null; }
+    }
+    private bool ShouldSerializeevent() { return eventSpecified; }
+    private void Resetevent() { eventSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _fantasy_league_id = default(uint);
+    private uint? _fantasy_league_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fantasy_league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fantasy_league_id
     {
-      get { return _fantasy_league_id; }
+      get { return _fantasy_league_id?? default(uint); }
       set { _fantasy_league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fantasy_league_idSpecified
+    {
+      get { return _fantasy_league_id != null; }
+      set { if (value == (_fantasy_league_id== null)) _fantasy_league_id = value ? this.fantasy_league_id : (uint?)null; }
+    }
+    private bool ShouldSerializefantasy_league_id() { return fantasy_league_idSpecified; }
+    private void Resetfantasy_league_id() { fantasy_league_idSpecified = false; }
+    
 
-    private uint _season = default(uint);
+    private uint? _season;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"season", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season
     {
-      get { return _season; }
+      get { return _season?? default(uint); }
       set { _season = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seasonSpecified
+    {
+      get { return _season != null; }
+      set { if (value == (_season== null)) _season = value ? this.season : (uint?)null; }
+    }
+    private bool ShouldSerializeseason() { return seasonSpecified; }
+    private void Resetseason() { seasonSpecified = false; }
+    
 
-    private uint _reference_data = default(uint);
+    private uint? _reference_data;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"reference_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reference_data
     {
-      get { return _reference_data; }
+      get { return _reference_data?? default(uint); }
       set { _reference_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reference_dataSpecified
+    {
+      get { return _reference_data != null; }
+      set { if (value == (_reference_data== null)) _reference_data = value ? this.reference_data : (uint?)null; }
+    }
+    private bool ShouldSerializereference_data() { return reference_dataSpecified; }
+    private void Resetreference_data() { reference_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1171,23 +2145,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHasItemQuery() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1199,14 +2191,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHasItemResponse() {}
     
 
-    private bool _has_item = default(bool);
+    private bool? _has_item;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_item", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_item
     {
-      get { return _has_item; }
+      get { return _has_item?? default(bool); }
       set { _has_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_itemSpecified
+    {
+      get { return _has_item != null; }
+      set { if (value == (_has_item== null)) _has_item = value ? this.has_item : (bool?)null; }
+    }
+    private bool ShouldSerializehas_item() { return has_itemSpecified; }
+    private void Resethas_item() { has_itemSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1218,14 +2219,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCIsProQuery() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1237,14 +2247,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCIsProResponse() {}
     
 
-    private bool _is_pro = default(bool);
+    private bool? _is_pro;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_pro", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pro
     {
-      get { return _is_pro; }
+      get { return _is_pro?? default(bool); }
       set { _is_pro = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_proSpecified
+    {
+      get { return _is_pro != null; }
+      set { if (value == (_is_pro== null)) _is_pro = value ? this.is_pro : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pro() { return is_proSpecified; }
+    private void Resetis_pro() { is_proSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1256,14 +2275,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHasItemDefsQuery() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _itemdef_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"itemdef_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> itemdef_ids
@@ -1282,14 +2310,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAHasItemDefsResponse() {}
     
 
-    private bool _has_items = default(bool);
+    private bool? _has_items;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_items
     {
-      get { return _has_items; }
+      get { return _has_items?? default(bool); }
       set { _has_items = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_itemsSpecified
+    {
+      get { return _has_items != null; }
+      set { if (value == (_has_items== null)) _has_items = value ? this.has_items : (bool?)null; }
+    }
+    private bool ShouldSerializehas_items() { return has_itemsSpecified; }
+    private void Resethas_items() { has_itemsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1301,14 +2338,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetPlayerCardItemInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _player_card_item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_card_item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> player_card_item_ids
@@ -1339,32 +2385,59 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerCardInfo() {}
     
 
-    private ulong _player_card_item_id = default(ulong);
+    private ulong? _player_card_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_card_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_card_item_id
     {
-      get { return _player_card_item_id; }
+      get { return _player_card_item_id?? default(ulong); }
       set { _player_card_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_card_item_idSpecified
+    {
+      get { return _player_card_item_id != null; }
+      set { if (value == (_player_card_item_id== null)) _player_card_item_id = value ? this.player_card_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_card_item_id() { return player_card_item_idSpecified; }
+    private void Resetplayer_card_item_id() { player_card_item_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _packed_bonuses = default(ulong);
+    private ulong? _packed_bonuses;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"packed_bonuses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong packed_bonuses
     {
-      get { return _packed_bonuses; }
+      get { return _packed_bonuses?? default(ulong); }
       set { _packed_bonuses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packed_bonusesSpecified
+    {
+      get { return _packed_bonuses != null; }
+      set { if (value == (_packed_bonuses== null)) _packed_bonuses = value ? this.packed_bonuses : (ulong?)null; }
+    }
+    private bool ShouldSerializepacked_bonuses() { return packed_bonusesSpecified; }
+    private void Resetpacked_bonuses() { packed_bonusesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1381,23 +2454,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCFantasySetMatchLeague() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1409,32 +2500,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAMapLocationState() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private int _location_id = default(int);
+    private int? _location_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"location_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int location_id
     {
-      get { return _location_id; }
+      get { return _location_id?? default(int); }
       set { _location_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool location_idSpecified
+    {
+      get { return _location_id != null; }
+      set { if (value == (_location_id== null)) _location_id = value ? this.location_id : (int?)null; }
+    }
+    private bool ShouldSerializelocation_id() { return location_idSpecified; }
+    private void Resetlocation_id() { location_idSpecified = false; }
+    
 
-    private bool _completed = default(bool);
+    private bool? _completed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool completed
     {
-      get { return _completed; }
+      get { return _completed?? default(bool); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (bool?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1463,50 +2581,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CCompendiumTimestampedData() {}
     
 
-    private uint _game_time = default(uint);
+    private uint? _game_time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(uint); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (uint?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private uint _gpm = default(uint);
+    private uint? _gpm;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(uint); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (uint?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private uint _xpm = default(uint);
+    private uint? _xpm;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"xpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xpm
     {
-      get { return _xpm; }
+      get { return _xpm?? default(uint); }
       set { _xpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xpmSpecified
+    {
+      get { return _xpm != null; }
+      set { if (value == (_xpm== null)) _xpm = value ? this.xpm : (uint?)null; }
+    }
+    private bool ShouldSerializexpm() { return xpmSpecified; }
+    private void Resetxpm() { xpmSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _item_purchases = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"item_purchases", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> item_purchases
@@ -1566,32 +2729,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CAdditionalEquipSlot() {}
     
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1603,356 +2793,707 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTACombatLogEntry() {}
     
 
-    private DOTA_COMBATLOG_TYPES _type = DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_INVALID;
+    private DOTA_COMBATLOG_TYPES? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_INVALID)]
     public DOTA_COMBATLOG_TYPES type
     {
-      get { return _type; }
+      get { return _type?? DOTA_COMBATLOG_TYPES.DOTA_COMBATLOG_INVALID; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (DOTA_COMBATLOG_TYPES?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private uint _target_name = default(uint);
+    private uint? _target_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_name", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_name
     {
-      get { return _target_name; }
+      get { return _target_name?? default(uint); }
       set { _target_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_nameSpecified
+    {
+      get { return _target_name != null; }
+      set { if (value == (_target_name== null)) _target_name = value ? this.target_name : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_name() { return target_nameSpecified; }
+    private void Resettarget_name() { target_nameSpecified = false; }
+    
 
-    private uint _target_source_name = default(uint);
+    private uint? _target_source_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"target_source_name", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_source_name
     {
-      get { return _target_source_name; }
+      get { return _target_source_name?? default(uint); }
       set { _target_source_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_source_nameSpecified
+    {
+      get { return _target_source_name != null; }
+      set { if (value == (_target_source_name== null)) _target_source_name = value ? this.target_source_name : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_source_name() { return target_source_nameSpecified; }
+    private void Resettarget_source_name() { target_source_nameSpecified = false; }
+    
 
-    private uint _attacker_name = default(uint);
+    private uint? _attacker_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"attacker_name", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attacker_name
     {
-      get { return _attacker_name; }
+      get { return _attacker_name?? default(uint); }
       set { _attacker_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attacker_nameSpecified
+    {
+      get { return _attacker_name != null; }
+      set { if (value == (_attacker_name== null)) _attacker_name = value ? this.attacker_name : (uint?)null; }
+    }
+    private bool ShouldSerializeattacker_name() { return attacker_nameSpecified; }
+    private void Resetattacker_name() { attacker_nameSpecified = false; }
+    
 
-    private uint _damage_source_name = default(uint);
+    private uint? _damage_source_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"damage_source_name", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_source_name
     {
-      get { return _damage_source_name; }
+      get { return _damage_source_name?? default(uint); }
       set { _damage_source_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_source_nameSpecified
+    {
+      get { return _damage_source_name != null; }
+      set { if (value == (_damage_source_name== null)) _damage_source_name = value ? this.damage_source_name : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_source_name() { return damage_source_nameSpecified; }
+    private void Resetdamage_source_name() { damage_source_nameSpecified = false; }
+    
 
-    private uint _inflictor_name = default(uint);
+    private uint? _inflictor_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"inflictor_name", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inflictor_name
     {
-      get { return _inflictor_name; }
+      get { return _inflictor_name?? default(uint); }
       set { _inflictor_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inflictor_nameSpecified
+    {
+      get { return _inflictor_name != null; }
+      set { if (value == (_inflictor_name== null)) _inflictor_name = value ? this.inflictor_name : (uint?)null; }
+    }
+    private bool ShouldSerializeinflictor_name() { return inflictor_nameSpecified; }
+    private void Resetinflictor_name() { inflictor_nameSpecified = false; }
+    
 
-    private bool _is_attacker_illusion = default(bool);
+    private bool? _is_attacker_illusion;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_attacker_illusion", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_attacker_illusion
     {
-      get { return _is_attacker_illusion; }
+      get { return _is_attacker_illusion?? default(bool); }
       set { _is_attacker_illusion = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_attacker_illusionSpecified
+    {
+      get { return _is_attacker_illusion != null; }
+      set { if (value == (_is_attacker_illusion== null)) _is_attacker_illusion = value ? this.is_attacker_illusion : (bool?)null; }
+    }
+    private bool ShouldSerializeis_attacker_illusion() { return is_attacker_illusionSpecified; }
+    private void Resetis_attacker_illusion() { is_attacker_illusionSpecified = false; }
+    
 
-    private bool _is_attacker_hero = default(bool);
+    private bool? _is_attacker_hero;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_attacker_hero", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_attacker_hero
     {
-      get { return _is_attacker_hero; }
+      get { return _is_attacker_hero?? default(bool); }
       set { _is_attacker_hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_attacker_heroSpecified
+    {
+      get { return _is_attacker_hero != null; }
+      set { if (value == (_is_attacker_hero== null)) _is_attacker_hero = value ? this.is_attacker_hero : (bool?)null; }
+    }
+    private bool ShouldSerializeis_attacker_hero() { return is_attacker_heroSpecified; }
+    private void Resetis_attacker_hero() { is_attacker_heroSpecified = false; }
+    
 
-    private bool _is_target_illusion = default(bool);
+    private bool? _is_target_illusion;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_target_illusion", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_target_illusion
     {
-      get { return _is_target_illusion; }
+      get { return _is_target_illusion?? default(bool); }
       set { _is_target_illusion = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_target_illusionSpecified
+    {
+      get { return _is_target_illusion != null; }
+      set { if (value == (_is_target_illusion== null)) _is_target_illusion = value ? this.is_target_illusion : (bool?)null; }
+    }
+    private bool ShouldSerializeis_target_illusion() { return is_target_illusionSpecified; }
+    private void Resetis_target_illusion() { is_target_illusionSpecified = false; }
+    
 
-    private bool _is_target_hero = default(bool);
+    private bool? _is_target_hero;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_target_hero", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_target_hero
     {
-      get { return _is_target_hero; }
+      get { return _is_target_hero?? default(bool); }
       set { _is_target_hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_target_heroSpecified
+    {
+      get { return _is_target_hero != null; }
+      set { if (value == (_is_target_hero== null)) _is_target_hero = value ? this.is_target_hero : (bool?)null; }
+    }
+    private bool ShouldSerializeis_target_hero() { return is_target_heroSpecified; }
+    private void Resetis_target_hero() { is_target_heroSpecified = false; }
+    
 
-    private bool _is_visible_radiant = default(bool);
+    private bool? _is_visible_radiant;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_visible_radiant", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_visible_radiant
     {
-      get { return _is_visible_radiant; }
+      get { return _is_visible_radiant?? default(bool); }
       set { _is_visible_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_visible_radiantSpecified
+    {
+      get { return _is_visible_radiant != null; }
+      set { if (value == (_is_visible_radiant== null)) _is_visible_radiant = value ? this.is_visible_radiant : (bool?)null; }
+    }
+    private bool ShouldSerializeis_visible_radiant() { return is_visible_radiantSpecified; }
+    private void Resetis_visible_radiant() { is_visible_radiantSpecified = false; }
+    
 
-    private bool _is_visible_dire = default(bool);
+    private bool? _is_visible_dire;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"is_visible_dire", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_visible_dire
     {
-      get { return _is_visible_dire; }
+      get { return _is_visible_dire?? default(bool); }
       set { _is_visible_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_visible_direSpecified
+    {
+      get { return _is_visible_dire != null; }
+      set { if (value == (_is_visible_dire== null)) _is_visible_dire = value ? this.is_visible_dire : (bool?)null; }
+    }
+    private bool ShouldSerializeis_visible_dire() { return is_visible_direSpecified; }
+    private void Resetis_visible_dire() { is_visible_direSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private int _health = default(int);
+    private int? _health;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"health", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int health
     {
-      get { return _health; }
+      get { return _health?? default(int); }
       set { _health = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healthSpecified
+    {
+      get { return _health != null; }
+      set { if (value == (_health== null)) _health = value ? this.health : (int?)null; }
+    }
+    private bool ShouldSerializehealth() { return healthSpecified; }
+    private void Resethealth() { healthSpecified = false; }
+    
 
-    private float _timestamp = default(float);
+    private float? _timestamp;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(float); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (float?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private float _stun_duration = default(float);
+    private float? _stun_duration;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"stun_duration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float stun_duration
     {
-      get { return _stun_duration; }
+      get { return _stun_duration?? default(float); }
       set { _stun_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stun_durationSpecified
+    {
+      get { return _stun_duration != null; }
+      set { if (value == (_stun_duration== null)) _stun_duration = value ? this.stun_duration : (float?)null; }
+    }
+    private bool ShouldSerializestun_duration() { return stun_durationSpecified; }
+    private void Resetstun_duration() { stun_durationSpecified = false; }
+    
 
-    private float _slow_duration = default(float);
+    private float? _slow_duration;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"slow_duration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float slow_duration
     {
-      get { return _slow_duration; }
+      get { return _slow_duration?? default(float); }
       set { _slow_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slow_durationSpecified
+    {
+      get { return _slow_duration != null; }
+      set { if (value == (_slow_duration== null)) _slow_duration = value ? this.slow_duration : (float?)null; }
+    }
+    private bool ShouldSerializeslow_duration() { return slow_durationSpecified; }
+    private void Resetslow_duration() { slow_durationSpecified = false; }
+    
 
-    private bool _is_ability_toggle_on = default(bool);
+    private bool? _is_ability_toggle_on;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"is_ability_toggle_on", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_ability_toggle_on
     {
-      get { return _is_ability_toggle_on; }
+      get { return _is_ability_toggle_on?? default(bool); }
       set { _is_ability_toggle_on = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_ability_toggle_onSpecified
+    {
+      get { return _is_ability_toggle_on != null; }
+      set { if (value == (_is_ability_toggle_on== null)) _is_ability_toggle_on = value ? this.is_ability_toggle_on : (bool?)null; }
+    }
+    private bool ShouldSerializeis_ability_toggle_on() { return is_ability_toggle_onSpecified; }
+    private void Resetis_ability_toggle_on() { is_ability_toggle_onSpecified = false; }
+    
 
-    private bool _is_ability_toggle_off = default(bool);
+    private bool? _is_ability_toggle_off;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"is_ability_toggle_off", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_ability_toggle_off
     {
-      get { return _is_ability_toggle_off; }
+      get { return _is_ability_toggle_off?? default(bool); }
       set { _is_ability_toggle_off = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_ability_toggle_offSpecified
+    {
+      get { return _is_ability_toggle_off != null; }
+      set { if (value == (_is_ability_toggle_off== null)) _is_ability_toggle_off = value ? this.is_ability_toggle_off : (bool?)null; }
+    }
+    private bool ShouldSerializeis_ability_toggle_off() { return is_ability_toggle_offSpecified; }
+    private void Resetis_ability_toggle_off() { is_ability_toggle_offSpecified = false; }
+    
 
-    private uint _ability_level = default(uint);
+    private uint? _ability_level;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"ability_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ability_level
     {
-      get { return _ability_level; }
+      get { return _ability_level?? default(uint); }
       set { _ability_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ability_levelSpecified
+    {
+      get { return _ability_level != null; }
+      set { if (value == (_ability_level== null)) _ability_level = value ? this.ability_level : (uint?)null; }
+    }
+    private bool ShouldSerializeability_level() { return ability_levelSpecified; }
+    private void Resetability_level() { ability_levelSpecified = false; }
+    
 
-    private float _location_x = default(float);
+    private float? _location_x;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"location_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float location_x
     {
-      get { return _location_x; }
+      get { return _location_x?? default(float); }
       set { _location_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool location_xSpecified
+    {
+      get { return _location_x != null; }
+      set { if (value == (_location_x== null)) _location_x = value ? this.location_x : (float?)null; }
+    }
+    private bool ShouldSerializelocation_x() { return location_xSpecified; }
+    private void Resetlocation_x() { location_xSpecified = false; }
+    
 
-    private float _location_y = default(float);
+    private float? _location_y;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"location_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float location_y
     {
-      get { return _location_y; }
+      get { return _location_y?? default(float); }
       set { _location_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool location_ySpecified
+    {
+      get { return _location_y != null; }
+      set { if (value == (_location_y== null)) _location_y = value ? this.location_y : (float?)null; }
+    }
+    private bool ShouldSerializelocation_y() { return location_ySpecified; }
+    private void Resetlocation_y() { location_ySpecified = false; }
+    
 
-    private uint _gold_reason = default(uint);
+    private uint? _gold_reason;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"gold_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_reason
     {
-      get { return _gold_reason; }
+      get { return _gold_reason?? default(uint); }
       set { _gold_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_reasonSpecified
+    {
+      get { return _gold_reason != null; }
+      set { if (value == (_gold_reason== null)) _gold_reason = value ? this.gold_reason : (uint?)null; }
+    }
+    private bool ShouldSerializegold_reason() { return gold_reasonSpecified; }
+    private void Resetgold_reason() { gold_reasonSpecified = false; }
+    
 
-    private float _timestamp_raw = default(float);
+    private float? _timestamp_raw;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"timestamp_raw", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float timestamp_raw
     {
-      get { return _timestamp_raw; }
+      get { return _timestamp_raw?? default(float); }
       set { _timestamp_raw = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_rawSpecified
+    {
+      get { return _timestamp_raw != null; }
+      set { if (value == (_timestamp_raw== null)) _timestamp_raw = value ? this.timestamp_raw : (float?)null; }
+    }
+    private bool ShouldSerializetimestamp_raw() { return timestamp_rawSpecified; }
+    private void Resettimestamp_raw() { timestamp_rawSpecified = false; }
+    
 
-    private float _modifier_duration = default(float);
+    private float? _modifier_duration;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"modifier_duration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float modifier_duration
     {
-      get { return _modifier_duration; }
+      get { return _modifier_duration?? default(float); }
       set { _modifier_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifier_durationSpecified
+    {
+      get { return _modifier_duration != null; }
+      set { if (value == (_modifier_duration== null)) _modifier_duration = value ? this.modifier_duration : (float?)null; }
+    }
+    private bool ShouldSerializemodifier_duration() { return modifier_durationSpecified; }
+    private void Resetmodifier_duration() { modifier_durationSpecified = false; }
+    
 
-    private uint _xp_reason = default(uint);
+    private uint? _xp_reason;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"xp_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp_reason
     {
-      get { return _xp_reason; }
+      get { return _xp_reason?? default(uint); }
       set { _xp_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_reasonSpecified
+    {
+      get { return _xp_reason != null; }
+      set { if (value == (_xp_reason== null)) _xp_reason = value ? this.xp_reason : (uint?)null; }
+    }
+    private bool ShouldSerializexp_reason() { return xp_reasonSpecified; }
+    private void Resetxp_reason() { xp_reasonSpecified = false; }
+    
 
-    private uint _last_hits = default(uint);
+    private uint? _last_hits;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(uint); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (uint?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private uint _attacker_team = default(uint);
+    private uint? _attacker_team;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"attacker_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attacker_team
     {
-      get { return _attacker_team; }
+      get { return _attacker_team?? default(uint); }
       set { _attacker_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attacker_teamSpecified
+    {
+      get { return _attacker_team != null; }
+      set { if (value == (_attacker_team== null)) _attacker_team = value ? this.attacker_team : (uint?)null; }
+    }
+    private bool ShouldSerializeattacker_team() { return attacker_teamSpecified; }
+    private void Resetattacker_team() { attacker_teamSpecified = false; }
+    
 
-    private uint _target_team = default(uint);
+    private uint? _target_team;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"target_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_team
     {
-      get { return _target_team; }
+      get { return _target_team?? default(uint); }
       set { _target_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_teamSpecified
+    {
+      get { return _target_team != null; }
+      set { if (value == (_target_team== null)) _target_team = value ? this.target_team : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_team() { return target_teamSpecified; }
+    private void Resettarget_team() { target_teamSpecified = false; }
+    
 
-    private uint _obs_wards_placed = default(uint);
+    private uint? _obs_wards_placed;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"obs_wards_placed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint obs_wards_placed
     {
-      get { return _obs_wards_placed; }
+      get { return _obs_wards_placed?? default(uint); }
       set { _obs_wards_placed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool obs_wards_placedSpecified
+    {
+      get { return _obs_wards_placed != null; }
+      set { if (value == (_obs_wards_placed== null)) _obs_wards_placed = value ? this.obs_wards_placed : (uint?)null; }
+    }
+    private bool ShouldSerializeobs_wards_placed() { return obs_wards_placedSpecified; }
+    private void Resetobs_wards_placed() { obs_wards_placedSpecified = false; }
+    
 
-    private uint _assist_player0 = default(uint);
+    private uint? _assist_player0;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"assist_player0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assist_player0
     {
-      get { return _assist_player0; }
+      get { return _assist_player0?? default(uint); }
       set { _assist_player0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assist_player0Specified
+    {
+      get { return _assist_player0 != null; }
+      set { if (value == (_assist_player0== null)) _assist_player0 = value ? this.assist_player0 : (uint?)null; }
+    }
+    private bool ShouldSerializeassist_player0() { return assist_player0Specified; }
+    private void Resetassist_player0() { assist_player0Specified = false; }
+    
 
-    private uint _assist_player1 = default(uint);
+    private uint? _assist_player1;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"assist_player1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assist_player1
     {
-      get { return _assist_player1; }
+      get { return _assist_player1?? default(uint); }
       set { _assist_player1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assist_player1Specified
+    {
+      get { return _assist_player1 != null; }
+      set { if (value == (_assist_player1== null)) _assist_player1 = value ? this.assist_player1 : (uint?)null; }
+    }
+    private bool ShouldSerializeassist_player1() { return assist_player1Specified; }
+    private void Resetassist_player1() { assist_player1Specified = false; }
+    
 
-    private uint _assist_player2 = default(uint);
+    private uint? _assist_player2;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"assist_player2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assist_player2
     {
-      get { return _assist_player2; }
+      get { return _assist_player2?? default(uint); }
       set { _assist_player2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assist_player2Specified
+    {
+      get { return _assist_player2 != null; }
+      set { if (value == (_assist_player2== null)) _assist_player2 = value ? this.assist_player2 : (uint?)null; }
+    }
+    private bool ShouldSerializeassist_player2() { return assist_player2Specified; }
+    private void Resetassist_player2() { assist_player2Specified = false; }
+    
 
-    private uint _assist_player3 = default(uint);
+    private uint? _assist_player3;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"assist_player3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assist_player3
     {
-      get { return _assist_player3; }
+      get { return _assist_player3?? default(uint); }
       set { _assist_player3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assist_player3Specified
+    {
+      get { return _assist_player3 != null; }
+      set { if (value == (_assist_player3== null)) _assist_player3 = value ? this.assist_player3 : (uint?)null; }
+    }
+    private bool ShouldSerializeassist_player3() { return assist_player3Specified; }
+    private void Resetassist_player3() { assist_player3Specified = false; }
+    
 
-    private uint _stack_count = default(uint);
+    private uint? _stack_count;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"stack_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stack_count
     {
-      get { return _stack_count; }
+      get { return _stack_count?? default(uint); }
       set { _stack_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stack_countSpecified
+    {
+      get { return _stack_count != null; }
+      set { if (value == (_stack_count== null)) _stack_count = value ? this.stack_count : (uint?)null; }
+    }
+    private bool ShouldSerializestack_count() { return stack_countSpecified; }
+    private void Resetstack_count() { stack_countSpecified = false; }
+    
 
-    private bool _hidden_modifier = default(bool);
+    private bool? _hidden_modifier;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"hidden_modifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool hidden_modifier
     {
-      get { return _hidden_modifier; }
+      get { return _hidden_modifier?? default(bool); }
       set { _hidden_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hidden_modifierSpecified
+    {
+      get { return _hidden_modifier != null; }
+      set { if (value == (_hidden_modifier== null)) _hidden_modifier = value ? this.hidden_modifier : (bool?)null; }
+    }
+    private bool ShouldSerializehidden_modifier() { return hidden_modifierSpecified; }
+    private void Resethidden_modifier() { hidden_modifierSpecified = false; }
+    
 
-    private bool _is_target_building = default(bool);
+    private bool? _is_target_building;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"is_target_building", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_target_building
     {
-      get { return _is_target_building; }
+      get { return _is_target_building?? default(bool); }
       set { _is_target_building = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_target_buildingSpecified
+    {
+      get { return _is_target_building != null; }
+      set { if (value == (_is_target_building== null)) _is_target_building = value ? this.is_target_building : (bool?)null; }
+    }
+    private bool ShouldSerializeis_target_building() { return is_target_buildingSpecified; }
+    private void Resetis_target_building() { is_target_buildingSpecified = false; }
+    
 
-    private uint _neutral_camp_type = default(uint);
+    private uint? _neutral_camp_type;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"neutral_camp_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint neutral_camp_type
     {
-      get { return _neutral_camp_type; }
+      get { return _neutral_camp_type?? default(uint); }
       set { _neutral_camp_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool neutral_camp_typeSpecified
+    {
+      get { return _neutral_camp_type != null; }
+      set { if (value == (_neutral_camp_type== null)) _neutral_camp_type = value ? this.neutral_camp_type : (uint?)null; }
+    }
+    private bool ShouldSerializeneutral_camp_type() { return neutral_camp_typeSpecified; }
+    private void Resetneutral_camp_type() { neutral_camp_typeSpecified = false; }
+    
 
-    private uint _rune_type = default(uint);
+    private uint? _rune_type;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"rune_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rune_type
     {
-      get { return _rune_type; }
+      get { return _rune_type?? default(uint); }
       set { _rune_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rune_typeSpecified
+    {
+      get { return _rune_type != null; }
+      set { if (value == (_rune_type== null)) _rune_type = value ? this.rune_type : (uint?)null; }
+    }
+    private bool ShouldSerializerune_type() { return rune_typeSpecified; }
+    private void Resetrune_type() { rune_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _assist_players = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(40, Name=@"assist_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> assist_players
@@ -1961,203 +3502,401 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _is_heal_save = default(bool);
+    private bool? _is_heal_save;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"is_heal_save", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_heal_save
     {
-      get { return _is_heal_save; }
+      get { return _is_heal_save?? default(bool); }
       set { _is_heal_save = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_heal_saveSpecified
+    {
+      get { return _is_heal_save != null; }
+      set { if (value == (_is_heal_save== null)) _is_heal_save = value ? this.is_heal_save : (bool?)null; }
+    }
+    private bool ShouldSerializeis_heal_save() { return is_heal_saveSpecified; }
+    private void Resetis_heal_save() { is_heal_saveSpecified = false; }
+    
 
-    private bool _is_ultimate_ability = default(bool);
+    private bool? _is_ultimate_ability;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"is_ultimate_ability", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_ultimate_ability
     {
-      get { return _is_ultimate_ability; }
+      get { return _is_ultimate_ability?? default(bool); }
       set { _is_ultimate_ability = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_ultimate_abilitySpecified
+    {
+      get { return _is_ultimate_ability != null; }
+      set { if (value == (_is_ultimate_ability== null)) _is_ultimate_ability = value ? this.is_ultimate_ability : (bool?)null; }
+    }
+    private bool ShouldSerializeis_ultimate_ability() { return is_ultimate_abilitySpecified; }
+    private void Resetis_ultimate_ability() { is_ultimate_abilitySpecified = false; }
+    
 
-    private uint _attacker_hero_level = default(uint);
+    private uint? _attacker_hero_level;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"attacker_hero_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attacker_hero_level
     {
-      get { return _attacker_hero_level; }
+      get { return _attacker_hero_level?? default(uint); }
       set { _attacker_hero_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attacker_hero_levelSpecified
+    {
+      get { return _attacker_hero_level != null; }
+      set { if (value == (_attacker_hero_level== null)) _attacker_hero_level = value ? this.attacker_hero_level : (uint?)null; }
+    }
+    private bool ShouldSerializeattacker_hero_level() { return attacker_hero_levelSpecified; }
+    private void Resetattacker_hero_level() { attacker_hero_levelSpecified = false; }
+    
 
-    private uint _target_hero_level = default(uint);
+    private uint? _target_hero_level;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"target_hero_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_hero_level
     {
-      get { return _target_hero_level; }
+      get { return _target_hero_level?? default(uint); }
       set { _target_hero_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_hero_levelSpecified
+    {
+      get { return _target_hero_level != null; }
+      set { if (value == (_target_hero_level== null)) _target_hero_level = value ? this.target_hero_level : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_hero_level() { return target_hero_levelSpecified; }
+    private void Resettarget_hero_level() { target_hero_levelSpecified = false; }
+    
 
-    private uint _xpm = default(uint);
+    private uint? _xpm;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"xpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xpm
     {
-      get { return _xpm; }
+      get { return _xpm?? default(uint); }
       set { _xpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xpmSpecified
+    {
+      get { return _xpm != null; }
+      set { if (value == (_xpm== null)) _xpm = value ? this.xpm : (uint?)null; }
+    }
+    private bool ShouldSerializexpm() { return xpmSpecified; }
+    private void Resetxpm() { xpmSpecified = false; }
+    
 
-    private uint _gpm = default(uint);
+    private uint? _gpm;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(uint); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (uint?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private uint _event_location = default(uint);
+    private uint? _event_location;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"event_location", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_location
     {
-      get { return _event_location; }
+      get { return _event_location?? default(uint); }
       set { _event_location = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_locationSpecified
+    {
+      get { return _event_location != null; }
+      set { if (value == (_event_location== null)) _event_location = value ? this.event_location : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_location() { return event_locationSpecified; }
+    private void Resetevent_location() { event_locationSpecified = false; }
+    
 
-    private bool _target_is_self = default(bool);
+    private bool? _target_is_self;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"target_is_self", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool target_is_self
     {
-      get { return _target_is_self; }
+      get { return _target_is_self?? default(bool); }
       set { _target_is_self = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_is_selfSpecified
+    {
+      get { return _target_is_self != null; }
+      set { if (value == (_target_is_self== null)) _target_is_self = value ? this.target_is_self : (bool?)null; }
+    }
+    private bool ShouldSerializetarget_is_self() { return target_is_selfSpecified; }
+    private void Resettarget_is_self() { target_is_selfSpecified = false; }
+    
 
-    private uint _damage_type = default(uint);
+    private uint? _damage_type;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"damage_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_type
     {
-      get { return _damage_type; }
+      get { return _damage_type?? default(uint); }
       set { _damage_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_typeSpecified
+    {
+      get { return _damage_type != null; }
+      set { if (value == (_damage_type== null)) _damage_type = value ? this.damage_type : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_type() { return damage_typeSpecified; }
+    private void Resetdamage_type() { damage_typeSpecified = false; }
+    
 
-    private bool _invisibility_modifier = default(bool);
+    private bool? _invisibility_modifier;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"invisibility_modifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool invisibility_modifier
     {
-      get { return _invisibility_modifier; }
+      get { return _invisibility_modifier?? default(bool); }
       set { _invisibility_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invisibility_modifierSpecified
+    {
+      get { return _invisibility_modifier != null; }
+      set { if (value == (_invisibility_modifier== null)) _invisibility_modifier = value ? this.invisibility_modifier : (bool?)null; }
+    }
+    private bool ShouldSerializeinvisibility_modifier() { return invisibility_modifierSpecified; }
+    private void Resetinvisibility_modifier() { invisibility_modifierSpecified = false; }
+    
 
-    private uint _damage_category = default(uint);
+    private uint? _damage_category;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"damage_category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_category
     {
-      get { return _damage_category; }
+      get { return _damage_category?? default(uint); }
       set { _damage_category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_categorySpecified
+    {
+      get { return _damage_category != null; }
+      set { if (value == (_damage_category== null)) _damage_category = value ? this.damage_category : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_category() { return damage_categorySpecified; }
+    private void Resetdamage_category() { damage_categorySpecified = false; }
+    
 
-    private uint _networth = default(uint);
+    private uint? _networth;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"networth", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint networth
     {
-      get { return _networth; }
+      get { return _networth?? default(uint); }
       set { _networth = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool networthSpecified
+    {
+      get { return _networth != null; }
+      set { if (value == (_networth== null)) _networth = value ? this.networth : (uint?)null; }
+    }
+    private bool ShouldSerializenetworth() { return networthSpecified; }
+    private void Resetnetworth() { networthSpecified = false; }
+    
 
-    private uint _building_type = default(uint);
+    private uint? _building_type;
     [global::ProtoBuf.ProtoMember(53, IsRequired = false, Name=@"building_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint building_type
     {
-      get { return _building_type; }
+      get { return _building_type?? default(uint); }
       set { _building_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool building_typeSpecified
+    {
+      get { return _building_type != null; }
+      set { if (value == (_building_type== null)) _building_type = value ? this.building_type : (uint?)null; }
+    }
+    private bool ShouldSerializebuilding_type() { return building_typeSpecified; }
+    private void Resetbuilding_type() { building_typeSpecified = false; }
+    
 
-    private float _modifier_elapsed_duration = default(float);
+    private float? _modifier_elapsed_duration;
     [global::ProtoBuf.ProtoMember(54, IsRequired = false, Name=@"modifier_elapsed_duration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float modifier_elapsed_duration
     {
-      get { return _modifier_elapsed_duration; }
+      get { return _modifier_elapsed_duration?? default(float); }
       set { _modifier_elapsed_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifier_elapsed_durationSpecified
+    {
+      get { return _modifier_elapsed_duration != null; }
+      set { if (value == (_modifier_elapsed_duration== null)) _modifier_elapsed_duration = value ? this.modifier_elapsed_duration : (float?)null; }
+    }
+    private bool ShouldSerializemodifier_elapsed_duration() { return modifier_elapsed_durationSpecified; }
+    private void Resetmodifier_elapsed_duration() { modifier_elapsed_durationSpecified = false; }
+    
 
-    private bool _silence_modifier = default(bool);
+    private bool? _silence_modifier;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"silence_modifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool silence_modifier
     {
-      get { return _silence_modifier; }
+      get { return _silence_modifier?? default(bool); }
       set { _silence_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool silence_modifierSpecified
+    {
+      get { return _silence_modifier != null; }
+      set { if (value == (_silence_modifier== null)) _silence_modifier = value ? this.silence_modifier : (bool?)null; }
+    }
+    private bool ShouldSerializesilence_modifier() { return silence_modifierSpecified; }
+    private void Resetsilence_modifier() { silence_modifierSpecified = false; }
+    
 
-    private bool _heal_from_lifesteal = default(bool);
+    private bool? _heal_from_lifesteal;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"heal_from_lifesteal", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool heal_from_lifesteal
     {
-      get { return _heal_from_lifesteal; }
+      get { return _heal_from_lifesteal?? default(bool); }
       set { _heal_from_lifesteal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heal_from_lifestealSpecified
+    {
+      get { return _heal_from_lifesteal != null; }
+      set { if (value == (_heal_from_lifesteal== null)) _heal_from_lifesteal = value ? this.heal_from_lifesteal : (bool?)null; }
+    }
+    private bool ShouldSerializeheal_from_lifesteal() { return heal_from_lifestealSpecified; }
+    private void Resetheal_from_lifesteal() { heal_from_lifestealSpecified = false; }
+    
 
-    private bool _modifier_purged = default(bool);
+    private bool? _modifier_purged;
     [global::ProtoBuf.ProtoMember(57, IsRequired = false, Name=@"modifier_purged", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool modifier_purged
     {
-      get { return _modifier_purged; }
+      get { return _modifier_purged?? default(bool); }
       set { _modifier_purged = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifier_purgedSpecified
+    {
+      get { return _modifier_purged != null; }
+      set { if (value == (_modifier_purged== null)) _modifier_purged = value ? this.modifier_purged : (bool?)null; }
+    }
+    private bool ShouldSerializemodifier_purged() { return modifier_purgedSpecified; }
+    private void Resetmodifier_purged() { modifier_purgedSpecified = false; }
+    
 
-    private bool _spell_evaded = default(bool);
+    private bool? _spell_evaded;
     [global::ProtoBuf.ProtoMember(58, IsRequired = false, Name=@"spell_evaded", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool spell_evaded
     {
-      get { return _spell_evaded; }
+      get { return _spell_evaded?? default(bool); }
       set { _spell_evaded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spell_evadedSpecified
+    {
+      get { return _spell_evaded != null; }
+      set { if (value == (_spell_evaded== null)) _spell_evaded = value ? this.spell_evaded : (bool?)null; }
+    }
+    private bool ShouldSerializespell_evaded() { return spell_evadedSpecified; }
+    private void Resetspell_evaded() { spell_evadedSpecified = false; }
+    
 
-    private bool _motion_controller_modifier = default(bool);
+    private bool? _motion_controller_modifier;
     [global::ProtoBuf.ProtoMember(59, IsRequired = false, Name=@"motion_controller_modifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool motion_controller_modifier
     {
-      get { return _motion_controller_modifier; }
+      get { return _motion_controller_modifier?? default(bool); }
       set { _motion_controller_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool motion_controller_modifierSpecified
+    {
+      get { return _motion_controller_modifier != null; }
+      set { if (value == (_motion_controller_modifier== null)) _motion_controller_modifier = value ? this.motion_controller_modifier : (bool?)null; }
+    }
+    private bool ShouldSerializemotion_controller_modifier() { return motion_controller_modifierSpecified; }
+    private void Resetmotion_controller_modifier() { motion_controller_modifierSpecified = false; }
+    
 
-    private bool _long_range_kill = default(bool);
+    private bool? _long_range_kill;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"long_range_kill", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool long_range_kill
     {
-      get { return _long_range_kill; }
+      get { return _long_range_kill?? default(bool); }
       set { _long_range_kill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool long_range_killSpecified
+    {
+      get { return _long_range_kill != null; }
+      set { if (value == (_long_range_kill== null)) _long_range_kill = value ? this.long_range_kill : (bool?)null; }
+    }
+    private bool ShouldSerializelong_range_kill() { return long_range_killSpecified; }
+    private void Resetlong_range_kill() { long_range_killSpecified = false; }
+    
 
-    private uint _modifier_purge_ability = default(uint);
+    private uint? _modifier_purge_ability;
     [global::ProtoBuf.ProtoMember(61, IsRequired = false, Name=@"modifier_purge_ability", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint modifier_purge_ability
     {
-      get { return _modifier_purge_ability; }
+      get { return _modifier_purge_ability?? default(uint); }
       set { _modifier_purge_ability = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifier_purge_abilitySpecified
+    {
+      get { return _modifier_purge_ability != null; }
+      set { if (value == (_modifier_purge_ability== null)) _modifier_purge_ability = value ? this.modifier_purge_ability : (uint?)null; }
+    }
+    private bool ShouldSerializemodifier_purge_ability() { return modifier_purge_abilitySpecified; }
+    private void Resetmodifier_purge_ability() { modifier_purge_abilitySpecified = false; }
+    
 
-    private uint _modifier_purge_npc = default(uint);
+    private uint? _modifier_purge_npc;
     [global::ProtoBuf.ProtoMember(62, IsRequired = false, Name=@"modifier_purge_npc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint modifier_purge_npc
     {
-      get { return _modifier_purge_npc; }
+      get { return _modifier_purge_npc?? default(uint); }
       set { _modifier_purge_npc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifier_purge_npcSpecified
+    {
+      get { return _modifier_purge_npc != null; }
+      set { if (value == (_modifier_purge_npc== null)) _modifier_purge_npc = value ? this.modifier_purge_npc : (uint?)null; }
+    }
+    private bool ShouldSerializemodifier_purge_npc() { return modifier_purge_npcSpecified; }
+    private void Resetmodifier_purge_npc() { modifier_purge_npcSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2169,23 +3908,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAProfileCard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _background_def_index = default(uint);
+    private uint? _background_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"background_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint background_def_index
     {
-      get { return _background_def_index; }
+      get { return _background_def_index?? default(uint); }
       set { _background_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool background_def_indexSpecified
+    {
+      get { return _background_def_index != null; }
+      set { if (value == (_background_def_index== null)) _background_def_index = value ? this.background_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializebackground_def_index() { return background_def_indexSpecified; }
+    private void Resetbackground_def_index() { background_def_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAProfileCard.Slot> _slots = new global::System.Collections.Generic.List<CMsgDOTAProfileCard.Slot>();
     [global::ProtoBuf.ProtoMember(3, Name=@"slots", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAProfileCard.Slot> slots
@@ -2194,32 +3951,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _badge_points = default(uint);
+    private uint? _badge_points;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"badge_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_points
     {
-      get { return _badge_points; }
+      get { return _badge_points?? default(uint); }
       set { _badge_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_pointsSpecified
+    {
+      get { return _badge_points != null; }
+      set { if (value == (_badge_points== null)) _badge_points = value ? this.badge_points : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_points() { return badge_pointsSpecified; }
+    private void Resetbadge_points() { badge_pointsSpecified = false; }
+    
 
-    private uint _event_points = default(uint);
+    private uint? _event_points;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"event_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_points
     {
-      get { return _event_points; }
+      get { return _event_points?? default(uint); }
       set { _event_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_pointsSpecified
+    {
+      get { return _event_points != null; }
+      set { if (value == (_event_points== null)) _event_points = value ? this.event_points : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_points() { return event_pointsSpecified; }
+    private void Resetevent_points() { event_pointsSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
     private CMsgBattleCupVictory _recent_battle_cup_victory = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"recent_battle_cup_victory", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2235,14 +4019,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Slot() {}
     
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
     private CMsgDOTAProfileCard.Slot.Trophy _trophy = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trophy", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2294,23 +4087,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Trophy() {}
     
 
-    private uint _trophy_id = default(uint);
+    private uint? _trophy_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"trophy_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_id
     {
-      get { return _trophy_id; }
+      get { return _trophy_id?? default(uint); }
       set { _trophy_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_idSpecified
+    {
+      get { return _trophy_id != null; }
+      set { if (value == (_trophy_id== null)) _trophy_id = value ? this.trophy_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_id() { return trophy_idSpecified; }
+    private void Resettrophy_id() { trophy_idSpecified = false; }
+    
 
-    private uint _trophy_score = default(uint);
+    private uint? _trophy_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trophy_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trophy_score
     {
-      get { return _trophy_score; }
+      get { return _trophy_score?? default(uint); }
       set { _trophy_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trophy_scoreSpecified
+    {
+      get { return _trophy_score != null; }
+      set { if (value == (_trophy_score== null)) _trophy_score = value ? this.trophy_score : (uint?)null; }
+    }
+    private bool ShouldSerializetrophy_score() { return trophy_scoreSpecified; }
+    private void Resettrophy_score() { trophy_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2322,23 +4133,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Stat() {}
     
 
-    private CMsgDOTAProfileCard.EStatID _stat_id = CMsgDOTAProfileCard.EStatID.k_eStat_SoloRank;
+    private CMsgDOTAProfileCard.EStatID? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAProfileCard.EStatID.k_eStat_SoloRank)]
     public CMsgDOTAProfileCard.EStatID stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? CMsgDOTAProfileCard.EStatID.k_eStat_SoloRank; }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (CMsgDOTAProfileCard.EStatID?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_score = default(uint);
+    private uint? _stat_score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_score
     {
-      get { return _stat_score; }
+      get { return _stat_score?? default(uint); }
       set { _stat_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_scoreSpecified
+    {
+      get { return _stat_score != null; }
+      set { if (value == (_stat_score== null)) _stat_score = value ? this.stat_score : (uint?)null; }
+    }
+    private bool ShouldSerializestat_score() { return stat_scoreSpecified; }
+    private void Resetstat_score() { stat_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2350,23 +4179,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Item() {}
     
 
-    private byte[] _serialized_item = null;
+    private byte[] _serialized_item;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serialized_item", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_item
     {
-      get { return _serialized_item; }
+      get { return _serialized_item?? null; }
       set { _serialized_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_itemSpecified
+    {
+      get { return _serialized_item != null; }
+      set { if (value == (_serialized_item== null)) _serialized_item = value ? this.serialized_item : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_item() { return serialized_itemSpecified; }
+    private void Resetserialized_item() { serialized_itemSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2378,32 +4225,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Hero() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _hero_wins = default(uint);
+    private uint? _hero_wins;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_wins
     {
-      get { return _hero_wins; }
+      get { return _hero_wins?? default(uint); }
       set { _hero_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_winsSpecified
+    {
+      get { return _hero_wins != null; }
+      set { if (value == (_hero_wins== null)) _hero_wins = value ? this.hero_wins : (uint?)null; }
+    }
+    private bool ShouldSerializehero_wins() { return hero_winsSpecified; }
+    private void Resethero_wins() { hero_winsSpecified = false; }
+    
 
-    private uint _hero_losses = default(uint);
+    private uint? _hero_losses;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_losses
     {
-      get { return _hero_losses; }
+      get { return _hero_losses?? default(uint); }
       set { _hero_losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_lossesSpecified
+    {
+      get { return _hero_losses != null; }
+      set { if (value == (_hero_losses== null)) _hero_losses = value ? this.hero_losses : (uint?)null; }
+    }
+    private bool ShouldSerializehero_losses() { return hero_lossesSpecified; }
+    private void Resethero_losses() { hero_lossesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2415,14 +4289,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Emoticon() {}
     
 
-    private uint _emoticon_id = default(uint);
+    private uint? _emoticon_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"emoticon_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint emoticon_id
     {
-      get { return _emoticon_id; }
+      get { return _emoticon_id?? default(uint); }
       set { _emoticon_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool emoticon_idSpecified
+    {
+      get { return _emoticon_id != null; }
+      set { if (value == (_emoticon_id== null)) _emoticon_id = value ? this.emoticon_id : (uint?)null; }
+    }
+    private bool ShouldSerializeemoticon_id() { return emoticon_idSpecified; }
+    private void Resetemoticon_id() { emoticon_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2467,131 +4350,257 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAPlayerChallenge() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private uint _challenge_type = default(uint);
+    private uint? _challenge_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"challenge_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_type
     {
-      get { return _challenge_type; }
+      get { return _challenge_type?? default(uint); }
       set { _challenge_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_typeSpecified
+    {
+      get { return _challenge_type != null; }
+      set { if (value == (_challenge_type== null)) _challenge_type = value ? this.challenge_type : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_type() { return challenge_typeSpecified; }
+    private void Resetchallenge_type() { challenge_typeSpecified = false; }
+    
 
-    private uint _int_param_0 = default(uint);
+    private uint? _int_param_0;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"int_param_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint int_param_0
     {
-      get { return _int_param_0; }
+      get { return _int_param_0?? default(uint); }
       set { _int_param_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool int_param_0Specified
+    {
+      get { return _int_param_0 != null; }
+      set { if (value == (_int_param_0== null)) _int_param_0 = value ? this.int_param_0 : (uint?)null; }
+    }
+    private bool ShouldSerializeint_param_0() { return int_param_0Specified; }
+    private void Resetint_param_0() { int_param_0Specified = false; }
+    
 
-    private uint _int_param_1 = default(uint);
+    private uint? _int_param_1;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"int_param_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint int_param_1
     {
-      get { return _int_param_1; }
+      get { return _int_param_1?? default(uint); }
       set { _int_param_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool int_param_1Specified
+    {
+      get { return _int_param_1 != null; }
+      set { if (value == (_int_param_1== null)) _int_param_1 = value ? this.int_param_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeint_param_1() { return int_param_1Specified; }
+    private void Resetint_param_1() { int_param_1Specified = false; }
+    
 
-    private uint _created_time = default(uint);
+    private uint? _created_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"created_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint created_time
     {
-      get { return _created_time; }
+      get { return _created_time?? default(uint); }
       set { _created_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool created_timeSpecified
+    {
+      get { return _created_time != null; }
+      set { if (value == (_created_time== null)) _created_time = value ? this.created_time : (uint?)null; }
+    }
+    private bool ShouldSerializecreated_time() { return created_timeSpecified; }
+    private void Resetcreated_time() { created_timeSpecified = false; }
+    
 
-    private uint _completed = default(uint);
+    private uint? _completed;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint completed
     {
-      get { return _completed; }
+      get { return _completed?? default(uint); }
       set { _completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completedSpecified
+    {
+      get { return _completed != null; }
+      set { if (value == (_completed== null)) _completed = value ? this.completed : (uint?)null; }
+    }
+    private bool ShouldSerializecompleted() { return completedSpecified; }
+    private void Resetcompleted() { completedSpecified = false; }
+    
 
-    private uint _sequence_id = default(uint);
+    private uint? _sequence_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"sequence_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sequence_id
     {
-      get { return _sequence_id; }
+      get { return _sequence_id?? default(uint); }
       set { _sequence_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_idSpecified
+    {
+      get { return _sequence_id != null; }
+      set { if (value == (_sequence_id== null)) _sequence_id = value ? this.sequence_id : (uint?)null; }
+    }
+    private bool ShouldSerializesequence_id() { return sequence_idSpecified; }
+    private void Resetsequence_id() { sequence_idSpecified = false; }
+    
 
-    private uint _challenge_tier = default(uint);
+    private uint? _challenge_tier;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"challenge_tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_tier
     {
-      get { return _challenge_tier; }
+      get { return _challenge_tier?? default(uint); }
       set { _challenge_tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_tierSpecified
+    {
+      get { return _challenge_tier != null; }
+      set { if (value == (_challenge_tier== null)) _challenge_tier = value ? this.challenge_tier : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_tier() { return challenge_tierSpecified; }
+    private void Resetchallenge_tier() { challenge_tierSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _attempts = default(uint);
+    private uint? _attempts;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"attempts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attempts
     {
-      get { return _attempts; }
+      get { return _attempts?? default(uint); }
       set { _attempts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attemptsSpecified
+    {
+      get { return _attempts != null; }
+      set { if (value == (_attempts== null)) _attempts = value ? this.attempts : (uint?)null; }
+    }
+    private bool ShouldSerializeattempts() { return attemptsSpecified; }
+    private void Resetattempts() { attemptsSpecified = false; }
+    
 
-    private uint _complete_limit = default(uint);
+    private uint? _complete_limit;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"complete_limit", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint complete_limit
     {
-      get { return _complete_limit; }
+      get { return _complete_limit?? default(uint); }
       set { _complete_limit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool complete_limitSpecified
+    {
+      get { return _complete_limit != null; }
+      set { if (value == (_complete_limit== null)) _complete_limit = value ? this.complete_limit : (uint?)null; }
+    }
+    private bool ShouldSerializecomplete_limit() { return complete_limitSpecified; }
+    private void Resetcomplete_limit() { complete_limitSpecified = false; }
+    
 
-    private uint _quest_rank = default(uint);
+    private uint? _quest_rank;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"quest_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_rank
     {
-      get { return _quest_rank; }
+      get { return _quest_rank?? default(uint); }
       set { _quest_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_rankSpecified
+    {
+      get { return _quest_rank != null; }
+      set { if (value == (_quest_rank== null)) _quest_rank = value ? this.quest_rank : (uint?)null; }
+    }
+    private bool ShouldSerializequest_rank() { return quest_rankSpecified; }
+    private void Resetquest_rank() { quest_rankSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EFlags", EnumPassthru=true)]
     public enum EFlags
     {
@@ -2614,23 +4623,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRerollPlayerChallenge() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _sequence_id = default(uint);
+    private uint? _sequence_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sequence_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sequence_id
     {
-      get { return _sequence_id; }
+      get { return _sequence_id?? default(uint); }
       set { _sequence_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_idSpecified
+    {
+      get { return _sequence_id != null; }
+      set { if (value == (_sequence_id== null)) _sequence_id = value ? this.sequence_id : (uint?)null; }
+    }
+    private bool ShouldSerializesequence_id() { return sequence_idSpecified; }
+    private void Resetsequence_id() { sequence_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2642,14 +4669,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCRerollPlayerChallengeResponse() {}
     
 
-    private CMsgGCRerollPlayerChallengeResponse.EResult _result = CMsgGCRerollPlayerChallengeResponse.EResult.eResult_Success;
+    private CMsgGCRerollPlayerChallengeResponse.EResult? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRerollPlayerChallengeResponse.EResult.eResult_Success)]
     public CMsgGCRerollPlayerChallengeResponse.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgGCRerollPlayerChallengeResponse.EResult.eResult_Success; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGCRerollPlayerChallengeResponse.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -2688,14 +4724,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _game_of_the_day = default(ulong);
+    private ulong? _game_of_the_day;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_of_the_day", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_of_the_day
     {
-      get { return _game_of_the_day; }
+      get { return _game_of_the_day?? default(ulong); }
       set { _game_of_the_day = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_of_the_daySpecified
+    {
+      get { return _game_of_the_day != null; }
+      set { if (value == (_game_of_the_day== null)) _game_of_the_day = value ? this.game_of_the_day : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_of_the_day() { return game_of_the_daySpecified; }
+    private void Resetgame_of_the_day() { game_of_the_daySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2739,64 +4784,118 @@ namespace SteamKit2.GC.Dota.Internal
       set { _graph_data = value; }
     }
 
-    private bool _delta_frame = default(bool);
+    private bool? _delta_frame;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"delta_frame", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool delta_frame
     {
-      get { return _delta_frame; }
+      get { return _delta_frame?? default(bool); }
       set { _delta_frame = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delta_frameSpecified
+    {
+      get { return _delta_frame != null; }
+      set { if (value == (_delta_frame== null)) _delta_frame = value ? this.delta_frame : (bool?)null; }
+    }
+    private bool ShouldSerializedelta_frame() { return delta_frameSpecified; }
+    private void Resetdelta_frame() { delta_frameSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"TeamDetails")]
   public partial class TeamDetails : global::ProtoBuf.IExtensible
   {
     public TeamDetails() {}
     
 
-    private uint _team_number = default(uint);
+    private uint? _team_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_number
     {
-      get { return _team_number; }
+      get { return _team_number?? default(uint); }
       set { _team_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_numberSpecified
+    {
+      get { return _team_number != null; }
+      set { if (value == (_team_number== null)) _team_number = value ? this.team_number : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_number() { return team_numberSpecified; }
+    private void Resetteam_number() { team_numberSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PlayerDetails> _players = new global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PlayerDetails>();
     [global::ProtoBuf.ProtoMember(6, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PlayerDetails> players
@@ -2805,23 +4904,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _only_team = default(bool);
+    private bool? _only_team;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"only_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_team
     {
-      get { return _only_team; }
+      get { return _only_team?? default(bool); }
       set { _only_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_teamSpecified
+    {
+      get { return _only_team != null; }
+      set { if (value == (_only_team== null)) _only_team = value ? this.only_team : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_team() { return only_teamSpecified; }
+    private void Resetonly_team() { only_teamSpecified = false; }
+    
 
-    private uint _cheers = default(uint);
+    private uint? _cheers;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"cheers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cheers
     {
-      get { return _cheers; }
+      get { return _cheers?? default(uint); }
       set { _cheers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cheersSpecified
+    {
+      get { return _cheers != null; }
+      set { if (value == (_cheers== null)) _cheers = value ? this.cheers : (uint?)null; }
+    }
+    private bool ShouldSerializecheers() { return cheersSpecified; }
+    private void Resetcheers() { cheersSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2833,50 +4950,95 @@ namespace SteamKit2.GC.Dota.Internal
     public ItemDetails() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private int _time = default(int);
+    private int? _time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int time
     {
-      get { return _time; }
+      get { return _time?? default(int); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (int?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
 
-    private bool _sold = default(bool);
+    private bool? _sold;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sold", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sold
     {
-      get { return _sold; }
+      get { return _sold?? default(bool); }
       set { _sold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool soldSpecified
+    {
+      get { return _sold != null; }
+      set { if (value == (_sold== null)) _sold = value ? this.sold : (bool?)null; }
+    }
+    private bool ShouldSerializesold() { return soldSpecified; }
+    private void Resetsold() { soldSpecified = false; }
+    
 
-    private uint _stackcount = default(uint);
+    private uint? _stackcount;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"stackcount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stackcount
     {
-      get { return _stackcount; }
+      get { return _stackcount?? default(uint); }
       set { _stackcount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stackcountSpecified
+    {
+      get { return _stackcount != null; }
+      set { if (value == (_stackcount== null)) _stackcount = value ? this.stackcount : (uint?)null; }
+    }
+    private bool ShouldSerializestackcount() { return stackcountSpecified; }
+    private void Resetstackcount() { stackcountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2888,50 +5050,95 @@ namespace SteamKit2.GC.Dota.Internal
     public AbilityDetails() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private float _cooldown = default(float);
+    private float? _cooldown;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cooldown", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cooldown
     {
-      get { return _cooldown; }
+      get { return _cooldown?? default(float); }
       set { _cooldown = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cooldownSpecified
+    {
+      get { return _cooldown != null; }
+      set { if (value == (_cooldown== null)) _cooldown = value ? this.cooldown : (float?)null; }
+    }
+    private bool ShouldSerializecooldown() { return cooldownSpecified; }
+    private void Resetcooldown() { cooldownSpecified = false; }
+    
 
-    private float _cooldown_max = default(float);
+    private float? _cooldown_max;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cooldown_max", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cooldown_max
     {
-      get { return _cooldown_max; }
+      get { return _cooldown_max?? default(float); }
       set { _cooldown_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cooldown_maxSpecified
+    {
+      get { return _cooldown_max != null; }
+      set { if (value == (_cooldown_max== null)) _cooldown_max = value ? this.cooldown_max : (float?)null; }
+    }
+    private bool ShouldSerializecooldown_max() { return cooldown_maxSpecified; }
+    private void Resetcooldown_max() { cooldown_maxSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2943,32 +5150,59 @@ namespace SteamKit2.GC.Dota.Internal
     public HeroToHeroStats() {}
     
 
-    private uint _victimid = default(uint);
+    private uint? _victimid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"victimid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint victimid
     {
-      get { return _victimid; }
+      get { return _victimid?? default(uint); }
       set { _victimid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victimidSpecified
+    {
+      get { return _victimid != null; }
+      set { if (value == (_victimid== null)) _victimid = value ? this.victimid : (uint?)null; }
+    }
+    private bool ShouldSerializevictimid() { return victimidSpecified; }
+    private void Resetvictimid() { victimidSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2997,230 +5231,455 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerDetails() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _playerid = default(uint);
+    private uint? _playerid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"playerid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint playerid
     {
-      get { return _playerid; }
+      get { return _playerid?? default(uint); }
       set { _playerid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playeridSpecified
+    {
+      get { return _playerid != null; }
+      set { if (value == (_playerid== null)) _playerid = value ? this.playerid : (uint?)null; }
+    }
+    private bool ShouldSerializeplayerid() { return playeridSpecified; }
+    private void Resetplayerid() { playeridSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _heroid = default(uint);
+    private uint? _heroid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"heroid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint heroid
     {
-      get { return _heroid; }
+      get { return _heroid?? default(uint); }
       set { _heroid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heroidSpecified
+    {
+      get { return _heroid != null; }
+      set { if (value == (_heroid== null)) _heroid = value ? this.heroid : (uint?)null; }
+    }
+    private bool ShouldSerializeheroid() { return heroidSpecified; }
+    private void Resetheroid() { heroidSpecified = false; }
+    
 
-    private uint _healthpoints = default(uint);
+    private uint? _healthpoints;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"healthpoints", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healthpoints
     {
-      get { return _healthpoints; }
+      get { return _healthpoints?? default(uint); }
       set { _healthpoints = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healthpointsSpecified
+    {
+      get { return _healthpoints != null; }
+      set { if (value == (_healthpoints== null)) _healthpoints = value ? this.healthpoints : (uint?)null; }
+    }
+    private bool ShouldSerializehealthpoints() { return healthpointsSpecified; }
+    private void Resethealthpoints() { healthpointsSpecified = false; }
+    
 
-    private uint _maxhealthpoints = default(uint);
+    private uint? _maxhealthpoints;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"maxhealthpoints", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint maxhealthpoints
     {
-      get { return _maxhealthpoints; }
+      get { return _maxhealthpoints?? default(uint); }
       set { _maxhealthpoints = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maxhealthpointsSpecified
+    {
+      get { return _maxhealthpoints != null; }
+      set { if (value == (_maxhealthpoints== null)) _maxhealthpoints = value ? this.maxhealthpoints : (uint?)null; }
+    }
+    private bool ShouldSerializemaxhealthpoints() { return maxhealthpointsSpecified; }
+    private void Resetmaxhealthpoints() { maxhealthpointsSpecified = false; }
+    
 
-    private float _healthregenrate = default(float);
+    private float? _healthregenrate;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"healthregenrate", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float healthregenrate
     {
-      get { return _healthregenrate; }
+      get { return _healthregenrate?? default(float); }
       set { _healthregenrate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healthregenrateSpecified
+    {
+      get { return _healthregenrate != null; }
+      set { if (value == (_healthregenrate== null)) _healthregenrate = value ? this.healthregenrate : (float?)null; }
+    }
+    private bool ShouldSerializehealthregenrate() { return healthregenrateSpecified; }
+    private void Resethealthregenrate() { healthregenrateSpecified = false; }
+    
 
-    private uint _manapoints = default(uint);
+    private uint? _manapoints;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"manapoints", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint manapoints
     {
-      get { return _manapoints; }
+      get { return _manapoints?? default(uint); }
       set { _manapoints = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manapointsSpecified
+    {
+      get { return _manapoints != null; }
+      set { if (value == (_manapoints== null)) _manapoints = value ? this.manapoints : (uint?)null; }
+    }
+    private bool ShouldSerializemanapoints() { return manapointsSpecified; }
+    private void Resetmanapoints() { manapointsSpecified = false; }
+    
 
-    private uint _maxmanapoints = default(uint);
+    private uint? _maxmanapoints;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"maxmanapoints", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint maxmanapoints
     {
-      get { return _maxmanapoints; }
+      get { return _maxmanapoints?? default(uint); }
       set { _maxmanapoints = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maxmanapointsSpecified
+    {
+      get { return _maxmanapoints != null; }
+      set { if (value == (_maxmanapoints== null)) _maxmanapoints = value ? this.maxmanapoints : (uint?)null; }
+    }
+    private bool ShouldSerializemaxmanapoints() { return maxmanapointsSpecified; }
+    private void Resetmaxmanapoints() { maxmanapointsSpecified = false; }
+    
 
-    private float _manaregenrate = default(float);
+    private float? _manaregenrate;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"manaregenrate", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float manaregenrate
     {
-      get { return _manaregenrate; }
+      get { return _manaregenrate?? default(float); }
       set { _manaregenrate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manaregenrateSpecified
+    {
+      get { return _manaregenrate != null; }
+      set { if (value == (_manaregenrate== null)) _manaregenrate = value ? this.manaregenrate : (float?)null; }
+    }
+    private bool ShouldSerializemanaregenrate() { return manaregenrateSpecified; }
+    private void Resetmanaregenrate() { manaregenrateSpecified = false; }
+    
 
-    private uint _base_strength = default(uint);
+    private uint? _base_strength;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"base_strength", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_strength
     {
-      get { return _base_strength; }
+      get { return _base_strength?? default(uint); }
       set { _base_strength = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_strengthSpecified
+    {
+      get { return _base_strength != null; }
+      set { if (value == (_base_strength== null)) _base_strength = value ? this.base_strength : (uint?)null; }
+    }
+    private bool ShouldSerializebase_strength() { return base_strengthSpecified; }
+    private void Resetbase_strength() { base_strengthSpecified = false; }
+    
 
-    private uint _base_agility = default(uint);
+    private uint? _base_agility;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"base_agility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_agility
     {
-      get { return _base_agility; }
+      get { return _base_agility?? default(uint); }
       set { _base_agility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_agilitySpecified
+    {
+      get { return _base_agility != null; }
+      set { if (value == (_base_agility== null)) _base_agility = value ? this.base_agility : (uint?)null; }
+    }
+    private bool ShouldSerializebase_agility() { return base_agilitySpecified; }
+    private void Resetbase_agility() { base_agilitySpecified = false; }
+    
 
-    private uint _base_intelligence = default(uint);
+    private uint? _base_intelligence;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"base_intelligence", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_intelligence
     {
-      get { return _base_intelligence; }
+      get { return _base_intelligence?? default(uint); }
       set { _base_intelligence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_intelligenceSpecified
+    {
+      get { return _base_intelligence != null; }
+      set { if (value == (_base_intelligence== null)) _base_intelligence = value ? this.base_intelligence : (uint?)null; }
+    }
+    private bool ShouldSerializebase_intelligence() { return base_intelligenceSpecified; }
+    private void Resetbase_intelligence() { base_intelligenceSpecified = false; }
+    
 
-    private int _base_armor = default(int);
+    private int? _base_armor;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"base_armor", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int base_armor
     {
-      get { return _base_armor; }
+      get { return _base_armor?? default(int); }
       set { _base_armor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_armorSpecified
+    {
+      get { return _base_armor != null; }
+      set { if (value == (_base_armor== null)) _base_armor = value ? this.base_armor : (int?)null; }
+    }
+    private bool ShouldSerializebase_armor() { return base_armorSpecified; }
+    private void Resetbase_armor() { base_armorSpecified = false; }
+    
 
-    private uint _base_movespeed = default(uint);
+    private uint? _base_movespeed;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"base_movespeed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_movespeed
     {
-      get { return _base_movespeed; }
+      get { return _base_movespeed?? default(uint); }
       set { _base_movespeed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_movespeedSpecified
+    {
+      get { return _base_movespeed != null; }
+      set { if (value == (_base_movespeed== null)) _base_movespeed = value ? this.base_movespeed : (uint?)null; }
+    }
+    private bool ShouldSerializebase_movespeed() { return base_movespeedSpecified; }
+    private void Resetbase_movespeed() { base_movespeedSpecified = false; }
+    
 
-    private uint _base_damage = default(uint);
+    private uint? _base_damage;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"base_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_damage
     {
-      get { return _base_damage; }
+      get { return _base_damage?? default(uint); }
       set { _base_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_damageSpecified
+    {
+      get { return _base_damage != null; }
+      set { if (value == (_base_damage== null)) _base_damage = value ? this.base_damage : (uint?)null; }
+    }
+    private bool ShouldSerializebase_damage() { return base_damageSpecified; }
+    private void Resetbase_damage() { base_damageSpecified = false; }
+    
 
-    private uint _strength = default(uint);
+    private uint? _strength;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"strength", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strength
     {
-      get { return _strength; }
+      get { return _strength?? default(uint); }
       set { _strength = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strengthSpecified
+    {
+      get { return _strength != null; }
+      set { if (value == (_strength== null)) _strength = value ? this.strength : (uint?)null; }
+    }
+    private bool ShouldSerializestrength() { return strengthSpecified; }
+    private void Resetstrength() { strengthSpecified = false; }
+    
 
-    private uint _agility = default(uint);
+    private uint? _agility;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"agility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint agility
     {
-      get { return _agility; }
+      get { return _agility?? default(uint); }
       set { _agility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool agilitySpecified
+    {
+      get { return _agility != null; }
+      set { if (value == (_agility== null)) _agility = value ? this.agility : (uint?)null; }
+    }
+    private bool ShouldSerializeagility() { return agilitySpecified; }
+    private void Resetagility() { agilitySpecified = false; }
+    
 
-    private uint _intelligence = default(uint);
+    private uint? _intelligence;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"intelligence", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint intelligence
     {
-      get { return _intelligence; }
+      get { return _intelligence?? default(uint); }
       set { _intelligence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool intelligenceSpecified
+    {
+      get { return _intelligence != null; }
+      set { if (value == (_intelligence== null)) _intelligence = value ? this.intelligence : (uint?)null; }
+    }
+    private bool ShouldSerializeintelligence() { return intelligenceSpecified; }
+    private void Resetintelligence() { intelligenceSpecified = false; }
+    
 
-    private int _armor = default(int);
+    private int? _armor;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"armor", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int armor
     {
-      get { return _armor; }
+      get { return _armor?? default(int); }
       set { _armor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool armorSpecified
+    {
+      get { return _armor != null; }
+      set { if (value == (_armor== null)) _armor = value ? this.armor : (int?)null; }
+    }
+    private bool ShouldSerializearmor() { return armorSpecified; }
+    private void Resetarmor() { armorSpecified = false; }
+    
 
-    private uint _movespeed = default(uint);
+    private uint? _movespeed;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"movespeed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint movespeed
     {
-      get { return _movespeed; }
+      get { return _movespeed?? default(uint); }
       set { _movespeed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool movespeedSpecified
+    {
+      get { return _movespeed != null; }
+      set { if (value == (_movespeed== null)) _movespeed = value ? this.movespeed : (uint?)null; }
+    }
+    private bool ShouldSerializemovespeed() { return movespeedSpecified; }
+    private void Resetmovespeed() { movespeedSpecified = false; }
+    
 
-    private uint _damage = default(uint);
+    private uint? _damage;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage
     {
-      get { return _damage; }
+      get { return _damage?? default(uint); }
       set { _damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damageSpecified
+    {
+      get { return _damage != null; }
+      set { if (value == (_damage== null)) _damage = value ? this.damage : (uint?)null; }
+    }
+    private bool ShouldSerializedamage() { return damageSpecified; }
+    private void Resetdamage() { damageSpecified = false; }
+    
 
-    private uint _hero_damage = default(uint);
+    private uint? _hero_damage;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"hero_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_damage
     {
-      get { return _hero_damage; }
+      get { return _hero_damage?? default(uint); }
       set { _hero_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_damageSpecified
+    {
+      get { return _hero_damage != null; }
+      set { if (value == (_hero_damage== null)) _hero_damage = value ? this.hero_damage : (uint?)null; }
+    }
+    private bool ShouldSerializehero_damage() { return hero_damageSpecified; }
+    private void Resethero_damage() { hero_damageSpecified = false; }
+    
 
-    private uint _tower_damage = default(uint);
+    private uint? _tower_damage;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"tower_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tower_damage
     {
-      get { return _tower_damage; }
+      get { return _tower_damage?? default(uint); }
       set { _tower_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_damageSpecified
+    {
+      get { return _tower_damage != null; }
+      set { if (value == (_tower_damage== null)) _tower_damage = value ? this.tower_damage : (uint?)null; }
+    }
+    private bool ShouldSerializetower_damage() { return tower_damageSpecified; }
+    private void Resettower_damage() { tower_damageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.AbilityDetails> _abilities = new global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.AbilityDetails>();
     [global::ProtoBuf.ProtoMember(26, Name=@"abilities", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.AbilityDetails> abilities
@@ -3229,149 +5688,293 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _kill_count = default(uint);
+    private uint? _kill_count;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"kill_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kill_count
     {
-      get { return _kill_count; }
+      get { return _kill_count?? default(uint); }
       set { _kill_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kill_countSpecified
+    {
+      get { return _kill_count != null; }
+      set { if (value == (_kill_count== null)) _kill_count = value ? this.kill_count : (uint?)null; }
+    }
+    private bool ShouldSerializekill_count() { return kill_countSpecified; }
+    private void Resetkill_count() { kill_countSpecified = false; }
+    
 
-    private uint _death_count = default(uint);
+    private uint? _death_count;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"death_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint death_count
     {
-      get { return _death_count; }
+      get { return _death_count?? default(uint); }
       set { _death_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool death_countSpecified
+    {
+      get { return _death_count != null; }
+      set { if (value == (_death_count== null)) _death_count = value ? this.death_count : (uint?)null; }
+    }
+    private bool ShouldSerializedeath_count() { return death_countSpecified; }
+    private void Resetdeath_count() { death_countSpecified = false; }
+    
 
-    private uint _assists_count = default(uint);
+    private uint? _assists_count;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"assists_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists_count
     {
-      get { return _assists_count; }
+      get { return _assists_count?? default(uint); }
       set { _assists_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assists_countSpecified
+    {
+      get { return _assists_count != null; }
+      set { if (value == (_assists_count== null)) _assists_count = value ? this.assists_count : (uint?)null; }
+    }
+    private bool ShouldSerializeassists_count() { return assists_countSpecified; }
+    private void Resetassists_count() { assists_countSpecified = false; }
+    
 
-    private uint _denies_count = default(uint);
+    private uint? _denies_count;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"denies_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies_count
     {
-      get { return _denies_count; }
+      get { return _denies_count?? default(uint); }
       set { _denies_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool denies_countSpecified
+    {
+      get { return _denies_count != null; }
+      set { if (value == (_denies_count== null)) _denies_count = value ? this.denies_count : (uint?)null; }
+    }
+    private bool ShouldSerializedenies_count() { return denies_countSpecified; }
+    private void Resetdenies_count() { denies_countSpecified = false; }
+    
 
-    private uint _lh_count = default(uint);
+    private uint? _lh_count;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"lh_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lh_count
     {
-      get { return _lh_count; }
+      get { return _lh_count?? default(uint); }
       set { _lh_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lh_countSpecified
+    {
+      get { return _lh_count != null; }
+      set { if (value == (_lh_count== null)) _lh_count = value ? this.lh_count : (uint?)null; }
+    }
+    private bool ShouldSerializelh_count() { return lh_countSpecified; }
+    private void Resetlh_count() { lh_countSpecified = false; }
+    
 
-    private uint _hero_healing = default(uint);
+    private uint? _hero_healing;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"hero_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_healing
     {
-      get { return _hero_healing; }
+      get { return _hero_healing?? default(uint); }
       set { _hero_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_healingSpecified
+    {
+      get { return _hero_healing != null; }
+      set { if (value == (_hero_healing== null)) _hero_healing = value ? this.hero_healing : (uint?)null; }
+    }
+    private bool ShouldSerializehero_healing() { return hero_healingSpecified; }
+    private void Resethero_healing() { hero_healingSpecified = false; }
+    
 
-    private uint _gold_per_min = default(uint);
+    private uint? _gold_per_min;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"gold_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_per_min
     {
-      get { return _gold_per_min; }
+      get { return _gold_per_min?? default(uint); }
       set { _gold_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_per_minSpecified
+    {
+      get { return _gold_per_min != null; }
+      set { if (value == (_gold_per_min== null)) _gold_per_min = value ? this.gold_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializegold_per_min() { return gold_per_minSpecified; }
+    private void Resetgold_per_min() { gold_per_minSpecified = false; }
+    
 
-    private uint _xp_per_min = default(uint);
+    private uint? _xp_per_min;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"xp_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp_per_min
     {
-      get { return _xp_per_min; }
+      get { return _xp_per_min?? default(uint); }
       set { _xp_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_per_minSpecified
+    {
+      get { return _xp_per_min != null; }
+      set { if (value == (_xp_per_min== null)) _xp_per_min = value ? this.xp_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializexp_per_min() { return xp_per_minSpecified; }
+    private void Resetxp_per_min() { xp_per_minSpecified = false; }
+    
 
-    private uint _net_gold = default(uint);
+    private uint? _net_gold;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"net_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint net_gold
     {
-      get { return _net_gold; }
+      get { return _net_gold?? default(uint); }
       set { _net_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_goldSpecified
+    {
+      get { return _net_gold != null; }
+      set { if (value == (_net_gold== null)) _net_gold = value ? this.net_gold : (uint?)null; }
+    }
+    private bool ShouldSerializenet_gold() { return net_goldSpecified; }
+    private void Resetnet_gold() { net_goldSpecified = false; }
+    
 
-    private uint _gold = default(uint);
+    private uint? _gold;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold
     {
-      get { return _gold; }
+      get { return _gold?? default(uint); }
       set { _gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goldSpecified
+    {
+      get { return _gold != null; }
+      set { if (value == (_gold== null)) _gold = value ? this.gold : (uint?)null; }
+    }
+    private bool ShouldSerializegold() { return goldSpecified; }
+    private void Resetgold() { goldSpecified = false; }
+    
 
-    private float _x = default(float);
+    private float? _x;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float x
     {
-      get { return _x; }
+      get { return _x?? default(float); }
       set { _x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xSpecified
+    {
+      get { return _x != null; }
+      set { if (value == (_x== null)) _x = value ? this.x : (float?)null; }
+    }
+    private bool ShouldSerializex() { return xSpecified; }
+    private void Resetx() { xSpecified = false; }
+    
 
-    private float _y = default(float);
+    private float? _y;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float y
     {
-      get { return _y; }
+      get { return _y?? default(float); }
       set { _y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ySpecified
+    {
+      get { return _y != null; }
+      set { if (value == (_y== null)) _y = value ? this.y : (float?)null; }
+    }
+    private bool ShouldSerializey() { return ySpecified; }
+    private void Resety() { ySpecified = false; }
+    
 
-    private int _respawn_time = default(int);
+    private int? _respawn_time;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"respawn_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int respawn_time
     {
-      get { return _respawn_time; }
+      get { return _respawn_time?? default(int); }
       set { _respawn_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool respawn_timeSpecified
+    {
+      get { return _respawn_time != null; }
+      set { if (value == (_respawn_time== null)) _respawn_time = value ? this.respawn_time : (int?)null; }
+    }
+    private bool ShouldSerializerespawn_time() { return respawn_timeSpecified; }
+    private void Resetrespawn_time() { respawn_timeSpecified = false; }
+    
 
-    private uint _ultimate_cooldown = default(uint);
+    private uint? _ultimate_cooldown;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"ultimate_cooldown", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ultimate_cooldown
     {
-      get { return _ultimate_cooldown; }
+      get { return _ultimate_cooldown?? default(uint); }
       set { _ultimate_cooldown = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ultimate_cooldownSpecified
+    {
+      get { return _ultimate_cooldown != null; }
+      set { if (value == (_ultimate_cooldown== null)) _ultimate_cooldown = value ? this.ultimate_cooldown : (uint?)null; }
+    }
+    private bool ShouldSerializeultimate_cooldown() { return ultimate_cooldownSpecified; }
+    private void Resetultimate_cooldown() { ultimate_cooldownSpecified = false; }
+    
 
-    private bool _has_buyback = default(bool);
+    private bool? _has_buyback;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"has_buyback", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_buyback
     {
-      get { return _has_buyback; }
+      get { return _has_buyback?? default(bool); }
       set { _has_buyback = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_buybackSpecified
+    {
+      get { return _has_buyback != null; }
+      set { if (value == (_has_buyback== null)) _has_buyback = value ? this.has_buyback : (bool?)null; }
+    }
+    private bool ShouldSerializehas_buyback() { return has_buybackSpecified; }
+    private void Resethas_buyback() { has_buybackSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.ItemDetails> _items = new global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.ItemDetails>();
     [global::ProtoBuf.ProtoMember(43, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.ItemDetails> items
@@ -3408,23 +6011,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _has_ultimate = default(bool);
+    private bool? _has_ultimate;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"has_ultimate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_ultimate
     {
-      get { return _has_ultimate; }
+      get { return _has_ultimate?? default(bool); }
       set { _has_ultimate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_ultimateSpecified
+    {
+      get { return _has_ultimate != null; }
+      set { if (value == (_has_ultimate== null)) _has_ultimate = value ? this.has_ultimate : (bool?)null; }
+    }
+    private bool ShouldSerializehas_ultimate() { return has_ultimateSpecified; }
+    private void Resethas_ultimate() { has_ultimateSpecified = false; }
+    
 
-    private bool _has_ultimate_mana = default(bool);
+    private bool? _has_ultimate_mana;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"has_ultimate_mana", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_ultimate_mana
     {
-      get { return _has_ultimate_mana; }
+      get { return _has_ultimate_mana?? default(bool); }
       set { _has_ultimate_mana = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_ultimate_manaSpecified
+    {
+      get { return _has_ultimate_mana != null; }
+      set { if (value == (_has_ultimate_mana== null)) _has_ultimate_mana = value ? this.has_ultimate_mana : (bool?)null; }
+    }
+    private bool ShouldSerializehas_ultimate_mana() { return has_ultimate_manaSpecified; }
+    private void Resethas_ultimate_mana() { has_ultimate_manaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3436,77 +6057,149 @@ namespace SteamKit2.GC.Dota.Internal
     public BuildingDetails() {}
     
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private float _heading = default(float);
+    private float? _heading;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"heading", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float heading
     {
-      get { return _heading; }
+      get { return _heading?? default(float); }
       set { _heading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool headingSpecified
+    {
+      get { return _heading != null; }
+      set { if (value == (_heading== null)) _heading = value ? this.heading : (float?)null; }
+    }
+    private bool ShouldSerializeheading() { return headingSpecified; }
+    private void Resetheading() { headingSpecified = false; }
+    
 
-    private uint _lane = default(uint);
+    private uint? _lane;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lane", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lane
     {
-      get { return _lane; }
+      get { return _lane?? default(uint); }
       set { _lane = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool laneSpecified
+    {
+      get { return _lane != null; }
+      set { if (value == (_lane== null)) _lane = value ? this.lane : (uint?)null; }
+    }
+    private bool ShouldSerializelane() { return laneSpecified; }
+    private void Resetlane() { laneSpecified = false; }
+    
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private float _x = default(float);
+    private float? _x;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float x
     {
-      get { return _x; }
+      get { return _x?? default(float); }
       set { _x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xSpecified
+    {
+      get { return _x != null; }
+      set { if (value == (_x== null)) _x = value ? this.x : (float?)null; }
+    }
+    private bool ShouldSerializex() { return xSpecified; }
+    private void Resetx() { xSpecified = false; }
+    
 
-    private float _y = default(float);
+    private float? _y;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float y
     {
-      get { return _y; }
+      get { return _y?? default(float); }
       set { _y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ySpecified
+    {
+      get { return _y != null; }
+      set { if (value == (_y== null)) _y = value ? this.y : (float?)null; }
+    }
+    private bool ShouldSerializey() { return ySpecified; }
+    private void Resety() { ySpecified = false; }
+    
 
-    private bool _destroyed = default(bool);
+    private bool? _destroyed;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"destroyed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool destroyed
     {
-      get { return _destroyed; }
+      get { return _destroyed?? default(bool); }
       set { _destroyed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool destroyedSpecified
+    {
+      get { return _destroyed != null; }
+      set { if (value == (_destroyed== null)) _destroyed = value ? this.destroyed : (bool?)null; }
+    }
+    private bool ShouldSerializedestroyed() { return destroyedSpecified; }
+    private void Resetdestroyed() { destroyedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3518,32 +6211,59 @@ namespace SteamKit2.GC.Dota.Internal
     public KillDetails() {}
     
 
-    private uint _player_id = default(uint);
+    private uint? _player_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_id
     {
-      get { return _player_id; }
+      get { return _player_id?? default(uint); }
       set { _player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_idSpecified
+    {
+      get { return _player_id != null; }
+      set { if (value == (_player_id== null)) _player_id = value ? this.player_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_id() { return player_idSpecified; }
+    private void Resetplayer_id() { player_idSpecified = false; }
+    
 
-    private int _death_time = default(int);
+    private int? _death_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"death_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int death_time
     {
-      get { return _death_time; }
+      get { return _death_time?? default(int); }
       set { _death_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool death_timeSpecified
+    {
+      get { return _death_time != null; }
+      set { if (value == (_death_time== null)) _death_time = value ? this.death_time : (int?)null; }
+    }
+    private bool ShouldSerializedeath_time() { return death_timeSpecified; }
+    private void Resetdeath_time() { death_timeSpecified = false; }
+    
 
-    private uint _killer_player_id = default(uint);
+    private uint? _killer_player_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"killer_player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_player_id
     {
-      get { return _killer_player_id; }
+      get { return _killer_player_id?? default(uint); }
       set { _killer_player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_player_idSpecified
+    {
+      get { return _killer_player_id != null; }
+      set { if (value == (_killer_player_id== null)) _killer_player_id = value ? this.killer_player_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_player_id() { return killer_player_idSpecified; }
+    private void Resetkiller_player_id() { killer_player_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3555,32 +6275,59 @@ namespace SteamKit2.GC.Dota.Internal
     public BroadcasterDetails() {}
     
 
-    private uint _player_id = default(uint);
+    private uint? _player_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_id
     {
-      get { return _player_id; }
+      get { return _player_id?? default(uint); }
       set { _player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_idSpecified
+    {
+      get { return _player_id != null; }
+      set { if (value == (_player_id== null)) _player_id = value ? this.player_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_id() { return player_idSpecified; }
+    private void Resetplayer_id() { player_idSpecified = false; }
+    
 
-    private uint _selected_hero = default(uint);
+    private uint? _selected_hero;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"selected_hero", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selected_hero
     {
-      get { return _selected_hero; }
+      get { return _selected_hero?? default(uint); }
       set { _selected_hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selected_heroSpecified
+    {
+      get { return _selected_hero != null; }
+      set { if (value == (_selected_hero== null)) _selected_hero = value ? this.selected_hero : (uint?)null; }
+    }
+    private bool ShouldSerializeselected_hero() { return selected_heroSpecified; }
+    private void Resetselected_hero() { selected_heroSpecified = false; }
+    
 
-    private uint _selected_graph = default(uint);
+    private uint? _selected_graph;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"selected_graph", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selected_graph
     {
-      get { return _selected_graph; }
+      get { return _selected_graph?? default(uint); }
       set { _selected_graph = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selected_graphSpecified
+    {
+      get { return _selected_graph != null; }
+      set { if (value == (_selected_graph== null)) _selected_graph = value ? this.selected_graph : (uint?)null; }
+    }
+    private bool ShouldSerializeselected_graph() { return selected_graphSpecified; }
+    private void Resetselected_graph() { selected_graphSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3592,23 +6339,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PickBanDetails() {}
     
 
-    private uint _hero = default(uint);
+    private uint? _hero;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero
     {
-      get { return _hero; }
+      get { return _hero?? default(uint); }
       set { _hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heroSpecified
+    {
+      get { return _hero != null; }
+      set { if (value == (_hero== null)) _hero = value ? this.hero : (uint?)null; }
+    }
+    private bool ShouldSerializehero() { return heroSpecified; }
+    private void Resethero() { heroSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3620,77 +6385,149 @@ namespace SteamKit2.GC.Dota.Internal
     public MatchDetails() {}
     
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private ulong _matchid = default(ulong);
+    private ulong? _matchid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matchid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong matchid
     {
-      get { return _matchid; }
+      get { return _matchid?? default(ulong); }
       set { _matchid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchidSpecified
+    {
+      get { return _matchid != null; }
+      set { if (value == (_matchid== null)) _matchid = value ? this.matchid : (ulong?)null; }
+    }
+    private bool ShouldSerializematchid() { return matchidSpecified; }
+    private void Resetmatchid() { matchidSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private float _time_of_day = default(float);
+    private float? _time_of_day;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_of_day", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float time_of_day
     {
-      get { return _time_of_day; }
+      get { return _time_of_day?? default(float); }
       set { _time_of_day = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_of_daySpecified
+    {
+      get { return _time_of_day != null; }
+      set { if (value == (_time_of_day== null)) _time_of_day = value ? this.time_of_day : (float?)null; }
+    }
+    private bool ShouldSerializetime_of_day() { return time_of_daySpecified; }
+    private void Resettime_of_day() { time_of_daySpecified = false; }
+    
 
-    private bool _is_nightstalker_night = default(bool);
+    private bool? _is_nightstalker_night;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_nightstalker_night", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_nightstalker_night
     {
-      get { return _is_nightstalker_night; }
+      get { return _is_nightstalker_night?? default(bool); }
       set { _is_nightstalker_night = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_nightstalker_nightSpecified
+    {
+      get { return _is_nightstalker_night != null; }
+      set { if (value == (_is_nightstalker_night== null)) _is_nightstalker_night = value ? this.is_nightstalker_night : (bool?)null; }
+    }
+    private bool ShouldSerializeis_nightstalker_night() { return is_nightstalker_nightSpecified; }
+    private void Resetis_nightstalker_night() { is_nightstalker_nightSpecified = false; }
+    
 
-    private int _game_time = default(int);
+    private int? _game_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(int); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (int?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private uint _teamid_radiant = default(uint);
+    private uint? _teamid_radiant;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"teamid_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teamid_radiant
     {
-      get { return _teamid_radiant; }
+      get { return _teamid_radiant?? default(uint); }
       set { _teamid_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamid_radiantSpecified
+    {
+      get { return _teamid_radiant != null; }
+      set { if (value == (_teamid_radiant== null)) _teamid_radiant = value ? this.teamid_radiant : (uint?)null; }
+    }
+    private bool ShouldSerializeteamid_radiant() { return teamid_radiantSpecified; }
+    private void Resetteamid_radiant() { teamid_radiantSpecified = false; }
+    
 
-    private uint _teamid_dire = default(uint);
+    private uint? _teamid_dire;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"teamid_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teamid_dire
     {
-      get { return _teamid_dire; }
+      get { return _teamid_dire?? default(uint); }
       set { _teamid_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamid_direSpecified
+    {
+      get { return _teamid_dire != null; }
+      set { if (value == (_teamid_dire== null)) _teamid_dire = value ? this.teamid_dire : (uint?)null; }
+    }
+    private bool ShouldSerializeteamid_dire() { return teamid_direSpecified; }
+    private void Resetteamid_dire() { teamid_direSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PickBanDetails> _picks = new global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PickBanDetails>();
     [global::ProtoBuf.ProtoMember(10, Name=@"picks", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTARealtimeGameStats.PickBanDetails> picks
@@ -3720,41 +6557,77 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private bool _single_team = default(bool);
+    private bool? _single_team;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"single_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool single_team
     {
-      get { return _single_team; }
+      get { return _single_team?? default(bool); }
       set { _single_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool single_teamSpecified
+    {
+      get { return _single_team != null; }
+      set { if (value == (_single_team== null)) _single_team = value ? this.single_team : (bool?)null; }
+    }
+    private bool ShouldSerializesingle_team() { return single_teamSpecified; }
+    private void Resetsingle_team() { single_teamSpecified = false; }
+    
 
-    private uint _cheers_peak = default(uint);
+    private uint? _cheers_peak;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"cheers_peak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cheers_peak
     {
-      get { return _cheers_peak; }
+      get { return _cheers_peak?? default(uint); }
       set { _cheers_peak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cheers_peakSpecified
+    {
+      get { return _cheers_peak != null; }
+      set { if (value == (_cheers_peak== null)) _cheers_peak = value ? this.cheers_peak : (uint?)null; }
+    }
+    private bool ShouldSerializecheers_peak() { return cheers_peakSpecified; }
+    private void Resetcheers_peak() { cheers_peakSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3929,64 +6802,118 @@ namespace SteamKit2.GC.Dota.Internal
       set { _graph_data = value; }
     }
 
-    private bool _delta_frame = default(bool);
+    private bool? _delta_frame;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"delta_frame", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool delta_frame
     {
-      get { return _delta_frame; }
+      get { return _delta_frame?? default(bool); }
       set { _delta_frame = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delta_frameSpecified
+    {
+      get { return _delta_frame != null; }
+      set { if (value == (_delta_frame== null)) _delta_frame = value ? this.delta_frame : (bool?)null; }
+    }
+    private bool ShouldSerializedelta_frame() { return delta_frameSpecified; }
+    private void Resetdelta_frame() { delta_frameSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"TeamDetails")]
   public partial class TeamDetails : global::ProtoBuf.IExtensible
   {
     public TeamDetails() {}
     
 
-    private uint _team_number = default(uint);
+    private uint? _team_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_number
     {
-      get { return _team_number; }
+      get { return _team_number?? default(uint); }
       set { _team_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_numberSpecified
+    {
+      get { return _team_number != null; }
+      set { if (value == (_team_number== null)) _team_number = value ? this.team_number : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_number() { return team_numberSpecified; }
+    private void Resetteam_number() { team_numberSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTARealtimeGameStatsTerse.PlayerDetails> _players = new global::System.Collections.Generic.List<CMsgDOTARealtimeGameStatsTerse.PlayerDetails>();
     [global::ProtoBuf.ProtoMember(6, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTARealtimeGameStatsTerse.PlayerDetails> players
@@ -4005,131 +6932,257 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerDetails() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _playerid = default(uint);
+    private uint? _playerid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"playerid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint playerid
     {
-      get { return _playerid; }
+      get { return _playerid?? default(uint); }
       set { _playerid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playeridSpecified
+    {
+      get { return _playerid != null; }
+      set { if (value == (_playerid== null)) _playerid = value ? this.playerid : (uint?)null; }
+    }
+    private bool ShouldSerializeplayerid() { return playeridSpecified; }
+    private void Resetplayerid() { playeridSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _heroid = default(uint);
+    private uint? _heroid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"heroid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint heroid
     {
-      get { return _heroid; }
+      get { return _heroid?? default(uint); }
       set { _heroid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heroidSpecified
+    {
+      get { return _heroid != null; }
+      set { if (value == (_heroid== null)) _heroid = value ? this.heroid : (uint?)null; }
+    }
+    private bool ShouldSerializeheroid() { return heroidSpecified; }
+    private void Resetheroid() { heroidSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _kill_count = default(uint);
+    private uint? _kill_count;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"kill_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kill_count
     {
-      get { return _kill_count; }
+      get { return _kill_count?? default(uint); }
       set { _kill_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kill_countSpecified
+    {
+      get { return _kill_count != null; }
+      set { if (value == (_kill_count== null)) _kill_count = value ? this.kill_count : (uint?)null; }
+    }
+    private bool ShouldSerializekill_count() { return kill_countSpecified; }
+    private void Resetkill_count() { kill_countSpecified = false; }
+    
 
-    private uint _death_count = default(uint);
+    private uint? _death_count;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"death_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint death_count
     {
-      get { return _death_count; }
+      get { return _death_count?? default(uint); }
       set { _death_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool death_countSpecified
+    {
+      get { return _death_count != null; }
+      set { if (value == (_death_count== null)) _death_count = value ? this.death_count : (uint?)null; }
+    }
+    private bool ShouldSerializedeath_count() { return death_countSpecified; }
+    private void Resetdeath_count() { death_countSpecified = false; }
+    
 
-    private uint _assists_count = default(uint);
+    private uint? _assists_count;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"assists_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists_count
     {
-      get { return _assists_count; }
+      get { return _assists_count?? default(uint); }
       set { _assists_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assists_countSpecified
+    {
+      get { return _assists_count != null; }
+      set { if (value == (_assists_count== null)) _assists_count = value ? this.assists_count : (uint?)null; }
+    }
+    private bool ShouldSerializeassists_count() { return assists_countSpecified; }
+    private void Resetassists_count() { assists_countSpecified = false; }
+    
 
-    private uint _denies_count = default(uint);
+    private uint? _denies_count;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"denies_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies_count
     {
-      get { return _denies_count; }
+      get { return _denies_count?? default(uint); }
       set { _denies_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool denies_countSpecified
+    {
+      get { return _denies_count != null; }
+      set { if (value == (_denies_count== null)) _denies_count = value ? this.denies_count : (uint?)null; }
+    }
+    private bool ShouldSerializedenies_count() { return denies_countSpecified; }
+    private void Resetdenies_count() { denies_countSpecified = false; }
+    
 
-    private uint _lh_count = default(uint);
+    private uint? _lh_count;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"lh_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lh_count
     {
-      get { return _lh_count; }
+      get { return _lh_count?? default(uint); }
       set { _lh_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lh_countSpecified
+    {
+      get { return _lh_count != null; }
+      set { if (value == (_lh_count== null)) _lh_count = value ? this.lh_count : (uint?)null; }
+    }
+    private bool ShouldSerializelh_count() { return lh_countSpecified; }
+    private void Resetlh_count() { lh_countSpecified = false; }
+    
 
-    private uint _gold = default(uint);
+    private uint? _gold;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold
     {
-      get { return _gold; }
+      get { return _gold?? default(uint); }
       set { _gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goldSpecified
+    {
+      get { return _gold != null; }
+      set { if (value == (_gold== null)) _gold = value ? this.gold : (uint?)null; }
+    }
+    private bool ShouldSerializegold() { return goldSpecified; }
+    private void Resetgold() { goldSpecified = false; }
+    
 
-    private float _x = default(float);
+    private float? _x;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float x
     {
-      get { return _x; }
+      get { return _x?? default(float); }
       set { _x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xSpecified
+    {
+      get { return _x != null; }
+      set { if (value == (_x== null)) _x = value ? this.x : (float?)null; }
+    }
+    private bool ShouldSerializex() { return xSpecified; }
+    private void Resetx() { xSpecified = false; }
+    
 
-    private float _y = default(float);
+    private float? _y;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float y
     {
-      get { return _y; }
+      get { return _y?? default(float); }
       set { _y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ySpecified
+    {
+      get { return _y != null; }
+      set { if (value == (_y== null)) _y = value ? this.y : (float?)null; }
+    }
+    private bool ShouldSerializey() { return ySpecified; }
+    private void Resety() { ySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4141,77 +7194,149 @@ namespace SteamKit2.GC.Dota.Internal
     public BuildingDetails() {}
     
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private float _heading = default(float);
+    private float? _heading;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"heading", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float heading
     {
-      get { return _heading; }
+      get { return _heading?? default(float); }
       set { _heading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool headingSpecified
+    {
+      get { return _heading != null; }
+      set { if (value == (_heading== null)) _heading = value ? this.heading : (float?)null; }
+    }
+    private bool ShouldSerializeheading() { return headingSpecified; }
+    private void Resetheading() { headingSpecified = false; }
+    
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private uint _lane = default(uint);
+    private uint? _lane;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lane", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lane
     {
-      get { return _lane; }
+      get { return _lane?? default(uint); }
       set { _lane = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool laneSpecified
+    {
+      get { return _lane != null; }
+      set { if (value == (_lane== null)) _lane = value ? this.lane : (uint?)null; }
+    }
+    private bool ShouldSerializelane() { return laneSpecified; }
+    private void Resetlane() { laneSpecified = false; }
+    
 
-    private uint _tier = default(uint);
+    private uint? _tier;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tier
     {
-      get { return _tier; }
+      get { return _tier?? default(uint); }
       set { _tier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tierSpecified
+    {
+      get { return _tier != null; }
+      set { if (value == (_tier== null)) _tier = value ? this.tier : (uint?)null; }
+    }
+    private bool ShouldSerializetier() { return tierSpecified; }
+    private void Resettier() { tierSpecified = false; }
+    
 
-    private float _x = default(float);
+    private float? _x;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float x
     {
-      get { return _x; }
+      get { return _x?? default(float); }
       set { _x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xSpecified
+    {
+      get { return _x != null; }
+      set { if (value == (_x== null)) _x = value ? this.x : (float?)null; }
+    }
+    private bool ShouldSerializex() { return xSpecified; }
+    private void Resetx() { xSpecified = false; }
+    
 
-    private float _y = default(float);
+    private float? _y;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float y
     {
-      get { return _y; }
+      get { return _y?? default(float); }
       set { _y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ySpecified
+    {
+      get { return _y != null; }
+      set { if (value == (_y== null)) _y = value ? this.y : (float?)null; }
+    }
+    private bool ShouldSerializey() { return ySpecified; }
+    private void Resety() { ySpecified = false; }
+    
 
-    private bool _destroyed = default(bool);
+    private bool? _destroyed;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"destroyed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool destroyed
     {
-      get { return _destroyed; }
+      get { return _destroyed?? default(bool); }
       set { _destroyed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool destroyedSpecified
+    {
+      get { return _destroyed != null; }
+      set { if (value == (_destroyed== null)) _destroyed = value ? this.destroyed : (bool?)null; }
+    }
+    private bool ShouldSerializedestroyed() { return destroyedSpecified; }
+    private void Resetdestroyed() { destroyedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4223,41 +7348,77 @@ namespace SteamKit2.GC.Dota.Internal
     public MatchDetails() {}
     
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private ulong _matchid = default(ulong);
+    private ulong? _matchid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matchid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong matchid
     {
-      get { return _matchid; }
+      get { return _matchid?? default(ulong); }
       set { _matchid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchidSpecified
+    {
+      get { return _matchid != null; }
+      set { if (value == (_matchid== null)) _matchid = value ? this.matchid : (ulong?)null; }
+    }
+    private bool ShouldSerializematchid() { return matchidSpecified; }
+    private void Resetmatchid() { matchidSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private int _game_time = default(int);
+    private int? _game_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(int); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (int?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _steam_broadcaster_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"steam_broadcaster_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> steam_broadcaster_account_ids
@@ -4266,23 +7427,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4316,14 +7495,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientMatchGroupsVersion() {}
     
 
-    private uint _matchgroups_version = default(uint);
+    private uint? _matchgroups_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchgroups_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchgroups_version
     {
-      get { return _matchgroups_version; }
+      get { return _matchgroups_version?? default(uint); }
       set { _matchgroups_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroups_versionSpecified
+    {
+      get { return _matchgroups_version != null; }
+      set { if (value == (_matchgroups_version== null)) _matchgroups_version = value ? this.matchgroups_version : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroups_version() { return matchgroups_versionSpecified; }
+    private void Resetmatchgroups_version() { matchgroups_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4335,95 +7523,185 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTASDOHeroStatsHistory() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
 
-    private uint _lobby_type = default(uint);
+    private uint? _lobby_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(uint); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private bool _won = default(bool);
+    private bool? _won;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"won", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool won
     {
-      get { return _won; }
+      get { return _won?? default(bool); }
       set { _won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wonSpecified
+    {
+      get { return _won != null; }
+      set { if (value == (_won== null)) _won = value ? this.won : (bool?)null; }
+    }
+    private bool ShouldSerializewon() { return wonSpecified; }
+    private void Resetwon() { wonSpecified = false; }
+    
 
-    private uint _gpm = default(uint);
+    private uint? _gpm;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(uint); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (uint?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private uint _xpm = default(uint);
+    private uint? _xpm;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"xpm", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xpm
     {
-      get { return _xpm; }
+      get { return _xpm?? default(uint); }
       set { _xpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xpmSpecified
+    {
+      get { return _xpm != null; }
+      set { if (value == (_xpm== null)) _xpm = value ? this.xpm : (uint?)null; }
+    }
+    private bool ShouldSerializexpm() { return xpmSpecified; }
+    private void Resetxpm() { xpmSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4447,86 +7725,167 @@ namespace SteamKit2.GC.Dota.Internal
     public Reward() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _itemdef = default(uint);
+    private uint? _itemdef;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemdef", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint itemdef
     {
-      get { return _itemdef; }
+      get { return _itemdef?? default(uint); }
       set { _itemdef = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdefSpecified
+    {
+      get { return _itemdef != null; }
+      set { if (value == (_itemdef== null)) _itemdef = value ? this.itemdef : (uint?)null; }
+    }
+    private bool ShouldSerializeitemdef() { return itemdefSpecified; }
+    private void Resetitemdef() { itemdefSpecified = false; }
+    
 
-    private uint _importance = default(uint);
+    private uint? _importance;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"importance", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint importance
     {
-      get { return _importance; }
+      get { return _importance?? default(uint); }
       set { _importance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool importanceSpecified
+    {
+      get { return _importance != null; }
+      set { if (value == (_importance== null)) _importance = value ? this.importance : (uint?)null; }
+    }
+    private bool ShouldSerializeimportance() { return importanceSpecified; }
+    private void Resetimportance() { importanceSpecified = false; }
+    
 
-    private uint _base_level = default(uint);
+    private uint? _base_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"base_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint base_level
     {
-      get { return _base_level; }
+      get { return _base_level?? default(uint); }
       set { _base_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool base_levelSpecified
+    {
+      get { return _base_level != null; }
+      set { if (value == (_base_level== null)) _base_level = value ? this.base_level : (uint?)null; }
+    }
+    private bool ShouldSerializebase_level() { return base_levelSpecified; }
+    private void Resetbase_level() { base_levelSpecified = false; }
+    
 
-    private uint _repeat_level = default(uint);
+    private uint? _repeat_level;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"repeat_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint repeat_level
     {
-      get { return _repeat_level; }
+      get { return _repeat_level?? default(uint); }
       set { _repeat_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool repeat_levelSpecified
+    {
+      get { return _repeat_level != null; }
+      set { if (value == (_repeat_level== null)) _repeat_level = value ? this.repeat_level : (uint?)null; }
+    }
+    private bool ShouldSerializerepeat_level() { return repeat_levelSpecified; }
+    private void Resetrepeat_level() { repeat_levelSpecified = false; }
+    
 
-    private CMsgDOTASeasonRewards.ERewardType _reward_type = CMsgDOTASeasonRewards.ERewardType.EconItem;
+    private CMsgDOTASeasonRewards.ERewardType? _reward_type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"reward_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonRewards.ERewardType.EconItem)]
     public CMsgDOTASeasonRewards.ERewardType reward_type
     {
-      get { return _reward_type; }
+      get { return _reward_type?? CMsgDOTASeasonRewards.ERewardType.EconItem; }
       set { _reward_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_typeSpecified
+    {
+      get { return _reward_type != null; }
+      set { if (value == (_reward_type== null)) _reward_type = value ? this.reward_type : (CMsgDOTASeasonRewards.ERewardType?)null; }
+    }
+    private bool ShouldSerializereward_type() { return reward_typeSpecified; }
+    private void Resetreward_type() { reward_typeSpecified = false; }
+    
 
-    private string _image = "";
+    private string _image;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"image", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string image
     {
-      get { return _image; }
+      get { return _image?? ""; }
       set { _image = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool imageSpecified
+    {
+      get { return _image != null; }
+      set { if (value == (_image== null)) _image = value ? this.image : (string)null; }
+    }
+    private bool ShouldSerializeimage() { return imageSpecified; }
+    private void Resetimage() { imageSpecified = false; }
+    
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
 
-    private uint _effect_index = default(uint);
+    private uint? _effect_index;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"effect_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint effect_index
     {
-      get { return _effect_index; }
+      get { return _effect_index?? default(uint); }
       set { _effect_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool effect_indexSpecified
+    {
+      get { return _effect_index != null; }
+      set { if (value == (_effect_index== null)) _effect_index = value ? this.effect_index : (uint?)null; }
+    }
+    private bool ShouldSerializeeffect_index() { return effect_indexSpecified; }
+    private void Reseteffect_index() { effect_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4575,86 +7934,167 @@ namespace SteamKit2.GC.Dota.Internal
     public Achievement() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private string _image = "";
+    private string _image;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"image", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string image
     {
-      get { return _image; }
+      get { return _image?? ""; }
       set { _image = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool imageSpecified
+    {
+      get { return _image != null; }
+      set { if (value == (_image== null)) _image = value ? this.image : (string)null; }
+    }
+    private bool ShouldSerializeimage() { return imageSpecified; }
+    private void Resetimage() { imageSpecified = false; }
+    
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
 
-    private uint _max_grants = default(uint);
+    private uint? _max_grants;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"max_grants", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_grants
     {
-      get { return _max_grants; }
+      get { return _max_grants?? default(uint); }
       set { _max_grants = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_grantsSpecified
+    {
+      get { return _max_grants != null; }
+      set { if (value == (_max_grants== null)) _max_grants = value ? this.max_grants : (uint?)null; }
+    }
+    private bool ShouldSerializemax_grants() { return max_grantsSpecified; }
+    private void Resetmax_grants() { max_grantsSpecified = false; }
+    
 
-    private uint _normal_points = default(uint);
+    private uint? _normal_points;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"normal_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint normal_points
     {
-      get { return _normal_points; }
+      get { return _normal_points?? default(uint); }
       set { _normal_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool normal_pointsSpecified
+    {
+      get { return _normal_points != null; }
+      set { if (value == (_normal_points== null)) _normal_points = value ? this.normal_points : (uint?)null; }
+    }
+    private bool ShouldSerializenormal_points() { return normal_pointsSpecified; }
+    private void Resetnormal_points() { normal_pointsSpecified = false; }
+    
 
-    private uint _tracking_achievement = default(uint);
+    private uint? _tracking_achievement;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"tracking_achievement", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tracking_achievement
     {
-      get { return _tracking_achievement; }
+      get { return _tracking_achievement?? default(uint); }
       set { _tracking_achievement = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tracking_achievementSpecified
+    {
+      get { return _tracking_achievement != null; }
+      set { if (value == (_tracking_achievement== null)) _tracking_achievement = value ? this.tracking_achievement : (uint?)null; }
+    }
+    private bool ShouldSerializetracking_achievement() { return tracking_achievementSpecified; }
+    private void Resettracking_achievement() { tracking_achievementSpecified = false; }
+    
 
-    private uint _achievement_goal = default(uint);
+    private uint? _achievement_goal;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"achievement_goal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_goal
     {
-      get { return _achievement_goal; }
+      get { return _achievement_goal?? default(uint); }
       set { _achievement_goal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_goalSpecified
+    {
+      get { return _achievement_goal != null; }
+      set { if (value == (_achievement_goal== null)) _achievement_goal = value ? this.achievement_goal : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_goal() { return achievement_goalSpecified; }
+    private void Resetachievement_goal() { achievement_goalSpecified = false; }
+    
 
-    private uint _achievement_level = default(uint);
+    private uint? _achievement_level;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"achievement_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_level
     {
-      get { return _achievement_level; }
+      get { return _achievement_level?? default(uint); }
       set { _achievement_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_levelSpecified
+    {
+      get { return _achievement_level != null; }
+      set { if (value == (_achievement_level== null)) _achievement_level = value ? this.achievement_level : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_level() { return achievement_levelSpecified; }
+    private void Resetachievement_level() { achievement_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4685,64 +8125,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _in_game_prediction_count_per_game = default(uint);
+    private uint? _in_game_prediction_count_per_game;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"in_game_prediction_count_per_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint in_game_prediction_count_per_game
     {
-      get { return _in_game_prediction_count_per_game; }
+      get { return _in_game_prediction_count_per_game?? default(uint); }
       set { _in_game_prediction_count_per_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_game_prediction_count_per_gameSpecified
+    {
+      get { return _in_game_prediction_count_per_game != null; }
+      set { if (value == (_in_game_prediction_count_per_game== null)) _in_game_prediction_count_per_game = value ? this.in_game_prediction_count_per_game : (uint?)null; }
+    }
+    private bool ShouldSerializein_game_prediction_count_per_game() { return in_game_prediction_count_per_gameSpecified; }
+    private void Resetin_game_prediction_count_per_game() { in_game_prediction_count_per_gameSpecified = false; }
+    
 
-    private uint _in_game_prediction_voting_period_minutes = default(uint);
+    private uint? _in_game_prediction_voting_period_minutes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"in_game_prediction_voting_period_minutes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint in_game_prediction_voting_period_minutes
     {
-      get { return _in_game_prediction_voting_period_minutes; }
+      get { return _in_game_prediction_voting_period_minutes?? default(uint); }
       set { _in_game_prediction_voting_period_minutes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_game_prediction_voting_period_minutesSpecified
+    {
+      get { return _in_game_prediction_voting_period_minutes != null; }
+      set { if (value == (_in_game_prediction_voting_period_minutes== null)) _in_game_prediction_voting_period_minutes = value ? this.in_game_prediction_voting_period_minutes : (uint?)null; }
+    }
+    private bool ShouldSerializein_game_prediction_voting_period_minutes() { return in_game_prediction_voting_period_minutesSpecified; }
+    private void Resetin_game_prediction_voting_period_minutes() { in_game_prediction_voting_period_minutesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Choice")]
   public partial class Choice : global::ProtoBuf.IExtensible
   {
     public Choice() {}
     
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _min_raw_value = default(uint);
+    private uint? _min_raw_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"min_raw_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint min_raw_value
     {
-      get { return _min_raw_value; }
+      get { return _min_raw_value?? default(uint); }
       set { _min_raw_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_raw_valueSpecified
+    {
+      get { return _min_raw_value != null; }
+      set { if (value == (_min_raw_value== null)) _min_raw_value = value ? this.min_raw_value : (uint?)null; }
+    }
+    private bool ShouldSerializemin_raw_value() { return min_raw_valueSpecified; }
+    private void Resetmin_raw_value() { min_raw_valueSpecified = false; }
+    
 
-    private uint _max_raw_value = default(uint);
+    private uint? _max_raw_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_raw_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_raw_value
     {
-      get { return _max_raw_value; }
+      get { return _max_raw_value?? default(uint); }
       set { _max_raw_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_raw_valueSpecified
+    {
+      get { return _max_raw_value != null; }
+      set { if (value == (_max_raw_value== null)) _max_raw_value = value ? this.max_raw_value : (uint?)null; }
+    }
+    private bool ShouldSerializemax_raw_value() { return max_raw_valueSpecified; }
+    private void Resetmax_raw_value() { max_raw_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4754,14 +8248,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Answers() {}
     
 
-    private uint _answer_id = default(uint);
+    private uint? _answer_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"answer_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint answer_id
     {
-      get { return _answer_id; }
+      get { return _answer_id?? default(uint); }
       set { _answer_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_idSpecified
+    {
+      get { return _answer_id != null; }
+      set { if (value == (_answer_id== null)) _answer_id = value ? this.answer_id : (uint?)null; }
+    }
+    private bool ShouldSerializeanswer_id() { return answer_idSpecified; }
+    private void Resetanswer_id() { answer_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4773,23 +8276,41 @@ namespace SteamKit2.GC.Dota.Internal
     public QueryKeyValues() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4801,23 +8322,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Prediction() {}
     
 
-    private CMsgDOTASeasonPredictions.ePredictionType _type = CMsgDOTASeasonPredictions.ePredictionType.Generic;
+    private CMsgDOTASeasonPredictions.ePredictionType? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.ePredictionType.Generic)]
     public CMsgDOTASeasonPredictions.ePredictionType type
     {
-      get { return _type; }
+      get { return _type?? CMsgDOTASeasonPredictions.ePredictionType.Generic; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (CMsgDOTASeasonPredictions.ePredictionType?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private string _question = "";
+    private string _question;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"question", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string question
     {
-      get { return _question; }
+      get { return _question?? ""; }
       set { _question = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool questionSpecified
+    {
+      get { return _question != null; }
+      set { if (value == (_question== null)) _question = value ? this.question : (string)null; }
+    }
+    private bool ShouldSerializequestion() { return questionSpecified; }
+    private void Resetquestion() { questionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice> _choices = new global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice>();
     [global::ProtoBuf.ProtoMember(3, Name=@"choices", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice> choices
@@ -4826,59 +8365,113 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _selection_id = default(uint);
+    private uint? _selection_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"selection_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint selection_id
     {
-      get { return _selection_id; }
+      get { return _selection_id?? default(uint); }
       set { _selection_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool selection_idSpecified
+    {
+      get { return _selection_id != null; }
+      set { if (value == (_selection_id== null)) _selection_id = value ? this.selection_id : (uint?)null; }
+    }
+    private bool ShouldSerializeselection_id() { return selection_idSpecified; }
+    private void Resetselection_id() { selection_idSpecified = false; }
+    
 
-    private uint _start_date = default(uint);
+    private uint? _start_date;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"start_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_date
     {
-      get { return _start_date; }
+      get { return _start_date?? default(uint); }
       set { _start_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_dateSpecified
+    {
+      get { return _start_date != null; }
+      set { if (value == (_start_date== null)) _start_date = value ? this.start_date : (uint?)null; }
+    }
+    private bool ShouldSerializestart_date() { return start_dateSpecified; }
+    private void Resetstart_date() { start_dateSpecified = false; }
+    
 
-    private uint _lock_date = default(uint);
+    private uint? _lock_date;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lock_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lock_date
     {
-      get { return _lock_date; }
+      get { return _lock_date?? default(uint); }
       set { _lock_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lock_dateSpecified
+    {
+      get { return _lock_date != null; }
+      set { if (value == (_lock_date== null)) _lock_date = value ? this.lock_date : (uint?)null; }
+    }
+    private bool ShouldSerializelock_date() { return lock_dateSpecified; }
+    private void Resetlock_date() { lock_dateSpecified = false; }
+    
 
-    private uint _reward = default(uint);
+    private uint? _reward;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"reward", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward
     {
-      get { return _reward; }
+      get { return _reward?? default(uint); }
       set { _reward = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rewardSpecified
+    {
+      get { return _reward != null; }
+      set { if (value == (_reward== null)) _reward = value ? this.reward : (uint?)null; }
+    }
+    private bool ShouldSerializereward() { return rewardSpecified; }
+    private void Resetreward() { rewardSpecified = false; }
+    
 
-    private CMsgDOTASeasonPredictions.eAnswerType _answer_type = CMsgDOTASeasonPredictions.eAnswerType.SingleInt;
+    private CMsgDOTASeasonPredictions.eAnswerType? _answer_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"answer_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.eAnswerType.SingleInt)]
     public CMsgDOTASeasonPredictions.eAnswerType answer_type
     {
-      get { return _answer_type; }
+      get { return _answer_type?? CMsgDOTASeasonPredictions.eAnswerType.SingleInt; }
       set { _answer_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_typeSpecified
+    {
+      get { return _answer_type != null; }
+      set { if (value == (_answer_type== null)) _answer_type = value ? this.answer_type : (CMsgDOTASeasonPredictions.eAnswerType?)null; }
+    }
+    private bool ShouldSerializeanswer_type() { return answer_typeSpecified; }
+    private void Resetanswer_type() { answer_typeSpecified = false; }
+    
 
-    private uint _answer_id = default(uint);
+    private uint? _answer_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"answer_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint answer_id
     {
-      get { return _answer_id; }
+      get { return _answer_id?? default(uint); }
       set { _answer_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_idSpecified
+    {
+      get { return _answer_id != null; }
+      set { if (value == (_answer_id== null)) _answer_id = value ? this.answer_id : (uint?)null; }
+    }
+    private bool ShouldSerializeanswer_id() { return answer_idSpecified; }
+    private void Resetanswer_id() { answer_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Answers> _answers = new global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Answers>();
     [global::ProtoBuf.ProtoMember(10, Name=@"answers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Answers> answers
@@ -4887,14 +8480,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _query_name = "";
+    private string _query_name;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"query_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string query_name
     {
-      get { return _query_name; }
+      get { return _query_name?? ""; }
       set { _query_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_nameSpecified
+    {
+      get { return _query_name != null; }
+      set { if (value == (_query_name== null)) _query_name = value ? this.query_name : (string)null; }
+    }
+    private bool ShouldSerializequery_name() { return query_nameSpecified; }
+    private void Resetquery_name() { query_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _query_bind_params = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(12, Name=@"query_bind_params", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> query_bind_params
@@ -4903,32 +8505,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _lock_on_selection_id = default(uint);
+    private uint? _lock_on_selection_id;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"lock_on_selection_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lock_on_selection_id
     {
-      get { return _lock_on_selection_id; }
+      get { return _lock_on_selection_id?? default(uint); }
       set { _lock_on_selection_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lock_on_selection_idSpecified
+    {
+      get { return _lock_on_selection_id != null; }
+      set { if (value == (_lock_on_selection_id== null)) _lock_on_selection_id = value ? this.lock_on_selection_id : (uint?)null; }
+    }
+    private bool ShouldSerializelock_on_selection_id() { return lock_on_selection_idSpecified; }
+    private void Resetlock_on_selection_id() { lock_on_selection_idSpecified = false; }
+    
 
-    private uint _lock_on_selection_value = default(uint);
+    private uint? _lock_on_selection_value;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"lock_on_selection_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lock_on_selection_value
     {
-      get { return _lock_on_selection_value; }
+      get { return _lock_on_selection_value?? default(uint); }
       set { _lock_on_selection_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lock_on_selection_valueSpecified
+    {
+      get { return _lock_on_selection_value != null; }
+      set { if (value == (_lock_on_selection_value== null)) _lock_on_selection_value = value ? this.lock_on_selection_value : (uint?)null; }
+    }
+    private bool ShouldSerializelock_on_selection_value() { return lock_on_selection_valueSpecified; }
+    private void Resetlock_on_selection_value() { lock_on_selection_valueSpecified = false; }
+    
 
-    private bool _lock_on_selection_set = default(bool);
+    private bool? _lock_on_selection_set;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"lock_on_selection_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool lock_on_selection_set
     {
-      get { return _lock_on_selection_set; }
+      get { return _lock_on_selection_set?? default(bool); }
       set { _lock_on_selection_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lock_on_selection_setSpecified
+    {
+      get { return _lock_on_selection_set != null; }
+      set { if (value == (_lock_on_selection_set== null)) _lock_on_selection_set = value ? this.lock_on_selection_set : (bool?)null; }
+    }
+    private bool ShouldSerializelock_on_selection_set() { return lock_on_selection_setSpecified; }
+    private void Resetlock_on_selection_set() { lock_on_selection_setSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4940,50 +8569,95 @@ namespace SteamKit2.GC.Dota.Internal
     public InGamePrediction() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private CMsgDOTASeasonPredictions.ePredictionType _type = CMsgDOTASeasonPredictions.ePredictionType.Generic;
+    private CMsgDOTASeasonPredictions.ePredictionType? _type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.ePredictionType.Generic)]
     public CMsgDOTASeasonPredictions.ePredictionType type
     {
-      get { return _type; }
+      get { return _type?? CMsgDOTASeasonPredictions.ePredictionType.Generic; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (CMsgDOTASeasonPredictions.ePredictionType?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private CMsgDOTASeasonPredictions.eRandomSelectionGroup_t _group = CMsgDOTASeasonPredictions.eRandomSelectionGroup_t.EarlyGame;
+    private CMsgDOTASeasonPredictions.eRandomSelectionGroup_t? _group;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.eRandomSelectionGroup_t.EarlyGame)]
     public CMsgDOTASeasonPredictions.eRandomSelectionGroup_t group
     {
-      get { return _group; }
+      get { return _group?? CMsgDOTASeasonPredictions.eRandomSelectionGroup_t.EarlyGame; }
       set { _group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupSpecified
+    {
+      get { return _group != null; }
+      set { if (value == (_group== null)) _group = value ? this.group : (CMsgDOTASeasonPredictions.eRandomSelectionGroup_t?)null; }
+    }
+    private bool ShouldSerializegroup() { return groupSpecified; }
+    private void Resetgroup() { groupSpecified = false; }
+    
 
-    private string _question = "";
+    private string _question;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"question", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string question
     {
-      get { return _question; }
+      get { return _question?? ""; }
       set { _question = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool questionSpecified
+    {
+      get { return _question != null; }
+      set { if (value == (_question== null)) _question = value ? this.question : (string)null; }
+    }
+    private bool ShouldSerializequestion() { return questionSpecified; }
+    private void Resetquestion() { questionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice> _choices = new global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice>();
     [global::ProtoBuf.ProtoMember(6, Name=@"choices", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.Choice> choices
@@ -4999,14 +8673,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _query_name = "";
+    private string _query_name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"query_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string query_name
     {
-      get { return _query_name; }
+      get { return _query_name?? ""; }
       set { _query_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_nameSpecified
+    {
+      get { return _query_name != null; }
+      set { if (value == (_query_name== null)) _query_name = value ? this.query_name : (string)null; }
+    }
+    private bool ShouldSerializequery_name() { return query_nameSpecified; }
+    private void Resetquery_name() { query_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.QueryKeyValues> _query_values = new global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.QueryKeyValues>();
     [global::ProtoBuf.ProtoMember(9, Name=@"query_values", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTASeasonPredictions.QueryKeyValues> query_values
@@ -5015,50 +8698,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgDOTASeasonPredictions.eResolutionType_t _answer_resolution_type = CMsgDOTASeasonPredictions.eResolutionType_t.InvalidQuery;
+    private CMsgDOTASeasonPredictions.eResolutionType_t? _answer_resolution_type;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"answer_resolution_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.eResolutionType_t.InvalidQuery)]
     public CMsgDOTASeasonPredictions.eResolutionType_t answer_resolution_type
     {
-      get { return _answer_resolution_type; }
+      get { return _answer_resolution_type?? CMsgDOTASeasonPredictions.eResolutionType_t.InvalidQuery; }
       set { _answer_resolution_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool answer_resolution_typeSpecified
+    {
+      get { return _answer_resolution_type != null; }
+      set { if (value == (_answer_resolution_type== null)) _answer_resolution_type = value ? this.answer_resolution_type : (CMsgDOTASeasonPredictions.eResolutionType_t?)null; }
+    }
+    private bool ShouldSerializeanswer_resolution_type() { return answer_resolution_typeSpecified; }
+    private void Resetanswer_resolution_type() { answer_resolution_typeSpecified = false; }
+    
 
-    private uint _points_to_grant = default(uint);
+    private uint? _points_to_grant;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"points_to_grant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_to_grant
     {
-      get { return _points_to_grant; }
+      get { return _points_to_grant?? default(uint); }
       set { _points_to_grant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_to_grantSpecified
+    {
+      get { return _points_to_grant != null; }
+      set { if (value == (_points_to_grant== null)) _points_to_grant = value ? this.points_to_grant : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_to_grant() { return points_to_grantSpecified; }
+    private void Resetpoints_to_grant() { points_to_grantSpecified = false; }
+    
 
-    private uint _reward_action = default(uint);
+    private uint? _reward_action;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"reward_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_action
     {
-      get { return _reward_action; }
+      get { return _reward_action?? default(uint); }
       set { _reward_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_actionSpecified
+    {
+      get { return _reward_action != null; }
+      set { if (value == (_reward_action== null)) _reward_action = value ? this.reward_action : (uint?)null; }
+    }
+    private bool ShouldSerializereward_action() { return reward_actionSpecified; }
+    private void Resetreward_action() { reward_actionSpecified = false; }
+    
 
-    private uint _debug_force_selection = default(uint);
+    private uint? _debug_force_selection;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"debug_force_selection", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint debug_force_selection
     {
-      get { return _debug_force_selection; }
+      get { return _debug_force_selection?? default(uint); }
       set { _debug_force_selection = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool debug_force_selectionSpecified
+    {
+      get { return _debug_force_selection != null; }
+      set { if (value == (_debug_force_selection== null)) _debug_force_selection = value ? this.debug_force_selection : (uint?)null; }
+    }
+    private bool ShouldSerializedebug_force_selection() { return debug_force_selectionSpecified; }
+    private void Resetdebug_force_selection() { debug_force_selectionSpecified = false; }
+    
 
-    private CMsgDOTASeasonPredictions.eRawValueType_t _raw_value_type = CMsgDOTASeasonPredictions.eRawValueType_t.Number;
+    private CMsgDOTASeasonPredictions.eRawValueType_t? _raw_value_type;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"raw_value_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTASeasonPredictions.eRawValueType_t.Number)]
     public CMsgDOTASeasonPredictions.eRawValueType_t raw_value_type
     {
-      get { return _raw_value_type; }
+      get { return _raw_value_type?? CMsgDOTASeasonPredictions.eRawValueType_t.Number; }
       set { _raw_value_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_value_typeSpecified
+    {
+      get { return _raw_value_type != null; }
+      set { if (value == (_raw_value_type== null)) _raw_value_type = value ? this.raw_value_type : (CMsgDOTASeasonPredictions.eRawValueType_t?)null; }
+    }
+    private bool ShouldSerializeraw_value_type() { return raw_value_typeSpecified; }
+    private void Resetraw_value_type() { raw_value_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5187,23 +8915,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAMatch() {}
     
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private uint _startTime = default(uint);
+    private uint? _startTime;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"startTime", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint startTime
     {
-      get { return _startTime; }
+      get { return _startTime?? default(uint); }
       set { _startTime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool startTimeSpecified
+    {
+      get { return _startTime != null; }
+      set { if (value == (_startTime== null)) _startTime = value ? this.startTime : (uint?)null; }
+    }
+    private bool ShouldSerializestartTime() { return startTimeSpecified; }
+    private void ResetstartTime() { startTimeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAMatch.Player> _players = new global::System.Collections.Generic.List<CMsgDOTAMatch.Player>();
     [global::ProtoBuf.ProtoMember(5, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAMatch.Player> players
@@ -5212,14 +8958,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _tower_status = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(8, Name=@"tower_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> tower_status
@@ -5235,194 +8990,383 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _cluster = default(uint);
+    private uint? _cluster;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cluster
     {
-      get { return _cluster; }
+      get { return _cluster?? default(uint); }
       set { _cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clusterSpecified
+    {
+      get { return _cluster != null; }
+      set { if (value == (_cluster== null)) _cluster = value ? this.cluster : (uint?)null; }
+    }
+    private bool ShouldSerializecluster() { return clusterSpecified; }
+    private void Resetcluster() { clusterSpecified = false; }
+    
 
-    private uint _first_blood_time = default(uint);
+    private uint? _first_blood_time;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"first_blood_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_time
     {
-      get { return _first_blood_time; }
+      get { return _first_blood_time?? default(uint); }
       set { _first_blood_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_timeSpecified
+    {
+      get { return _first_blood_time != null; }
+      set { if (value == (_first_blood_time== null)) _first_blood_time = value ? this.first_blood_time : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_time() { return first_blood_timeSpecified; }
+    private void Resetfirst_blood_time() { first_blood_timeSpecified = false; }
+    
 
-    private uint _replay_salt = default(uint);
+    private uint? _replay_salt;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"replay_salt", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_salt
     {
-      get { return _replay_salt; }
+      get { return _replay_salt?? default(uint); }
       set { _replay_salt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_saltSpecified
+    {
+      get { return _replay_salt != null; }
+      set { if (value == (_replay_salt== null)) _replay_salt = value ? this.replay_salt : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_salt() { return replay_saltSpecified; }
+    private void Resetreplay_salt() { replay_saltSpecified = false; }
+    
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _lobby_type = default(uint);
+    private uint? _lobby_type;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(uint); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private uint _human_players = default(uint);
+    private uint? _human_players;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"human_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint human_players
     {
-      get { return _human_players; }
+      get { return _human_players?? default(uint); }
       set { _human_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool human_playersSpecified
+    {
+      get { return _human_players != null; }
+      set { if (value == (_human_players== null)) _human_players = value ? this.human_players : (uint?)null; }
+    }
+    private bool ShouldSerializehuman_players() { return human_playersSpecified; }
+    private void Resethuman_players() { human_playersSpecified = false; }
+    
 
-    private uint _average_skill = default(uint);
+    private uint? _average_skill;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"average_skill", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint average_skill
     {
-      get { return _average_skill; }
+      get { return _average_skill?? default(uint); }
       set { _average_skill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_skillSpecified
+    {
+      get { return _average_skill != null; }
+      set { if (value == (_average_skill== null)) _average_skill = value ? this.average_skill : (uint?)null; }
+    }
+    private bool ShouldSerializeaverage_skill() { return average_skillSpecified; }
+    private void Resetaverage_skill() { average_skillSpecified = false; }
+    
 
-    private float _game_balance = default(float);
+    private float? _game_balance;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"game_balance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float game_balance
     {
-      get { return _game_balance; }
+      get { return _game_balance?? default(float); }
       set { _game_balance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_balanceSpecified
+    {
+      get { return _game_balance != null; }
+      set { if (value == (_game_balance== null)) _game_balance = value ? this.game_balance : (float?)null; }
+    }
+    private bool ShouldSerializegame_balance() { return game_balanceSpecified; }
+    private void Resetgame_balance() { game_balanceSpecified = false; }
+    
 
-    private uint _radiant_team_id = default(uint);
+    private uint? _radiant_team_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"radiant_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_team_id
     {
-      get { return _radiant_team_id; }
+      get { return _radiant_team_id?? default(uint); }
       set { _radiant_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_idSpecified
+    {
+      get { return _radiant_team_id != null; }
+      set { if (value == (_radiant_team_id== null)) _radiant_team_id = value ? this.radiant_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_team_id() { return radiant_team_idSpecified; }
+    private void Resetradiant_team_id() { radiant_team_idSpecified = false; }
+    
 
-    private uint _dire_team_id = default(uint);
+    private uint? _dire_team_id;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"dire_team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_team_id
     {
-      get { return _dire_team_id; }
+      get { return _dire_team_id?? default(uint); }
       set { _dire_team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_idSpecified
+    {
+      get { return _dire_team_id != null; }
+      set { if (value == (_dire_team_id== null)) _dire_team_id = value ? this.dire_team_id : (uint?)null; }
+    }
+    private bool ShouldSerializedire_team_id() { return dire_team_idSpecified; }
+    private void Resetdire_team_id() { dire_team_idSpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
 
-    private string _radiant_team_name = "";
+    private string _radiant_team_name;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"radiant_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string radiant_team_name
     {
-      get { return _radiant_team_name; }
+      get { return _radiant_team_name?? ""; }
       set { _radiant_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_nameSpecified
+    {
+      get { return _radiant_team_name != null; }
+      set { if (value == (_radiant_team_name== null)) _radiant_team_name = value ? this.radiant_team_name : (string)null; }
+    }
+    private bool ShouldSerializeradiant_team_name() { return radiant_team_nameSpecified; }
+    private void Resetradiant_team_name() { radiant_team_nameSpecified = false; }
+    
 
-    private string _dire_team_name = "";
+    private string _dire_team_name;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"dire_team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string dire_team_name
     {
-      get { return _dire_team_name; }
+      get { return _dire_team_name?? ""; }
       set { _dire_team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_nameSpecified
+    {
+      get { return _dire_team_name != null; }
+      set { if (value == (_dire_team_name== null)) _dire_team_name = value ? this.dire_team_name : (string)null; }
+    }
+    private bool ShouldSerializedire_team_name() { return dire_team_nameSpecified; }
+    private void Resetdire_team_name() { dire_team_nameSpecified = false; }
+    
 
-    private ulong _radiant_team_logo = default(ulong);
+    private ulong? _radiant_team_logo;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"radiant_team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong radiant_team_logo
     {
-      get { return _radiant_team_logo; }
+      get { return _radiant_team_logo?? default(ulong); }
       set { _radiant_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_logoSpecified
+    {
+      get { return _radiant_team_logo != null; }
+      set { if (value == (_radiant_team_logo== null)) _radiant_team_logo = value ? this.radiant_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeradiant_team_logo() { return radiant_team_logoSpecified; }
+    private void Resetradiant_team_logo() { radiant_team_logoSpecified = false; }
+    
 
-    private ulong _dire_team_logo = default(ulong);
+    private ulong? _dire_team_logo;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"dire_team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong dire_team_logo
     {
-      get { return _dire_team_logo; }
+      get { return _dire_team_logo?? default(ulong); }
       set { _dire_team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_logoSpecified
+    {
+      get { return _dire_team_logo != null; }
+      set { if (value == (_dire_team_logo== null)) _dire_team_logo = value ? this.dire_team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializedire_team_logo() { return dire_team_logoSpecified; }
+    private void Resetdire_team_logo() { dire_team_logoSpecified = false; }
+    
 
-    private uint _radiant_team_complete = default(uint);
+    private uint? _radiant_team_complete;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"radiant_team_complete", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_team_complete
     {
-      get { return _radiant_team_complete; }
+      get { return _radiant_team_complete?? default(uint); }
       set { _radiant_team_complete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_completeSpecified
+    {
+      get { return _radiant_team_complete != null; }
+      set { if (value == (_radiant_team_complete== null)) _radiant_team_complete = value ? this.radiant_team_complete : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_team_complete() { return radiant_team_completeSpecified; }
+    private void Resetradiant_team_complete() { radiant_team_completeSpecified = false; }
+    
 
-    private uint _dire_team_complete = default(uint);
+    private uint? _dire_team_complete;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"dire_team_complete", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_team_complete
     {
-      get { return _dire_team_complete; }
+      get { return _dire_team_complete?? default(uint); }
       set { _dire_team_complete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_completeSpecified
+    {
+      get { return _dire_team_complete != null; }
+      set { if (value == (_dire_team_complete== null)) _dire_team_complete = value ? this.dire_team_complete : (uint?)null; }
+    }
+    private bool ShouldSerializedire_team_complete() { return dire_team_completeSpecified; }
+    private void Resetdire_team_complete() { dire_team_completeSpecified = false; }
+    
 
-    private uint _positive_votes = default(uint);
+    private uint? _positive_votes;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"positive_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint positive_votes
     {
-      get { return _positive_votes; }
+      get { return _positive_votes?? default(uint); }
       set { _positive_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool positive_votesSpecified
+    {
+      get { return _positive_votes != null; }
+      set { if (value == (_positive_votes== null)) _positive_votes = value ? this.positive_votes : (uint?)null; }
+    }
+    private bool ShouldSerializepositive_votes() { return positive_votesSpecified; }
+    private void Resetpositive_votes() { positive_votesSpecified = false; }
+    
 
-    private uint _negative_votes = default(uint);
+    private uint? _negative_votes;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"negative_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint negative_votes
     {
-      get { return _negative_votes; }
+      get { return _negative_votes?? default(uint); }
       set { _negative_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool negative_votesSpecified
+    {
+      get { return _negative_votes != null; }
+      set { if (value == (_negative_votes== null)) _negative_votes = value ? this.negative_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenegative_votes() { return negative_votesSpecified; }
+    private void Resetnegative_votes() { negative_votesSpecified = false; }
+    
 
-    private DOTA_GameMode _game_mode = DOTA_GameMode.DOTA_GAMEMODE_NONE;
+    private DOTA_GameMode? _game_mode;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameMode.DOTA_GAMEMODE_NONE)]
     public DOTA_GameMode game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? DOTA_GameMode.DOTA_GAMEMODE_NONE; }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (DOTA_GameMode?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMatchHeroSelectEvent> _picks_bans = new global::System.Collections.Generic.List<CMatchHeroSelectEvent>();
     [global::ProtoBuf.ProtoMember(32, Name=@"picks_bans", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMatchHeroSelectEvent> picks_bans
@@ -5431,77 +9375,149 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_seq_num = default(ulong);
+    private ulong? _match_seq_num;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"match_seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_seq_num
     {
-      get { return _match_seq_num; }
+      get { return _match_seq_num?? default(ulong); }
       set { _match_seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_seq_numSpecified
+    {
+      get { return _match_seq_num != null; }
+      set { if (value == (_match_seq_num== null)) _match_seq_num = value ? this.match_seq_num : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_seq_num() { return match_seq_numSpecified; }
+    private void Resetmatch_seq_num() { match_seq_numSpecified = false; }
+    
 
-    private CMsgDOTAMatch.ReplayState _replay_state = CMsgDOTAMatch.ReplayState.REPLAY_AVAILABLE;
+    private CMsgDOTAMatch.ReplayState? _replay_state;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"replay_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTAMatch.ReplayState.REPLAY_AVAILABLE)]
     public CMsgDOTAMatch.ReplayState replay_state
     {
-      get { return _replay_state; }
+      get { return _replay_state?? CMsgDOTAMatch.ReplayState.REPLAY_AVAILABLE; }
       set { _replay_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_stateSpecified
+    {
+      get { return _replay_state != null; }
+      set { if (value == (_replay_state== null)) _replay_state = value ? this.replay_state : (CMsgDOTAMatch.ReplayState?)null; }
+    }
+    private bool ShouldSerializereplay_state() { return replay_stateSpecified; }
+    private void Resetreplay_state() { replay_stateSpecified = false; }
+    
 
-    private uint _radiant_guild_id = default(uint);
+    private uint? _radiant_guild_id;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"radiant_guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_guild_id
     {
-      get { return _radiant_guild_id; }
+      get { return _radiant_guild_id?? default(uint); }
       set { _radiant_guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_guild_idSpecified
+    {
+      get { return _radiant_guild_id != null; }
+      set { if (value == (_radiant_guild_id== null)) _radiant_guild_id = value ? this.radiant_guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_guild_id() { return radiant_guild_idSpecified; }
+    private void Resetradiant_guild_id() { radiant_guild_idSpecified = false; }
+    
 
-    private uint _dire_guild_id = default(uint);
+    private uint? _dire_guild_id;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"dire_guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_guild_id
     {
-      get { return _dire_guild_id; }
+      get { return _dire_guild_id?? default(uint); }
       set { _dire_guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_guild_idSpecified
+    {
+      get { return _dire_guild_id != null; }
+      set { if (value == (_dire_guild_id== null)) _dire_guild_id = value ? this.dire_guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializedire_guild_id() { return dire_guild_idSpecified; }
+    private void Resetdire_guild_id() { dire_guild_idSpecified = false; }
+    
 
-    private string _radiant_team_tag = "";
+    private string _radiant_team_tag;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"radiant_team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string radiant_team_tag
     {
-      get { return _radiant_team_tag; }
+      get { return _radiant_team_tag?? ""; }
       set { _radiant_team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_tagSpecified
+    {
+      get { return _radiant_team_tag != null; }
+      set { if (value == (_radiant_team_tag== null)) _radiant_team_tag = value ? this.radiant_team_tag : (string)null; }
+    }
+    private bool ShouldSerializeradiant_team_tag() { return radiant_team_tagSpecified; }
+    private void Resetradiant_team_tag() { radiant_team_tagSpecified = false; }
+    
 
-    private string _dire_team_tag = "";
+    private string _dire_team_tag;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"dire_team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string dire_team_tag
     {
-      get { return _dire_team_tag; }
+      get { return _dire_team_tag?? ""; }
       set { _dire_team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_tagSpecified
+    {
+      get { return _dire_team_tag != null; }
+      set { if (value == (_dire_team_tag== null)) _dire_team_tag = value ? this.dire_team_tag : (string)null; }
+    }
+    private bool ShouldSerializedire_team_tag() { return dire_team_tagSpecified; }
+    private void Resetdire_team_tag() { dire_team_tagSpecified = false; }
+    
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterChannel> _broadcaster_channels = new global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterChannel>();
     [global::ProtoBuf.ProtoMember(43, Name=@"broadcaster_channels", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterChannel> broadcaster_channels
@@ -5510,14 +9526,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _engine = default(uint);
+    private uint? _engine;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"engine", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint engine
     {
-      get { return _engine; }
+      get { return _engine?? default(uint); }
       set { _engine = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool engineSpecified
+    {
+      get { return _engine != null; }
+      set { if (value == (_engine== null)) _engine = value ? this.engine : (uint?)null; }
+    }
+    private bool ShouldSerializeengine() { return engineSpecified; }
+    private void Resetengine() { engineSpecified = false; }
+    
 
     private CMsgDOTAMatch.CustomGameData _custom_game_data = null;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"custom_game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -5528,550 +9553,1090 @@ namespace SteamKit2.GC.Dota.Internal
       set { _custom_game_data = value; }
     }
 
-    private uint _match_flags = default(uint);
+    private uint? _match_flags;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"match_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_flags
     {
-      get { return _match_flags; }
+      get { return _match_flags?? default(uint); }
       set { _match_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_flagsSpecified
+    {
+      get { return _match_flags != null; }
+      set { if (value == (_match_flags== null)) _match_flags = value ? this.match_flags : (uint?)null; }
+    }
+    private bool ShouldSerializematch_flags() { return match_flagsSpecified; }
+    private void Resetmatch_flags() { match_flagsSpecified = false; }
+    
 
-    private uint _private_metadata_key = default(uint);
+    private uint? _private_metadata_key;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"private_metadata_key", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint private_metadata_key
     {
-      get { return _private_metadata_key; }
+      get { return _private_metadata_key?? default(uint); }
       set { _private_metadata_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool private_metadata_keySpecified
+    {
+      get { return _private_metadata_key != null; }
+      set { if (value == (_private_metadata_key== null)) _private_metadata_key = value ? this.private_metadata_key : (uint?)null; }
+    }
+    private bool ShouldSerializeprivate_metadata_key() { return private_metadata_keySpecified; }
+    private void Resetprivate_metadata_key() { private_metadata_keySpecified = false; }
+    
 
-    private uint _radiant_team_score = default(uint);
+    private uint? _radiant_team_score;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"radiant_team_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_team_score
     {
-      get { return _radiant_team_score; }
+      get { return _radiant_team_score?? default(uint); }
       set { _radiant_team_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_team_scoreSpecified
+    {
+      get { return _radiant_team_score != null; }
+      set { if (value == (_radiant_team_score== null)) _radiant_team_score = value ? this.radiant_team_score : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_team_score() { return radiant_team_scoreSpecified; }
+    private void Resetradiant_team_score() { radiant_team_scoreSpecified = false; }
+    
 
-    private uint _dire_team_score = default(uint);
+    private uint? _dire_team_score;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"dire_team_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_team_score
     {
-      get { return _dire_team_score; }
+      get { return _dire_team_score?? default(uint); }
       set { _dire_team_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_team_scoreSpecified
+    {
+      get { return _dire_team_score != null; }
+      set { if (value == (_dire_team_score== null)) _dire_team_score = value ? this.dire_team_score : (uint?)null; }
+    }
+    private bool ShouldSerializedire_team_score() { return dire_team_scoreSpecified; }
+    private void Resetdire_team_score() { dire_team_scoreSpecified = false; }
+    
 
-    private EMatchOutcome _match_outcome = EMatchOutcome.k_EMatchOutcome_Unknown;
+    private EMatchOutcome? _match_outcome;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"match_outcome", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EMatchOutcome.k_EMatchOutcome_Unknown)]
     public EMatchOutcome match_outcome
     {
-      get { return _match_outcome; }
+      get { return _match_outcome?? EMatchOutcome.k_EMatchOutcome_Unknown; }
       set { _match_outcome = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_outcomeSpecified
+    {
+      get { return _match_outcome != null; }
+      set { if (value == (_match_outcome== null)) _match_outcome = value ? this.match_outcome : (EMatchOutcome?)null; }
+    }
+    private bool ShouldSerializematch_outcome() { return match_outcomeSpecified; }
+    private void Resetmatch_outcome() { match_outcomeSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _tournament_round = default(uint);
+    private uint? _tournament_round;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"tournament_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_round
     {
-      get { return _tournament_round; }
+      get { return _tournament_round?? default(uint); }
       set { _tournament_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_roundSpecified
+    {
+      get { return _tournament_round != null; }
+      set { if (value == (_tournament_round== null)) _tournament_round = value ? this.tournament_round : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_round() { return tournament_roundSpecified; }
+    private void Resettournament_round() { tournament_roundSpecified = false; }
+    
 
-    private uint _pre_game_duration = default(uint);
+    private uint? _pre_game_duration;
     [global::ProtoBuf.ProtoMember(53, IsRequired = false, Name=@"pre_game_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pre_game_duration
     {
-      get { return _pre_game_duration; }
+      get { return _pre_game_duration?? default(uint); }
       set { _pre_game_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pre_game_durationSpecified
+    {
+      get { return _pre_game_duration != null; }
+      set { if (value == (_pre_game_duration== null)) _pre_game_duration = value ? this.pre_game_duration : (uint?)null; }
+    }
+    private bool ShouldSerializepre_game_duration() { return pre_game_durationSpecified; }
+    private void Resetpre_game_duration() { pre_game_durationSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _player_slot = default(uint);
+    private uint? _player_slot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_slot
     {
-      get { return _player_slot; }
+      get { return _player_slot?? default(uint); }
       set { _player_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_slotSpecified
+    {
+      get { return _player_slot != null; }
+      set { if (value == (_player_slot== null)) _player_slot = value ? this.player_slot : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_slot() { return player_slotSpecified; }
+    private void Resetplayer_slot() { player_slotSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _item_0 = default(uint);
+    private uint? _item_0;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"item_0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_0
     {
-      get { return _item_0; }
+      get { return _item_0?? default(uint); }
       set { _item_0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_0Specified
+    {
+      get { return _item_0 != null; }
+      set { if (value == (_item_0== null)) _item_0 = value ? this.item_0 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_0() { return item_0Specified; }
+    private void Resetitem_0() { item_0Specified = false; }
+    
 
-    private uint _item_1 = default(uint);
+    private uint? _item_1;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_1
     {
-      get { return _item_1; }
+      get { return _item_1?? default(uint); }
       set { _item_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_1Specified
+    {
+      get { return _item_1 != null; }
+      set { if (value == (_item_1== null)) _item_1 = value ? this.item_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_1() { return item_1Specified; }
+    private void Resetitem_1() { item_1Specified = false; }
+    
 
-    private uint _item_2 = default(uint);
+    private uint? _item_2;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"item_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_2
     {
-      get { return _item_2; }
+      get { return _item_2?? default(uint); }
       set { _item_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_2Specified
+    {
+      get { return _item_2 != null; }
+      set { if (value == (_item_2== null)) _item_2 = value ? this.item_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_2() { return item_2Specified; }
+    private void Resetitem_2() { item_2Specified = false; }
+    
 
-    private uint _item_3 = default(uint);
+    private uint? _item_3;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"item_3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_3
     {
-      get { return _item_3; }
+      get { return _item_3?? default(uint); }
       set { _item_3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_3Specified
+    {
+      get { return _item_3 != null; }
+      set { if (value == (_item_3== null)) _item_3 = value ? this.item_3 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_3() { return item_3Specified; }
+    private void Resetitem_3() { item_3Specified = false; }
+    
 
-    private uint _item_4 = default(uint);
+    private uint? _item_4;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"item_4", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_4
     {
-      get { return _item_4; }
+      get { return _item_4?? default(uint); }
       set { _item_4 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_4Specified
+    {
+      get { return _item_4 != null; }
+      set { if (value == (_item_4== null)) _item_4 = value ? this.item_4 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_4() { return item_4Specified; }
+    private void Resetitem_4() { item_4Specified = false; }
+    
 
-    private uint _item_5 = default(uint);
+    private uint? _item_5;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"item_5", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_5
     {
-      get { return _item_5; }
+      get { return _item_5?? default(uint); }
       set { _item_5 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_5Specified
+    {
+      get { return _item_5 != null; }
+      set { if (value == (_item_5== null)) _item_5 = value ? this.item_5 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_5() { return item_5Specified; }
+    private void Resetitem_5() { item_5Specified = false; }
+    
 
-    private uint _item_6 = default(uint);
+    private uint? _item_6;
     [global::ProtoBuf.ProtoMember(59, IsRequired = false, Name=@"item_6", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_6
     {
-      get { return _item_6; }
+      get { return _item_6?? default(uint); }
       set { _item_6 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_6Specified
+    {
+      get { return _item_6 != null; }
+      set { if (value == (_item_6== null)) _item_6 = value ? this.item_6 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_6() { return item_6Specified; }
+    private void Resetitem_6() { item_6Specified = false; }
+    
 
-    private uint _item_7 = default(uint);
+    private uint? _item_7;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"item_7", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_7
     {
-      get { return _item_7; }
+      get { return _item_7?? default(uint); }
       set { _item_7 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_7Specified
+    {
+      get { return _item_7 != null; }
+      set { if (value == (_item_7== null)) _item_7 = value ? this.item_7 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_7() { return item_7Specified; }
+    private void Resetitem_7() { item_7Specified = false; }
+    
 
-    private uint _item_8 = default(uint);
+    private uint? _item_8;
     [global::ProtoBuf.ProtoMember(61, IsRequired = false, Name=@"item_8", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_8
     {
-      get { return _item_8; }
+      get { return _item_8?? default(uint); }
       set { _item_8 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_8Specified
+    {
+      get { return _item_8 != null; }
+      set { if (value == (_item_8== null)) _item_8 = value ? this.item_8 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_8() { return item_8Specified; }
+    private void Resetitem_8() { item_8Specified = false; }
+    
 
-    private float _expected_team_contribution = default(float);
+    private float? _expected_team_contribution;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"expected_team_contribution", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float expected_team_contribution
     {
-      get { return _expected_team_contribution; }
+      get { return _expected_team_contribution?? default(float); }
       set { _expected_team_contribution = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expected_team_contributionSpecified
+    {
+      get { return _expected_team_contribution != null; }
+      set { if (value == (_expected_team_contribution== null)) _expected_team_contribution = value ? this.expected_team_contribution : (float?)null; }
+    }
+    private bool ShouldSerializeexpected_team_contribution() { return expected_team_contributionSpecified; }
+    private void Resetexpected_team_contribution() { expected_team_contributionSpecified = false; }
+    
 
-    private float _scaled_metric = default(float);
+    private float? _scaled_metric;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"scaled_metric", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_metric
     {
-      get { return _scaled_metric; }
+      get { return _scaled_metric?? default(float); }
       set { _scaled_metric = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_metricSpecified
+    {
+      get { return _scaled_metric != null; }
+      set { if (value == (_scaled_metric== null)) _scaled_metric = value ? this.scaled_metric : (float?)null; }
+    }
+    private bool ShouldSerializescaled_metric() { return scaled_metricSpecified; }
+    private void Resetscaled_metric() { scaled_metricSpecified = false; }
+    
 
-    private uint _previous_rank = default(uint);
+    private uint? _previous_rank;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"previous_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint previous_rank
     {
-      get { return _previous_rank; }
+      get { return _previous_rank?? default(uint); }
       set { _previous_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool previous_rankSpecified
+    {
+      get { return _previous_rank != null; }
+      set { if (value == (_previous_rank== null)) _previous_rank = value ? this.previous_rank : (uint?)null; }
+    }
+    private bool ShouldSerializeprevious_rank() { return previous_rankSpecified; }
+    private void Resetprevious_rank() { previous_rankSpecified = false; }
+    
 
-    private int _rank_change = default(int);
+    private int? _rank_change;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"rank_change", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int rank_change
     {
-      get { return _rank_change; }
+      get { return _rank_change?? default(int); }
       set { _rank_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_changeSpecified
+    {
+      get { return _rank_change != null; }
+      set { if (value == (_rank_change== null)) _rank_change = value ? this.rank_change : (int?)null; }
+    }
+    private bool ShouldSerializerank_change() { return rank_changeSpecified; }
+    private void Resetrank_change() { rank_changeSpecified = false; }
+    
 
-    private bool _solo_rank = default(bool);
+    private bool? _solo_rank;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"solo_rank", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool solo_rank
     {
-      get { return _solo_rank; }
+      get { return _solo_rank?? default(bool); }
       set { _solo_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solo_rankSpecified
+    {
+      get { return _solo_rank != null; }
+      set { if (value == (_solo_rank== null)) _solo_rank = value ? this.solo_rank : (bool?)null; }
+    }
+    private bool ShouldSerializesolo_rank() { return solo_rankSpecified; }
+    private void Resetsolo_rank() { solo_rankSpecified = false; }
+    
 
-    private bool _seasonal_rank = default(bool);
+    private bool? _seasonal_rank;
     [global::ProtoBuf.ProtoMember(53, IsRequired = false, Name=@"seasonal_rank", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool seasonal_rank
     {
-      get { return _seasonal_rank; }
+      get { return _seasonal_rank?? default(bool); }
       set { _seasonal_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seasonal_rankSpecified
+    {
+      get { return _seasonal_rank != null; }
+      set { if (value == (_seasonal_rank== null)) _seasonal_rank = value ? this.seasonal_rank : (bool?)null; }
+    }
+    private bool ShouldSerializeseasonal_rank() { return seasonal_rankSpecified; }
+    private void Resetseasonal_rank() { seasonal_rankSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private uint _leaver_status = default(uint);
+    private uint? _leaver_status;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"leaver_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leaver_status
     {
-      get { return _leaver_status; }
+      get { return _leaver_status?? default(uint); }
       set { _leaver_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_statusSpecified
+    {
+      get { return _leaver_status != null; }
+      set { if (value == (_leaver_status== null)) _leaver_status = value ? this.leaver_status : (uint?)null; }
+    }
+    private bool ShouldSerializeleaver_status() { return leaver_statusSpecified; }
+    private void Resetleaver_status() { leaver_statusSpecified = false; }
+    
 
-    private uint _gold = default(uint);
+    private uint? _gold;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold
     {
-      get { return _gold; }
+      get { return _gold?? default(uint); }
       set { _gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goldSpecified
+    {
+      get { return _gold != null; }
+      set { if (value == (_gold== null)) _gold = value ? this.gold : (uint?)null; }
+    }
+    private bool ShouldSerializegold() { return goldSpecified; }
+    private void Resetgold() { goldSpecified = false; }
+    
 
-    private uint _last_hits = default(uint);
+    private uint? _last_hits;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(uint); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (uint?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private uint _denies = default(uint);
+    private uint? _denies;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies
     {
-      get { return _denies; }
+      get { return _denies?? default(uint); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (uint?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private uint _gold_per_min = default(uint);
+    private uint? _gold_per_min;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"gold_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_per_min
     {
-      get { return _gold_per_min; }
+      get { return _gold_per_min?? default(uint); }
       set { _gold_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_per_minSpecified
+    {
+      get { return _gold_per_min != null; }
+      set { if (value == (_gold_per_min== null)) _gold_per_min = value ? this.gold_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializegold_per_min() { return gold_per_minSpecified; }
+    private void Resetgold_per_min() { gold_per_minSpecified = false; }
+    
 
-    private uint _XP_per_min = default(uint);
+    private uint? _XP_per_min;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"XP_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint XP_per_min
     {
-      get { return _XP_per_min; }
+      get { return _XP_per_min?? default(uint); }
       set { _XP_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool XP_per_minSpecified
+    {
+      get { return _XP_per_min != null; }
+      set { if (value == (_XP_per_min== null)) _XP_per_min = value ? this.XP_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializeXP_per_min() { return XP_per_minSpecified; }
+    private void ResetXP_per_min() { XP_per_minSpecified = false; }
+    
 
-    private uint _gold_spent = default(uint);
+    private uint? _gold_spent;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"gold_spent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_spent
     {
-      get { return _gold_spent; }
+      get { return _gold_spent?? default(uint); }
       set { _gold_spent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_spentSpecified
+    {
+      get { return _gold_spent != null; }
+      set { if (value == (_gold_spent== null)) _gold_spent = value ? this.gold_spent : (uint?)null; }
+    }
+    private bool ShouldSerializegold_spent() { return gold_spentSpecified; }
+    private void Resetgold_spent() { gold_spentSpecified = false; }
+    
 
-    private uint _hero_damage = default(uint);
+    private uint? _hero_damage;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"hero_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_damage
     {
-      get { return _hero_damage; }
+      get { return _hero_damage?? default(uint); }
       set { _hero_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_damageSpecified
+    {
+      get { return _hero_damage != null; }
+      set { if (value == (_hero_damage== null)) _hero_damage = value ? this.hero_damage : (uint?)null; }
+    }
+    private bool ShouldSerializehero_damage() { return hero_damageSpecified; }
+    private void Resethero_damage() { hero_damageSpecified = false; }
+    
 
-    private uint _tower_damage = default(uint);
+    private uint? _tower_damage;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"tower_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tower_damage
     {
-      get { return _tower_damage; }
+      get { return _tower_damage?? default(uint); }
       set { _tower_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_damageSpecified
+    {
+      get { return _tower_damage != null; }
+      set { if (value == (_tower_damage== null)) _tower_damage = value ? this.tower_damage : (uint?)null; }
+    }
+    private bool ShouldSerializetower_damage() { return tower_damageSpecified; }
+    private void Resettower_damage() { tower_damageSpecified = false; }
+    
 
-    private uint _hero_healing = default(uint);
+    private uint? _hero_healing;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"hero_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_healing
     {
-      get { return _hero_healing; }
+      get { return _hero_healing?? default(uint); }
       set { _hero_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_healingSpecified
+    {
+      get { return _hero_healing != null; }
+      set { if (value == (_hero_healing== null)) _hero_healing = value ? this.hero_healing : (uint?)null; }
+    }
+    private bool ShouldSerializehero_healing() { return hero_healingSpecified; }
+    private void Resethero_healing() { hero_healingSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _time_last_seen = default(uint);
+    private uint? _time_last_seen;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"time_last_seen", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_last_seen
     {
-      get { return _time_last_seen; }
+      get { return _time_last_seen?? default(uint); }
       set { _time_last_seen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_last_seenSpecified
+    {
+      get { return _time_last_seen != null; }
+      set { if (value == (_time_last_seen== null)) _time_last_seen = value ? this.time_last_seen : (uint?)null; }
+    }
+    private bool ShouldSerializetime_last_seen() { return time_last_seenSpecified; }
+    private void Resettime_last_seen() { time_last_seenSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private uint _support_ability_value = default(uint);
+    private uint? _support_ability_value;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"support_ability_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_ability_value
     {
-      get { return _support_ability_value; }
+      get { return _support_ability_value?? default(uint); }
       set { _support_ability_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_ability_valueSpecified
+    {
+      get { return _support_ability_value != null; }
+      set { if (value == (_support_ability_value== null)) _support_ability_value = value ? this.support_ability_value : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_ability_value() { return support_ability_valueSpecified; }
+    private void Resetsupport_ability_value() { support_ability_valueSpecified = false; }
+    
 
-    private bool _feeding_detected = default(bool);
+    private bool? _feeding_detected;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"feeding_detected", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool feeding_detected
     {
-      get { return _feeding_detected; }
+      get { return _feeding_detected?? default(bool); }
       set { _feeding_detected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool feeding_detectedSpecified
+    {
+      get { return _feeding_detected != null; }
+      set { if (value == (_feeding_detected== null)) _feeding_detected = value ? this.feeding_detected : (bool?)null; }
+    }
+    private bool ShouldSerializefeeding_detected() { return feeding_detectedSpecified; }
+    private void Resetfeeding_detected() { feeding_detectedSpecified = false; }
+    
 
-    private uint _search_rank = default(uint);
+    private uint? _search_rank;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"search_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_rank
     {
-      get { return _search_rank; }
+      get { return _search_rank?? default(uint); }
       set { _search_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_rankSpecified
+    {
+      get { return _search_rank != null; }
+      set { if (value == (_search_rank== null)) _search_rank = value ? this.search_rank : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_rank() { return search_rankSpecified; }
+    private void Resetsearch_rank() { search_rankSpecified = false; }
+    
 
-    private uint _search_rank_uncertainty = default(uint);
+    private uint? _search_rank_uncertainty;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"search_rank_uncertainty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_rank_uncertainty
     {
-      get { return _search_rank_uncertainty; }
+      get { return _search_rank_uncertainty?? default(uint); }
       set { _search_rank_uncertainty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_rank_uncertaintySpecified
+    {
+      get { return _search_rank_uncertainty != null; }
+      set { if (value == (_search_rank_uncertainty== null)) _search_rank_uncertainty = value ? this.search_rank_uncertainty : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_rank_uncertainty() { return search_rank_uncertaintySpecified; }
+    private void Resetsearch_rank_uncertainty() { search_rank_uncertaintySpecified = false; }
+    
 
-    private int _rank_uncertainty_change = default(int);
+    private int? _rank_uncertainty_change;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"rank_uncertainty_change", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int rank_uncertainty_change
     {
-      get { return _rank_uncertainty_change; }
+      get { return _rank_uncertainty_change?? default(int); }
       set { _rank_uncertainty_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_uncertainty_changeSpecified
+    {
+      get { return _rank_uncertainty_change != null; }
+      set { if (value == (_rank_uncertainty_change== null)) _rank_uncertainty_change = value ? this.rank_uncertainty_change : (int?)null; }
+    }
+    private bool ShouldSerializerank_uncertainty_change() { return rank_uncertainty_changeSpecified; }
+    private void Resetrank_uncertainty_change() { rank_uncertainty_changeSpecified = false; }
+    
 
-    private uint _hero_play_count = default(uint);
+    private uint? _hero_play_count;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"hero_play_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_play_count
     {
-      get { return _hero_play_count; }
+      get { return _hero_play_count?? default(uint); }
       set { _hero_play_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_play_countSpecified
+    {
+      get { return _hero_play_count != null; }
+      set { if (value == (_hero_play_count== null)) _hero_play_count = value ? this.hero_play_count : (uint?)null; }
+    }
+    private bool ShouldSerializehero_play_count() { return hero_play_countSpecified; }
+    private void Resethero_play_count() { hero_play_countSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _scaled_hero_damage = default(uint);
+    private uint? _scaled_hero_damage;
     [global::ProtoBuf.ProtoMember(54, IsRequired = false, Name=@"scaled_hero_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_hero_damage
     {
-      get { return _scaled_hero_damage; }
+      get { return _scaled_hero_damage?? default(uint); }
       set { _scaled_hero_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_hero_damageSpecified
+    {
+      get { return _scaled_hero_damage != null; }
+      set { if (value == (_scaled_hero_damage== null)) _scaled_hero_damage = value ? this.scaled_hero_damage : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_hero_damage() { return scaled_hero_damageSpecified; }
+    private void Resetscaled_hero_damage() { scaled_hero_damageSpecified = false; }
+    
 
-    private uint _scaled_tower_damage = default(uint);
+    private uint? _scaled_tower_damage;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"scaled_tower_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_tower_damage
     {
-      get { return _scaled_tower_damage; }
+      get { return _scaled_tower_damage?? default(uint); }
       set { _scaled_tower_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_tower_damageSpecified
+    {
+      get { return _scaled_tower_damage != null; }
+      set { if (value == (_scaled_tower_damage== null)) _scaled_tower_damage = value ? this.scaled_tower_damage : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_tower_damage() { return scaled_tower_damageSpecified; }
+    private void Resetscaled_tower_damage() { scaled_tower_damageSpecified = false; }
+    
 
-    private uint _scaled_hero_healing = default(uint);
+    private uint? _scaled_hero_healing;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"scaled_hero_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_hero_healing
     {
-      get { return _scaled_hero_healing; }
+      get { return _scaled_hero_healing?? default(uint); }
       set { _scaled_hero_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_hero_healingSpecified
+    {
+      get { return _scaled_hero_healing != null; }
+      set { if (value == (_scaled_hero_healing== null)) _scaled_hero_healing = value ? this.scaled_hero_healing : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_hero_healing() { return scaled_hero_healingSpecified; }
+    private void Resetscaled_hero_healing() { scaled_hero_healingSpecified = false; }
+    
 
-    private float _scaled_kills = default(float);
+    private float? _scaled_kills;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"scaled_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_kills
     {
-      get { return _scaled_kills; }
+      get { return _scaled_kills?? default(float); }
       set { _scaled_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_killsSpecified
+    {
+      get { return _scaled_kills != null; }
+      set { if (value == (_scaled_kills== null)) _scaled_kills = value ? this.scaled_kills : (float?)null; }
+    }
+    private bool ShouldSerializescaled_kills() { return scaled_killsSpecified; }
+    private void Resetscaled_kills() { scaled_killsSpecified = false; }
+    
 
-    private float _scaled_deaths = default(float);
+    private float? _scaled_deaths;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"scaled_deaths", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_deaths
     {
-      get { return _scaled_deaths; }
+      get { return _scaled_deaths?? default(float); }
       set { _scaled_deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_deathsSpecified
+    {
+      get { return _scaled_deaths != null; }
+      set { if (value == (_scaled_deaths== null)) _scaled_deaths = value ? this.scaled_deaths : (float?)null; }
+    }
+    private bool ShouldSerializescaled_deaths() { return scaled_deathsSpecified; }
+    private void Resetscaled_deaths() { scaled_deathsSpecified = false; }
+    
 
-    private float _scaled_assists = default(float);
+    private float? _scaled_assists;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"scaled_assists", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_assists
     {
-      get { return _scaled_assists; }
+      get { return _scaled_assists?? default(float); }
       set { _scaled_assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_assistsSpecified
+    {
+      get { return _scaled_assists != null; }
+      set { if (value == (_scaled_assists== null)) _scaled_assists = value ? this.scaled_assists : (float?)null; }
+    }
+    private bool ShouldSerializescaled_assists() { return scaled_assistsSpecified; }
+    private void Resetscaled_assists() { scaled_assistsSpecified = false; }
+    
 
-    private uint _claimed_farm_gold = default(uint);
+    private uint? _claimed_farm_gold;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"claimed_farm_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_farm_gold
     {
-      get { return _claimed_farm_gold; }
+      get { return _claimed_farm_gold?? default(uint); }
       set { _claimed_farm_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_farm_goldSpecified
+    {
+      get { return _claimed_farm_gold != null; }
+      set { if (value == (_claimed_farm_gold== null)) _claimed_farm_gold = value ? this.claimed_farm_gold : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_farm_gold() { return claimed_farm_goldSpecified; }
+    private void Resetclaimed_farm_gold() { claimed_farm_goldSpecified = false; }
+    
 
-    private uint _support_gold = default(uint);
+    private uint? _support_gold;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"support_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_gold
     {
-      get { return _support_gold; }
+      get { return _support_gold?? default(uint); }
       set { _support_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_goldSpecified
+    {
+      get { return _support_gold != null; }
+      set { if (value == (_support_gold== null)) _support_gold = value ? this.support_gold : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_gold() { return support_goldSpecified; }
+    private void Resetsupport_gold() { support_goldSpecified = false; }
+    
 
-    private uint _claimed_denies = default(uint);
+    private uint? _claimed_denies;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"claimed_denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_denies
     {
-      get { return _claimed_denies; }
+      get { return _claimed_denies?? default(uint); }
       set { _claimed_denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_deniesSpecified
+    {
+      get { return _claimed_denies != null; }
+      set { if (value == (_claimed_denies== null)) _claimed_denies = value ? this.claimed_denies : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_denies() { return claimed_deniesSpecified; }
+    private void Resetclaimed_denies() { claimed_deniesSpecified = false; }
+    
 
-    private uint _claimed_misses = default(uint);
+    private uint? _claimed_misses;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"claimed_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_misses
     {
-      get { return _claimed_misses; }
+      get { return _claimed_misses?? default(uint); }
       set { _claimed_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_missesSpecified
+    {
+      get { return _claimed_misses != null; }
+      set { if (value == (_claimed_misses== null)) _claimed_misses = value ? this.claimed_misses : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_misses() { return claimed_missesSpecified; }
+    private void Resetclaimed_misses() { claimed_missesSpecified = false; }
+    
 
-    private uint _misses = default(uint);
+    private uint? _misses;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint misses
     {
-      get { return _misses; }
+      get { return _misses?? default(uint); }
       set { _misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool missesSpecified
+    {
+      get { return _misses != null; }
+      set { if (value == (_misses== null)) _misses = value ? this.misses : (uint?)null; }
+    }
+    private bool ShouldSerializemisses() { return missesSpecified; }
+    private void Resetmisses() { missesSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade> _ability_upgrades = new global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade>();
     [global::ProtoBuf.ProtoMember(47, Name=@"ability_upgrades", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade> ability_upgrades
@@ -6103,55 +10668,100 @@ namespace SteamKit2.GC.Dota.Internal
       set { _custom_game_data = value; }
     }
 
-    private bool _active_battle_pass = default(bool);
+    private bool? _active_battle_pass;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"active_battle_pass", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool active_battle_pass
     {
-      get { return _active_battle_pass; }
+      get { return _active_battle_pass?? default(bool); }
       set { _active_battle_pass = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_battle_passSpecified
+    {
+      get { return _active_battle_pass != null; }
+      set { if (value == (_active_battle_pass== null)) _active_battle_pass = value ? this.active_battle_pass : (bool?)null; }
+    }
+    private bool ShouldSerializeactive_battle_pass() { return active_battle_passSpecified; }
+    private void Resetactive_battle_pass() { active_battle_passSpecified = false; }
+    
 
-    private uint _net_worth = default(uint);
+    private uint? _net_worth;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"net_worth", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint net_worth
     {
-      get { return _net_worth; }
+      get { return _net_worth?? default(uint); }
       set { _net_worth = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_worthSpecified
+    {
+      get { return _net_worth != null; }
+      set { if (value == (_net_worth== null)) _net_worth = value ? this.net_worth : (uint?)null; }
+    }
+    private bool ShouldSerializenet_worth() { return net_worthSpecified; }
+    private void Resetnet_worth() { net_worthSpecified = false; }
+    
 
-    private uint _bot_difficulty = default(uint);
+    private uint? _bot_difficulty;
     [global::ProtoBuf.ProtoMember(58, IsRequired = false, Name=@"bot_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bot_difficulty
     {
-      get { return _bot_difficulty; }
+      get { return _bot_difficulty?? default(uint); }
       set { _bot_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficultySpecified
+    {
+      get { return _bot_difficulty != null; }
+      set { if (value == (_bot_difficulty== null)) _bot_difficulty = value ? this.bot_difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializebot_difficulty() { return bot_difficultySpecified; }
+    private void Resetbot_difficulty() { bot_difficultySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CustomGameData")]
   public partial class CustomGameData : global::ProtoBuf.IExtensible
   {
     public CustomGameData() {}
     
 
-    private uint _dota_team = default(uint);
+    private uint? _dota_team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dota_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dota_team
     {
-      get { return _dota_team; }
+      get { return _dota_team?? default(uint); }
       set { _dota_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dota_teamSpecified
+    {
+      get { return _dota_team != null; }
+      set { if (value == (_dota_team== null)) _dota_team = value ? this.dota_team : (uint?)null; }
+    }
+    private bool ShouldSerializedota_team() { return dota_teamSpecified; }
+    private void Resetdota_team() { dota_teamSpecified = false; }
+    
 
-    private bool _winner = default(bool);
+    private bool? _winner;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"winner", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool winner
     {
-      get { return _winner; }
+      get { return _winner?? default(bool); }
       set { _winner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winnerSpecified
+    {
+      get { return _winner != null; }
+      set { if (value == (_winner== null)) _winner = value ? this.winner : (bool?)null; }
+    }
+    private bool ShouldSerializewinner() { return winnerSpecified; }
+    private void Resetwinner() { winnerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6168,23 +10778,41 @@ namespace SteamKit2.GC.Dota.Internal
     public BroadcasterInfo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6196,23 +10824,41 @@ namespace SteamKit2.GC.Dota.Internal
     public BroadcasterChannel() {}
     
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterInfo> _broadcaster_infos = new global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterInfo>();
     [global::ProtoBuf.ProtoMember(3, Name=@"broadcaster_infos", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAMatch.BroadcasterInfo> broadcaster_infos
@@ -6221,14 +10867,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _language_code = "";
+    private string _language_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"language_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language_code
     {
-      get { return _language_code; }
+      get { return _language_code?? ""; }
       set { _language_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool language_codeSpecified
+    {
+      get { return _language_code != null; }
+      set { if (value == (_language_code== null)) _language_code = value ? this.language_code : (string)null; }
+    }
+    private bool ShouldSerializelanguage_code() { return language_codeSpecified; }
+    private void Resetlanguage_code() { language_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6240,23 +10895,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CustomGameData() {}
     
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private string _map_name = "";
+    private string _map_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map_name
     {
-      get { return _map_name; }
+      get { return _map_name?? ""; }
       set { _map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_nameSpecified
+    {
+      get { return _map_name != null; }
+      set { if (value == (_map_name== null)) _map_name = value ? this.map_name : (string)null; }
+    }
+    private bool ShouldSerializemap_name() { return map_nameSpecified; }
+    private void Resetmap_name() { map_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6287,14 +10960,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPlayerCard() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPlayerCard.StatModifier> _stat_modifier = new global::System.Collections.Generic.List<CMsgPlayerCard.StatModifier>();
     [global::ProtoBuf.ProtoMember(2, Name=@"stat_modifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPlayerCard.StatModifier> stat_modifier
@@ -6308,23 +10990,41 @@ namespace SteamKit2.GC.Dota.Internal
     public StatModifier() {}
     
 
-    private uint _stat = default(uint);
+    private uint? _stat;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat
     {
-      get { return _stat; }
+      get { return _stat?? default(uint); }
       set { _stat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statSpecified
+    {
+      get { return _stat != null; }
+      set { if (value == (_stat== null)) _stat = value ? this.stat : (uint?)null; }
+    }
+    private bool ShouldSerializestat() { return statSpecified; }
+    private void Resetstat() { statSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6341,185 +11041,365 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyPlayerStats() {}
     
 
-    private uint _player_account_id = default(uint);
+    private uint? _player_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_account_id
     {
-      get { return _player_account_id; }
+      get { return _player_account_id?? default(uint); }
       set { _player_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_account_idSpecified
+    {
+      get { return _player_account_id != null; }
+      set { if (value == (_player_account_id== null)) _player_account_id = value ? this.player_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_account_id() { return player_account_idSpecified; }
+    private void Resetplayer_account_id() { player_account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private bool _match_completed = default(bool);
+    private bool? _match_completed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool match_completed
     {
-      get { return _match_completed; }
+      get { return _match_completed?? default(bool); }
       set { _match_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_completedSpecified
+    {
+      get { return _match_completed != null; }
+      set { if (value == (_match_completed== null)) _match_completed = value ? this.match_completed : (bool?)null; }
+    }
+    private bool ShouldSerializematch_completed() { return match_completedSpecified; }
+    private void Resetmatch_completed() { match_completedSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _delay = default(uint);
+    private uint? _delay;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint delay
     {
-      get { return _delay; }
+      get { return _delay?? default(uint); }
       set { _delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delaySpecified
+    {
+      get { return _delay != null; }
+      set { if (value == (_delay== null)) _delay = value ? this.delay : (uint?)null; }
+    }
+    private bool ShouldSerializedelay() { return delaySpecified; }
+    private void Resetdelay() { delaySpecified = false; }
+    
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _cs = default(uint);
+    private uint? _cs;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"cs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cs
     {
-      get { return _cs; }
+      get { return _cs?? default(uint); }
       set { _cs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool csSpecified
+    {
+      get { return _cs != null; }
+      set { if (value == (_cs== null)) _cs = value ? this.cs : (uint?)null; }
+    }
+    private bool ShouldSerializecs() { return csSpecified; }
+    private void Resetcs() { csSpecified = false; }
+    
 
-    private float _gpm = default(float);
+    private float? _gpm;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(float); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (float?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private uint _tower_kills = default(uint);
+    private uint? _tower_kills;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"tower_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tower_kills
     {
-      get { return _tower_kills; }
+      get { return _tower_kills?? default(uint); }
       set { _tower_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_killsSpecified
+    {
+      get { return _tower_kills != null; }
+      set { if (value == (_tower_kills== null)) _tower_kills = value ? this.tower_kills : (uint?)null; }
+    }
+    private bool ShouldSerializetower_kills() { return tower_killsSpecified; }
+    private void Resettower_kills() { tower_killsSpecified = false; }
+    
 
-    private uint _roshan_kills = default(uint);
+    private uint? _roshan_kills;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"roshan_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint roshan_kills
     {
-      get { return _roshan_kills; }
+      get { return _roshan_kills?? default(uint); }
       set { _roshan_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roshan_killsSpecified
+    {
+      get { return _roshan_kills != null; }
+      set { if (value == (_roshan_kills== null)) _roshan_kills = value ? this.roshan_kills : (uint?)null; }
+    }
+    private bool ShouldSerializeroshan_kills() { return roshan_killsSpecified; }
+    private void Resetroshan_kills() { roshan_killsSpecified = false; }
+    
 
-    private float _teamfight_participation = default(float);
+    private float? _teamfight_participation;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"teamfight_participation", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float teamfight_participation
     {
-      get { return _teamfight_participation; }
+      get { return _teamfight_participation?? default(float); }
       set { _teamfight_participation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamfight_participationSpecified
+    {
+      get { return _teamfight_participation != null; }
+      set { if (value == (_teamfight_participation== null)) _teamfight_participation = value ? this.teamfight_participation : (float?)null; }
+    }
+    private bool ShouldSerializeteamfight_participation() { return teamfight_participationSpecified; }
+    private void Resetteamfight_participation() { teamfight_participationSpecified = false; }
+    
 
-    private uint _wards_placed = default(uint);
+    private uint? _wards_placed;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"wards_placed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wards_placed
     {
-      get { return _wards_placed; }
+      get { return _wards_placed?? default(uint); }
       set { _wards_placed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wards_placedSpecified
+    {
+      get { return _wards_placed != null; }
+      set { if (value == (_wards_placed== null)) _wards_placed = value ? this.wards_placed : (uint?)null; }
+    }
+    private bool ShouldSerializewards_placed() { return wards_placedSpecified; }
+    private void Resetwards_placed() { wards_placedSpecified = false; }
+    
 
-    private uint _camps_stacked = default(uint);
+    private uint? _camps_stacked;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"camps_stacked", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint camps_stacked
     {
-      get { return _camps_stacked; }
+      get { return _camps_stacked?? default(uint); }
       set { _camps_stacked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool camps_stackedSpecified
+    {
+      get { return _camps_stacked != null; }
+      set { if (value == (_camps_stacked== null)) _camps_stacked = value ? this.camps_stacked : (uint?)null; }
+    }
+    private bool ShouldSerializecamps_stacked() { return camps_stackedSpecified; }
+    private void Resetcamps_stacked() { camps_stackedSpecified = false; }
+    
 
-    private uint _runes_grabbed = default(uint);
+    private uint? _runes_grabbed;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"runes_grabbed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint runes_grabbed
     {
-      get { return _runes_grabbed; }
+      get { return _runes_grabbed?? default(uint); }
       set { _runes_grabbed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool runes_grabbedSpecified
+    {
+      get { return _runes_grabbed != null; }
+      set { if (value == (_runes_grabbed== null)) _runes_grabbed = value ? this.runes_grabbed : (uint?)null; }
+    }
+    private bool ShouldSerializerunes_grabbed() { return runes_grabbedSpecified; }
+    private void Resetrunes_grabbed() { runes_grabbedSpecified = false; }
+    
 
-    private uint _first_blood = default(uint);
+    private uint? _first_blood;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"first_blood", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood
     {
-      get { return _first_blood; }
+      get { return _first_blood?? default(uint); }
       set { _first_blood = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_bloodSpecified
+    {
+      get { return _first_blood != null; }
+      set { if (value == (_first_blood== null)) _first_blood = value ? this.first_blood : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood() { return first_bloodSpecified; }
+    private void Resetfirst_blood() { first_bloodSpecified = false; }
+    
 
-    private float _stuns = default(float);
+    private float? _stuns;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"stuns", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float stuns
     {
-      get { return _stuns; }
+      get { return _stuns?? default(float); }
       set { _stuns = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stunsSpecified
+    {
+      get { return _stuns != null; }
+      set { if (value == (_stuns== null)) _stuns = value ? this.stuns : (float?)null; }
+    }
+    private bool ShouldSerializestuns() { return stunsSpecified; }
+    private void Resetstuns() { stunsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6555,104 +11435,203 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private float _desire_push_lane_top = default(float);
+    private float? _desire_push_lane_top;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"desire_push_lane_top", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_push_lane_top
     {
-      get { return _desire_push_lane_top; }
+      get { return _desire_push_lane_top?? default(float); }
       set { _desire_push_lane_top = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_push_lane_topSpecified
+    {
+      get { return _desire_push_lane_top != null; }
+      set { if (value == (_desire_push_lane_top== null)) _desire_push_lane_top = value ? this.desire_push_lane_top : (float?)null; }
+    }
+    private bool ShouldSerializedesire_push_lane_top() { return desire_push_lane_topSpecified; }
+    private void Resetdesire_push_lane_top() { desire_push_lane_topSpecified = false; }
+    
 
-    private float _desire_push_lane_mid = default(float);
+    private float? _desire_push_lane_mid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"desire_push_lane_mid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_push_lane_mid
     {
-      get { return _desire_push_lane_mid; }
+      get { return _desire_push_lane_mid?? default(float); }
       set { _desire_push_lane_mid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_push_lane_midSpecified
+    {
+      get { return _desire_push_lane_mid != null; }
+      set { if (value == (_desire_push_lane_mid== null)) _desire_push_lane_mid = value ? this.desire_push_lane_mid : (float?)null; }
+    }
+    private bool ShouldSerializedesire_push_lane_mid() { return desire_push_lane_midSpecified; }
+    private void Resetdesire_push_lane_mid() { desire_push_lane_midSpecified = false; }
+    
 
-    private float _desire_push_lane_bot = default(float);
+    private float? _desire_push_lane_bot;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"desire_push_lane_bot", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_push_lane_bot
     {
-      get { return _desire_push_lane_bot; }
+      get { return _desire_push_lane_bot?? default(float); }
       set { _desire_push_lane_bot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_push_lane_botSpecified
+    {
+      get { return _desire_push_lane_bot != null; }
+      set { if (value == (_desire_push_lane_bot== null)) _desire_push_lane_bot = value ? this.desire_push_lane_bot : (float?)null; }
+    }
+    private bool ShouldSerializedesire_push_lane_bot() { return desire_push_lane_botSpecified; }
+    private void Resetdesire_push_lane_bot() { desire_push_lane_botSpecified = false; }
+    
 
-    private float _desire_defend_lane_top = default(float);
+    private float? _desire_defend_lane_top;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"desire_defend_lane_top", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_defend_lane_top
     {
-      get { return _desire_defend_lane_top; }
+      get { return _desire_defend_lane_top?? default(float); }
       set { _desire_defend_lane_top = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_defend_lane_topSpecified
+    {
+      get { return _desire_defend_lane_top != null; }
+      set { if (value == (_desire_defend_lane_top== null)) _desire_defend_lane_top = value ? this.desire_defend_lane_top : (float?)null; }
+    }
+    private bool ShouldSerializedesire_defend_lane_top() { return desire_defend_lane_topSpecified; }
+    private void Resetdesire_defend_lane_top() { desire_defend_lane_topSpecified = false; }
+    
 
-    private float _desire_defend_lane_mid = default(float);
+    private float? _desire_defend_lane_mid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"desire_defend_lane_mid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_defend_lane_mid
     {
-      get { return _desire_defend_lane_mid; }
+      get { return _desire_defend_lane_mid?? default(float); }
       set { _desire_defend_lane_mid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_defend_lane_midSpecified
+    {
+      get { return _desire_defend_lane_mid != null; }
+      set { if (value == (_desire_defend_lane_mid== null)) _desire_defend_lane_mid = value ? this.desire_defend_lane_mid : (float?)null; }
+    }
+    private bool ShouldSerializedesire_defend_lane_mid() { return desire_defend_lane_midSpecified; }
+    private void Resetdesire_defend_lane_mid() { desire_defend_lane_midSpecified = false; }
+    
 
-    private float _desire_defend_lane_bot = default(float);
+    private float? _desire_defend_lane_bot;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"desire_defend_lane_bot", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_defend_lane_bot
     {
-      get { return _desire_defend_lane_bot; }
+      get { return _desire_defend_lane_bot?? default(float); }
       set { _desire_defend_lane_bot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_defend_lane_botSpecified
+    {
+      get { return _desire_defend_lane_bot != null; }
+      set { if (value == (_desire_defend_lane_bot== null)) _desire_defend_lane_bot = value ? this.desire_defend_lane_bot : (float?)null; }
+    }
+    private bool ShouldSerializedesire_defend_lane_bot() { return desire_defend_lane_botSpecified; }
+    private void Resetdesire_defend_lane_bot() { desire_defend_lane_botSpecified = false; }
+    
 
-    private float _desire_farm_lane_top = default(float);
+    private float? _desire_farm_lane_top;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"desire_farm_lane_top", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_farm_lane_top
     {
-      get { return _desire_farm_lane_top; }
+      get { return _desire_farm_lane_top?? default(float); }
       set { _desire_farm_lane_top = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_farm_lane_topSpecified
+    {
+      get { return _desire_farm_lane_top != null; }
+      set { if (value == (_desire_farm_lane_top== null)) _desire_farm_lane_top = value ? this.desire_farm_lane_top : (float?)null; }
+    }
+    private bool ShouldSerializedesire_farm_lane_top() { return desire_farm_lane_topSpecified; }
+    private void Resetdesire_farm_lane_top() { desire_farm_lane_topSpecified = false; }
+    
 
-    private float _desire_farm_lane_mid = default(float);
+    private float? _desire_farm_lane_mid;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"desire_farm_lane_mid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_farm_lane_mid
     {
-      get { return _desire_farm_lane_mid; }
+      get { return _desire_farm_lane_mid?? default(float); }
       set { _desire_farm_lane_mid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_farm_lane_midSpecified
+    {
+      get { return _desire_farm_lane_mid != null; }
+      set { if (value == (_desire_farm_lane_mid== null)) _desire_farm_lane_mid = value ? this.desire_farm_lane_mid : (float?)null; }
+    }
+    private bool ShouldSerializedesire_farm_lane_mid() { return desire_farm_lane_midSpecified; }
+    private void Resetdesire_farm_lane_mid() { desire_farm_lane_midSpecified = false; }
+    
 
-    private float _desire_farm_lane_bot = default(float);
+    private float? _desire_farm_lane_bot;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"desire_farm_lane_bot", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_farm_lane_bot
     {
-      get { return _desire_farm_lane_bot; }
+      get { return _desire_farm_lane_bot?? default(float); }
       set { _desire_farm_lane_bot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_farm_lane_botSpecified
+    {
+      get { return _desire_farm_lane_bot != null; }
+      set { if (value == (_desire_farm_lane_bot== null)) _desire_farm_lane_bot = value ? this.desire_farm_lane_bot : (float?)null; }
+    }
+    private bool ShouldSerializedesire_farm_lane_bot() { return desire_farm_lane_botSpecified; }
+    private void Resetdesire_farm_lane_bot() { desire_farm_lane_botSpecified = false; }
+    
 
-    private float _desire_farm_roshan = default(float);
+    private float? _desire_farm_roshan;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"desire_farm_roshan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire_farm_roshan
     {
-      get { return _desire_farm_roshan; }
+      get { return _desire_farm_roshan?? default(float); }
       set { _desire_farm_roshan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desire_farm_roshanSpecified
+    {
+      get { return _desire_farm_roshan != null; }
+      set { if (value == (_desire_farm_roshan== null)) _desire_farm_roshan = value ? this.desire_farm_roshan : (float?)null; }
+    }
+    private bool ShouldSerializedesire_farm_roshan() { return desire_farm_roshanSpecified; }
+    private void Resetdesire_farm_roshan() { desire_farm_roshanSpecified = false; }
+    
 
-    private float _execution_time = default(float);
+    private float? _execution_time;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"execution_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float execution_time
     {
-      get { return _execution_time; }
+      get { return _execution_time?? default(float); }
       set { _execution_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool execution_timeSpecified
+    {
+      get { return _execution_time != null; }
+      set { if (value == (_execution_time== null)) _execution_time = value ? this.execution_time : (float?)null; }
+    }
+    private bool ShouldSerializeexecution_time() { return execution_timeSpecified; }
+    private void Resetexecution_time() { execution_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _rune_status = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(13, Name=@"rune_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> rune_status
@@ -6666,95 +11645,185 @@ namespace SteamKit2.GC.Dota.Internal
     public Bot() {}
     
 
-    private uint _player_owner_id = default(uint);
+    private uint? _player_owner_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_owner_id
     {
-      get { return _player_owner_id; }
+      get { return _player_owner_id?? default(uint); }
       set { _player_owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_owner_idSpecified
+    {
+      get { return _player_owner_id != null; }
+      set { if (value == (_player_owner_id== null)) _player_owner_id = value ? this.player_owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_owner_id() { return player_owner_idSpecified; }
+    private void Resetplayer_owner_id() { player_owner_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _difficulty = default(uint);
+    private uint? _difficulty;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint difficulty
     {
-      get { return _difficulty; }
+      get { return _difficulty?? default(uint); }
       set { _difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool difficultySpecified
+    {
+      get { return _difficulty != null; }
+      set { if (value == (_difficulty== null)) _difficulty = value ? this.difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializedifficulty() { return difficultySpecified; }
+    private void Resetdifficulty() { difficultySpecified = false; }
+    
 
-    private uint _power_current = default(uint);
+    private uint? _power_current;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"power_current", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint power_current
     {
-      get { return _power_current; }
+      get { return _power_current?? default(uint); }
       set { _power_current = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool power_currentSpecified
+    {
+      get { return _power_current != null; }
+      set { if (value == (_power_current== null)) _power_current = value ? this.power_current : (uint?)null; }
+    }
+    private bool ShouldSerializepower_current() { return power_currentSpecified; }
+    private void Resetpower_current() { power_currentSpecified = false; }
+    
 
-    private uint _power_max = default(uint);
+    private uint? _power_max;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"power_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint power_max
     {
-      get { return _power_max; }
+      get { return _power_max?? default(uint); }
       set { _power_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool power_maxSpecified
+    {
+      get { return _power_max != null; }
+      set { if (value == (_power_max== null)) _power_max = value ? this.power_max : (uint?)null; }
+    }
+    private bool ShouldSerializepower_max() { return power_maxSpecified; }
+    private void Resetpower_max() { power_maxSpecified = false; }
+    
 
-    private uint _move_target_x = default(uint);
+    private uint? _move_target_x;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"move_target_x", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint move_target_x
     {
-      get { return _move_target_x; }
+      get { return _move_target_x?? default(uint); }
       set { _move_target_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool move_target_xSpecified
+    {
+      get { return _move_target_x != null; }
+      set { if (value == (_move_target_x== null)) _move_target_x = value ? this.move_target_x : (uint?)null; }
+    }
+    private bool ShouldSerializemove_target_x() { return move_target_xSpecified; }
+    private void Resetmove_target_x() { move_target_xSpecified = false; }
+    
 
-    private uint _move_target_y = default(uint);
+    private uint? _move_target_y;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"move_target_y", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint move_target_y
     {
-      get { return _move_target_y; }
+      get { return _move_target_y?? default(uint); }
       set { _move_target_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool move_target_ySpecified
+    {
+      get { return _move_target_y != null; }
+      set { if (value == (_move_target_y== null)) _move_target_y = value ? this.move_target_y : (uint?)null; }
+    }
+    private bool ShouldSerializemove_target_y() { return move_target_ySpecified; }
+    private void Resetmove_target_y() { move_target_ySpecified = false; }
+    
 
-    private uint _move_target_z = default(uint);
+    private uint? _move_target_z;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"move_target_z", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint move_target_z
     {
-      get { return _move_target_z; }
+      get { return _move_target_z?? default(uint); }
       set { _move_target_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool move_target_zSpecified
+    {
+      get { return _move_target_z != null; }
+      set { if (value == (_move_target_z== null)) _move_target_z = value ? this.move_target_z : (uint?)null; }
+    }
+    private bool ShouldSerializemove_target_z() { return move_target_zSpecified; }
+    private void Resetmove_target_z() { move_target_zSpecified = false; }
+    
 
-    private uint _active_mode_id = default(uint);
+    private uint? _active_mode_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"active_mode_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_mode_id
     {
-      get { return _active_mode_id; }
+      get { return _active_mode_id?? default(uint); }
       set { _active_mode_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_mode_idSpecified
+    {
+      get { return _active_mode_id != null; }
+      set { if (value == (_active_mode_id== null)) _active_mode_id = value ? this.active_mode_id : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_mode_id() { return active_mode_idSpecified; }
+    private void Resetactive_mode_id() { active_mode_idSpecified = false; }
+    
 
-    private float _execution_time = default(float);
+    private float? _execution_time;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"execution_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float execution_time
     {
-      get { return _execution_time; }
+      get { return _execution_time?? default(float); }
       set { _execution_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool execution_timeSpecified
+    {
+      get { return _execution_time != null; }
+      set { if (value == (_execution_time== null)) _execution_time = value ? this.execution_time : (float?)null; }
+    }
+    private bool ShouldSerializeexecution_time() { return execution_timeSpecified; }
+    private void Resetexecution_time() { execution_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTABotDebugInfo.Bot.Mode> _modes = new global::System.Collections.Generic.List<CMsgDOTABotDebugInfo.Bot.Mode>();
     [global::ProtoBuf.ProtoMember(11, Name=@"modes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTABotDebugInfo.Bot.Mode> modes
@@ -6777,59 +11846,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Mode() {}
     
 
-    private uint _mode_id = default(uint);
+    private uint? _mode_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"mode_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mode_id
     {
-      get { return _mode_id; }
+      get { return _mode_id?? default(uint); }
       set { _mode_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mode_idSpecified
+    {
+      get { return _mode_id != null; }
+      set { if (value == (_mode_id== null)) _mode_id = value ? this.mode_id : (uint?)null; }
+    }
+    private bool ShouldSerializemode_id() { return mode_idSpecified; }
+    private void Resetmode_id() { mode_idSpecified = false; }
+    
 
-    private float _desire = default(float);
+    private float? _desire;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"desire", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float desire
     {
-      get { return _desire; }
+      get { return _desire?? default(float); }
       set { _desire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desireSpecified
+    {
+      get { return _desire != null; }
+      set { if (value == (_desire== null)) _desire = value ? this.desire : (float?)null; }
+    }
+    private bool ShouldSerializedesire() { return desireSpecified; }
+    private void Resetdesire() { desireSpecified = false; }
+    
 
-    private uint _target_entity = default(uint);
+    private uint? _target_entity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"target_entity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_entity
     {
-      get { return _target_entity; }
+      get { return _target_entity?? default(uint); }
       set { _target_entity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_entitySpecified
+    {
+      get { return _target_entity != null; }
+      set { if (value == (_target_entity== null)) _target_entity = value ? this.target_entity : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_entity() { return target_entitySpecified; }
+    private void Resettarget_entity() { target_entitySpecified = false; }
+    
 
-    private uint _target_x = default(uint);
+    private uint? _target_x;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"target_x", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_x
     {
-      get { return _target_x; }
+      get { return _target_x?? default(uint); }
       set { _target_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_xSpecified
+    {
+      get { return _target_x != null; }
+      set { if (value == (_target_x== null)) _target_x = value ? this.target_x : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_x() { return target_xSpecified; }
+    private void Resettarget_x() { target_xSpecified = false; }
+    
 
-    private uint _target_y = default(uint);
+    private uint? _target_y;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"target_y", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_y
     {
-      get { return _target_y; }
+      get { return _target_y?? default(uint); }
       set { _target_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_ySpecified
+    {
+      get { return _target_y != null; }
+      set { if (value == (_target_y== null)) _target_y = value ? this.target_y : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_y() { return target_ySpecified; }
+    private void Resettarget_y() { target_ySpecified = false; }
+    
 
-    private uint _target_z = default(uint);
+    private uint? _target_z;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"target_z", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_z
     {
-      get { return _target_z; }
+      get { return _target_z?? default(uint); }
       set { _target_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_zSpecified
+    {
+      get { return _target_z != null; }
+      set { if (value == (_target_z== null)) _target_z = value ? this.target_z : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_z() { return target_zSpecified; }
+    private void Resettarget_z() { target_zSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6841,23 +11964,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Action() {}
     
 
-    private uint _action_id = default(uint);
+    private uint? _action_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"action_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action_id
     {
-      get { return _action_id; }
+      get { return _action_id?? default(uint); }
       set { _action_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_idSpecified
+    {
+      get { return _action_id != null; }
+      set { if (value == (_action_id== null)) _action_id = value ? this.action_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaction_id() { return action_idSpecified; }
+    private void Resetaction_id() { action_idSpecified = false; }
+    
 
-    private string _action_target = "";
+    private string _action_target;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"action_target", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string action_target
     {
-      get { return _action_target; }
+      get { return _action_target?? ""; }
       set { _action_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool action_targetSpecified
+    {
+      get { return _action_target != null; }
+      set { if (value == (_action_target== null)) _action_target = value ? this.action_target : (string)null; }
+    }
+    private bool ShouldSerializeaction_target() { return action_targetSpecified; }
+    private void Resetaction_target() { action_targetSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCCommonMatchMgmt.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCCommonMatchMgmt.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_common_match_management.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: gcsdk_gcmessages.proto
@@ -20,23 +22,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAPartyMember() {}
     
 
-    private PartnerAccountType _partner_type = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _partner_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"partner_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType partner_type
     {
-      get { return _partner_type; }
+      get { return _partner_type?? PartnerAccountType.PARTNER_NONE; }
       set { _partner_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_typeSpecified
+    {
+      get { return _partner_type != null; }
+      set { if (value == (_partner_type== null)) _partner_type = value ? this.partner_type : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializepartner_type() { return partner_typeSpecified; }
+    private void Resetpartner_type() { partner_typeSpecified = false; }
+    
 
-    private bool _is_coach = default(bool);
+    private bool? _is_coach;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_coach
     {
-      get { return _is_coach; }
+      get { return _is_coach?? default(bool); }
       set { _is_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_coachSpecified
+    {
+      get { return _is_coach != null; }
+      set { if (value == (_is_coach== null)) _is_coach = value ? this.is_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeis_coach() { return is_coachSpecified; }
+    private void Resetis_coach() { is_coachSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _region_ping_codes = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"region_ping_codes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement, Options = global::ProtoBuf.MemberSerializationOptions.Packed)]
     public global::System.Collections.Generic.List<uint> region_ping_codes
@@ -52,41 +72,77 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _region_ping_failed_bitmask = default(uint);
+    private uint? _region_ping_failed_bitmask;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"region_ping_failed_bitmask", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_ping_failed_bitmask
     {
-      get { return _region_ping_failed_bitmask; }
+      get { return _region_ping_failed_bitmask?? default(uint); }
       set { _region_ping_failed_bitmask = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_ping_failed_bitmaskSpecified
+    {
+      get { return _region_ping_failed_bitmask != null; }
+      set { if (value == (_region_ping_failed_bitmask== null)) _region_ping_failed_bitmask = value ? this.region_ping_failed_bitmask : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_ping_failed_bitmask() { return region_ping_failed_bitmaskSpecified; }
+    private void Resetregion_ping_failed_bitmask() { region_ping_failed_bitmaskSpecified = false; }
+    
 
-    private uint _tourney_skill_level = default(uint);
+    private uint? _tourney_skill_level;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_skill_level
     {
-      get { return _tourney_skill_level; }
+      get { return _tourney_skill_level?? default(uint); }
       set { _tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_skill_levelSpecified
+    {
+      get { return _tourney_skill_level != null; }
+      set { if (value == (_tourney_skill_level== null)) _tourney_skill_level = value ? this.tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_skill_level() { return tourney_skill_levelSpecified; }
+    private void Resettourney_skill_level() { tourney_skill_levelSpecified = false; }
+    
 
-    private uint _tourney_buyin = default(uint);
+    private uint? _tourney_buyin;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"tourney_buyin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_buyin
     {
-      get { return _tourney_buyin; }
+      get { return _tourney_buyin?? default(uint); }
       set { _tourney_buyin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_buyinSpecified
+    {
+      get { return _tourney_buyin != null; }
+      set { if (value == (_tourney_buyin== null)) _tourney_buyin = value ? this.tourney_buyin : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_buyin() { return tourney_buyinSpecified; }
+    private void Resettourney_buyin() { tourney_buyinSpecified = false; }
+    
 
-    private uint _tourney_prevent_until = default(uint);
+    private uint? _tourney_prevent_until;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"tourney_prevent_until", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_prevent_until
     {
-      get { return _tourney_prevent_until; }
+      get { return _tourney_prevent_until?? default(uint); }
       set { _tourney_prevent_until = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_prevent_untilSpecified
+    {
+      get { return _tourney_prevent_until != null; }
+      set { if (value == (_tourney_prevent_until== null)) _tourney_prevent_until = value ? this.tourney_prevent_until : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_prevent_until() { return tourney_prevent_untilSpecified; }
+    private void Resettourney_prevent_until() { tourney_prevent_untilSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -98,23 +154,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAParty() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private ulong _leader_id = default(ulong);
+    private ulong? _leader_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leader_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong leader_id
     {
-      get { return _leader_id; }
+      get { return _leader_id?? default(ulong); }
       set { _leader_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_idSpecified
+    {
+      get { return _leader_id != null; }
+      set { if (value == (_leader_id== null)) _leader_id = value ? this.leader_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeleader_id() { return leader_idSpecified; }
+    private void Resetleader_id() { leader_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _member_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"member_ids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> member_ids
@@ -123,176 +197,347 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _game_modes = default(uint);
+    private uint? _game_modes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_modes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_modes
     {
-      get { return _game_modes; }
+      get { return _game_modes?? default(uint); }
       set { _game_modes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modesSpecified
+    {
+      get { return _game_modes != null; }
+      set { if (value == (_game_modes== null)) _game_modes = value ? this.game_modes : (uint?)null; }
+    }
+    private bool ShouldSerializegame_modes() { return game_modesSpecified; }
+    private void Resetgame_modes() { game_modesSpecified = false; }
+    
 
-    private CSODOTAParty.State _state = CSODOTAParty.State.UI;
+    private CSODOTAParty.State? _state;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSODOTAParty.State.UI)]
     public CSODOTAParty.State state
     {
-      get { return _state; }
+      get { return _state?? CSODOTAParty.State.UI; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (CSODOTAParty.State?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private uint _effective_started_matchmaking_time = default(uint);
+    private uint? _effective_started_matchmaking_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"effective_started_matchmaking_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint effective_started_matchmaking_time
     {
-      get { return _effective_started_matchmaking_time; }
+      get { return _effective_started_matchmaking_time?? default(uint); }
       set { _effective_started_matchmaking_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool effective_started_matchmaking_timeSpecified
+    {
+      get { return _effective_started_matchmaking_time != null; }
+      set { if (value == (_effective_started_matchmaking_time== null)) _effective_started_matchmaking_time = value ? this.effective_started_matchmaking_time : (uint?)null; }
+    }
+    private bool ShouldSerializeeffective_started_matchmaking_time() { return effective_started_matchmaking_timeSpecified; }
+    private void Reseteffective_started_matchmaking_time() { effective_started_matchmaking_timeSpecified = false; }
+    
 
-    private uint _raw_started_matchmaking_time = default(uint);
+    private uint? _raw_started_matchmaking_time;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"raw_started_matchmaking_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_started_matchmaking_time
     {
-      get { return _raw_started_matchmaking_time; }
+      get { return _raw_started_matchmaking_time?? default(uint); }
       set { _raw_started_matchmaking_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_started_matchmaking_timeSpecified
+    {
+      get { return _raw_started_matchmaking_time != null; }
+      set { if (value == (_raw_started_matchmaking_time== null)) _raw_started_matchmaking_time = value ? this.raw_started_matchmaking_time : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_started_matchmaking_time() { return raw_started_matchmaking_timeSpecified; }
+    private void Resetraw_started_matchmaking_time() { raw_started_matchmaking_timeSpecified = false; }
+    
 
-    private uint _attempt_start_time = default(uint);
+    private uint? _attempt_start_time;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"attempt_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attempt_start_time
     {
-      get { return _attempt_start_time; }
+      get { return _attempt_start_time?? default(uint); }
       set { _attempt_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attempt_start_timeSpecified
+    {
+      get { return _attempt_start_time != null; }
+      set { if (value == (_attempt_start_time== null)) _attempt_start_time = value ? this.attempt_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializeattempt_start_time() { return attempt_start_timeSpecified; }
+    private void Resetattempt_start_time() { attempt_start_timeSpecified = false; }
+    
 
-    private uint _attempt_num = default(uint);
+    private uint? _attempt_num;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"attempt_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attempt_num
     {
-      get { return _attempt_num; }
+      get { return _attempt_num?? default(uint); }
       set { _attempt_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attempt_numSpecified
+    {
+      get { return _attempt_num != null; }
+      set { if (value == (_attempt_num== null)) _attempt_num = value ? this.attempt_num : (uint?)null; }
+    }
+    private bool ShouldSerializeattempt_num() { return attempt_numSpecified; }
+    private void Resetattempt_num() { attempt_numSpecified = false; }
+    
 
-    private uint _matchgroups = default(uint);
+    private uint? _matchgroups;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"matchgroups", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchgroups
     {
-      get { return _matchgroups; }
+      get { return _matchgroups?? default(uint); }
       set { _matchgroups = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroupsSpecified
+    {
+      get { return _matchgroups != null; }
+      set { if (value == (_matchgroups== null)) _matchgroups = value ? this.matchgroups : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroups() { return matchgroupsSpecified; }
+    private void Resetmatchgroups() { matchgroupsSpecified = false; }
+    
 
-    private uint _low_priority_account_id = default(uint);
+    private uint? _low_priority_account_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"low_priority_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint low_priority_account_id
     {
-      get { return _low_priority_account_id; }
+      get { return _low_priority_account_id?? default(uint); }
       set { _low_priority_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_priority_account_idSpecified
+    {
+      get { return _low_priority_account_id != null; }
+      set { if (value == (_low_priority_account_id== null)) _low_priority_account_id = value ? this.low_priority_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializelow_priority_account_id() { return low_priority_account_idSpecified; }
+    private void Resetlow_priority_account_id() { low_priority_account_idSpecified = false; }
+    
 
-    private MatchType _match_type = MatchType.MATCH_TYPE_CASUAL;
+    private MatchType? _match_type;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"match_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchType.MATCH_TYPE_CASUAL)]
     public MatchType match_type
     {
-      get { return _match_type; }
+      get { return _match_type?? MatchType.MATCH_TYPE_CASUAL; }
       set { _match_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_typeSpecified
+    {
+      get { return _match_type != null; }
+      set { if (value == (_match_type== null)) _match_type = value ? this.match_type : (MatchType?)null; }
+    }
+    private bool ShouldSerializematch_type() { return match_typeSpecified; }
+    private void Resetmatch_type() { match_typeSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"bot_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty
     {
-      get { return _bot_difficulty; }
+      get { return _bot_difficulty?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficultySpecified
+    {
+      get { return _bot_difficulty != null; }
+      set { if (value == (_bot_difficulty== null)) _bot_difficulty = value ? this.bot_difficulty : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty() { return bot_difficultySpecified; }
+    private void Resetbot_difficulty() { bot_difficultySpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private ulong _team_ui_logo = default(ulong);
+    private ulong? _team_ui_logo;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"team_ui_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_ui_logo
     {
-      get { return _team_ui_logo; }
+      get { return _team_ui_logo?? default(ulong); }
       set { _team_ui_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_ui_logoSpecified
+    {
+      get { return _team_ui_logo != null; }
+      set { if (value == (_team_ui_logo== null)) _team_ui_logo = value ? this.team_ui_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_ui_logo() { return team_ui_logoSpecified; }
+    private void Resetteam_ui_logo() { team_ui_logoSpecified = false; }
+    
 
-    private ulong _team_base_logo = default(ulong);
+    private ulong? _team_base_logo;
     [global::ProtoBuf.ProtoMember(53, IsRequired = false, Name=@"team_base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_base_logo
     {
-      get { return _team_base_logo; }
+      get { return _team_base_logo?? default(ulong); }
       set { _team_base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_base_logoSpecified
+    {
+      get { return _team_base_logo != null; }
+      set { if (value == (_team_base_logo== null)) _team_base_logo = value ? this.team_base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_base_logo() { return team_base_logoSpecified; }
+    private void Resetteam_base_logo() { team_base_logoSpecified = false; }
+    
 
-    private uint _match_disabled_until_date = default(uint);
+    private uint? _match_disabled_until_date;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"match_disabled_until_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_disabled_until_date
     {
-      get { return _match_disabled_until_date; }
+      get { return _match_disabled_until_date?? default(uint); }
       set { _match_disabled_until_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_disabled_until_dateSpecified
+    {
+      get { return _match_disabled_until_date != null; }
+      set { if (value == (_match_disabled_until_date== null)) _match_disabled_until_date = value ? this.match_disabled_until_date : (uint?)null; }
+    }
+    private bool ShouldSerializematch_disabled_until_date() { return match_disabled_until_dateSpecified; }
+    private void Resetmatch_disabled_until_date() { match_disabled_until_dateSpecified = false; }
+    
 
-    private uint _match_disabled_account_id = default(uint);
+    private uint? _match_disabled_account_id;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"match_disabled_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_disabled_account_id
     {
-      get { return _match_disabled_account_id; }
+      get { return _match_disabled_account_id?? default(uint); }
       set { _match_disabled_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_disabled_account_idSpecified
+    {
+      get { return _match_disabled_account_id != null; }
+      set { if (value == (_match_disabled_account_id== null)) _match_disabled_account_id = value ? this.match_disabled_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializematch_disabled_account_id() { return match_disabled_account_idSpecified; }
+    private void Resetmatch_disabled_account_id() { match_disabled_account_idSpecified = false; }
+    
 
-    private uint _matchmaking_max_range_minutes = default(uint);
+    private uint? _matchmaking_max_range_minutes;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"matchmaking_max_range_minutes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_max_range_minutes
     {
-      get { return _matchmaking_max_range_minutes; }
+      get { return _matchmaking_max_range_minutes?? default(uint); }
       set { _matchmaking_max_range_minutes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_max_range_minutesSpecified
+    {
+      get { return _matchmaking_max_range_minutes != null; }
+      set { if (value == (_matchmaking_max_range_minutes== null)) _matchmaking_max_range_minutes = value ? this.matchmaking_max_range_minutes : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_max_range_minutes() { return matchmaking_max_range_minutesSpecified; }
+    private void Resetmatchmaking_max_range_minutes() { matchmaking_max_range_minutesSpecified = false; }
+    
 
-    private uint _matchlanguages = default(uint);
+    private uint? _matchlanguages;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"matchlanguages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchlanguages
     {
-      get { return _matchlanguages; }
+      get { return _matchlanguages?? default(uint); }
       set { _matchlanguages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchlanguagesSpecified
+    {
+      get { return _matchlanguages != null; }
+      set { if (value == (_matchlanguages== null)) _matchlanguages = value ? this.matchlanguages : (uint?)null; }
+    }
+    private bool ShouldSerializematchlanguages() { return matchlanguagesSpecified; }
+    private void Resetmatchlanguages() { matchlanguagesSpecified = false; }
+    
 
-    private uint _map_preference = default(uint);
+    private uint? _map_preference;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"map_preference", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint map_preference
     {
-      get { return _map_preference; }
+      get { return _map_preference?? default(uint); }
       set { _map_preference = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_preferenceSpecified
+    {
+      get { return _map_preference != null; }
+      set { if (value == (_map_preference== null)) _map_preference = value ? this.map_preference : (uint?)null; }
+    }
+    private bool ShouldSerializemap_preference() { return map_preferenceSpecified; }
+    private void Resetmap_preference() { map_preferenceSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSODOTAPartyMember> _members = new global::System.Collections.Generic.List<CSODOTAPartyMember>();
     [global::ProtoBuf.ProtoMember(29, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSODOTAPartyMember> members
@@ -301,14 +546,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _open_guild_id = default(uint);
+    private uint? _open_guild_id;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"open_guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint open_guild_id
     {
-      get { return _open_guild_id; }
+      get { return _open_guild_id?? default(uint); }
       set { _open_guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool open_guild_idSpecified
+    {
+      get { return _open_guild_id != null; }
+      set { if (value == (_open_guild_id== null)) _open_guild_id = value ? this.open_guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeopen_guild_id() { return open_guild_idSpecified; }
+    private void Resetopen_guild_id() { open_guild_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _common_guilds = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(31, Name=@"common_guilds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> common_guilds
@@ -317,14 +571,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _low_priority_games_remaining = default(uint);
+    private uint? _low_priority_games_remaining;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"low_priority_games_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint low_priority_games_remaining
     {
-      get { return _low_priority_games_remaining; }
+      get { return _low_priority_games_remaining?? default(uint); }
       set { _low_priority_games_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_priority_games_remainingSpecified
+    {
+      get { return _low_priority_games_remaining != null; }
+      set { if (value == (_low_priority_games_remaining== null)) _low_priority_games_remaining = value ? this.low_priority_games_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializelow_priority_games_remaining() { return low_priority_games_remainingSpecified; }
+    private void Resetlow_priority_games_remaining() { low_priority_games_remainingSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<EEvent> _active_ingame_events = new global::System.Collections.Generic.List<EEvent>();
     [global::ProtoBuf.ProtoMember(39, Name=@"active_ingame_events", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<EEvent> active_ingame_events
@@ -333,14 +596,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _open_for_join_requests = default(bool);
+    private bool? _open_for_join_requests;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"open_for_join_requests", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool open_for_join_requests
     {
-      get { return _open_for_join_requests; }
+      get { return _open_for_join_requests?? default(bool); }
       set { _open_for_join_requests = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool open_for_join_requestsSpecified
+    {
+      get { return _open_for_join_requests != null; }
+      set { if (value == (_open_for_join_requests== null)) _open_for_join_requests = value ? this.open_for_join_requests : (bool?)null; }
+    }
+    private bool ShouldSerializeopen_for_join_requests() { return open_for_join_requestsSpecified; }
+    private void Resetopen_for_join_requests() { open_for_join_requestsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSODOTAPartyInvite> _sent_invites = new global::System.Collections.Generic.List<CSODOTAPartyInvite>();
     [global::ProtoBuf.ProtoMember(41, Name=@"sent_invites", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSODOTAPartyInvite> sent_invites
@@ -356,113 +628,221 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _account_flags = default(uint);
+    private uint? _account_flags;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_flags
     {
-      get { return _account_flags; }
+      get { return _account_flags?? default(uint); }
       set { _account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_flagsSpecified
+    {
+      get { return _account_flags != null; }
+      set { if (value == (_account_flags== null)) _account_flags = value ? this.account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_flags() { return account_flagsSpecified; }
+    private void Resetaccount_flags() { account_flagsSpecified = false; }
+    
 
-    private uint _region_select_flags = default(uint);
+    private uint? _region_select_flags;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"region_select_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_select_flags
     {
-      get { return _region_select_flags; }
+      get { return _region_select_flags?? default(uint); }
       set { _region_select_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_select_flagsSpecified
+    {
+      get { return _region_select_flags != null; }
+      set { if (value == (_region_select_flags== null)) _region_select_flags = value ? this.region_select_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_select_flags() { return region_select_flagsSpecified; }
+    private void Resetregion_select_flags() { region_select_flagsSpecified = false; }
+    
 
-    private uint _exclusive_tournament_id = default(uint);
+    private uint? _exclusive_tournament_id;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"exclusive_tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint exclusive_tournament_id
     {
-      get { return _exclusive_tournament_id; }
+      get { return _exclusive_tournament_id?? default(uint); }
       set { _exclusive_tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool exclusive_tournament_idSpecified
+    {
+      get { return _exclusive_tournament_id != null; }
+      set { if (value == (_exclusive_tournament_id== null)) _exclusive_tournament_id = value ? this.exclusive_tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializeexclusive_tournament_id() { return exclusive_tournament_idSpecified; }
+    private void Resetexclusive_tournament_id() { exclusive_tournament_idSpecified = false; }
+    
 
-    private uint _tourney_division_id = default(uint);
+    private uint? _tourney_division_id;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"tourney_division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_division_id
     {
-      get { return _tourney_division_id; }
+      get { return _tourney_division_id?? default(uint); }
       set { _tourney_division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_division_idSpecified
+    {
+      get { return _tourney_division_id != null; }
+      set { if (value == (_tourney_division_id== null)) _tourney_division_id = value ? this.tourney_division_id : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_division_id() { return tourney_division_idSpecified; }
+    private void Resettourney_division_id() { tourney_division_idSpecified = false; }
+    
 
-    private uint _tourney_schedule_time = default(uint);
+    private uint? _tourney_schedule_time;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"tourney_schedule_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_schedule_time
     {
-      get { return _tourney_schedule_time; }
+      get { return _tourney_schedule_time?? default(uint); }
       set { _tourney_schedule_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_schedule_timeSpecified
+    {
+      get { return _tourney_schedule_time != null; }
+      set { if (value == (_tourney_schedule_time== null)) _tourney_schedule_time = value ? this.tourney_schedule_time : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_schedule_time() { return tourney_schedule_timeSpecified; }
+    private void Resettourney_schedule_time() { tourney_schedule_timeSpecified = false; }
+    
 
-    private uint _tourney_skill_level = default(uint);
+    private uint? _tourney_skill_level;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_skill_level
     {
-      get { return _tourney_skill_level; }
+      get { return _tourney_skill_level?? default(uint); }
       set { _tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_skill_levelSpecified
+    {
+      get { return _tourney_skill_level != null; }
+      set { if (value == (_tourney_skill_level== null)) _tourney_skill_level = value ? this.tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_skill_level() { return tourney_skill_levelSpecified; }
+    private void Resettourney_skill_level() { tourney_skill_levelSpecified = false; }
+    
 
-    private uint _tourney_bracket_round = default(uint);
+    private uint? _tourney_bracket_round;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"tourney_bracket_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_bracket_round
     {
-      get { return _tourney_bracket_round; }
+      get { return _tourney_bracket_round?? default(uint); }
       set { _tourney_bracket_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_bracket_roundSpecified
+    {
+      get { return _tourney_bracket_round != null; }
+      set { if (value == (_tourney_bracket_round== null)) _tourney_bracket_round = value ? this.tourney_bracket_round : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_bracket_round() { return tourney_bracket_roundSpecified; }
+    private void Resettourney_bracket_round() { tourney_bracket_roundSpecified = false; }
+    
 
-    private uint _tourney_queue_deadline_time = default(uint);
+    private uint? _tourney_queue_deadline_time;
     [global::ProtoBuf.ProtoMember(54, IsRequired = false, Name=@"tourney_queue_deadline_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tourney_queue_deadline_time
     {
-      get { return _tourney_queue_deadline_time; }
+      get { return _tourney_queue_deadline_time?? default(uint); }
       set { _tourney_queue_deadline_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_queue_deadline_timeSpecified
+    {
+      get { return _tourney_queue_deadline_time != null; }
+      set { if (value == (_tourney_queue_deadline_time== null)) _tourney_queue_deadline_time = value ? this.tourney_queue_deadline_time : (uint?)null; }
+    }
+    private bool ShouldSerializetourney_queue_deadline_time() { return tourney_queue_deadline_timeSpecified; }
+    private void Resettourney_queue_deadline_time() { tourney_queue_deadline_timeSpecified = false; }
+    
 
-    private ETourneyQueueDeadlineState _tourney_queue_deadline_state = ETourneyQueueDeadlineState.k_ETourneyQueueDeadlineState_Normal;
+    private ETourneyQueueDeadlineState? _tourney_queue_deadline_state;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"tourney_queue_deadline_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ETourneyQueueDeadlineState.k_ETourneyQueueDeadlineState_Normal)]
     public ETourneyQueueDeadlineState tourney_queue_deadline_state
     {
-      get { return _tourney_queue_deadline_state; }
+      get { return _tourney_queue_deadline_state?? ETourneyQueueDeadlineState.k_ETourneyQueueDeadlineState_Normal; }
       set { _tourney_queue_deadline_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tourney_queue_deadline_stateSpecified
+    {
+      get { return _tourney_queue_deadline_state != null; }
+      set { if (value == (_tourney_queue_deadline_state== null)) _tourney_queue_deadline_state = value ? this.tourney_queue_deadline_state : (ETourneyQueueDeadlineState?)null; }
+    }
+    private bool ShouldSerializetourney_queue_deadline_state() { return tourney_queue_deadline_stateSpecified; }
+    private void Resettourney_queue_deadline_state() { tourney_queue_deadline_stateSpecified = false; }
+    
 
-    private uint _party_builder_slots_to_fill = default(uint);
+    private uint? _party_builder_slots_to_fill;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"party_builder_slots_to_fill", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint party_builder_slots_to_fill
     {
-      get { return _party_builder_slots_to_fill; }
+      get { return _party_builder_slots_to_fill?? default(uint); }
       set { _party_builder_slots_to_fill = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_builder_slots_to_fillSpecified
+    {
+      get { return _party_builder_slots_to_fill != null; }
+      set { if (value == (_party_builder_slots_to_fill== null)) _party_builder_slots_to_fill = value ? this.party_builder_slots_to_fill : (uint?)null; }
+    }
+    private bool ShouldSerializeparty_builder_slots_to_fill() { return party_builder_slots_to_fillSpecified; }
+    private void Resetparty_builder_slots_to_fill() { party_builder_slots_to_fillSpecified = false; }
+    
 
-    private uint _party_builder_match_groups = default(uint);
+    private uint? _party_builder_match_groups;
     [global::ProtoBuf.ProtoMember(57, IsRequired = false, Name=@"party_builder_match_groups", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint party_builder_match_groups
     {
-      get { return _party_builder_match_groups; }
+      get { return _party_builder_match_groups?? default(uint); }
       set { _party_builder_match_groups = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_builder_match_groupsSpecified
+    {
+      get { return _party_builder_match_groups != null; }
+      set { if (value == (_party_builder_match_groups== null)) _party_builder_match_groups = value ? this.party_builder_match_groups : (uint?)null; }
+    }
+    private bool ShouldSerializeparty_builder_match_groups() { return party_builder_match_groupsSpecified; }
+    private void Resetparty_builder_match_groups() { party_builder_match_groupsSpecified = false; }
+    
 
-    private uint _party_builder_start_time = default(uint);
+    private uint? _party_builder_start_time;
     [global::ProtoBuf.ProtoMember(58, IsRequired = false, Name=@"party_builder_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint party_builder_start_time
     {
-      get { return _party_builder_start_time; }
+      get { return _party_builder_start_time?? default(uint); }
       set { _party_builder_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_builder_start_timeSpecified
+    {
+      get { return _party_builder_start_time != null; }
+      set { if (value == (_party_builder_start_time== null)) _party_builder_start_time = value ? this.party_builder_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializeparty_builder_start_time() { return party_builder_start_timeSpecified; }
+    private void Resetparty_builder_start_time() { party_builder_start_timeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"State", EnumPassthru=true)]
     public enum State
     {
@@ -488,32 +868,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTAPartyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSODOTAPartyInvite.PartyMember> _members = new global::System.Collections.Generic.List<CSODOTAPartyInvite.PartyMember>();
     [global::ProtoBuf.ProtoMember(4, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSODOTAPartyInvite.PartyMember> members
@@ -522,73 +929,136 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private bool _low_priority_status = default(bool);
+    private bool? _low_priority_status;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"low_priority_status", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority_status
     {
-      get { return _low_priority_status; }
+      get { return _low_priority_status?? default(bool); }
       set { _low_priority_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_priority_statusSpecified
+    {
+      get { return _low_priority_status != null; }
+      set { if (value == (_low_priority_status== null)) _low_priority_status = value ? this.low_priority_status : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority_status() { return low_priority_statusSpecified; }
+    private void Resetlow_priority_status() { low_priority_statusSpecified = false; }
+    
 
-    private bool _as_coach = default(bool);
+    private bool? _as_coach;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"as_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool as_coach
     {
-      get { return _as_coach; }
+      get { return _as_coach?? default(bool); }
       set { _as_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool as_coachSpecified
+    {
+      get { return _as_coach != null; }
+      set { if (value == (_as_coach== null)) _as_coach = value ? this.as_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeas_coach() { return as_coachSpecified; }
+    private void Resetas_coach() { as_coachSpecified = false; }
+    
 
-    private ulong _invite_gid = default(ulong);
+    private ulong? _invite_gid;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"invite_gid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong invite_gid
     {
-      get { return _invite_gid; }
+      get { return _invite_gid?? default(ulong); }
       set { _invite_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invite_gidSpecified
+    {
+      get { return _invite_gid != null; }
+      set { if (value == (_invite_gid== null)) _invite_gid = value ? this.invite_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeinvite_gid() { return invite_gidSpecified; }
+    private void Resetinvite_gid() { invite_gidSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PartyMember")]
   public partial class PartyMember : global::ProtoBuf.IExtensible
   {
     public PartyMember() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private bool _is_coach = default(bool);
+    private bool? _is_coach;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_coach
     {
-      get { return _is_coach; }
+      get { return _is_coach?? default(bool); }
       set { _is_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_coachSpecified
+    {
+      get { return _is_coach != null; }
+      set { if (value == (_is_coach== null)) _is_coach = value ? this.is_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeis_coach() { return is_coachSpecified; }
+    private void Resetis_coach() { is_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -605,32 +1075,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTALobbyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSODOTALobbyInvite.LobbyMember> _members = new global::System.Collections.Generic.List<CSODOTALobbyInvite.LobbyMember>();
     [global::ProtoBuf.ProtoMember(4, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSODOTALobbyInvite.LobbyMember> members
@@ -639,64 +1136,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private ulong _invite_gid = default(ulong);
+    private ulong? _invite_gid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"invite_gid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong invite_gid
     {
-      get { return _invite_gid; }
+      get { return _invite_gid?? default(ulong); }
       set { _invite_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool invite_gidSpecified
+    {
+      get { return _invite_gid != null; }
+      set { if (value == (_invite_gid== null)) _invite_gid = value ? this.invite_gid : (ulong?)null; }
+    }
+    private bool ShouldSerializeinvite_gid() { return invite_gidSpecified; }
+    private void Resetinvite_gid() { invite_gidSpecified = false; }
+    
 
-    private ulong _custom_game_crc = default(ulong);
+    private ulong? _custom_game_crc;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_game_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_crc
     {
-      get { return _custom_game_crc; }
+      get { return _custom_game_crc?? default(ulong); }
       set { _custom_game_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_crcSpecified
+    {
+      get { return _custom_game_crc != null; }
+      set { if (value == (_custom_game_crc== null)) _custom_game_crc = value ? this.custom_game_crc : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_crc() { return custom_game_crcSpecified; }
+    private void Resetcustom_game_crc() { custom_game_crcSpecified = false; }
+    
 
-    private uint _custom_game_timestamp = default(uint);
+    private uint? _custom_game_timestamp;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"custom_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_game_timestamp
     {
-      get { return _custom_game_timestamp; }
+      get { return _custom_game_timestamp?? default(uint); }
       set { _custom_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_timestampSpecified
+    {
+      get { return _custom_game_timestamp != null; }
+      set { if (value == (_custom_game_timestamp== null)) _custom_game_timestamp = value ? this.custom_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_game_timestamp() { return custom_game_timestampSpecified; }
+    private void Resetcustom_game_timestamp() { custom_game_timestampSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"LobbyMember")]
   public partial class LobbyMember : global::ProtoBuf.IExtensible
   {
     public LobbyMember() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -713,59 +1264,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeaverState() {}
     
 
-    private uint _lobby_state = default(uint);
+    private uint? _lobby_state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_state
     {
-      get { return _lobby_state; }
+      get { return _lobby_state?? default(uint); }
       set { _lobby_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_stateSpecified
+    {
+      get { return _lobby_state != null; }
+      set { if (value == (_lobby_state== null)) _lobby_state = value ? this.lobby_state : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_state() { return lobby_stateSpecified; }
+    private void Resetlobby_state() { lobby_stateSpecified = false; }
+    
 
-    private DOTA_GameState _game_state = DOTA_GameState.DOTA_GAMERULES_STATE_INIT;
+    private DOTA_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameState.DOTA_GAMERULES_STATE_INIT)]
     public DOTA_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? DOTA_GameState.DOTA_GAMERULES_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (DOTA_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private bool _leaver_detected = default(bool);
+    private bool? _leaver_detected;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"leaver_detected", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool leaver_detected
     {
-      get { return _leaver_detected; }
+      get { return _leaver_detected?? default(bool); }
       set { _leaver_detected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_detectedSpecified
+    {
+      get { return _leaver_detected != null; }
+      set { if (value == (_leaver_detected== null)) _leaver_detected = value ? this.leaver_detected : (bool?)null; }
+    }
+    private bool ShouldSerializeleaver_detected() { return leaver_detectedSpecified; }
+    private void Resetleaver_detected() { leaver_detectedSpecified = false; }
+    
 
-    private bool _first_blood_happened = default(bool);
+    private bool? _first_blood_happened;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"first_blood_happened", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool first_blood_happened
     {
-      get { return _first_blood_happened; }
+      get { return _first_blood_happened?? default(bool); }
       set { _first_blood_happened = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_happenedSpecified
+    {
+      get { return _first_blood_happened != null; }
+      set { if (value == (_first_blood_happened== null)) _first_blood_happened = value ? this.first_blood_happened : (bool?)null; }
+    }
+    private bool ShouldSerializefirst_blood_happened() { return first_blood_happenedSpecified; }
+    private void Resetfirst_blood_happened() { first_blood_happenedSpecified = false; }
+    
 
-    private bool _discard_match_results = default(bool);
+    private bool? _discard_match_results;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"discard_match_results", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool discard_match_results
     {
-      get { return _discard_match_results; }
+      get { return _discard_match_results?? default(bool); }
       set { _discard_match_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool discard_match_resultsSpecified
+    {
+      get { return _discard_match_results != null; }
+      set { if (value == (_discard_match_results== null)) _discard_match_results = value ? this.discard_match_results : (bool?)null; }
+    }
+    private bool ShouldSerializediscard_match_results() { return discard_match_resultsSpecified; }
+    private void Resetdiscard_match_results() { discard_match_resultsSpecified = false; }
+    
 
-    private bool _mass_disconnect = default(bool);
+    private bool? _mass_disconnect;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"mass_disconnect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool mass_disconnect
     {
-      get { return _mass_disconnect; }
+      get { return _mass_disconnect?? default(bool); }
       set { _mass_disconnect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mass_disconnectSpecified
+    {
+      get { return _mass_disconnect != null; }
+      set { if (value == (_mass_disconnect== null)) _mass_disconnect = value ? this.mass_disconnect : (bool?)null; }
+    }
+    private bool ShouldSerializemass_disconnect() { return mass_disconnectSpecified; }
+    private void Resetmass_disconnect() { mass_disconnectSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -777,122 +1382,239 @@ namespace SteamKit2.GC.Dota.Internal
     public CDOTALobbyMember() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private DOTA_GC_TEAM _team = DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    private DOTA_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS)]
     public DOTA_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _slot = default(uint);
+    private uint? _slot;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot
     {
-      get { return _slot; }
+      get { return _slot?? default(uint); }
       set { _slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slotSpecified
+    {
+      get { return _slot != null; }
+      set { if (value == (_slot== null)) _slot = value ? this.slot : (uint?)null; }
+    }
+    private bool ShouldSerializeslot() { return slotSpecified; }
+    private void Resetslot() { slotSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _meta_level = default(uint);
+    private uint? _meta_level;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"meta_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint meta_level
     {
-      get { return _meta_level; }
+      get { return _meta_level?? default(uint); }
       set { _meta_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_levelSpecified
+    {
+      get { return _meta_level != null; }
+      set { if (value == (_meta_level== null)) _meta_level = value ? this.meta_level : (uint?)null; }
+    }
+    private bool ShouldSerializemeta_level() { return meta_levelSpecified; }
+    private void Resetmeta_level() { meta_levelSpecified = false; }
+    
 
-    private uint _meta_xp = default(uint);
+    private uint? _meta_xp;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"meta_xp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint meta_xp
     {
-      get { return _meta_xp; }
+      get { return _meta_xp?? default(uint); }
       set { _meta_xp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_xpSpecified
+    {
+      get { return _meta_xp != null; }
+      set { if (value == (_meta_xp== null)) _meta_xp = value ? this.meta_xp : (uint?)null; }
+    }
+    private bool ShouldSerializemeta_xp() { return meta_xpSpecified; }
+    private void Resetmeta_xp() { meta_xpSpecified = false; }
+    
 
-    private uint _meta_xp_awarded = default(uint);
+    private uint? _meta_xp_awarded;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"meta_xp_awarded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint meta_xp_awarded
     {
-      get { return _meta_xp_awarded; }
+      get { return _meta_xp_awarded?? default(uint); }
       set { _meta_xp_awarded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_xp_awardedSpecified
+    {
+      get { return _meta_xp_awarded != null; }
+      set { if (value == (_meta_xp_awarded== null)) _meta_xp_awarded = value ? this.meta_xp_awarded : (uint?)null; }
+    }
+    private bool ShouldSerializemeta_xp_awarded() { return meta_xp_awardedSpecified; }
+    private void Resetmeta_xp_awarded() { meta_xp_awardedSpecified = false; }
+    
 
-    private DOTALeaverStatus_t _leaver_status = DOTALeaverStatus_t.DOTA_LEAVER_NONE;
+    private DOTALeaverStatus_t? _leaver_status;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"leaver_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTALeaverStatus_t.DOTA_LEAVER_NONE)]
     public DOTALeaverStatus_t leaver_status
     {
-      get { return _leaver_status; }
+      get { return _leaver_status?? DOTALeaverStatus_t.DOTA_LEAVER_NONE; }
       set { _leaver_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_statusSpecified
+    {
+      get { return _leaver_status != null; }
+      set { if (value == (_leaver_status== null)) _leaver_status = value ? this.leaver_status : (DOTALeaverStatus_t?)null; }
+    }
+    private bool ShouldSerializeleaver_status() { return leaver_statusSpecified; }
+    private void Resetleaver_status() { leaver_statusSpecified = false; }
+    
 
-    private uint _leaver_actions = default(uint);
+    private uint? _leaver_actions;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"leaver_actions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leaver_actions
     {
-      get { return _leaver_actions; }
+      get { return _leaver_actions?? default(uint); }
       set { _leaver_actions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_actionsSpecified
+    {
+      get { return _leaver_actions != null; }
+      set { if (value == (_leaver_actions== null)) _leaver_actions = value ? this.leaver_actions : (uint?)null; }
+    }
+    private bool ShouldSerializeleaver_actions() { return leaver_actionsSpecified; }
+    private void Resetleaver_actions() { leaver_actionsSpecified = false; }
+    
 
-    private uint _channel = default(uint);
+    private uint? _channel;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"channel", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel
     {
-      get { return _channel; }
+      get { return _channel?? default(uint); }
       set { _channel = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channelSpecified
+    {
+      get { return _channel != null; }
+      set { if (value == (_channel== null)) _channel = value ? this.channel : (uint?)null; }
+    }
+    private bool ShouldSerializechannel() { return channelSpecified; }
+    private void Resetchannel() { channelSpecified = false; }
+    
 
-    private uint _prize_def_index = default(uint);
+    private uint? _prize_def_index;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"prize_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_def_index
     {
-      get { return _prize_def_index; }
+      get { return _prize_def_index?? default(uint); }
       set { _prize_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_def_indexSpecified
+    {
+      get { return _prize_def_index != null; }
+      set { if (value == (_prize_def_index== null)) _prize_def_index = value ? this.prize_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_def_index() { return prize_def_indexSpecified; }
+    private void Resetprize_def_index() { prize_def_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _disabled_hero_id = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(20, Name=@"disabled_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> disabled_hero_id
@@ -901,14 +1623,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private PartnerAccountType _partner_account_type = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _partner_account_type;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"partner_account_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType partner_account_type
     {
-      get { return _partner_account_type; }
+      get { return _partner_account_type?? PartnerAccountType.PARTNER_NONE; }
       set { _partner_account_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_account_typeSpecified
+    {
+      get { return _partner_account_type != null; }
+      set { if (value == (_partner_account_type== null)) _partner_account_type = value ? this.partner_account_type : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializepartner_account_type() { return partner_account_typeSpecified; }
+    private void Resetpartner_account_type() { partner_account_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _enabled_hero_id = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(22, Name=@"enabled_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> enabled_hero_id
@@ -917,32 +1648,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private DOTA_GC_TEAM _coach_team = DOTA_GC_TEAM.DOTA_GC_TEAM_NOTEAM;
+    private DOTA_GC_TEAM? _coach_team;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"coach_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_NOTEAM)]
     public DOTA_GC_TEAM coach_team
     {
-      get { return _coach_team; }
+      get { return _coach_team?? DOTA_GC_TEAM.DOTA_GC_TEAM_NOTEAM; }
       set { _coach_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coach_teamSpecified
+    {
+      get { return _coach_team != null; }
+      set { if (value == (_coach_team== null)) _coach_team = value ? this.coach_team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializecoach_team() { return coach_teamSpecified; }
+    private void Resetcoach_team() { coach_teamSpecified = false; }
+    
 
-    private uint _nexon_pc_bang_no = default(uint);
+    private uint? _nexon_pc_bang_no;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"nexon_pc_bang_no", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint nexon_pc_bang_no
     {
-      get { return _nexon_pc_bang_no; }
+      get { return _nexon_pc_bang_no?? default(uint); }
       set { _nexon_pc_bang_no = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nexon_pc_bang_noSpecified
+    {
+      get { return _nexon_pc_bang_no != null; }
+      set { if (value == (_nexon_pc_bang_no== null)) _nexon_pc_bang_no = value ? this.nexon_pc_bang_no : (uint?)null; }
+    }
+    private bool ShouldSerializenexon_pc_bang_no() { return nexon_pc_bang_noSpecified; }
+    private void Resetnexon_pc_bang_no() { nexon_pc_bang_noSpecified = false; }
+    
 
-    private string _nexon_pc_bang_name = "";
+    private string _nexon_pc_bang_name;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"nexon_pc_bang_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string nexon_pc_bang_name
     {
-      get { return _nexon_pc_bang_name; }
+      get { return _nexon_pc_bang_name?? ""; }
       set { _nexon_pc_bang_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nexon_pc_bang_nameSpecified
+    {
+      get { return _nexon_pc_bang_name != null; }
+      set { if (value == (_nexon_pc_bang_name== null)) _nexon_pc_bang_name = value ? this.nexon_pc_bang_name : (string)null; }
+    }
+    private bool ShouldSerializenexon_pc_bang_name() { return nexon_pc_bang_nameSpecified; }
+    private void Resetnexon_pc_bang_name() { nexon_pc_bang_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDOTALobbyMember.CDOTALobbyMemberXPBonus> _xp_bonuses = new global::System.Collections.Generic.List<CDOTALobbyMember.CDOTALobbyMemberXPBonus>();
     [global::ProtoBuf.ProtoMember(27, Name=@"xp_bonuses", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDOTALobbyMember.CDOTALobbyMemberXPBonus> xp_bonuses
@@ -951,23 +1709,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private int _rank_change = default(int);
+    private int? _rank_change;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"rank_change", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int rank_change
     {
-      get { return _rank_change; }
+      get { return _rank_change?? default(int); }
       set { _rank_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_changeSpecified
+    {
+      get { return _rank_change != null; }
+      set { if (value == (_rank_change== null)) _rank_change = value ? this.rank_change : (int?)null; }
+    }
+    private bool ShouldSerializerank_change() { return rank_changeSpecified; }
+    private void Resetrank_change() { rank_changeSpecified = false; }
+    
 
-    private bool _cameraman = default(bool);
+    private bool? _cameraman;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"cameraman", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool cameraman
     {
-      get { return _cameraman; }
+      get { return _cameraman?? default(bool); }
       set { _cameraman = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cameramanSpecified
+    {
+      get { return _cameraman != null; }
+      set { if (value == (_cameraman== null)) _cameraman = value ? this.cameraman : (bool?)null; }
+    }
+    private bool ShouldSerializecameraman() { return cameramanSpecified; }
+    private void Resetcameraman() { cameramanSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _custom_game_product_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(31, Name=@"custom_game_product_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> custom_game_product_ids
@@ -976,64 +1752,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _lobby_mvp_vote_account_id = default(uint);
+    private uint? _lobby_mvp_vote_account_id;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"lobby_mvp_vote_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_mvp_vote_account_id
     {
-      get { return _lobby_mvp_vote_account_id; }
+      get { return _lobby_mvp_vote_account_id?? default(uint); }
       set { _lobby_mvp_vote_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_mvp_vote_account_idSpecified
+    {
+      get { return _lobby_mvp_vote_account_id != null; }
+      set { if (value == (_lobby_mvp_vote_account_id== null)) _lobby_mvp_vote_account_id = value ? this.lobby_mvp_vote_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_mvp_vote_account_id() { return lobby_mvp_vote_account_idSpecified; }
+    private void Resetlobby_mvp_vote_account_id() { lobby_mvp_vote_account_idSpecified = false; }
+    
 
-    private MatchType _search_match_type = MatchType.MATCH_TYPE_CASUAL;
+    private MatchType? _search_match_type;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"search_match_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(MatchType.MATCH_TYPE_CASUAL)]
     public MatchType search_match_type
     {
-      get { return _search_match_type; }
+      get { return _search_match_type?? MatchType.MATCH_TYPE_CASUAL; }
       set { _search_match_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_match_typeSpecified
+    {
+      get { return _search_match_type != null; }
+      set { if (value == (_search_match_type== null)) _search_match_type = value ? this.search_match_type : (MatchType?)null; }
+    }
+    private bool ShouldSerializesearch_match_type() { return search_match_typeSpecified; }
+    private void Resetsearch_match_type() { search_match_typeSpecified = false; }
+    
 
-    private uint _favorite_team_and_quality = default(uint);
+    private uint? _favorite_team_and_quality;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"favorite_team_and_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorite_team_and_quality
     {
-      get { return _favorite_team_and_quality; }
+      get { return _favorite_team_and_quality?? default(uint); }
       set { _favorite_team_and_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favorite_team_and_qualitySpecified
+    {
+      get { return _favorite_team_and_quality != null; }
+      set { if (value == (_favorite_team_and_quality== null)) _favorite_team_and_quality = value ? this.favorite_team_and_quality : (uint?)null; }
+    }
+    private bool ShouldSerializefavorite_team_and_quality() { return favorite_team_and_qualitySpecified; }
+    private void Resetfavorite_team_and_quality() { favorite_team_and_qualitySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CDOTALobbyMemberXPBonus")]
   public partial class CDOTALobbyMemberXPBonus : global::ProtoBuf.IExtensible
   {
     public CDOTALobbyMemberXPBonus() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private float _xp_bonus = default(float);
+    private float? _xp_bonus;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"xp_bonus", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float xp_bonus
     {
-      get { return _xp_bonus; }
+      get { return _xp_bonus?? default(float); }
       set { _xp_bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_bonusSpecified
+    {
+      get { return _xp_bonus != null; }
+      set { if (value == (_xp_bonus== null)) _xp_bonus = value ? this.xp_bonus : (float?)null; }
+    }
+    private bool ShouldSerializexp_bonus() { return xp_bonusSpecified; }
+    private void Resetxp_bonus() { xp_bonusSpecified = false; }
+    
 
-    private ulong _source_key = default(ulong);
+    private ulong? _source_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong source_key
     {
-      get { return _source_key; }
+      get { return _source_key?? default(ulong); }
       set { _source_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_keySpecified
+    {
+      get { return _source_key != null; }
+      set { if (value == (_source_key== null)) _source_key = value ? this.source_key : (ulong?)null; }
+    }
+    private bool ShouldSerializesource_key() { return source_keySpecified; }
+    private void Resetsource_key() { source_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1050,149 +1880,293 @@ namespace SteamKit2.GC.Dota.Internal
     public CLobbyTeamDetails() {}
     
 
-    private string _team_name = "";
+    private string _team_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_name
     {
-      get { return _team_name; }
+      get { return _team_name?? ""; }
       set { _team_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_nameSpecified
+    {
+      get { return _team_name != null; }
+      set { if (value == (_team_name== null)) _team_name = value ? this.team_name : (string)null; }
+    }
+    private bool ShouldSerializeteam_name() { return team_nameSpecified; }
+    private void Resetteam_name() { team_nameSpecified = false; }
+    
 
-    private string _team_tag = "";
+    private string _team_tag;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string team_tag
     {
-      get { return _team_tag; }
+      get { return _team_tag?? ""; }
       set { _team_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_tagSpecified
+    {
+      get { return _team_tag != null; }
+      set { if (value == (_team_tag== null)) _team_tag = value ? this.team_tag : (string)null; }
+    }
+    private bool ShouldSerializeteam_tag() { return team_tagSpecified; }
+    private void Resetteam_tag() { team_tagSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private ulong _team_logo = default(ulong);
+    private ulong? _team_logo;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_logo
     {
-      get { return _team_logo; }
+      get { return _team_logo?? default(ulong); }
       set { _team_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_logoSpecified
+    {
+      get { return _team_logo != null; }
+      set { if (value == (_team_logo== null)) _team_logo = value ? this.team_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_logo() { return team_logoSpecified; }
+    private void Resetteam_logo() { team_logoSpecified = false; }
+    
 
-    private ulong _team_base_logo = default(ulong);
+    private ulong? _team_base_logo;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_base_logo
     {
-      get { return _team_base_logo; }
+      get { return _team_base_logo?? default(ulong); }
       set { _team_base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_base_logoSpecified
+    {
+      get { return _team_base_logo != null; }
+      set { if (value == (_team_base_logo== null)) _team_base_logo = value ? this.team_base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_base_logo() { return team_base_logoSpecified; }
+    private void Resetteam_base_logo() { team_base_logoSpecified = false; }
+    
 
-    private ulong _team_banner_logo = default(ulong);
+    private ulong? _team_banner_logo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong team_banner_logo
     {
-      get { return _team_banner_logo; }
+      get { return _team_banner_logo?? default(ulong); }
       set { _team_banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_banner_logoSpecified
+    {
+      get { return _team_banner_logo != null; }
+      set { if (value == (_team_banner_logo== null)) _team_banner_logo = value ? this.team_banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeteam_banner_logo() { return team_banner_logoSpecified; }
+    private void Resetteam_banner_logo() { team_banner_logoSpecified = false; }
+    
 
-    private bool _team_complete = default(bool);
+    private bool? _team_complete;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team_complete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool team_complete
     {
-      get { return _team_complete; }
+      get { return _team_complete?? default(bool); }
       set { _team_complete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_completeSpecified
+    {
+      get { return _team_complete != null; }
+      set { if (value == (_team_complete== null)) _team_complete = value ? this.team_complete : (bool?)null; }
+    }
+    private bool ShouldSerializeteam_complete() { return team_completeSpecified; }
+    private void Resetteam_complete() { team_completeSpecified = false; }
+    
 
-    private string _guild_name = "";
+    private string _guild_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"guild_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string guild_name
     {
-      get { return _guild_name; }
+      get { return _guild_name?? ""; }
       set { _guild_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_nameSpecified
+    {
+      get { return _guild_name != null; }
+      set { if (value == (_guild_name== null)) _guild_name = value ? this.guild_name : (string)null; }
+    }
+    private bool ShouldSerializeguild_name() { return guild_nameSpecified; }
+    private void Resetguild_name() { guild_nameSpecified = false; }
+    
 
-    private string _guild_tag = "";
+    private string _guild_tag;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"guild_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string guild_tag
     {
-      get { return _guild_tag; }
+      get { return _guild_tag?? ""; }
       set { _guild_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_tagSpecified
+    {
+      get { return _guild_tag != null; }
+      set { if (value == (_guild_tag== null)) _guild_tag = value ? this.guild_tag : (string)null; }
+    }
+    private bool ShouldSerializeguild_tag() { return guild_tagSpecified; }
+    private void Resetguild_tag() { guild_tagSpecified = false; }
+    
 
-    private uint _guild_id = default(uint);
+    private uint? _guild_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"guild_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint guild_id
     {
-      get { return _guild_id; }
+      get { return _guild_id?? default(uint); }
       set { _guild_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_idSpecified
+    {
+      get { return _guild_id != null; }
+      set { if (value == (_guild_id== null)) _guild_id = value ? this.guild_id : (uint?)null; }
+    }
+    private bool ShouldSerializeguild_id() { return guild_idSpecified; }
+    private void Resetguild_id() { guild_idSpecified = false; }
+    
 
-    private ulong _guild_logo = default(ulong);
+    private ulong? _guild_logo;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"guild_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong guild_logo
     {
-      get { return _guild_logo; }
+      get { return _guild_logo?? default(ulong); }
       set { _guild_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_logoSpecified
+    {
+      get { return _guild_logo != null; }
+      set { if (value == (_guild_logo== null)) _guild_logo = value ? this.guild_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeguild_logo() { return guild_logoSpecified; }
+    private void Resetguild_logo() { guild_logoSpecified = false; }
+    
 
-    private ulong _guild_base_logo = default(ulong);
+    private ulong? _guild_base_logo;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"guild_base_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong guild_base_logo
     {
-      get { return _guild_base_logo; }
+      get { return _guild_base_logo?? default(ulong); }
       set { _guild_base_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_base_logoSpecified
+    {
+      get { return _guild_base_logo != null; }
+      set { if (value == (_guild_base_logo== null)) _guild_base_logo = value ? this.guild_base_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeguild_base_logo() { return guild_base_logoSpecified; }
+    private void Resetguild_base_logo() { guild_base_logoSpecified = false; }
+    
 
-    private ulong _guild_banner_logo = default(ulong);
+    private ulong? _guild_banner_logo;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"guild_banner_logo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong guild_banner_logo
     {
-      get { return _guild_banner_logo; }
+      get { return _guild_banner_logo?? default(ulong); }
       set { _guild_banner_logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guild_banner_logoSpecified
+    {
+      get { return _guild_banner_logo != null; }
+      set { if (value == (_guild_banner_logo== null)) _guild_banner_logo = value ? this.guild_banner_logo : (ulong?)null; }
+    }
+    private bool ShouldSerializeguild_banner_logo() { return guild_banner_logoSpecified; }
+    private void Resetguild_banner_logo() { guild_banner_logoSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private int _rank_change = default(int);
+    private int? _rank_change;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"rank_change", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int rank_change
     {
-      get { return _rank_change; }
+      get { return _rank_change?? default(int); }
       set { _rank_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_changeSpecified
+    {
+      get { return _rank_change != null; }
+      set { if (value == (_rank_change== null)) _rank_change = value ? this.rank_change : (int?)null; }
+    }
+    private bool ShouldSerializerank_change() { return rank_changeSpecified; }
+    private void Resetrank_change() { rank_changeSpecified = false; }
+    
 
-    private bool _is_home_team = default(bool);
+    private bool? _is_home_team;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"is_home_team", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_home_team
     {
-      get { return _is_home_team; }
+      get { return _is_home_team?? default(bool); }
       set { _is_home_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_home_teamSpecified
+    {
+      get { return _is_home_team != null; }
+      set { if (value == (_is_home_team== null)) _is_home_team = value ? this.is_home_team : (bool?)null; }
+    }
+    private bool ShouldSerializeis_home_team() { return is_home_teamSpecified; }
+    private void Resetis_home_team() { is_home_teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1204,50 +2178,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CLobbyTimedRewardDetails() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private bool _is_supply_crate = default(bool);
+    private bool? _is_supply_crate;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_supply_crate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_supply_crate
     {
-      get { return _is_supply_crate; }
+      get { return _is_supply_crate?? default(bool); }
       set { _is_supply_crate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_supply_crateSpecified
+    {
+      get { return _is_supply_crate != null; }
+      set { if (value == (_is_supply_crate== null)) _is_supply_crate = value ? this.is_supply_crate : (bool?)null; }
+    }
+    private bool ShouldSerializeis_supply_crate() { return is_supply_crateSpecified; }
+    private void Resetis_supply_crate() { is_supply_crateSpecified = false; }
+    
 
-    private bool _is_timed_drop = default(bool);
+    private bool? _is_timed_drop;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_timed_drop", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_timed_drop
     {
-      get { return _is_timed_drop; }
+      get { return _is_timed_drop?? default(bool); }
       set { _is_timed_drop = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_timed_dropSpecified
+    {
+      get { return _is_timed_drop != null; }
+      set { if (value == (_is_timed_drop== null)) _is_timed_drop = value ? this.is_timed_drop : (bool?)null; }
+    }
+    private bool ShouldSerializeis_timed_drop() { return is_timed_dropSpecified; }
+    private void Resetis_timed_drop() { is_timed_dropSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1259,41 +2278,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CLobbyBroadcastChannelInfo() {}
     
 
-    private uint _channel_id = default(uint);
+    private uint? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(uint); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (uint?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private string _language_code = "";
+    private string _language_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"language_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language_code
     {
-      get { return _language_code; }
+      get { return _language_code?? ""; }
       set { _language_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool language_codeSpecified
+    {
+      get { return _language_code != null; }
+      set { if (value == (_language_code== null)) _language_code = value ? this.language_code : (string)null; }
+    }
+    private bool ShouldSerializelanguage_code() { return language_codeSpecified; }
+    private void Resetlanguage_code() { language_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1305,14 +2360,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CSODOTALobby() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDOTALobbyMember> _members = new global::System.Collections.Generic.List<CDOTALobbyMember>();
     [global::ProtoBuf.ProtoMember(2, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDOTALobbyMember> members
@@ -1328,32 +2392,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _leader_id = default(ulong);
+    private ulong? _leader_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"leader_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong leader_id
     {
-      get { return _leader_id; }
+      get { return _leader_id?? default(ulong); }
       set { _leader_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_idSpecified
+    {
+      get { return _leader_id != null; }
+      set { if (value == (_leader_id== null)) _leader_id = value ? this.leader_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeleader_id() { return leader_idSpecified; }
+    private void Resetleader_id() { leader_idSpecified = false; }
+    
 
-    private ulong _server_id = (ulong)0;
+    private ulong? _server_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong server_id
     {
-      get { return _server_id; }
+      get { return _server_id?? (ulong)0; }
       set { _server_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_idSpecified
+    {
+      get { return _server_id != null; }
+      set { if (value == (_server_id== null)) _server_id = value ? this.server_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_id() { return server_idSpecified; }
+    private void Resetserver_id() { server_idSpecified = false; }
+    
 
-    private uint _game_mode = default(uint);
+    private uint? _game_mode;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_mode
     {
-      get { return _game_mode; }
+      get { return _game_mode?? default(uint); }
       set { _game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_modeSpecified
+    {
+      get { return _game_mode != null; }
+      set { if (value == (_game_mode== null)) _game_mode = value ? this.game_mode : (uint?)null; }
+    }
+    private bool ShouldSerializegame_mode() { return game_modeSpecified; }
+    private void Resetgame_mode() { game_modeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _pending_invites = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(10, Name=@"pending_invites", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> pending_invites
@@ -1362,68 +2453,131 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CSODOTALobby.State _state = CSODOTALobby.State.UI;
+    private CSODOTALobby.State? _state;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSODOTALobby.State.UI)]
     public CSODOTALobby.State state
     {
-      get { return _state; }
+      get { return _state?? CSODOTALobby.State.UI; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (CSODOTALobby.State?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _connect = "";
+    private string _connect;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"connect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string connect
     {
-      get { return _connect; }
+      get { return _connect?? ""; }
       set { _connect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connectSpecified
+    {
+      get { return _connect != null; }
+      set { if (value == (_connect== null)) _connect = value ? this.connect : (string)null; }
+    }
+    private bool ShouldSerializeconnect() { return connectSpecified; }
+    private void Resetconnect() { connectSpecified = false; }
+    
 
-    private CSODOTALobby.LobbyType _lobby_type = CSODOTALobby.LobbyType.INVALID;
+    private CSODOTALobby.LobbyType? _lobby_type;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSODOTALobby.LobbyType.INVALID)]
     public CSODOTALobby.LobbyType lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? CSODOTALobby.LobbyType.INVALID; }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (CSODOTALobby.LobbyType?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private bool _allow_cheats = default(bool);
+    private bool? _allow_cheats;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"allow_cheats", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_cheats
     {
-      get { return _allow_cheats; }
+      get { return _allow_cheats?? default(bool); }
       set { _allow_cheats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_cheatsSpecified
+    {
+      get { return _allow_cheats != null; }
+      set { if (value == (_allow_cheats== null)) _allow_cheats = value ? this.allow_cheats : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_cheats() { return allow_cheatsSpecified; }
+    private void Resetallow_cheats() { allow_cheatsSpecified = false; }
+    
 
-    private bool _fill_with_bots = default(bool);
+    private bool? _fill_with_bots;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"fill_with_bots", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool fill_with_bots
     {
-      get { return _fill_with_bots; }
+      get { return _fill_with_bots?? default(bool); }
       set { _fill_with_bots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fill_with_botsSpecified
+    {
+      get { return _fill_with_bots != null; }
+      set { if (value == (_fill_with_bots== null)) _fill_with_bots = value ? this.fill_with_bots : (bool?)null; }
+    }
+    private bool ShouldSerializefill_with_bots() { return fill_with_botsSpecified; }
+    private void Resetfill_with_bots() { fill_with_botsSpecified = false; }
+    
 
-    private bool _intro_mode = default(bool);
+    private bool? _intro_mode;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"intro_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool intro_mode
     {
-      get { return _intro_mode; }
+      get { return _intro_mode?? default(bool); }
       set { _intro_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool intro_modeSpecified
+    {
+      get { return _intro_mode != null; }
+      set { if (value == (_intro_mode== null)) _intro_mode = value ? this.intro_mode : (bool?)null; }
+    }
+    private bool ShouldSerializeintro_mode() { return intro_modeSpecified; }
+    private void Resetintro_mode() { intro_modeSpecified = false; }
+    
 
-    private string _game_name = "";
+    private string _game_name;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"game_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_name
     {
-      get { return _game_name; }
+      get { return _game_name?? ""; }
       set { _game_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_nameSpecified
+    {
+      get { return _game_name != null; }
+      set { if (value == (_game_name== null)) _game_name = value ? this.game_name : (string)null; }
+    }
+    private bool ShouldSerializegame_name() { return game_nameSpecified; }
+    private void Resetgame_name() { game_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CLobbyTeamDetails> _team_details = new global::System.Collections.Generic.List<CLobbyTeamDetails>();
     [global::ProtoBuf.ProtoMember(17, Name=@"team_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CLobbyTeamDetails> team_details
@@ -1432,113 +2586,221 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _tutorial_lesson = default(uint);
+    private uint? _tutorial_lesson;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"tutorial_lesson", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tutorial_lesson
     {
-      get { return _tutorial_lesson; }
+      get { return _tutorial_lesson?? default(uint); }
       set { _tutorial_lesson = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tutorial_lessonSpecified
+    {
+      get { return _tutorial_lesson != null; }
+      set { if (value == (_tutorial_lesson== null)) _tutorial_lesson = value ? this.tutorial_lesson : (uint?)null; }
+    }
+    private bool ShouldSerializetutorial_lesson() { return tutorial_lessonSpecified; }
+    private void Resettutorial_lesson() { tutorial_lessonSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _tournament_game_id = default(uint);
+    private uint? _tournament_game_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"tournament_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_game_id
     {
-      get { return _tournament_game_id; }
+      get { return _tournament_game_id?? default(uint); }
       set { _tournament_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_game_idSpecified
+    {
+      get { return _tournament_game_id != null; }
+      set { if (value == (_tournament_game_id== null)) _tournament_game_id = value ? this.tournament_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_game_id() { return tournament_game_idSpecified; }
+    private void Resettournament_game_id() { tournament_game_idSpecified = false; }
+    
 
-    private uint _server_region = (uint)0;
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? (uint)0; }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private DOTA_GameState _game_state = DOTA_GameState.DOTA_GAMERULES_STATE_INIT;
+    private DOTA_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameState.DOTA_GAMERULES_STATE_INIT)]
     public DOTA_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? DOTA_GameState.DOTA_GAMERULES_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (DOTA_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private uint _num_spectators = default(uint);
+    private uint? _num_spectators;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"num_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_spectators
     {
-      get { return _num_spectators; }
+      get { return _num_spectators?? default(uint); }
       set { _num_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_spectatorsSpecified
+    {
+      get { return _num_spectators != null; }
+      set { if (value == (_num_spectators== null)) _num_spectators = value ? this.num_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializenum_spectators() { return num_spectatorsSpecified; }
+    private void Resetnum_spectators() { num_spectatorsSpecified = false; }
+    
 
-    private uint _matchgroup = default(uint);
+    private uint? _matchgroup;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"matchgroup", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchgroup
     {
-      get { return _matchgroup; }
+      get { return _matchgroup?? default(uint); }
       set { _matchgroup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchgroupSpecified
+    {
+      get { return _matchgroup != null; }
+      set { if (value == (_matchgroup== null)) _matchgroup = value ? this.matchgroup : (uint?)null; }
+    }
+    private bool ShouldSerializematchgroup() { return matchgroupSpecified; }
+    private void Resetmatchgroup() { matchgroupSpecified = false; }
+    
 
-    private DOTA_CM_PICK _cm_pick = DOTA_CM_PICK.DOTA_CM_RANDOM;
+    private DOTA_CM_PICK? _cm_pick;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"cm_pick", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_CM_PICK.DOTA_CM_RANDOM)]
     public DOTA_CM_PICK cm_pick
     {
-      get { return _cm_pick; }
+      get { return _cm_pick?? DOTA_CM_PICK.DOTA_CM_RANDOM; }
       set { _cm_pick = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cm_pickSpecified
+    {
+      get { return _cm_pick != null; }
+      set { if (value == (_cm_pick== null)) _cm_pick = value ? this.cm_pick : (DOTA_CM_PICK?)null; }
+    }
+    private bool ShouldSerializecm_pick() { return cm_pickSpecified; }
+    private void Resetcm_pick() { cm_pickSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private bool _allow_spectating = (bool)true;
+    private bool? _allow_spectating;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"allow_spectating", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool allow_spectating
     {
-      get { return _allow_spectating; }
+      get { return _allow_spectating?? (bool)true; }
       set { _allow_spectating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_spectatingSpecified
+    {
+      get { return _allow_spectating != null; }
+      set { if (value == (_allow_spectating== null)) _allow_spectating = value ? this.allow_spectating : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_spectating() { return allow_spectatingSpecified; }
+    private void Resetallow_spectating() { allow_spectatingSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_radiant = DOTABotDifficulty.BOT_DIFFICULTY_HARD;
+    private DOTABotDifficulty? _bot_difficulty_radiant;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"bot_difficulty_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_HARD)]
     public DOTABotDifficulty bot_difficulty_radiant
     {
-      get { return _bot_difficulty_radiant; }
+      get { return _bot_difficulty_radiant?? DOTABotDifficulty.BOT_DIFFICULTY_HARD; }
       set { _bot_difficulty_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_radiantSpecified
+    {
+      get { return _bot_difficulty_radiant != null; }
+      set { if (value == (_bot_difficulty_radiant== null)) _bot_difficulty_radiant = value ? this.bot_difficulty_radiant : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_radiant() { return bot_difficulty_radiantSpecified; }
+    private void Resetbot_difficulty_radiant() { bot_difficulty_radiantSpecified = false; }
+    
 
-    private DOTAGameVersion _game_version = DOTAGameVersion.GAME_VERSION_CURRENT;
+    private DOTAGameVersion? _game_version;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"game_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTAGameVersion.GAME_VERSION_CURRENT)]
     public DOTAGameVersion game_version
     {
-      get { return _game_version; }
+      get { return _game_version?? DOTAGameVersion.GAME_VERSION_CURRENT; }
       set { _game_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_versionSpecified
+    {
+      get { return _game_version != null; }
+      set { if (value == (_game_version== null)) _game_version = value ? this.game_version : (DOTAGameVersion?)null; }
+    }
+    private bool ShouldSerializegame_version() { return game_versionSpecified; }
+    private void Resetgame_version() { game_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CLobbyTimedRewardDetails> _timed_reward_details = new global::System.Collections.Generic.List<CLobbyTimedRewardDetails>();
     [global::ProtoBuf.ProtoMember(38, Name=@"timed_reward_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CLobbyTimedRewardDetails> timed_reward_details
@@ -1547,149 +2809,293 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private string _pass_key = "";
+    private string _pass_key;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"pass_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string pass_key
     {
-      get { return _pass_key; }
+      get { return _pass_key?? ""; }
       set { _pass_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pass_keySpecified
+    {
+      get { return _pass_key != null; }
+      set { if (value == (_pass_key== null)) _pass_key = value ? this.pass_key : (string)null; }
+    }
+    private bool ShouldSerializepass_key() { return pass_keySpecified; }
+    private void Resetpass_key() { pass_keySpecified = false; }
+    
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
 
-    private uint _penalty_level_radiant = (uint)0;
+    private uint? _penalty_level_radiant;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"penalty_level_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint penalty_level_radiant
     {
-      get { return _penalty_level_radiant; }
+      get { return _penalty_level_radiant?? (uint)0; }
       set { _penalty_level_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_level_radiantSpecified
+    {
+      get { return _penalty_level_radiant != null; }
+      set { if (value == (_penalty_level_radiant== null)) _penalty_level_radiant = value ? this.penalty_level_radiant : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_level_radiant() { return penalty_level_radiantSpecified; }
+    private void Resetpenalty_level_radiant() { penalty_level_radiantSpecified = false; }
+    
 
-    private uint _penalty_level_dire = (uint)0;
+    private uint? _penalty_level_dire;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"penalty_level_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint penalty_level_dire
     {
-      get { return _penalty_level_dire; }
+      get { return _penalty_level_dire?? (uint)0; }
       set { _penalty_level_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool penalty_level_direSpecified
+    {
+      get { return _penalty_level_dire != null; }
+      set { if (value == (_penalty_level_dire== null)) _penalty_level_dire = value ? this.penalty_level_dire : (uint?)null; }
+    }
+    private bool ShouldSerializepenalty_level_dire() { return penalty_level_direSpecified; }
+    private void Resetpenalty_level_dire() { penalty_level_direSpecified = false; }
+    
 
-    private uint _load_game_id = default(uint);
+    private uint? _load_game_id;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"load_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint load_game_id
     {
-      get { return _load_game_id; }
+      get { return _load_game_id?? default(uint); }
       set { _load_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool load_game_idSpecified
+    {
+      get { return _load_game_id != null; }
+      set { if (value == (_load_game_id== null)) _load_game_id = value ? this.load_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializeload_game_id() { return load_game_idSpecified; }
+    private void Resetload_game_id() { load_game_idSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _radiant_series_wins = default(uint);
+    private uint? _radiant_series_wins;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"radiant_series_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_series_wins
     {
-      get { return _radiant_series_wins; }
+      get { return _radiant_series_wins?? default(uint); }
       set { _radiant_series_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_series_winsSpecified
+    {
+      get { return _radiant_series_wins != null; }
+      set { if (value == (_radiant_series_wins== null)) _radiant_series_wins = value ? this.radiant_series_wins : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_series_wins() { return radiant_series_winsSpecified; }
+    private void Resetradiant_series_wins() { radiant_series_winsSpecified = false; }
+    
 
-    private uint _dire_series_wins = default(uint);
+    private uint? _dire_series_wins;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"dire_series_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_series_wins
     {
-      get { return _dire_series_wins; }
+      get { return _dire_series_wins?? default(uint); }
       set { _dire_series_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_series_winsSpecified
+    {
+      get { return _dire_series_wins != null; }
+      set { if (value == (_dire_series_wins== null)) _dire_series_wins = value ? this.dire_series_wins : (uint?)null; }
+    }
+    private bool ShouldSerializedire_series_wins() { return dire_series_winsSpecified; }
+    private void Resetdire_series_wins() { dire_series_winsSpecified = false; }
+    
 
-    private uint _loot_generated = default(uint);
+    private uint? _loot_generated;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"loot_generated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint loot_generated
     {
-      get { return _loot_generated; }
+      get { return _loot_generated?? default(uint); }
       set { _loot_generated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_generatedSpecified
+    {
+      get { return _loot_generated != null; }
+      set { if (value == (_loot_generated== null)) _loot_generated = value ? this.loot_generated : (uint?)null; }
+    }
+    private bool ShouldSerializeloot_generated() { return loot_generatedSpecified; }
+    private void Resetloot_generated() { loot_generatedSpecified = false; }
+    
 
-    private uint _loot_awarded = default(uint);
+    private uint? _loot_awarded;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"loot_awarded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint loot_awarded
     {
-      get { return _loot_awarded; }
+      get { return _loot_awarded?? default(uint); }
       set { _loot_awarded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_awardedSpecified
+    {
+      get { return _loot_awarded != null; }
+      set { if (value == (_loot_awarded== null)) _loot_awarded = value ? this.loot_awarded : (uint?)null; }
+    }
+    private bool ShouldSerializeloot_awarded() { return loot_awardedSpecified; }
+    private void Resetloot_awarded() { loot_awardedSpecified = false; }
+    
 
-    private bool _allchat = (bool)false;
+    private bool? _allchat;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"allchat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool allchat
     {
-      get { return _allchat; }
+      get { return _allchat?? (bool)false; }
       set { _allchat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allchatSpecified
+    {
+      get { return _allchat != null; }
+      set { if (value == (_allchat== null)) _allchat = value ? this.allchat : (bool?)null; }
+    }
+    private bool ShouldSerializeallchat() { return allchatSpecified; }
+    private void Resetallchat() { allchatSpecified = false; }
+    
 
-    private LobbyDotaTVDelay _dota_tv_delay = LobbyDotaTVDelay.LobbyDotaTV_10;
+    private LobbyDotaTVDelay? _dota_tv_delay;
     [global::ProtoBuf.ProtoMember(53, IsRequired = false, Name=@"dota_tv_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(LobbyDotaTVDelay.LobbyDotaTV_10)]
     public LobbyDotaTVDelay dota_tv_delay
     {
-      get { return _dota_tv_delay; }
+      get { return _dota_tv_delay?? LobbyDotaTVDelay.LobbyDotaTV_10; }
       set { _dota_tv_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dota_tv_delaySpecified
+    {
+      get { return _dota_tv_delay != null; }
+      set { if (value == (_dota_tv_delay== null)) _dota_tv_delay = value ? this.dota_tv_delay : (LobbyDotaTVDelay?)null; }
+    }
+    private bool ShouldSerializedota_tv_delay() { return dota_tv_delaySpecified; }
+    private void Resetdota_tv_delay() { dota_tv_delaySpecified = false; }
+    
 
-    private string _custom_game_mode = "";
+    private string _custom_game_mode;
     [global::ProtoBuf.ProtoMember(54, IsRequired = false, Name=@"custom_game_mode", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_game_mode
     {
-      get { return _custom_game_mode; }
+      get { return _custom_game_mode?? ""; }
       set { _custom_game_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_modeSpecified
+    {
+      get { return _custom_game_mode != null; }
+      set { if (value == (_custom_game_mode== null)) _custom_game_mode = value ? this.custom_game_mode : (string)null; }
+    }
+    private bool ShouldSerializecustom_game_mode() { return custom_game_modeSpecified; }
+    private void Resetcustom_game_mode() { custom_game_modeSpecified = false; }
+    
 
-    private string _custom_map_name = "";
+    private string _custom_map_name;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"custom_map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_map_name
     {
-      get { return _custom_map_name; }
+      get { return _custom_map_name?? ""; }
       set { _custom_map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_map_nameSpecified
+    {
+      get { return _custom_map_name != null; }
+      set { if (value == (_custom_map_name== null)) _custom_map_name = value ? this.custom_map_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_map_name() { return custom_map_nameSpecified; }
+    private void Resetcustom_map_name() { custom_map_nameSpecified = false; }
+    
 
-    private uint _custom_difficulty = default(uint);
+    private uint? _custom_difficulty;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"custom_difficulty", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_difficulty
     {
-      get { return _custom_difficulty; }
+      get { return _custom_difficulty?? default(uint); }
       set { _custom_difficulty = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_difficultySpecified
+    {
+      get { return _custom_difficulty != null; }
+      set { if (value == (_custom_difficulty== null)) _custom_difficulty = value ? this.custom_difficulty : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_difficulty() { return custom_difficultySpecified; }
+    private void Resetcustom_difficulty() { custom_difficultySpecified = false; }
+    
 
-    private bool _lan = default(bool);
+    private bool? _lan;
     [global::ProtoBuf.ProtoMember(57, IsRequired = false, Name=@"lan", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool lan
     {
-      get { return _lan; }
+      get { return _lan?? default(bool); }
       set { _lan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lanSpecified
+    {
+      get { return _lan != null; }
+      set { if (value == (_lan== null)) _lan = value ? this.lan : (bool?)null; }
+    }
+    private bool ShouldSerializelan() { return lanSpecified; }
+    private void Resetlan() { lanSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CLobbyBroadcastChannelInfo> _broadcast_channel_info = new global::System.Collections.Generic.List<CLobbyBroadcastChannelInfo>();
     [global::ProtoBuf.ProtoMember(58, Name=@"broadcast_channel_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CLobbyBroadcastChannelInfo> broadcast_channel_info
@@ -1698,32 +3104,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _first_leaver_accountid = default(uint);
+    private uint? _first_leaver_accountid;
     [global::ProtoBuf.ProtoMember(59, IsRequired = false, Name=@"first_leaver_accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_leaver_accountid
     {
-      get { return _first_leaver_accountid; }
+      get { return _first_leaver_accountid?? default(uint); }
       set { _first_leaver_accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_leaver_accountidSpecified
+    {
+      get { return _first_leaver_accountid != null; }
+      set { if (value == (_first_leaver_accountid== null)) _first_leaver_accountid = value ? this.first_leaver_accountid : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_leaver_accountid() { return first_leaver_accountidSpecified; }
+    private void Resetfirst_leaver_accountid() { first_leaver_accountidSpecified = false; }
+    
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private bool _low_priority = default(bool);
+    private bool? _low_priority;
     [global::ProtoBuf.ProtoMember(61, IsRequired = false, Name=@"low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority
     {
-      get { return _low_priority; }
+      get { return _low_priority?? default(bool); }
       set { _low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_prioritySpecified
+    {
+      get { return _low_priority != null; }
+      set { if (value == (_low_priority== null)) _low_priority = value ? this.low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority() { return low_prioritySpecified; }
+    private void Resetlow_priority() { low_prioritySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSODOTALobby.CExtraMsg> _extra_messages = new global::System.Collections.Generic.List<CSODOTALobby.CExtraMsg>();
     [global::ProtoBuf.ProtoMember(62, Name=@"extra_messages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSODOTALobby.CExtraMsg> extra_messages
@@ -1741,41 +3174,77 @@ namespace SteamKit2.GC.Dota.Internal
       set { _save_game = value; }
     }
 
-    private bool _first_blood_happened = default(bool);
+    private bool? _first_blood_happened;
     [global::ProtoBuf.ProtoMember(65, IsRequired = false, Name=@"first_blood_happened", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool first_blood_happened
     {
-      get { return _first_blood_happened; }
+      get { return _first_blood_happened?? default(bool); }
       set { _first_blood_happened = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_happenedSpecified
+    {
+      get { return _first_blood_happened != null; }
+      set { if (value == (_first_blood_happened== null)) _first_blood_happened = value ? this.first_blood_happened : (bool?)null; }
+    }
+    private bool ShouldSerializefirst_blood_happened() { return first_blood_happenedSpecified; }
+    private void Resetfirst_blood_happened() { first_blood_happenedSpecified = false; }
+    
 
-    private EMatchOutcome _match_outcome = EMatchOutcome.k_EMatchOutcome_Unknown;
+    private EMatchOutcome? _match_outcome;
     [global::ProtoBuf.ProtoMember(70, IsRequired = false, Name=@"match_outcome", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EMatchOutcome.k_EMatchOutcome_Unknown)]
     public EMatchOutcome match_outcome
     {
-      get { return _match_outcome; }
+      get { return _match_outcome?? EMatchOutcome.k_EMatchOutcome_Unknown; }
       set { _match_outcome = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_outcomeSpecified
+    {
+      get { return _match_outcome != null; }
+      set { if (value == (_match_outcome== null)) _match_outcome = value ? this.match_outcome : (EMatchOutcome?)null; }
+    }
+    private bool ShouldSerializematch_outcome() { return match_outcomeSpecified; }
+    private void Resetmatch_outcome() { match_outcomeSpecified = false; }
+    
 
-    private bool _mass_disconnect = default(bool);
+    private bool? _mass_disconnect;
     [global::ProtoBuf.ProtoMember(67, IsRequired = false, Name=@"mass_disconnect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool mass_disconnect
     {
-      get { return _mass_disconnect; }
+      get { return _mass_disconnect?? default(bool); }
       set { _mass_disconnect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mass_disconnectSpecified
+    {
+      get { return _mass_disconnect != null; }
+      set { if (value == (_mass_disconnect== null)) _mass_disconnect = value ? this.mass_disconnect : (bool?)null; }
+    }
+    private bool ShouldSerializemass_disconnect() { return mass_disconnectSpecified; }
+    private void Resetmass_disconnect() { mass_disconnectSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(68, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<EEvent> _active_ingame_events = new global::System.Collections.Generic.List<EEvent>();
     [global::ProtoBuf.ProtoMember(69, Name=@"active_ingame_events", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<EEvent> active_ingame_events
@@ -1784,95 +3253,185 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _custom_min_players = default(uint);
+    private uint? _custom_min_players;
     [global::ProtoBuf.ProtoMember(71, IsRequired = false, Name=@"custom_min_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_min_players
     {
-      get { return _custom_min_players; }
+      get { return _custom_min_players?? default(uint); }
       set { _custom_min_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_min_playersSpecified
+    {
+      get { return _custom_min_players != null; }
+      set { if (value == (_custom_min_players== null)) _custom_min_players = value ? this.custom_min_players : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_min_players() { return custom_min_playersSpecified; }
+    private void Resetcustom_min_players() { custom_min_playersSpecified = false; }
+    
 
-    private uint _custom_max_players = default(uint);
+    private uint? _custom_max_players;
     [global::ProtoBuf.ProtoMember(72, IsRequired = false, Name=@"custom_max_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_max_players
     {
-      get { return _custom_max_players; }
+      get { return _custom_max_players?? default(uint); }
       set { _custom_max_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_max_playersSpecified
+    {
+      get { return _custom_max_players != null; }
+      set { if (value == (_custom_max_players== null)) _custom_max_players = value ? this.custom_max_players : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_max_players() { return custom_max_playersSpecified; }
+    private void Resetcustom_max_players() { custom_max_playersSpecified = false; }
+    
 
-    private PartnerAccountType _partner_type = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _partner_type;
     [global::ProtoBuf.ProtoMember(73, IsRequired = false, Name=@"partner_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType partner_type
     {
-      get { return _partner_type; }
+      get { return _partner_type?? PartnerAccountType.PARTNER_NONE; }
       set { _partner_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_typeSpecified
+    {
+      get { return _partner_type != null; }
+      set { if (value == (_partner_type== null)) _partner_type = value ? this.partner_type : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializepartner_type() { return partner_typeSpecified; }
+    private void Resetpartner_type() { partner_typeSpecified = false; }
+    
 
-    private uint _lan_host_ping_to_server_region = default(uint);
+    private uint? _lan_host_ping_to_server_region;
     [global::ProtoBuf.ProtoMember(74, IsRequired = false, Name=@"lan_host_ping_to_server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lan_host_ping_to_server_region
     {
-      get { return _lan_host_ping_to_server_region; }
+      get { return _lan_host_ping_to_server_region?? default(uint); }
       set { _lan_host_ping_to_server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lan_host_ping_to_server_regionSpecified
+    {
+      get { return _lan_host_ping_to_server_region != null; }
+      set { if (value == (_lan_host_ping_to_server_region== null)) _lan_host_ping_to_server_region = value ? this.lan_host_ping_to_server_region : (uint?)null; }
+    }
+    private bool ShouldSerializelan_host_ping_to_server_region() { return lan_host_ping_to_server_regionSpecified; }
+    private void Resetlan_host_ping_to_server_region() { lan_host_ping_to_server_regionSpecified = false; }
+    
 
-    private DOTALobbyVisibility _visibility = DOTALobbyVisibility.DOTALobbyVisibility_Public;
+    private DOTALobbyVisibility? _visibility;
     [global::ProtoBuf.ProtoMember(75, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTALobbyVisibility.DOTALobbyVisibility_Public)]
     public DOTALobbyVisibility visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? DOTALobbyVisibility.DOTALobbyVisibility_Public; }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (DOTALobbyVisibility?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private ulong _custom_game_crc = default(ulong);
+    private ulong? _custom_game_crc;
     [global::ProtoBuf.ProtoMember(76, IsRequired = false, Name=@"custom_game_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_crc
     {
-      get { return _custom_game_crc; }
+      get { return _custom_game_crc?? default(ulong); }
       set { _custom_game_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_crcSpecified
+    {
+      get { return _custom_game_crc != null; }
+      set { if (value == (_custom_game_crc== null)) _custom_game_crc = value ? this.custom_game_crc : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_crc() { return custom_game_crcSpecified; }
+    private void Resetcustom_game_crc() { custom_game_crcSpecified = false; }
+    
 
-    private bool _custom_game_auto_created_lobby = default(bool);
+    private bool? _custom_game_auto_created_lobby;
     [global::ProtoBuf.ProtoMember(77, IsRequired = false, Name=@"custom_game_auto_created_lobby", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool custom_game_auto_created_lobby
     {
-      get { return _custom_game_auto_created_lobby; }
+      get { return _custom_game_auto_created_lobby?? default(bool); }
       set { _custom_game_auto_created_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_auto_created_lobbySpecified
+    {
+      get { return _custom_game_auto_created_lobby != null; }
+      set { if (value == (_custom_game_auto_created_lobby== null)) _custom_game_auto_created_lobby = value ? this.custom_game_auto_created_lobby : (bool?)null; }
+    }
+    private bool ShouldSerializecustom_game_auto_created_lobby() { return custom_game_auto_created_lobbySpecified; }
+    private void Resetcustom_game_auto_created_lobby() { custom_game_auto_created_lobbySpecified = false; }
+    
 
-    private uint _league_series_id = default(uint);
+    private uint? _league_series_id;
     [global::ProtoBuf.ProtoMember(78, IsRequired = false, Name=@"league_series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_series_id
     {
-      get { return _league_series_id; }
+      get { return _league_series_id?? default(uint); }
       set { _league_series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_series_idSpecified
+    {
+      get { return _league_series_id != null; }
+      set { if (value == (_league_series_id== null)) _league_series_id = value ? this.league_series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_series_id() { return league_series_idSpecified; }
+    private void Resetleague_series_id() { league_series_idSpecified = false; }
+    
 
-    private uint _league_game_id = default(uint);
+    private uint? _league_game_id;
     [global::ProtoBuf.ProtoMember(79, IsRequired = false, Name=@"league_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_game_id
     {
-      get { return _league_game_id; }
+      get { return _league_game_id?? default(uint); }
       set { _league_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_game_idSpecified
+    {
+      get { return _league_game_id != null; }
+      set { if (value == (_league_game_id== null)) _league_game_id = value ? this.league_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_game_id() { return league_game_idSpecified; }
+    private void Resetleague_game_id() { league_game_idSpecified = false; }
+    
 
-    private uint _custom_game_timestamp = default(uint);
+    private uint? _custom_game_timestamp;
     [global::ProtoBuf.ProtoMember(80, IsRequired = false, Name=@"custom_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_game_timestamp
     {
-      get { return _custom_game_timestamp; }
+      get { return _custom_game_timestamp?? default(uint); }
       set { _custom_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_timestampSpecified
+    {
+      get { return _custom_game_timestamp != null; }
+      set { if (value == (_custom_game_timestamp== null)) _custom_game_timestamp = value ? this.custom_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_game_timestamp() { return custom_game_timestampSpecified; }
+    private void Resetcustom_game_timestamp() { custom_game_timestampSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _previous_series_matches = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(81, Name=@"previous_series_matches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> previous_series_matches
@@ -1881,154 +3440,298 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _previous_match_override = default(ulong);
+    private ulong? _previous_match_override;
     [global::ProtoBuf.ProtoMember(82, IsRequired = false, Name=@"previous_match_override", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong previous_match_override
     {
-      get { return _previous_match_override; }
+      get { return _previous_match_override?? default(ulong); }
       set { _previous_match_override = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool previous_match_overrideSpecified
+    {
+      get { return _previous_match_override != null; }
+      set { if (value == (_previous_match_override== null)) _previous_match_override = value ? this.previous_match_override : (ulong?)null; }
+    }
+    private bool ShouldSerializeprevious_match_override() { return previous_match_overrideSpecified; }
+    private void Resetprevious_match_override() { previous_match_overrideSpecified = false; }
+    
 
-    private bool _custom_game_uses_account_records = default(bool);
+    private bool? _custom_game_uses_account_records;
     [global::ProtoBuf.ProtoMember(83, IsRequired = false, Name=@"custom_game_uses_account_records", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool custom_game_uses_account_records
     {
-      get { return _custom_game_uses_account_records; }
+      get { return _custom_game_uses_account_records?? default(bool); }
       set { _custom_game_uses_account_records = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_uses_account_recordsSpecified
+    {
+      get { return _custom_game_uses_account_records != null; }
+      set { if (value == (_custom_game_uses_account_records== null)) _custom_game_uses_account_records = value ? this.custom_game_uses_account_records : (bool?)null; }
+    }
+    private bool ShouldSerializecustom_game_uses_account_records() { return custom_game_uses_account_recordsSpecified; }
+    private void Resetcustom_game_uses_account_records() { custom_game_uses_account_recordsSpecified = false; }
+    
 
-    private uint _league_selection_priority_team = default(uint);
+    private uint? _league_selection_priority_team;
     [global::ProtoBuf.ProtoMember(84, IsRequired = false, Name=@"league_selection_priority_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_selection_priority_team
     {
-      get { return _league_selection_priority_team; }
+      get { return _league_selection_priority_team?? default(uint); }
       set { _league_selection_priority_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_selection_priority_teamSpecified
+    {
+      get { return _league_selection_priority_team != null; }
+      set { if (value == (_league_selection_priority_team== null)) _league_selection_priority_team = value ? this.league_selection_priority_team : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_selection_priority_team() { return league_selection_priority_teamSpecified; }
+    private void Resetleague_selection_priority_team() { league_selection_priority_teamSpecified = false; }
+    
 
-    private SelectionPriorityType _league_selection_priority_choice = SelectionPriorityType.UNDEFINED;
+    private SelectionPriorityType? _league_selection_priority_choice;
     [global::ProtoBuf.ProtoMember(85, IsRequired = false, Name=@"league_selection_priority_choice", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SelectionPriorityType.UNDEFINED)]
     public SelectionPriorityType league_selection_priority_choice
     {
-      get { return _league_selection_priority_choice; }
+      get { return _league_selection_priority_choice?? SelectionPriorityType.UNDEFINED; }
       set { _league_selection_priority_choice = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_selection_priority_choiceSpecified
+    {
+      get { return _league_selection_priority_choice != null; }
+      set { if (value == (_league_selection_priority_choice== null)) _league_selection_priority_choice = value ? this.league_selection_priority_choice : (SelectionPriorityType?)null; }
+    }
+    private bool ShouldSerializeleague_selection_priority_choice() { return league_selection_priority_choiceSpecified; }
+    private void Resetleague_selection_priority_choice() { league_selection_priority_choiceSpecified = false; }
+    
 
-    private SelectionPriorityType _league_non_selection_priority_choice = SelectionPriorityType.UNDEFINED;
+    private SelectionPriorityType? _league_non_selection_priority_choice;
     [global::ProtoBuf.ProtoMember(86, IsRequired = false, Name=@"league_non_selection_priority_choice", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SelectionPriorityType.UNDEFINED)]
     public SelectionPriorityType league_non_selection_priority_choice
     {
-      get { return _league_non_selection_priority_choice; }
+      get { return _league_non_selection_priority_choice?? SelectionPriorityType.UNDEFINED; }
       set { _league_non_selection_priority_choice = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_non_selection_priority_choiceSpecified
+    {
+      get { return _league_non_selection_priority_choice != null; }
+      set { if (value == (_league_non_selection_priority_choice== null)) _league_non_selection_priority_choice = value ? this.league_non_selection_priority_choice : (SelectionPriorityType?)null; }
+    }
+    private bool ShouldSerializeleague_non_selection_priority_choice() { return league_non_selection_priority_choiceSpecified; }
+    private void Resetleague_non_selection_priority_choice() { league_non_selection_priority_choiceSpecified = false; }
+    
 
-    private uint _game_start_time = default(uint);
+    private uint? _game_start_time;
     [global::ProtoBuf.ProtoMember(87, IsRequired = false, Name=@"game_start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_start_time
     {
-      get { return _game_start_time; }
+      get { return _game_start_time?? default(uint); }
       set { _game_start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_start_timeSpecified
+    {
+      get { return _game_start_time != null; }
+      set { if (value == (_game_start_time== null)) _game_start_time = value ? this.game_start_time : (uint?)null; }
+    }
+    private bool ShouldSerializegame_start_time() { return game_start_timeSpecified; }
+    private void Resetgame_start_time() { game_start_timeSpecified = false; }
+    
 
-    private LobbyDotaPauseSetting _pause_setting = LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited;
+    private LobbyDotaPauseSetting? _pause_setting;
     [global::ProtoBuf.ProtoMember(88, IsRequired = false, Name=@"pause_setting", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited)]
     public LobbyDotaPauseSetting pause_setting
     {
-      get { return _pause_setting; }
+      get { return _pause_setting?? LobbyDotaPauseSetting.LobbyDotaPauseSetting_Unlimited; }
       set { _pause_setting = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pause_settingSpecified
+    {
+      get { return _pause_setting != null; }
+      set { if (value == (_pause_setting== null)) _pause_setting = value ? this.pause_setting : (LobbyDotaPauseSetting?)null; }
+    }
+    private bool ShouldSerializepause_setting() { return pause_settingSpecified; }
+    private void Resetpause_setting() { pause_settingSpecified = false; }
+    
 
-    private uint _lobby_mvp_account_id = default(uint);
+    private uint? _lobby_mvp_account_id;
     [global::ProtoBuf.ProtoMember(89, IsRequired = false, Name=@"lobby_mvp_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_mvp_account_id
     {
-      get { return _lobby_mvp_account_id; }
+      get { return _lobby_mvp_account_id?? default(uint); }
       set { _lobby_mvp_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_mvp_account_idSpecified
+    {
+      get { return _lobby_mvp_account_id != null; }
+      set { if (value == (_lobby_mvp_account_id== null)) _lobby_mvp_account_id = value ? this.lobby_mvp_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_mvp_account_id() { return lobby_mvp_account_idSpecified; }
+    private void Resetlobby_mvp_account_id() { lobby_mvp_account_idSpecified = false; }
+    
 
-    private uint _weekend_tourney_division_id = default(uint);
+    private uint? _weekend_tourney_division_id;
     [global::ProtoBuf.ProtoMember(90, IsRequired = false, Name=@"weekend_tourney_division_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_division_id
     {
-      get { return _weekend_tourney_division_id; }
+      get { return _weekend_tourney_division_id?? default(uint); }
       set { _weekend_tourney_division_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_division_idSpecified
+    {
+      get { return _weekend_tourney_division_id != null; }
+      set { if (value == (_weekend_tourney_division_id== null)) _weekend_tourney_division_id = value ? this.weekend_tourney_division_id : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_division_id() { return weekend_tourney_division_idSpecified; }
+    private void Resetweekend_tourney_division_id() { weekend_tourney_division_idSpecified = false; }
+    
 
-    private uint _weekend_tourney_skill_level = default(uint);
+    private uint? _weekend_tourney_skill_level;
     [global::ProtoBuf.ProtoMember(91, IsRequired = false, Name=@"weekend_tourney_skill_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_skill_level
     {
-      get { return _weekend_tourney_skill_level; }
+      get { return _weekend_tourney_skill_level?? default(uint); }
       set { _weekend_tourney_skill_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_skill_levelSpecified
+    {
+      get { return _weekend_tourney_skill_level != null; }
+      set { if (value == (_weekend_tourney_skill_level== null)) _weekend_tourney_skill_level = value ? this.weekend_tourney_skill_level : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_skill_level() { return weekend_tourney_skill_levelSpecified; }
+    private void Resetweekend_tourney_skill_level() { weekend_tourney_skill_levelSpecified = false; }
+    
 
-    private uint _weekend_tourney_bracket_round = default(uint);
+    private uint? _weekend_tourney_bracket_round;
     [global::ProtoBuf.ProtoMember(92, IsRequired = false, Name=@"weekend_tourney_bracket_round", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint weekend_tourney_bracket_round
     {
-      get { return _weekend_tourney_bracket_round; }
+      get { return _weekend_tourney_bracket_round?? default(uint); }
       set { _weekend_tourney_bracket_round = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weekend_tourney_bracket_roundSpecified
+    {
+      get { return _weekend_tourney_bracket_round != null; }
+      set { if (value == (_weekend_tourney_bracket_round== null)) _weekend_tourney_bracket_round = value ? this.weekend_tourney_bracket_round : (uint?)null; }
+    }
+    private bool ShouldSerializeweekend_tourney_bracket_round() { return weekend_tourney_bracket_roundSpecified; }
+    private void Resetweekend_tourney_bracket_round() { weekend_tourney_bracket_roundSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_dire = DOTABotDifficulty.BOT_DIFFICULTY_HARD;
+    private DOTABotDifficulty? _bot_difficulty_dire;
     [global::ProtoBuf.ProtoMember(93, IsRequired = false, Name=@"bot_difficulty_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_HARD)]
     public DOTABotDifficulty bot_difficulty_dire
     {
-      get { return _bot_difficulty_dire; }
+      get { return _bot_difficulty_dire?? DOTABotDifficulty.BOT_DIFFICULTY_HARD; }
       set { _bot_difficulty_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_direSpecified
+    {
+      get { return _bot_difficulty_dire != null; }
+      set { if (value == (_bot_difficulty_dire== null)) _bot_difficulty_dire = value ? this.bot_difficulty_dire : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_dire() { return bot_difficulty_direSpecified; }
+    private void Resetbot_difficulty_dire() { bot_difficulty_direSpecified = false; }
+    
 
-    private ulong _bot_radiant = default(ulong);
+    private ulong? _bot_radiant;
     [global::ProtoBuf.ProtoMember(94, IsRequired = false, Name=@"bot_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bot_radiant
     {
-      get { return _bot_radiant; }
+      get { return _bot_radiant?? default(ulong); }
       set { _bot_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_radiantSpecified
+    {
+      get { return _bot_radiant != null; }
+      set { if (value == (_bot_radiant== null)) _bot_radiant = value ? this.bot_radiant : (ulong?)null; }
+    }
+    private bool ShouldSerializebot_radiant() { return bot_radiantSpecified; }
+    private void Resetbot_radiant() { bot_radiantSpecified = false; }
+    
 
-    private ulong _bot_dire = default(ulong);
+    private ulong? _bot_dire;
     [global::ProtoBuf.ProtoMember(95, IsRequired = false, Name=@"bot_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bot_dire
     {
-      get { return _bot_dire; }
+      get { return _bot_dire?? default(ulong); }
       set { _bot_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_direSpecified
+    {
+      get { return _bot_dire != null; }
+      set { if (value == (_bot_dire== null)) _bot_dire = value ? this.bot_dire : (ulong?)null; }
+    }
+    private bool ShouldSerializebot_dire() { return bot_direSpecified; }
+    private void Resetbot_dire() { bot_direSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CExtraMsg")]
   public partial class CExtraMsg : global::ProtoBuf.IExtensible
   {
     public CExtraMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private byte[] _contents = null;
+    private byte[] _contents;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"contents", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] contents
     {
-      get { return _contents; }
+      get { return _contents?? null; }
       set { _contents = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contentsSpecified
+    {
+      get { return _contents != null; }
+      set { if (value == (_contents== null)) _contents = value ? this.contents : (byte[])null; }
+    }
+    private bool ShouldSerializecontents() { return contentsSpecified; }
+    private void Resetcontents() { contentsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2112,14 +3815,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLobbyPlaytestDetails() {}
     
 
-    private string _json = "";
+    private string _json;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"json", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string json
     {
-      get { return _json; }
+      get { return _json?? ""; }
       set { _json = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool jsonSpecified
+    {
+      get { return _json != null; }
+      set { if (value == (_json== null)) _json = value ? this.json : (string)null; }
+    }
+    private bool ShouldSerializejson() { return jsonSpecified; }
+    private void Resetjson() { jsonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCMsgId.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCMsgId.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_msgid.proto
 namespace SteamKit2.GC.Dota.Internal
 {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCServer.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgGCServer.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_gcmessages_server.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: dota_shared_enums.proto
@@ -23,14 +25,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPoorNetworkConditions() {}
     
 
-    private EPoorNetworkConditionsType _detection_type = EPoorNetworkConditionsType.k_EPoorNetworkConditions_None;
+    private EPoorNetworkConditionsType? _detection_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"detection_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EPoorNetworkConditionsType.k_EPoorNetworkConditions_None)]
     public EPoorNetworkConditionsType detection_type
     {
-      get { return _detection_type; }
+      get { return _detection_type?? EPoorNetworkConditionsType.k_EPoorNetworkConditions_None; }
       set { _detection_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool detection_typeSpecified
+    {
+      get { return _detection_type != null; }
+      set { if (value == (_detection_type== null)) _detection_type = value ? this.detection_type : (EPoorNetworkConditionsType?)null; }
+    }
+    private bool ShouldSerializedetection_type() { return detection_typeSpecified; }
+    private void Resetdetection_type() { detection_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgPoorNetworkConditions.Player> _players = new global::System.Collections.Generic.List<CMsgPoorNetworkConditions.Player>();
     [global::ProtoBuf.ProtoMember(2, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgPoorNetworkConditions.Player> players
@@ -44,41 +55,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ENetworkDisconnectionReason _disconnect_reason = ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID;
+    private ENetworkDisconnectionReason? _disconnect_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"disconnect_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID)]
     public ENetworkDisconnectionReason disconnect_reason
     {
-      get { return _disconnect_reason; }
+      get { return _disconnect_reason?? ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID; }
       set { _disconnect_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool disconnect_reasonSpecified
+    {
+      get { return _disconnect_reason != null; }
+      set { if (value == (_disconnect_reason== null)) _disconnect_reason = value ? this.disconnect_reason : (ENetworkDisconnectionReason?)null; }
+    }
+    private bool ShouldSerializedisconnect_reason() { return disconnect_reasonSpecified; }
+    private void Resetdisconnect_reason() { disconnect_reasonSpecified = false; }
+    
 
-    private uint _num_bad_intervals = default(uint);
+    private uint? _num_bad_intervals;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_bad_intervals", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_bad_intervals
     {
-      get { return _num_bad_intervals; }
+      get { return _num_bad_intervals?? default(uint); }
       set { _num_bad_intervals = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_bad_intervalsSpecified
+    {
+      get { return _num_bad_intervals != null; }
+      set { if (value == (_num_bad_intervals== null)) _num_bad_intervals = value ? this.num_bad_intervals : (uint?)null; }
+    }
+    private bool ShouldSerializenum_bad_intervals() { return num_bad_intervalsSpecified; }
+    private void Resetnum_bad_intervals() { num_bad_intervalsSpecified = false; }
+    
 
-    private uint _peak_loss_pct = default(uint);
+    private uint? _peak_loss_pct;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"peak_loss_pct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint peak_loss_pct
     {
-      get { return _peak_loss_pct; }
+      get { return _peak_loss_pct?? default(uint); }
       set { _peak_loss_pct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool peak_loss_pctSpecified
+    {
+      get { return _peak_loss_pct != null; }
+      set { if (value == (_peak_loss_pct== null)) _peak_loss_pct = value ? this.peak_loss_pct : (uint?)null; }
+    }
+    private bool ShouldSerializepeak_loss_pct() { return peak_loss_pctSpecified; }
+    private void Resetpeak_loss_pct() { peak_loss_pctSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -95,113 +142,221 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameserverCrash() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private DOTA_GameState _game_state = DOTA_GameState.DOTA_GAMERULES_STATE_INIT;
+    private DOTA_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameState.DOTA_GAMERULES_STATE_INIT)]
     public DOTA_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? DOTA_GameState.DOTA_GAMERULES_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (DOTA_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private uint _sentinel_save_time = default(uint);
+    private uint? _sentinel_save_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sentinel_save_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sentinel_save_time
     {
-      get { return _sentinel_save_time; }
+      get { return _sentinel_save_time?? default(uint); }
       set { _sentinel_save_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sentinel_save_timeSpecified
+    {
+      get { return _sentinel_save_time != null; }
+      set { if (value == (_sentinel_save_time== null)) _sentinel_save_time = value ? this.sentinel_save_time : (uint?)null; }
+    }
+    private bool ShouldSerializesentinel_save_time() { return sentinel_save_timeSpecified; }
+    private void Resetsentinel_save_time() { sentinel_save_timeSpecified = false; }
+    
 
-    private ulong _custom_game_id = default(ulong);
+    private ulong? _custom_game_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"custom_game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_id
     {
-      get { return _custom_game_id; }
+      get { return _custom_game_id?? default(ulong); }
       set { _custom_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_idSpecified
+    {
+      get { return _custom_game_id != null; }
+      set { if (value == (_custom_game_id== null)) _custom_game_id = value ? this.custom_game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_id() { return custom_game_idSpecified; }
+    private void Resetcustom_game_id() { custom_game_idSpecified = false; }
+    
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private uint _server_public_ip_addr = default(uint);
+    private uint? _server_public_ip_addr;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_public_ip_addr", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_public_ip_addr
     {
-      get { return _server_public_ip_addr; }
+      get { return _server_public_ip_addr?? default(uint); }
       set { _server_public_ip_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_public_ip_addrSpecified
+    {
+      get { return _server_public_ip_addr != null; }
+      set { if (value == (_server_public_ip_addr== null)) _server_public_ip_addr = value ? this.server_public_ip_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_public_ip_addr() { return server_public_ip_addrSpecified; }
+    private void Resetserver_public_ip_addr() { server_public_ip_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _server_cluster = default(uint);
+    private uint? _server_cluster;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"server_cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_cluster
     {
-      get { return _server_cluster; }
+      get { return _server_cluster?? default(uint); }
       set { _server_cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_clusterSpecified
+    {
+      get { return _server_cluster != null; }
+      set { if (value == (_server_cluster== null)) _server_cluster = value ? this.server_cluster : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_cluster() { return server_clusterSpecified; }
+    private void Resetserver_cluster() { server_clusterSpecified = false; }
+    
 
-    private uint _pid = default(uint);
+    private uint? _pid;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"pid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pid
     {
-      get { return _pid; }
+      get { return _pid?? default(uint); }
       set { _pid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pidSpecified
+    {
+      get { return _pid != null; }
+      set { if (value == (_pid== null)) _pid = value ? this.pid : (uint?)null; }
+    }
+    private bool ShouldSerializepid() { return pidSpecified; }
+    private void Resetpid() { pidSpecified = false; }
+    
 
-    private uint _engine = default(uint);
+    private uint? _engine;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"engine", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint engine
     {
-      get { return _engine; }
+      get { return _engine?? default(uint); }
       set { _engine = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool engineSpecified
+    {
+      get { return _engine != null; }
+      set { if (value == (_engine== null)) _engine = value ? this.engine : (uint?)null; }
+    }
+    private bool ShouldSerializeengine() { return engineSpecified; }
+    private void Resetengine() { engineSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -227,32 +382,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private DOTA_GameState _game_state = DOTA_GameState.DOTA_GAMERULES_STATE_INIT;
+    private DOTA_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GameState.DOTA_GAMERULES_STATE_INIT)]
     public DOTA_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? DOTA_GameState.DOTA_GAMERULES_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (DOTA_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private bool _first_blood_happened = default(bool);
+    private bool? _first_blood_happened;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"first_blood_happened", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool first_blood_happened
     {
-      get { return _first_blood_happened; }
+      get { return _first_blood_happened?? default(bool); }
       set { _first_blood_happened = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_happenedSpecified
+    {
+      get { return _first_blood_happened != null; }
+      set { if (value == (_first_blood_happened== null)) _first_blood_happened = value ? this.first_blood_happened : (bool?)null; }
+    }
+    private bool ShouldSerializefirst_blood_happened() { return first_blood_happenedSpecified; }
+    private void Resetfirst_blood_happened() { first_blood_happenedSpecified = false; }
+    
 
-    private bool _legacy_mass_disconnect = default(bool);
+    private bool? _legacy_mass_disconnect;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"legacy_mass_disconnect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool legacy_mass_disconnect
     {
-      get { return _legacy_mass_disconnect; }
+      get { return _legacy_mass_disconnect?? default(bool); }
       set { _legacy_mass_disconnect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_mass_disconnectSpecified
+    {
+      get { return _legacy_mass_disconnect != null; }
+      set { if (value == (_legacy_mass_disconnect== null)) _legacy_mass_disconnect = value ? this.legacy_mass_disconnect : (bool?)null; }
+    }
+    private bool ShouldSerializelegacy_mass_disconnect() { return legacy_mass_disconnectSpecified; }
+    private void Resetlegacy_mass_disconnect() { legacy_mass_disconnectSpecified = false; }
+    
 
     private CMsgPoorNetworkConditions _poor_network_conditions = null;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"poor_network_conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -263,73 +445,136 @@ namespace SteamKit2.GC.Dota.Internal
       set { _poor_network_conditions = value; }
     }
 
-    private CMsgConnectedPlayers.SendReason _send_reason = CMsgConnectedPlayers.SendReason.INVALID;
+    private CMsgConnectedPlayers.SendReason? _send_reason;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"send_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgConnectedPlayers.SendReason.INVALID)]
     public CMsgConnectedPlayers.SendReason send_reason
     {
-      get { return _send_reason; }
+      get { return _send_reason?? CMsgConnectedPlayers.SendReason.INVALID; }
       set { _send_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_reasonSpecified
+    {
+      get { return _send_reason != null; }
+      set { if (value == (_send_reason== null)) _send_reason = value ? this.send_reason : (CMsgConnectedPlayers.SendReason?)null; }
+    }
+    private bool ShouldSerializesend_reason() { return send_reasonSpecified; }
+    private void Resetsend_reason() { send_reasonSpecified = false; }
+    
 
-    private uint _radiant_kills = default(uint);
+    private uint? _radiant_kills;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"radiant_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_kills
     {
-      get { return _radiant_kills; }
+      get { return _radiant_kills?? default(uint); }
       set { _radiant_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_killsSpecified
+    {
+      get { return _radiant_kills != null; }
+      set { if (value == (_radiant_kills== null)) _radiant_kills = value ? this.radiant_kills : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_kills() { return radiant_killsSpecified; }
+    private void Resetradiant_kills() { radiant_killsSpecified = false; }
+    
 
-    private uint _dire_kills = default(uint);
+    private uint? _dire_kills;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"dire_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_kills
     {
-      get { return _dire_kills; }
+      get { return _dire_kills?? default(uint); }
       set { _dire_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_killsSpecified
+    {
+      get { return _dire_kills != null; }
+      set { if (value == (_dire_kills== null)) _dire_kills = value ? this.dire_kills : (uint?)null; }
+    }
+    private bool ShouldSerializedire_kills() { return dire_killsSpecified; }
+    private void Resetdire_kills() { dire_killsSpecified = false; }
+    
 
-    private int _radiant_lead = default(int);
+    private int? _radiant_lead;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"radiant_lead", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int radiant_lead
     {
-      get { return _radiant_lead; }
+      get { return _radiant_lead?? default(int); }
       set { _radiant_lead = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_leadSpecified
+    {
+      get { return _radiant_lead != null; }
+      set { if (value == (_radiant_lead== null)) _radiant_lead = value ? this.radiant_lead : (int?)null; }
+    }
+    private bool ShouldSerializeradiant_lead() { return radiant_leadSpecified; }
+    private void Resetradiant_lead() { radiant_leadSpecified = false; }
+    
 
-    private uint _building_state = default(uint);
+    private uint? _building_state;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"building_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint building_state
     {
-      get { return _building_state; }
+      get { return _building_state?? default(uint); }
       set { _building_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool building_stateSpecified
+    {
+      get { return _building_state != null; }
+      set { if (value == (_building_state== null)) _building_state = value ? this.building_state : (uint?)null; }
+    }
+    private bool ShouldSerializebuilding_state() { return building_stateSpecified; }
+    private void Resetbuilding_state() { building_stateSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
     private CMsgLeaverState _leaver_state = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"leaver_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -340,14 +585,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _leaver_state = value; }
     }
 
-    private ENetworkDisconnectionReason _disconnect_reason = ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID;
+    private ENetworkDisconnectionReason? _disconnect_reason;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"disconnect_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID)]
     public ENetworkDisconnectionReason disconnect_reason
     {
-      get { return _disconnect_reason; }
+      get { return _disconnect_reason?? ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID; }
       set { _disconnect_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool disconnect_reasonSpecified
+    {
+      get { return _disconnect_reason != null; }
+      set { if (value == (_disconnect_reason== null)) _disconnect_reason = value ? this.disconnect_reason : (ENetworkDisconnectionReason?)null; }
+    }
+    private bool ShouldSerializedisconnect_reason() { return disconnect_reasonSpecified; }
+    private void Resetdisconnect_reason() { disconnect_reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -405,212 +659,419 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameServerInfo() {}
     
 
-    private uint _server_public_ip_addr = default(uint);
+    private uint? _server_public_ip_addr;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_public_ip_addr", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_public_ip_addr
     {
-      get { return _server_public_ip_addr; }
+      get { return _server_public_ip_addr?? default(uint); }
       set { _server_public_ip_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_public_ip_addrSpecified
+    {
+      get { return _server_public_ip_addr != null; }
+      set { if (value == (_server_public_ip_addr== null)) _server_public_ip_addr = value ? this.server_public_ip_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_public_ip_addr() { return server_public_ip_addrSpecified; }
+    private void Resetserver_public_ip_addr() { server_public_ip_addrSpecified = false; }
+    
 
-    private uint _server_private_ip_addr = default(uint);
+    private uint? _server_private_ip_addr;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_private_ip_addr", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_private_ip_addr
     {
-      get { return _server_private_ip_addr; }
+      get { return _server_private_ip_addr?? default(uint); }
       set { _server_private_ip_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_private_ip_addrSpecified
+    {
+      get { return _server_private_ip_addr != null; }
+      set { if (value == (_server_private_ip_addr== null)) _server_private_ip_addr = value ? this.server_private_ip_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_private_ip_addr() { return server_private_ip_addrSpecified; }
+    private void Resetserver_private_ip_addr() { server_private_ip_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _server_tv_port = default(uint);
+    private uint? _server_tv_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_tv_port
     {
-      get { return _server_tv_port; }
+      get { return _server_tv_port?? default(uint); }
       set { _server_tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_tv_portSpecified
+    {
+      get { return _server_tv_port != null; }
+      set { if (value == (_server_tv_port== null)) _server_tv_port = value ? this.server_tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_tv_port() { return server_tv_portSpecified; }
+    private void Resetserver_tv_port() { server_tv_portSpecified = false; }
+    
 
-    private uint _assigned_server_tv_port = default(uint);
+    private uint? _assigned_server_tv_port;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"assigned_server_tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assigned_server_tv_port
     {
-      get { return _assigned_server_tv_port; }
+      get { return _assigned_server_tv_port?? default(uint); }
       set { _assigned_server_tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assigned_server_tv_portSpecified
+    {
+      get { return _assigned_server_tv_port != null; }
+      set { if (value == (_assigned_server_tv_port== null)) _assigned_server_tv_port = value ? this.assigned_server_tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializeassigned_server_tv_port() { return assigned_server_tv_portSpecified; }
+    private void Resetassigned_server_tv_port() { assigned_server_tv_portSpecified = false; }
+    
 
-    private uint _server_steamdatagram_port = default(uint);
+    private uint? _server_steamdatagram_port;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"server_steamdatagram_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_steamdatagram_port
     {
-      get { return _server_steamdatagram_port; }
+      get { return _server_steamdatagram_port?? default(uint); }
       set { _server_steamdatagram_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steamdatagram_portSpecified
+    {
+      get { return _server_steamdatagram_port != null; }
+      set { if (value == (_server_steamdatagram_port== null)) _server_steamdatagram_port = value ? this.server_steamdatagram_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_steamdatagram_port() { return server_steamdatagram_portSpecified; }
+    private void Resetserver_steamdatagram_port() { server_steamdatagram_portSpecified = false; }
+    
 
-    private string _server_key = "";
+    private string _server_key;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string server_key
     {
-      get { return _server_key; }
+      get { return _server_key?? ""; }
       set { _server_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_keySpecified
+    {
+      get { return _server_key != null; }
+      set { if (value == (_server_key== null)) _server_key = value ? this.server_key : (string)null; }
+    }
+    private bool ShouldSerializeserver_key() { return server_keySpecified; }
+    private void Resetserver_key() { server_keySpecified = false; }
+    
 
-    private bool _server_hibernation = default(bool);
+    private bool? _server_hibernation;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_hibernation", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool server_hibernation
     {
-      get { return _server_hibernation; }
+      get { return _server_hibernation?? default(bool); }
       set { _server_hibernation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_hibernationSpecified
+    {
+      get { return _server_hibernation != null; }
+      set { if (value == (_server_hibernation== null)) _server_hibernation = value ? this.server_hibernation : (bool?)null; }
+    }
+    private bool ShouldSerializeserver_hibernation() { return server_hibernationSpecified; }
+    private void Resetserver_hibernation() { server_hibernationSpecified = false; }
+    
 
-    private CMsgGameServerInfo.ServerType _server_type = CMsgGameServerInfo.ServerType.UNSPECIFIED;
+    private CMsgGameServerInfo.ServerType? _server_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"server_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerInfo.ServerType.UNSPECIFIED)]
     public CMsgGameServerInfo.ServerType server_type
     {
-      get { return _server_type; }
+      get { return _server_type?? CMsgGameServerInfo.ServerType.UNSPECIFIED; }
       set { _server_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_typeSpecified
+    {
+      get { return _server_type != null; }
+      set { if (value == (_server_type== null)) _server_type = value ? this.server_type : (CMsgGameServerInfo.ServerType?)null; }
+    }
+    private bool ShouldSerializeserver_type() { return server_typeSpecified; }
+    private void Resetserver_type() { server_typeSpecified = false; }
+    
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private float _server_loadavg = default(float);
+    private float? _server_loadavg;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"server_loadavg", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_loadavg
     {
-      get { return _server_loadavg; }
+      get { return _server_loadavg?? default(float); }
       set { _server_loadavg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_loadavgSpecified
+    {
+      get { return _server_loadavg != null; }
+      set { if (value == (_server_loadavg== null)) _server_loadavg = value ? this.server_loadavg : (float?)null; }
+    }
+    private bool ShouldSerializeserver_loadavg() { return server_loadavgSpecified; }
+    private void Resetserver_loadavg() { server_loadavgSpecified = false; }
+    
 
-    private float _server_tv_broadcast_time = default(float);
+    private float? _server_tv_broadcast_time;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"server_tv_broadcast_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_tv_broadcast_time
     {
-      get { return _server_tv_broadcast_time; }
+      get { return _server_tv_broadcast_time?? default(float); }
       set { _server_tv_broadcast_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_tv_broadcast_timeSpecified
+    {
+      get { return _server_tv_broadcast_time != null; }
+      set { if (value == (_server_tv_broadcast_time== null)) _server_tv_broadcast_time = value ? this.server_tv_broadcast_time : (float?)null; }
+    }
+    private bool ShouldSerializeserver_tv_broadcast_time() { return server_tv_broadcast_timeSpecified; }
+    private void Resetserver_tv_broadcast_time() { server_tv_broadcast_timeSpecified = false; }
+    
 
-    private float _server_game_time = default(float);
+    private float? _server_game_time;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"server_game_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_game_time
     {
-      get { return _server_game_time; }
+      get { return _server_game_time?? default(float); }
       set { _server_game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_game_timeSpecified
+    {
+      get { return _server_game_time != null; }
+      set { if (value == (_server_game_time== null)) _server_game_time = value ? this.server_game_time : (float?)null; }
+    }
+    private bool ShouldSerializeserver_game_time() { return server_game_timeSpecified; }
+    private void Resetserver_game_time() { server_game_timeSpecified = false; }
+    
 
-    private ulong _server_relay_connected_steam_id = default(ulong);
+    private ulong? _server_relay_connected_steam_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"server_relay_connected_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_relay_connected_steam_id
     {
-      get { return _server_relay_connected_steam_id; }
+      get { return _server_relay_connected_steam_id?? default(ulong); }
       set { _server_relay_connected_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_relay_connected_steam_idSpecified
+    {
+      get { return _server_relay_connected_steam_id != null; }
+      set { if (value == (_server_relay_connected_steam_id== null)) _server_relay_connected_steam_id = value ? this.server_relay_connected_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_relay_connected_steam_id() { return server_relay_connected_steam_idSpecified; }
+    private void Resetserver_relay_connected_steam_id() { server_relay_connected_steam_idSpecified = false; }
+    
 
-    private uint _relay_slots_max = default(uint);
+    private uint? _relay_slots_max;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"relay_slots_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint relay_slots_max
     {
-      get { return _relay_slots_max; }
+      get { return _relay_slots_max?? default(uint); }
       set { _relay_slots_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relay_slots_maxSpecified
+    {
+      get { return _relay_slots_max != null; }
+      set { if (value == (_relay_slots_max== null)) _relay_slots_max = value ? this.relay_slots_max : (uint?)null; }
+    }
+    private bool ShouldSerializerelay_slots_max() { return relay_slots_maxSpecified; }
+    private void Resetrelay_slots_max() { relay_slots_maxSpecified = false; }
+    
 
-    private int _relays_connected = default(int);
+    private int? _relays_connected;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"relays_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int relays_connected
     {
-      get { return _relays_connected; }
+      get { return _relays_connected?? default(int); }
       set { _relays_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relays_connectedSpecified
+    {
+      get { return _relays_connected != null; }
+      set { if (value == (_relays_connected== null)) _relays_connected = value ? this.relays_connected : (int?)null; }
+    }
+    private bool ShouldSerializerelays_connected() { return relays_connectedSpecified; }
+    private void Resetrelays_connected() { relays_connectedSpecified = false; }
+    
 
-    private int _relay_clients_connected = default(int);
+    private int? _relay_clients_connected;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"relay_clients_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int relay_clients_connected
     {
-      get { return _relay_clients_connected; }
+      get { return _relay_clients_connected?? default(int); }
       set { _relay_clients_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relay_clients_connectedSpecified
+    {
+      get { return _relay_clients_connected != null; }
+      set { if (value == (_relay_clients_connected== null)) _relay_clients_connected = value ? this.relay_clients_connected : (int?)null; }
+    }
+    private bool ShouldSerializerelay_clients_connected() { return relay_clients_connectedSpecified; }
+    private void Resetrelay_clients_connected() { relay_clients_connectedSpecified = false; }
+    
 
-    private ulong _relayed_game_server_steam_id = default(ulong);
+    private ulong? _relayed_game_server_steam_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"relayed_game_server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong relayed_game_server_steam_id
     {
-      get { return _relayed_game_server_steam_id; }
+      get { return _relayed_game_server_steam_id?? default(ulong); }
       set { _relayed_game_server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relayed_game_server_steam_idSpecified
+    {
+      get { return _relayed_game_server_steam_id != null; }
+      set { if (value == (_relayed_game_server_steam_id== null)) _relayed_game_server_steam_id = value ? this.relayed_game_server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerelayed_game_server_steam_id() { return relayed_game_server_steam_idSpecified; }
+    private void Resetrelayed_game_server_steam_id() { relayed_game_server_steam_idSpecified = false; }
+    
 
-    private uint _parent_relay_count = default(uint);
+    private uint? _parent_relay_count;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"parent_relay_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint parent_relay_count
     {
-      get { return _parent_relay_count; }
+      get { return _parent_relay_count?? default(uint); }
       set { _parent_relay_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parent_relay_countSpecified
+    {
+      get { return _parent_relay_count != null; }
+      set { if (value == (_parent_relay_count== null)) _parent_relay_count = value ? this.parent_relay_count : (uint?)null; }
+    }
+    private bool ShouldSerializeparent_relay_count() { return parent_relay_countSpecified; }
+    private void Resetparent_relay_count() { parent_relay_countSpecified = false; }
+    
 
-    private ulong _tv_secret_code = default(ulong);
+    private ulong? _tv_secret_code;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"tv_secret_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_secret_code
     {
-      get { return _tv_secret_code; }
+      get { return _tv_secret_code?? default(ulong); }
       set { _tv_secret_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_secret_codeSpecified
+    {
+      get { return _tv_secret_code != null; }
+      set { if (value == (_tv_secret_code== null)) _tv_secret_code = value ? this.tv_secret_code : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_secret_code() { return tv_secret_codeSpecified; }
+    private void Resettv_secret_code() { tv_secret_codeSpecified = false; }
+    
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
-    private uint _server_cluster = default(uint);
+    private uint? _server_cluster;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"server_cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_cluster
     {
-      get { return _server_cluster; }
+      get { return _server_cluster?? default(uint); }
       set { _server_cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_clusterSpecified
+    {
+      get { return _server_cluster != null; }
+      set { if (value == (_server_cluster== null)) _server_cluster = value ? this.server_cluster : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_cluster() { return server_clusterSpecified; }
+    private void Resetserver_cluster() { server_clusterSpecified = false; }
+    
 
-    private CMsgGameServerInfo.CustomGames _allow_custom_games = CMsgGameServerInfo.CustomGames.BOTH;
+    private CMsgGameServerInfo.CustomGames? _allow_custom_games;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"allow_custom_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerInfo.CustomGames.BOTH)]
     public CMsgGameServerInfo.CustomGames allow_custom_games
     {
-      get { return _allow_custom_games; }
+      get { return _allow_custom_games?? CMsgGameServerInfo.CustomGames.BOTH; }
       set { _allow_custom_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_custom_gamesSpecified
+    {
+      get { return _allow_custom_games != null; }
+      set { if (value == (_allow_custom_games== null)) _allow_custom_games = value ? this.allow_custom_games : (CMsgGameServerInfo.CustomGames?)null; }
+    }
+    private bool ShouldSerializeallow_custom_games() { return allow_custom_gamesSpecified; }
+    private void Resetallow_custom_games() { allow_custom_gamesSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ServerType", EnumPassthru=true)]
     public enum ServerType
     {
@@ -650,23 +1111,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeaverDetected() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private DOTALeaverStatus_t _leaver_status = DOTALeaverStatus_t.DOTA_LEAVER_NONE;
+    private DOTALeaverStatus_t? _leaver_status;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaver_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTALeaverStatus_t.DOTA_LEAVER_NONE)]
     public DOTALeaverStatus_t leaver_status
     {
-      get { return _leaver_status; }
+      get { return _leaver_status?? DOTALeaverStatus_t.DOTA_LEAVER_NONE; }
       set { _leaver_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_statusSpecified
+    {
+      get { return _leaver_status != null; }
+      set { if (value == (_leaver_status== null)) _leaver_status = value ? this.leaver_status : (DOTALeaverStatus_t?)null; }
+    }
+    private bool ShouldSerializeleaver_status() { return leaver_statusSpecified; }
+    private void Resetleaver_status() { leaver_statusSpecified = false; }
+    
 
     private CMsgLeaverState _leaver_state = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"leaver_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -677,23 +1156,41 @@ namespace SteamKit2.GC.Dota.Internal
       set { _leaver_state = value; }
     }
 
-    private uint _server_cluster = default(uint);
+    private uint? _server_cluster;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_cluster
     {
-      get { return _server_cluster; }
+      get { return _server_cluster?? default(uint); }
       set { _server_cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_clusterSpecified
+    {
+      get { return _server_cluster != null; }
+      set { if (value == (_server_cluster== null)) _server_cluster = value ? this.server_cluster : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_cluster() { return server_clusterSpecified; }
+    private void Resetserver_cluster() { server_clusterSpecified = false; }
+    
 
-    private ENetworkDisconnectionReason _disconnect_reason = ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID;
+    private ENetworkDisconnectionReason? _disconnect_reason;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"disconnect_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID)]
     public ENetworkDisconnectionReason disconnect_reason
     {
-      get { return _disconnect_reason; }
+      get { return _disconnect_reason?? ENetworkDisconnectionReason.NETWORK_DISCONNECT_INVALID; }
       set { _disconnect_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool disconnect_reasonSpecified
+    {
+      get { return _disconnect_reason != null; }
+      set { if (value == (_disconnect_reason== null)) _disconnect_reason = value ? this.disconnect_reason : (ENetworkDisconnectionReason?)null; }
+    }
+    private bool ShouldSerializedisconnect_reason() { return disconnect_reasonSpecified; }
+    private void Resetdisconnect_reason() { disconnect_reasonSpecified = false; }
+    
 
     private CMsgPoorNetworkConditions _poor_network_conditions = null;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"poor_network_conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -714,14 +1211,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLeaverDetectedResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -767,68 +1273,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFantasyMatch() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _series_id = default(uint);
+    private uint? _series_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"series_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_id
     {
-      get { return _series_id; }
+      get { return _series_id?? default(uint); }
       set { _series_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_idSpecified
+    {
+      get { return _series_id != null; }
+      set { if (value == (_series_id== null)) _series_id = value ? this.series_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_id() { return series_idSpecified; }
+    private void Resetseries_id() { series_idSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
 
-    private uint _series_type = default(uint);
+    private uint? _series_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"series_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint series_type
     {
-      get { return _series_type; }
+      get { return _series_type?? default(uint); }
       set { _series_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool series_typeSpecified
+    {
+      get { return _series_type != null; }
+      set { if (value == (_series_type== null)) _series_type = value ? this.series_type : (uint?)null; }
+    }
+    private bool ShouldSerializeseries_type() { return series_typeSpecified; }
+    private void Resetseries_type() { series_typeSpecified = false; }
+    
 
-    private uint _team_1 = default(uint);
+    private uint? _team_1;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_1
     {
-      get { return _team_1; }
+      get { return _team_1?? default(uint); }
       set { _team_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_1Specified
+    {
+      get { return _team_1 != null; }
+      set { if (value == (_team_1== null)) _team_1 = value ? this.team_1 : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_1() { return team_1Specified; }
+    private void Resetteam_1() { team_1Specified = false; }
+    
 
-    private uint _team_2 = default(uint);
+    private uint? _team_2;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"team_2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_2
     {
-      get { return _team_2; }
+      get { return _team_2?? default(uint); }
       set { _team_2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_2Specified
+    {
+      get { return _team_2 != null; }
+      set { if (value == (_team_2== null)) _team_2 = value ? this.team_2 : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_2() { return team_2Specified; }
+    private void Resetteam_2() { team_2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -868,23 +1437,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerRealtimeStatsStartStop() {}
     
 
-    private bool _delayed = default(bool);
+    private bool? _delayed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"delayed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool delayed
     {
-      get { return _delayed; }
+      get { return _delayed?? default(bool); }
       set { _delayed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delayedSpecified
+    {
+      get { return _delayed != null; }
+      set { if (value == (_delayed== null)) _delayed = value ? this.delayed : (bool?)null; }
+    }
+    private bool ShouldSerializedelayed() { return delayedSpecified; }
+    private void Resetdelayed() { delayedSpecified = false; }
+    
 
-    private bool _current = default(bool);
+    private bool? _current;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"current", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool current
     {
-      get { return _current; }
+      get { return _current?? default(bool); }
       set { _current = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currentSpecified
+    {
+      get { return _current != null; }
+      set { if (value == (_current== null)) _current = value ? this.current : (bool?)null; }
+    }
+    private bool ShouldSerializecurrent() { return currentSpecified; }
+    private void Resetcurrent() { currentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -896,41 +1483,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameMatchSignOut() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private bool _good_guys_win = default(bool);
+    private bool? _good_guys_win;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"good_guys_win", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool good_guys_win
     {
-      get { return _good_guys_win; }
+      get { return _good_guys_win?? default(bool); }
       set { _good_guys_win = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool good_guys_winSpecified
+    {
+      get { return _good_guys_win != null; }
+      set { if (value == (_good_guys_win== null)) _good_guys_win = value ? this.good_guys_win : (bool?)null; }
+    }
+    private bool ShouldSerializegood_guys_win() { return good_guys_winSpecified; }
+    private void Resetgood_guys_win() { good_guys_winSpecified = false; }
+    
 
-    private uint _date = default(uint);
+    private uint? _date;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"date", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date
     {
-      get { return _date; }
+      get { return _date?? default(uint); }
       set { _date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dateSpecified
+    {
+      get { return _date != null; }
+      set { if (value == (_date== null)) _date = value ? this.date : (uint?)null; }
+    }
+    private bool ShouldSerializedate() { return dateSpecified; }
+    private void Resetdate() { dateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _num_players = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"num_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> num_players
@@ -960,50 +1583,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _cluster = default(uint);
+    private uint? _cluster;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cluster
     {
-      get { return _cluster; }
+      get { return _cluster?? default(uint); }
       set { _cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clusterSpecified
+    {
+      get { return _cluster != null; }
+      set { if (value == (_cluster== null)) _cluster = value ? this.cluster : (uint?)null; }
+    }
+    private bool ShouldSerializecluster() { return clusterSpecified; }
+    private void Resetcluster() { clusterSpecified = false; }
+    
 
-    private string _server_addr = "";
+    private string _server_addr;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"server_addr", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string server_addr
     {
-      get { return _server_addr; }
+      get { return _server_addr?? ""; }
       set { _server_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addrSpecified
+    {
+      get { return _server_addr != null; }
+      set { if (value == (_server_addr== null)) _server_addr = value ? this.server_addr : (string)null; }
+    }
+    private bool ShouldSerializeserver_addr() { return server_addrSpecified; }
+    private void Resetserver_addr() { server_addrSpecified = false; }
+    
 
-    private uint _first_blood_time = default(uint);
+    private uint? _first_blood_time;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"first_blood_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_time
     {
-      get { return _first_blood_time; }
+      get { return _first_blood_time?? default(uint); }
       set { _first_blood_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_timeSpecified
+    {
+      get { return _first_blood_time != null; }
+      set { if (value == (_first_blood_time== null)) _first_blood_time = value ? this.first_blood_time : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_time() { return first_blood_timeSpecified; }
+    private void Resetfirst_blood_time() { first_blood_timeSpecified = false; }
+    
 
-    private float _game_balance = default(float);
+    private float? _game_balance;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"game_balance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float game_balance
     {
-      get { return _game_balance; }
+      get { return _game_balance?? default(float); }
       set { _game_balance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_balanceSpecified
+    {
+      get { return _game_balance != null; }
+      set { if (value == (_game_balance== null)) _game_balance = value ? this.game_balance : (float?)null; }
+    }
+    private bool ShouldSerializegame_balance() { return game_balanceSpecified; }
+    private void Resetgame_balance() { game_balanceSpecified = false; }
+    
 
-    private uint _event_score = default(uint);
+    private uint? _event_score;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"event_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_score
     {
-      get { return _event_score; }
+      get { return _event_score?? default(uint); }
       set { _event_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_scoreSpecified
+    {
+      get { return _event_score != null; }
+      set { if (value == (_event_score== null)) _event_score = value ? this.event_score : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_score() { return event_scoreSpecified; }
+    private void Resetevent_score() { event_scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMatchHeroSelectEvent> _picks_bans = new global::System.Collections.Generic.List<CMatchHeroSelectEvent>();
     [global::ProtoBuf.ProtoMember(15, Name=@"picks_bans", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMatchHeroSelectEvent> picks_bans
@@ -1026,32 +1694,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _automatic_surrender = default(bool);
+    private bool? _automatic_surrender;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"automatic_surrender", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool automatic_surrender
     {
-      get { return _automatic_surrender; }
+      get { return _automatic_surrender?? default(bool); }
       set { _automatic_surrender = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool automatic_surrenderSpecified
+    {
+      get { return _automatic_surrender != null; }
+      set { if (value == (_automatic_surrender== null)) _automatic_surrender = value ? this.automatic_surrender : (bool?)null; }
+    }
+    private bool ShouldSerializeautomatic_surrender() { return automatic_surrenderSpecified; }
+    private void Resetautomatic_surrender() { automatic_surrenderSpecified = false; }
+    
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
-    private bool _legacy_mass_disconnect = default(bool);
+    private bool? _legacy_mass_disconnect;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"legacy_mass_disconnect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool legacy_mass_disconnect
     {
-      get { return _legacy_mass_disconnect; }
+      get { return _legacy_mass_disconnect?? default(bool); }
       set { _legacy_mass_disconnect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_mass_disconnectSpecified
+    {
+      get { return _legacy_mass_disconnect != null; }
+      set { if (value == (_legacy_mass_disconnect== null)) _legacy_mass_disconnect = value ? this.legacy_mass_disconnect : (bool?)null; }
+    }
+    private bool ShouldSerializelegacy_mass_disconnect() { return legacy_mass_disconnectSpecified; }
+    private void Resetlegacy_mass_disconnect() { legacy_mass_disconnectSpecified = false; }
+    
 
     private CMsgPoorNetworkConditions _poor_network_conditions = null;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"poor_network_conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1076,122 +1771,239 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private int _average_networth_delta = default(int);
+    private int? _average_networth_delta;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"average_networth_delta", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int average_networth_delta
     {
-      get { return _average_networth_delta; }
+      get { return _average_networth_delta?? default(int); }
       set { _average_networth_delta = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_networth_deltaSpecified
+    {
+      get { return _average_networth_delta != null; }
+      set { if (value == (_average_networth_delta== null)) _average_networth_delta = value ? this.average_networth_delta : (int?)null; }
+    }
+    private bool ShouldSerializeaverage_networth_delta() { return average_networth_deltaSpecified; }
+    private void Resetaverage_networth_delta() { average_networth_deltaSpecified = false; }
+    
 
-    private int _networth_delta_min10 = default(int);
+    private int? _networth_delta_min10;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"networth_delta_min10", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int networth_delta_min10
     {
-      get { return _networth_delta_min10; }
+      get { return _networth_delta_min10?? default(int); }
       set { _networth_delta_min10 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool networth_delta_min10Specified
+    {
+      get { return _networth_delta_min10 != null; }
+      set { if (value == (_networth_delta_min10== null)) _networth_delta_min10 = value ? this.networth_delta_min10 : (int?)null; }
+    }
+    private bool ShouldSerializenetworth_delta_min10() { return networth_delta_min10Specified; }
+    private void Resetnetworth_delta_min10() { networth_delta_min10Specified = false; }
+    
 
-    private int _networth_delta_min20 = default(int);
+    private int? _networth_delta_min20;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"networth_delta_min20", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int networth_delta_min20
     {
-      get { return _networth_delta_min20; }
+      get { return _networth_delta_min20?? default(int); }
       set { _networth_delta_min20 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool networth_delta_min20Specified
+    {
+      get { return _networth_delta_min20 != null; }
+      set { if (value == (_networth_delta_min20== null)) _networth_delta_min20 = value ? this.networth_delta_min20 : (int?)null; }
+    }
+    private bool ShouldSerializenetworth_delta_min20() { return networth_delta_min20Specified; }
+    private void Resetnetworth_delta_min20() { networth_delta_min20Specified = false; }
+    
 
-    private int _maximum_losing_networth_lead = default(int);
+    private int? _maximum_losing_networth_lead;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"maximum_losing_networth_lead", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int maximum_losing_networth_lead
     {
-      get { return _maximum_losing_networth_lead; }
+      get { return _maximum_losing_networth_lead?? default(int); }
       set { _maximum_losing_networth_lead = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool maximum_losing_networth_leadSpecified
+    {
+      get { return _maximum_losing_networth_lead != null; }
+      set { if (value == (_maximum_losing_networth_lead== null)) _maximum_losing_networth_lead = value ? this.maximum_losing_networth_lead : (int?)null; }
+    }
+    private bool ShouldSerializemaximum_losing_networth_lead() { return maximum_losing_networth_leadSpecified; }
+    private void Resetmaximum_losing_networth_lead() { maximum_losing_networth_leadSpecified = false; }
+    
 
-    private int _average_experience_delta = default(int);
+    private int? _average_experience_delta;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"average_experience_delta", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int average_experience_delta
     {
-      get { return _average_experience_delta; }
+      get { return _average_experience_delta?? default(int); }
       set { _average_experience_delta = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_experience_deltaSpecified
+    {
+      get { return _average_experience_delta != null; }
+      set { if (value == (_average_experience_delta== null)) _average_experience_delta = value ? this.average_experience_delta : (int?)null; }
+    }
+    private bool ShouldSerializeaverage_experience_delta() { return average_experience_deltaSpecified; }
+    private void Resetaverage_experience_delta() { average_experience_deltaSpecified = false; }
+    
 
-    private int _experience_delta_min10 = default(int);
+    private int? _experience_delta_min10;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"experience_delta_min10", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int experience_delta_min10
     {
-      get { return _experience_delta_min10; }
+      get { return _experience_delta_min10?? default(int); }
       set { _experience_delta_min10 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experience_delta_min10Specified
+    {
+      get { return _experience_delta_min10 != null; }
+      set { if (value == (_experience_delta_min10== null)) _experience_delta_min10 = value ? this.experience_delta_min10 : (int?)null; }
+    }
+    private bool ShouldSerializeexperience_delta_min10() { return experience_delta_min10Specified; }
+    private void Resetexperience_delta_min10() { experience_delta_min10Specified = false; }
+    
 
-    private int _experience_delta_min20 = default(int);
+    private int? _experience_delta_min20;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"experience_delta_min20", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int experience_delta_min20
     {
-      get { return _experience_delta_min20; }
+      get { return _experience_delta_min20?? default(int); }
       set { _experience_delta_min20 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experience_delta_min20Specified
+    {
+      get { return _experience_delta_min20 != null; }
+      set { if (value == (_experience_delta_min20== null)) _experience_delta_min20 = value ? this.experience_delta_min20 : (int?)null; }
+    }
+    private bool ShouldSerializeexperience_delta_min20() { return experience_delta_min20Specified; }
+    private void Resetexperience_delta_min20() { experience_delta_min20Specified = false; }
+    
 
-    private int _bonus_gold_winner_min10 = default(int);
+    private int? _bonus_gold_winner_min10;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"bonus_gold_winner_min10", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bonus_gold_winner_min10
     {
-      get { return _bonus_gold_winner_min10; }
+      get { return _bonus_gold_winner_min10?? default(int); }
       set { _bonus_gold_winner_min10 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_winner_min10Specified
+    {
+      get { return _bonus_gold_winner_min10 != null; }
+      set { if (value == (_bonus_gold_winner_min10== null)) _bonus_gold_winner_min10 = value ? this.bonus_gold_winner_min10 : (int?)null; }
+    }
+    private bool ShouldSerializebonus_gold_winner_min10() { return bonus_gold_winner_min10Specified; }
+    private void Resetbonus_gold_winner_min10() { bonus_gold_winner_min10Specified = false; }
+    
 
-    private int _bonus_gold_winner_min20 = default(int);
+    private int? _bonus_gold_winner_min20;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"bonus_gold_winner_min20", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bonus_gold_winner_min20
     {
-      get { return _bonus_gold_winner_min20; }
+      get { return _bonus_gold_winner_min20?? default(int); }
       set { _bonus_gold_winner_min20 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_winner_min20Specified
+    {
+      get { return _bonus_gold_winner_min20 != null; }
+      set { if (value == (_bonus_gold_winner_min20== null)) _bonus_gold_winner_min20 = value ? this.bonus_gold_winner_min20 : (int?)null; }
+    }
+    private bool ShouldSerializebonus_gold_winner_min20() { return bonus_gold_winner_min20Specified; }
+    private void Resetbonus_gold_winner_min20() { bonus_gold_winner_min20Specified = false; }
+    
 
-    private uint _bonus_gold_winner_total = default(uint);
+    private uint? _bonus_gold_winner_total;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"bonus_gold_winner_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_gold_winner_total
     {
-      get { return _bonus_gold_winner_total; }
+      get { return _bonus_gold_winner_total?? default(uint); }
       set { _bonus_gold_winner_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_winner_totalSpecified
+    {
+      get { return _bonus_gold_winner_total != null; }
+      set { if (value == (_bonus_gold_winner_total== null)) _bonus_gold_winner_total = value ? this.bonus_gold_winner_total : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_gold_winner_total() { return bonus_gold_winner_totalSpecified; }
+    private void Resetbonus_gold_winner_total() { bonus_gold_winner_totalSpecified = false; }
+    
 
-    private int _bonus_gold_loser_min10 = default(int);
+    private int? _bonus_gold_loser_min10;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"bonus_gold_loser_min10", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bonus_gold_loser_min10
     {
-      get { return _bonus_gold_loser_min10; }
+      get { return _bonus_gold_loser_min10?? default(int); }
       set { _bonus_gold_loser_min10 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_loser_min10Specified
+    {
+      get { return _bonus_gold_loser_min10 != null; }
+      set { if (value == (_bonus_gold_loser_min10== null)) _bonus_gold_loser_min10 = value ? this.bonus_gold_loser_min10 : (int?)null; }
+    }
+    private bool ShouldSerializebonus_gold_loser_min10() { return bonus_gold_loser_min10Specified; }
+    private void Resetbonus_gold_loser_min10() { bonus_gold_loser_min10Specified = false; }
+    
 
-    private int _bonus_gold_loser_min20 = default(int);
+    private int? _bonus_gold_loser_min20;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"bonus_gold_loser_min20", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bonus_gold_loser_min20
     {
-      get { return _bonus_gold_loser_min20; }
+      get { return _bonus_gold_loser_min20?? default(int); }
       set { _bonus_gold_loser_min20 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_loser_min20Specified
+    {
+      get { return _bonus_gold_loser_min20 != null; }
+      set { if (value == (_bonus_gold_loser_min20== null)) _bonus_gold_loser_min20 = value ? this.bonus_gold_loser_min20 : (int?)null; }
+    }
+    private bool ShouldSerializebonus_gold_loser_min20() { return bonus_gold_loser_min20Specified; }
+    private void Resetbonus_gold_loser_min20() { bonus_gold_loser_min20Specified = false; }
+    
 
-    private uint _bonus_gold_loser_total = default(uint);
+    private uint? _bonus_gold_loser_total;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"bonus_gold_loser_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_gold_loser_total
     {
-      get { return _bonus_gold_loser_total; }
+      get { return _bonus_gold_loser_total?? default(uint); }
       set { _bonus_gold_loser_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_gold_loser_totalSpecified
+    {
+      get { return _bonus_gold_loser_total != null; }
+      set { if (value == (_bonus_gold_loser_total== null)) _bonus_gold_loser_total = value ? this.bonus_gold_loser_total : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_gold_loser_total() { return bonus_gold_loser_totalSpecified; }
+    private void Resetbonus_gold_loser_total() { bonus_gold_loser_totalSpecified = false; }
+    
 
     private CMsgGameMatchSignOut.CCustomGameData _custom_game_data = null;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"custom_game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1202,14 +2014,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _custom_game_data = value; }
     }
 
-    private uint _match_flags = default(uint);
+    private uint? _match_flags;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"match_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_flags
     {
-      get { return _match_flags; }
+      get { return _match_flags?? default(uint); }
       set { _match_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_flagsSpecified
+    {
+      get { return _match_flags != null; }
+      set { if (value == (_match_flags== null)) _match_flags = value ? this.match_flags : (uint?)null; }
+    }
+    private bool ShouldSerializematch_flags() { return match_flagsSpecified; }
+    private void Resetmatch_flags() { match_flagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _team_scores = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(39, Name=@"team_scores", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> team_scores
@@ -1218,14 +2039,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _pre_game_duration = default(uint);
+    private uint? _pre_game_duration;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"pre_game_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pre_game_duration
     {
-      get { return _pre_game_duration; }
+      get { return _pre_game_duration?? default(uint); }
       set { _pre_game_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pre_game_durationSpecified
+    {
+      get { return _pre_game_duration != null; }
+      set { if (value == (_pre_game_duration== null)) _pre_game_duration = value ? this.pre_game_duration : (uint?)null; }
+    }
+    private bool ShouldSerializepre_game_duration() { return pre_game_durationSpecified; }
+    private void Resetpre_game_duration() { pre_game_durationSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CTeam")]
   public partial class CTeam : global::ProtoBuf.IExtensible
   {
@@ -1244,23 +2074,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CPlayer() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _items = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> items
@@ -1269,266 +2117,527 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _gold = default(uint);
+    private uint? _gold;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold
     {
-      get { return _gold; }
+      get { return _gold?? default(uint); }
       set { _gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goldSpecified
+    {
+      get { return _gold != null; }
+      set { if (value == (_gold== null)) _gold = value ? this.gold : (uint?)null; }
+    }
+    private bool ShouldSerializegold() { return goldSpecified; }
+    private void Resetgold() { goldSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private uint _leaver_status = default(uint);
+    private uint? _leaver_status;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"leaver_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leaver_status
     {
-      get { return _leaver_status; }
+      get { return _leaver_status?? default(uint); }
       set { _leaver_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaver_statusSpecified
+    {
+      get { return _leaver_status != null; }
+      set { if (value == (_leaver_status== null)) _leaver_status = value ? this.leaver_status : (uint?)null; }
+    }
+    private bool ShouldSerializeleaver_status() { return leaver_statusSpecified; }
+    private void Resetleaver_status() { leaver_statusSpecified = false; }
+    
 
-    private uint _last_hits = default(uint);
+    private uint? _last_hits;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(uint); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (uint?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private uint _denies = default(uint);
+    private uint? _denies;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies
     {
-      get { return _denies; }
+      get { return _denies?? default(uint); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (uint?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private uint _gold_per_min = default(uint);
+    private uint? _gold_per_min;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"gold_per_min", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_per_min
     {
-      get { return _gold_per_min; }
+      get { return _gold_per_min?? default(uint); }
       set { _gold_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_per_minSpecified
+    {
+      get { return _gold_per_min != null; }
+      set { if (value == (_gold_per_min== null)) _gold_per_min = value ? this.gold_per_min : (uint?)null; }
+    }
+    private bool ShouldSerializegold_per_min() { return gold_per_minSpecified; }
+    private void Resetgold_per_min() { gold_per_minSpecified = false; }
+    
 
-    private uint _xp_per_minute = default(uint);
+    private uint? _xp_per_minute;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"xp_per_minute", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp_per_minute
     {
-      get { return _xp_per_minute; }
+      get { return _xp_per_minute?? default(uint); }
       set { _xp_per_minute = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_per_minuteSpecified
+    {
+      get { return _xp_per_minute != null; }
+      set { if (value == (_xp_per_minute== null)) _xp_per_minute = value ? this.xp_per_minute : (uint?)null; }
+    }
+    private bool ShouldSerializexp_per_minute() { return xp_per_minuteSpecified; }
+    private void Resetxp_per_minute() { xp_per_minuteSpecified = false; }
+    
 
-    private uint _gold_spent = default(uint);
+    private uint? _gold_spent;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"gold_spent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold_spent
     {
-      get { return _gold_spent; }
+      get { return _gold_spent?? default(uint); }
       set { _gold_spent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_spentSpecified
+    {
+      get { return _gold_spent != null; }
+      set { if (value == (_gold_spent== null)) _gold_spent = value ? this.gold_spent : (uint?)null; }
+    }
+    private bool ShouldSerializegold_spent() { return gold_spentSpecified; }
+    private void Resetgold_spent() { gold_spentSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _scaled_hero_damage = default(uint);
+    private uint? _scaled_hero_damage;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"scaled_hero_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_hero_damage
     {
-      get { return _scaled_hero_damage; }
+      get { return _scaled_hero_damage?? default(uint); }
       set { _scaled_hero_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_hero_damageSpecified
+    {
+      get { return _scaled_hero_damage != null; }
+      set { if (value == (_scaled_hero_damage== null)) _scaled_hero_damage = value ? this.scaled_hero_damage : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_hero_damage() { return scaled_hero_damageSpecified; }
+    private void Resetscaled_hero_damage() { scaled_hero_damageSpecified = false; }
+    
 
-    private uint _scaled_tower_damage = default(uint);
+    private uint? _scaled_tower_damage;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"scaled_tower_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_tower_damage
     {
-      get { return _scaled_tower_damage; }
+      get { return _scaled_tower_damage?? default(uint); }
       set { _scaled_tower_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_tower_damageSpecified
+    {
+      get { return _scaled_tower_damage != null; }
+      set { if (value == (_scaled_tower_damage== null)) _scaled_tower_damage = value ? this.scaled_tower_damage : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_tower_damage() { return scaled_tower_damageSpecified; }
+    private void Resetscaled_tower_damage() { scaled_tower_damageSpecified = false; }
+    
 
-    private uint _scaled_hero_healing = default(uint);
+    private uint? _scaled_hero_healing;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"scaled_hero_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scaled_hero_healing
     {
-      get { return _scaled_hero_healing; }
+      get { return _scaled_hero_healing?? default(uint); }
       set { _scaled_hero_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_hero_healingSpecified
+    {
+      get { return _scaled_hero_healing != null; }
+      set { if (value == (_scaled_hero_healing== null)) _scaled_hero_healing = value ? this.scaled_hero_healing : (uint?)null; }
+    }
+    private bool ShouldSerializescaled_hero_healing() { return scaled_hero_healingSpecified; }
+    private void Resetscaled_hero_healing() { scaled_hero_healingSpecified = false; }
+    
 
-    private uint _time_last_seen = default(uint);
+    private uint? _time_last_seen;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"time_last_seen", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_last_seen
     {
-      get { return _time_last_seen; }
+      get { return _time_last_seen?? default(uint); }
       set { _time_last_seen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_last_seenSpecified
+    {
+      get { return _time_last_seen != null; }
+      set { if (value == (_time_last_seen== null)) _time_last_seen = value ? this.time_last_seen : (uint?)null; }
+    }
+    private bool ShouldSerializetime_last_seen() { return time_last_seenSpecified; }
+    private void Resettime_last_seen() { time_last_seenSpecified = false; }
+    
 
-    private uint _support_ability_value = default(uint);
+    private uint? _support_ability_value;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"support_ability_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_ability_value
     {
-      get { return _support_ability_value; }
+      get { return _support_ability_value?? default(uint); }
       set { _support_ability_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_ability_valueSpecified
+    {
+      get { return _support_ability_value != null; }
+      set { if (value == (_support_ability_value== null)) _support_ability_value = value ? this.support_ability_value : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_ability_value() { return support_ability_valueSpecified; }
+    private void Resetsupport_ability_value() { support_ability_valueSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private float _scaled_kills = default(float);
+    private float? _scaled_kills;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"scaled_kills", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_kills
     {
-      get { return _scaled_kills; }
+      get { return _scaled_kills?? default(float); }
       set { _scaled_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_killsSpecified
+    {
+      get { return _scaled_kills != null; }
+      set { if (value == (_scaled_kills== null)) _scaled_kills = value ? this.scaled_kills : (float?)null; }
+    }
+    private bool ShouldSerializescaled_kills() { return scaled_killsSpecified; }
+    private void Resetscaled_kills() { scaled_killsSpecified = false; }
+    
 
-    private float _scaled_deaths = default(float);
+    private float? _scaled_deaths;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"scaled_deaths", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_deaths
     {
-      get { return _scaled_deaths; }
+      get { return _scaled_deaths?? default(float); }
       set { _scaled_deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_deathsSpecified
+    {
+      get { return _scaled_deaths != null; }
+      set { if (value == (_scaled_deaths== null)) _scaled_deaths = value ? this.scaled_deaths : (float?)null; }
+    }
+    private bool ShouldSerializescaled_deaths() { return scaled_deathsSpecified; }
+    private void Resetscaled_deaths() { scaled_deathsSpecified = false; }
+    
 
-    private float _scaled_assists = default(float);
+    private float? _scaled_assists;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"scaled_assists", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float scaled_assists
     {
-      get { return _scaled_assists; }
+      get { return _scaled_assists?? default(float); }
       set { _scaled_assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scaled_assistsSpecified
+    {
+      get { return _scaled_assists != null; }
+      set { if (value == (_scaled_assists== null)) _scaled_assists = value ? this.scaled_assists : (float?)null; }
+    }
+    private bool ShouldSerializescaled_assists() { return scaled_assistsSpecified; }
+    private void Resetscaled_assists() { scaled_assistsSpecified = false; }
+    
 
-    private uint _claimed_farm_gold = default(uint);
+    private uint? _claimed_farm_gold;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"claimed_farm_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_farm_gold
     {
-      get { return _claimed_farm_gold; }
+      get { return _claimed_farm_gold?? default(uint); }
       set { _claimed_farm_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_farm_goldSpecified
+    {
+      get { return _claimed_farm_gold != null; }
+      set { if (value == (_claimed_farm_gold== null)) _claimed_farm_gold = value ? this.claimed_farm_gold : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_farm_gold() { return claimed_farm_goldSpecified; }
+    private void Resetclaimed_farm_gold() { claimed_farm_goldSpecified = false; }
+    
 
-    private uint _support_gold = default(uint);
+    private uint? _support_gold;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"support_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_gold
     {
-      get { return _support_gold; }
+      get { return _support_gold?? default(uint); }
       set { _support_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_goldSpecified
+    {
+      get { return _support_gold != null; }
+      set { if (value == (_support_gold== null)) _support_gold = value ? this.support_gold : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_gold() { return support_goldSpecified; }
+    private void Resetsupport_gold() { support_goldSpecified = false; }
+    
 
-    private uint _claimed_denies = default(uint);
+    private uint? _claimed_denies;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"claimed_denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_denies
     {
-      get { return _claimed_denies; }
+      get { return _claimed_denies?? default(uint); }
       set { _claimed_denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_deniesSpecified
+    {
+      get { return _claimed_denies != null; }
+      set { if (value == (_claimed_denies== null)) _claimed_denies = value ? this.claimed_denies : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_denies() { return claimed_deniesSpecified; }
+    private void Resetclaimed_denies() { claimed_deniesSpecified = false; }
+    
 
-    private uint _claimed_misses = default(uint);
+    private uint? _claimed_misses;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"claimed_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint claimed_misses
     {
-      get { return _claimed_misses; }
+      get { return _claimed_misses?? default(uint); }
       set { _claimed_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool claimed_missesSpecified
+    {
+      get { return _claimed_misses != null; }
+      set { if (value == (_claimed_misses== null)) _claimed_misses = value ? this.claimed_misses : (uint?)null; }
+    }
+    private bool ShouldSerializeclaimed_misses() { return claimed_missesSpecified; }
+    private void Resetclaimed_misses() { claimed_missesSpecified = false; }
+    
 
-    private uint _misses = default(uint);
+    private uint? _misses;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint misses
     {
-      get { return _misses; }
+      get { return _misses?? default(uint); }
       set { _misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool missesSpecified
+    {
+      get { return _misses != null; }
+      set { if (value == (_misses== null)) _misses = value ? this.misses : (uint?)null; }
+    }
+    private bool ShouldSerializemisses() { return missesSpecified; }
+    private void Resetmisses() { missesSpecified = false; }
+    
 
-    private uint _net_worth = default(uint);
+    private uint? _net_worth;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"net_worth", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint net_worth
     {
-      get { return _net_worth; }
+      get { return _net_worth?? default(uint); }
       set { _net_worth = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_worthSpecified
+    {
+      get { return _net_worth != null; }
+      set { if (value == (_net_worth== null)) _net_worth = value ? this.net_worth : (uint?)null; }
+    }
+    private bool ShouldSerializenet_worth() { return net_worthSpecified; }
+    private void Resetnet_worth() { net_worthSpecified = false; }
+    
 
-    private uint _hero_damage = default(uint);
+    private uint? _hero_damage;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"hero_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_damage
     {
-      get { return _hero_damage; }
+      get { return _hero_damage?? default(uint); }
       set { _hero_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_damageSpecified
+    {
+      get { return _hero_damage != null; }
+      set { if (value == (_hero_damage== null)) _hero_damage = value ? this.hero_damage : (uint?)null; }
+    }
+    private bool ShouldSerializehero_damage() { return hero_damageSpecified; }
+    private void Resethero_damage() { hero_damageSpecified = false; }
+    
 
-    private uint _tower_damage = default(uint);
+    private uint? _tower_damage;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"tower_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tower_damage
     {
-      get { return _tower_damage; }
+      get { return _tower_damage?? default(uint); }
       set { _tower_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_damageSpecified
+    {
+      get { return _tower_damage != null; }
+      set { if (value == (_tower_damage== null)) _tower_damage = value ? this.tower_damage : (uint?)null; }
+    }
+    private bool ShouldSerializetower_damage() { return tower_damageSpecified; }
+    private void Resettower_damage() { tower_damageSpecified = false; }
+    
 
-    private uint _hero_healing = default(uint);
+    private uint? _hero_healing;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"hero_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_healing
     {
-      get { return _hero_healing; }
+      get { return _hero_healing?? default(uint); }
       set { _hero_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_healingSpecified
+    {
+      get { return _hero_healing != null; }
+      set { if (value == (_hero_healing== null)) _hero_healing = value ? this.hero_healing : (uint?)null; }
+    }
+    private bool ShouldSerializehero_healing() { return hero_healingSpecified; }
+    private void Resethero_healing() { hero_healingSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade> _ability_upgrades = new global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade>();
     [global::ProtoBuf.ProtoMember(32, Name=@"ability_upgrades", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMatchPlayerAbilityUpgrade> ability_upgrades
@@ -1560,14 +2669,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _custom_game_data = value; }
     }
 
-    private uint _match_player_flags = default(uint);
+    private uint? _match_player_flags;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"match_player_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_player_flags
     {
-      get { return _match_player_flags; }
+      get { return _match_player_flags?? default(uint); }
       set { _match_player_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_player_flagsSpecified
+    {
+      get { return _match_player_flags != null; }
+      set { if (value == (_match_player_flags== null)) _match_player_flags = value ? this.match_player_flags : (uint?)null; }
+    }
+    private bool ShouldSerializematch_player_flags() { return match_player_flagsSpecified; }
+    private void Resetmatch_player_flags() { match_player_flagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _talent_ability_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(41, Name=@"talent_ability_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> talent_ability_ids
@@ -1581,23 +2699,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CCustomGameData() {}
     
 
-    private uint _dota_team = default(uint);
+    private uint? _dota_team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dota_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dota_team
     {
-      get { return _dota_team; }
+      get { return _dota_team?? default(uint); }
       set { _dota_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dota_teamSpecified
+    {
+      get { return _dota_team != null; }
+      set { if (value == (_dota_team== null)) _dota_team = value ? this.dota_team : (uint?)null; }
+    }
+    private bool ShouldSerializedota_team() { return dota_teamSpecified; }
+    private void Resetdota_team() { dota_teamSpecified = false; }
+    
 
-    private bool _winner = default(bool);
+    private bool? _winner;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"winner", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool winner
     {
-      get { return _winner; }
+      get { return _winner?? default(bool); }
       set { _winner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winnerSpecified
+    {
+      get { return _winner != null; }
+      set { if (value == (_winner== null)) _winner = value ? this.winner : (bool?)null; }
+    }
+    private bool ShouldSerializewinner() { return winnerSpecified; }
+    private void Resetwinner() { winnerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1619,23 +2755,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CAdditionalSignoutMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private byte[] _contents = null;
+    private byte[] _contents;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"contents", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] contents
     {
-      get { return _contents; }
+      get { return _contents?? null; }
       set { _contents = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contentsSpecified
+    {
+      get { return _contents != null; }
+      set { if (value == (_contents== null)) _contents = value ? this.contents : (byte[])null; }
+    }
+    private bool ShouldSerializecontents() { return contentsSpecified; }
+    private void Resetcontents() { contentsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1647,50 +2801,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CSocialFeedMatchEvent() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private int _game_time = default(int);
+    private int? _game_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(int); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (int?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private uint _replay_time = default(uint);
+    private uint? _replay_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"replay_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_time
     {
-      get { return _replay_time; }
+      get { return _replay_time?? default(uint); }
       set { _replay_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_timeSpecified
+    {
+      get { return _replay_time != null; }
+      set { if (value == (_replay_time== null)) _replay_time = value ? this.replay_time : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_time() { return replay_timeSpecified; }
+    private void Resetreplay_time() { replay_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1702,14 +2901,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CCustomGameData() {}
     
 
-    private uint _publish_timestamp = default(uint);
+    private uint? _publish_timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publish_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint publish_timestamp
     {
-      get { return _publish_timestamp; }
+      get { return _publish_timestamp?? default(uint); }
       set { _publish_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publish_timestampSpecified
+    {
+      get { return _publish_timestamp != null; }
+      set { if (value == (_publish_timestamp== null)) _publish_timestamp = value ? this.publish_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializepublish_timestamp() { return publish_timestampSpecified; }
+    private void Resetpublish_timestamp() { publish_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1726,23 +2934,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSignOutDraftInfo() {}
     
 
-    private uint _radiant_captain_account_id = default(uint);
+    private uint? _radiant_captain_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"radiant_captain_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint radiant_captain_account_id
     {
-      get { return _radiant_captain_account_id; }
+      get { return _radiant_captain_account_id?? default(uint); }
       set { _radiant_captain_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool radiant_captain_account_idSpecified
+    {
+      get { return _radiant_captain_account_id != null; }
+      set { if (value == (_radiant_captain_account_id== null)) _radiant_captain_account_id = value ? this.radiant_captain_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeradiant_captain_account_id() { return radiant_captain_account_idSpecified; }
+    private void Resetradiant_captain_account_id() { radiant_captain_account_idSpecified = false; }
+    
 
-    private uint _dire_captain_account_id = default(uint);
+    private uint? _dire_captain_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"dire_captain_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dire_captain_account_id
     {
-      get { return _dire_captain_account_id; }
+      get { return _dire_captain_account_id?? default(uint); }
       set { _dire_captain_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dire_captain_account_idSpecified
+    {
+      get { return _dire_captain_account_id != null; }
+      set { if (value == (_dire_captain_account_id== null)) _dire_captain_account_id = value ? this.dire_captain_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializedire_captain_account_id() { return dire_captain_account_idSpecified; }
+    private void Resetdire_captain_account_id() { dire_captain_account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMatchHeroSelectEvent> _picks_bans = new global::System.Collections.Generic.List<CMatchHeroSelectEvent>();
     [global::ProtoBuf.ProtoMember(3, Name=@"picks_bans", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMatchHeroSelectEvent> picks_bans
@@ -1761,41 +2987,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSignOutBotInfo() {}
     
 
-    private bool _allow_cheats = default(bool);
+    private bool? _allow_cheats;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"allow_cheats", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_cheats
     {
-      get { return _allow_cheats; }
+      get { return _allow_cheats?? default(bool); }
       set { _allow_cheats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_cheatsSpecified
+    {
+      get { return _allow_cheats != null; }
+      set { if (value == (_allow_cheats== null)) _allow_cheats = value ? this.allow_cheats : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_cheats() { return allow_cheatsSpecified; }
+    private void Resetallow_cheats() { allow_cheatsSpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_radiant = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty_radiant;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bot_difficulty_radiant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty_radiant
     {
-      get { return _bot_difficulty_radiant; }
+      get { return _bot_difficulty_radiant?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_radiantSpecified
+    {
+      get { return _bot_difficulty_radiant != null; }
+      set { if (value == (_bot_difficulty_radiant== null)) _bot_difficulty_radiant = value ? this.bot_difficulty_radiant : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_radiant() { return bot_difficulty_radiantSpecified; }
+    private void Resetbot_difficulty_radiant() { bot_difficulty_radiantSpecified = false; }
+    
 
-    private bool _created_lobby = default(bool);
+    private bool? _created_lobby;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"created_lobby", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool created_lobby
     {
-      get { return _created_lobby; }
+      get { return _created_lobby?? default(bool); }
       set { _created_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool created_lobbySpecified
+    {
+      get { return _created_lobby != null; }
+      set { if (value == (_created_lobby== null)) _created_lobby = value ? this.created_lobby : (bool?)null; }
+    }
+    private bool ShouldSerializecreated_lobby() { return created_lobbySpecified; }
+    private void Resetcreated_lobby() { created_lobbySpecified = false; }
+    
 
-    private DOTABotDifficulty _bot_difficulty_dire = DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    private DOTABotDifficulty? _bot_difficulty_dire;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"bot_difficulty_dire", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE)]
     public DOTABotDifficulty bot_difficulty_dire
     {
-      get { return _bot_difficulty_dire; }
+      get { return _bot_difficulty_dire?? DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE; }
       set { _bot_difficulty_dire = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_difficulty_direSpecified
+    {
+      get { return _bot_difficulty_dire != null; }
+      set { if (value == (_bot_difficulty_dire== null)) _bot_difficulty_dire = value ? this.bot_difficulty_dire : (DOTABotDifficulty?)null; }
+    }
+    private bool ShouldSerializebot_difficulty_dire() { return bot_difficulty_direSpecified; }
+    private void Resetbot_difficulty_dire() { bot_difficulty_direSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1807,212 +3069,419 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSignOutPlayerStats() {}
     
 
-    private int _account_id = default(int);
+    private int? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(int); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (int?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _rampages = default(uint);
+    private uint? _rampages;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rampages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rampages
     {
-      get { return _rampages; }
+      get { return _rampages?? default(uint); }
       set { _rampages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rampagesSpecified
+    {
+      get { return _rampages != null; }
+      set { if (value == (_rampages== null)) _rampages = value ? this.rampages : (uint?)null; }
+    }
+    private bool ShouldSerializerampages() { return rampagesSpecified; }
+    private void Resetrampages() { rampagesSpecified = false; }
+    
 
-    private uint _triple_kills = default(uint);
+    private uint? _triple_kills;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"triple_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint triple_kills
     {
-      get { return _triple_kills; }
+      get { return _triple_kills?? default(uint); }
       set { _triple_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool triple_killsSpecified
+    {
+      get { return _triple_kills != null; }
+      set { if (value == (_triple_kills== null)) _triple_kills = value ? this.triple_kills : (uint?)null; }
+    }
+    private bool ShouldSerializetriple_kills() { return triple_killsSpecified; }
+    private void Resettriple_kills() { triple_killsSpecified = false; }
+    
 
-    private uint _first_blood_claimed = default(uint);
+    private uint? _first_blood_claimed;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"first_blood_claimed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_claimed
     {
-      get { return _first_blood_claimed; }
+      get { return _first_blood_claimed?? default(uint); }
       set { _first_blood_claimed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_claimedSpecified
+    {
+      get { return _first_blood_claimed != null; }
+      set { if (value == (_first_blood_claimed== null)) _first_blood_claimed = value ? this.first_blood_claimed : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_claimed() { return first_blood_claimedSpecified; }
+    private void Resetfirst_blood_claimed() { first_blood_claimedSpecified = false; }
+    
 
-    private uint _first_blood_given = default(uint);
+    private uint? _first_blood_given;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"first_blood_given", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_blood_given
     {
-      get { return _first_blood_given; }
+      get { return _first_blood_given?? default(uint); }
       set { _first_blood_given = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_blood_givenSpecified
+    {
+      get { return _first_blood_given != null; }
+      set { if (value == (_first_blood_given== null)) _first_blood_given = value ? this.first_blood_given : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_blood_given() { return first_blood_givenSpecified; }
+    private void Resetfirst_blood_given() { first_blood_givenSpecified = false; }
+    
 
-    private uint _couriers_killed = default(uint);
+    private uint? _couriers_killed;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"couriers_killed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint couriers_killed
     {
-      get { return _couriers_killed; }
+      get { return _couriers_killed?? default(uint); }
       set { _couriers_killed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool couriers_killedSpecified
+    {
+      get { return _couriers_killed != null; }
+      set { if (value == (_couriers_killed== null)) _couriers_killed = value ? this.couriers_killed : (uint?)null; }
+    }
+    private bool ShouldSerializecouriers_killed() { return couriers_killedSpecified; }
+    private void Resetcouriers_killed() { couriers_killedSpecified = false; }
+    
 
-    private uint _aegises_snatched = default(uint);
+    private uint? _aegises_snatched;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"aegises_snatched", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint aegises_snatched
     {
-      get { return _aegises_snatched; }
+      get { return _aegises_snatched?? default(uint); }
       set { _aegises_snatched = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool aegises_snatchedSpecified
+    {
+      get { return _aegises_snatched != null; }
+      set { if (value == (_aegises_snatched== null)) _aegises_snatched = value ? this.aegises_snatched : (uint?)null; }
+    }
+    private bool ShouldSerializeaegises_snatched() { return aegises_snatchedSpecified; }
+    private void Resetaegises_snatched() { aegises_snatchedSpecified = false; }
+    
 
-    private uint _cheeses_eaten = default(uint);
+    private uint? _cheeses_eaten;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"cheeses_eaten", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cheeses_eaten
     {
-      get { return _cheeses_eaten; }
+      get { return _cheeses_eaten?? default(uint); }
       set { _cheeses_eaten = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cheeses_eatenSpecified
+    {
+      get { return _cheeses_eaten != null; }
+      set { if (value == (_cheeses_eaten== null)) _cheeses_eaten = value ? this.cheeses_eaten : (uint?)null; }
+    }
+    private bool ShouldSerializecheeses_eaten() { return cheeses_eatenSpecified; }
+    private void Resetcheeses_eaten() { cheeses_eatenSpecified = false; }
+    
 
-    private uint _creeps_stacked = default(uint);
+    private uint? _creeps_stacked;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"creeps_stacked", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creeps_stacked
     {
-      get { return _creeps_stacked; }
+      get { return _creeps_stacked?? default(uint); }
       set { _creeps_stacked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creeps_stackedSpecified
+    {
+      get { return _creeps_stacked != null; }
+      set { if (value == (_creeps_stacked== null)) _creeps_stacked = value ? this.creeps_stacked : (uint?)null; }
+    }
+    private bool ShouldSerializecreeps_stacked() { return creeps_stackedSpecified; }
+    private void Resetcreeps_stacked() { creeps_stackedSpecified = false; }
+    
 
-    private float _fight_score = default(float);
+    private float? _fight_score;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"fight_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float fight_score
     {
-      get { return _fight_score; }
+      get { return _fight_score?? default(float); }
       set { _fight_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fight_scoreSpecified
+    {
+      get { return _fight_score != null; }
+      set { if (value == (_fight_score== null)) _fight_score = value ? this.fight_score : (float?)null; }
+    }
+    private bool ShouldSerializefight_score() { return fight_scoreSpecified; }
+    private void Resetfight_score() { fight_scoreSpecified = false; }
+    
 
-    private float _farm_score = default(float);
+    private float? _farm_score;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"farm_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float farm_score
     {
-      get { return _farm_score; }
+      get { return _farm_score?? default(float); }
       set { _farm_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool farm_scoreSpecified
+    {
+      get { return _farm_score != null; }
+      set { if (value == (_farm_score== null)) _farm_score = value ? this.farm_score : (float?)null; }
+    }
+    private bool ShouldSerializefarm_score() { return farm_scoreSpecified; }
+    private void Resetfarm_score() { farm_scoreSpecified = false; }
+    
 
-    private float _support_score = default(float);
+    private float? _support_score;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"support_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float support_score
     {
-      get { return _support_score; }
+      get { return _support_score?? default(float); }
       set { _support_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_scoreSpecified
+    {
+      get { return _support_score != null; }
+      set { if (value == (_support_score== null)) _support_score = value ? this.support_score : (float?)null; }
+    }
+    private bool ShouldSerializesupport_score() { return support_scoreSpecified; }
+    private void Resetsupport_score() { support_scoreSpecified = false; }
+    
 
-    private float _push_score = default(float);
+    private float? _push_score;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"push_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float push_score
     {
-      get { return _push_score; }
+      get { return _push_score?? default(float); }
       set { _push_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool push_scoreSpecified
+    {
+      get { return _push_score != null; }
+      set { if (value == (_push_score== null)) _push_score = value ? this.push_score : (float?)null; }
+    }
+    private bool ShouldSerializepush_score() { return push_scoreSpecified; }
+    private void Resetpush_score() { push_scoreSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private uint _last_hits = default(uint);
+    private uint? _last_hits;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(uint); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (uint?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private uint _denies = default(uint);
+    private uint? _denies;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies
     {
-      get { return _denies; }
+      get { return _denies?? default(uint); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (uint?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private float _gpm = default(float);
+    private float? _gpm;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"gpm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float gpm
     {
-      get { return _gpm; }
+      get { return _gpm?? default(float); }
       set { _gpm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gpmSpecified
+    {
+      get { return _gpm != null; }
+      set { if (value == (_gpm== null)) _gpm = value ? this.gpm : (float?)null; }
+    }
+    private bool ShouldSerializegpm() { return gpmSpecified; }
+    private void Resetgpm() { gpmSpecified = false; }
+    
 
-    private float _xppm = default(float);
+    private float? _xppm;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"xppm", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float xppm
     {
-      get { return _xppm; }
+      get { return _xppm?? default(float); }
       set { _xppm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xppmSpecified
+    {
+      get { return _xppm != null; }
+      set { if (value == (_xppm== null)) _xppm = value ? this.xppm : (float?)null; }
+    }
+    private bool ShouldSerializexppm() { return xppmSpecified; }
+    private void Resetxppm() { xppmSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2036,131 +3505,257 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerCommunication() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _pings = default(uint);
+    private uint? _pings;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pings", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pings
     {
-      get { return _pings; }
+      get { return _pings?? default(uint); }
       set { _pings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingsSpecified
+    {
+      get { return _pings != null; }
+      set { if (value == (_pings== null)) _pings = value ? this.pings : (uint?)null; }
+    }
+    private bool ShouldSerializepings() { return pingsSpecified; }
+    private void Resetpings() { pingsSpecified = false; }
+    
 
-    private uint _max_pings_per_interval = default(uint);
+    private uint? _max_pings_per_interval;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"max_pings_per_interval", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_pings_per_interval
     {
-      get { return _max_pings_per_interval; }
+      get { return _max_pings_per_interval?? default(uint); }
       set { _max_pings_per_interval = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_pings_per_intervalSpecified
+    {
+      get { return _max_pings_per_interval != null; }
+      set { if (value == (_max_pings_per_interval== null)) _max_pings_per_interval = value ? this.max_pings_per_interval : (uint?)null; }
+    }
+    private bool ShouldSerializemax_pings_per_interval() { return max_pings_per_intervalSpecified; }
+    private void Resetmax_pings_per_interval() { max_pings_per_intervalSpecified = false; }
+    
 
-    private uint _teammate_pings = default(uint);
+    private uint? _teammate_pings;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"teammate_pings", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint teammate_pings
     {
-      get { return _teammate_pings; }
+      get { return _teammate_pings?? default(uint); }
       set { _teammate_pings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teammate_pingsSpecified
+    {
+      get { return _teammate_pings != null; }
+      set { if (value == (_teammate_pings== null)) _teammate_pings = value ? this.teammate_pings : (uint?)null; }
+    }
+    private bool ShouldSerializeteammate_pings() { return teammate_pingsSpecified; }
+    private void Resetteammate_pings() { teammate_pingsSpecified = false; }
+    
 
-    private uint _max_teammate_pings_per_interval = default(uint);
+    private uint? _max_teammate_pings_per_interval;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"max_teammate_pings_per_interval", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_teammate_pings_per_interval
     {
-      get { return _max_teammate_pings_per_interval; }
+      get { return _max_teammate_pings_per_interval?? default(uint); }
       set { _max_teammate_pings_per_interval = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_teammate_pings_per_intervalSpecified
+    {
+      get { return _max_teammate_pings_per_interval != null; }
+      set { if (value == (_max_teammate_pings_per_interval== null)) _max_teammate_pings_per_interval = value ? this.max_teammate_pings_per_interval : (uint?)null; }
+    }
+    private bool ShouldSerializemax_teammate_pings_per_interval() { return max_teammate_pings_per_intervalSpecified; }
+    private void Resetmax_teammate_pings_per_interval() { max_teammate_pings_per_intervalSpecified = false; }
+    
 
-    private uint _team_chat_messages = default(uint);
+    private uint? _team_chat_messages;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"team_chat_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_chat_messages
     {
-      get { return _team_chat_messages; }
+      get { return _team_chat_messages?? default(uint); }
       set { _team_chat_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_chat_messagesSpecified
+    {
+      get { return _team_chat_messages != null; }
+      set { if (value == (_team_chat_messages== null)) _team_chat_messages = value ? this.team_chat_messages : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_chat_messages() { return team_chat_messagesSpecified; }
+    private void Resetteam_chat_messages() { team_chat_messagesSpecified = false; }
+    
 
-    private uint _all_chat_messages = default(uint);
+    private uint? _all_chat_messages;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"all_chat_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint all_chat_messages
     {
-      get { return _all_chat_messages; }
+      get { return _all_chat_messages?? default(uint); }
       set { _all_chat_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool all_chat_messagesSpecified
+    {
+      get { return _all_chat_messages != null; }
+      set { if (value == (_all_chat_messages== null)) _all_chat_messages = value ? this.all_chat_messages : (uint?)null; }
+    }
+    private bool ShouldSerializeall_chat_messages() { return all_chat_messagesSpecified; }
+    private void Resetall_chat_messages() { all_chat_messagesSpecified = false; }
+    
 
-    private uint _chat_wheel_messages = default(uint);
+    private uint? _chat_wheel_messages;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"chat_wheel_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint chat_wheel_messages
     {
-      get { return _chat_wheel_messages; }
+      get { return _chat_wheel_messages?? default(uint); }
       set { _chat_wheel_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_wheel_messagesSpecified
+    {
+      get { return _chat_wheel_messages != null; }
+      set { if (value == (_chat_wheel_messages== null)) _chat_wheel_messages = value ? this.chat_wheel_messages : (uint?)null; }
+    }
+    private bool ShouldSerializechat_wheel_messages() { return chat_wheel_messagesSpecified; }
+    private void Resetchat_wheel_messages() { chat_wheel_messagesSpecified = false; }
+    
 
-    private uint _pauses = default(uint);
+    private uint? _pauses;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"pauses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pauses
     {
-      get { return _pauses; }
+      get { return _pauses?? default(uint); }
       set { _pauses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pausesSpecified
+    {
+      get { return _pauses != null; }
+      set { if (value == (_pauses== null)) _pauses = value ? this.pauses : (uint?)null; }
+    }
+    private bool ShouldSerializepauses() { return pausesSpecified; }
+    private void Resetpauses() { pausesSpecified = false; }
+    
 
-    private uint _unpauses = default(uint);
+    private uint? _unpauses;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"unpauses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unpauses
     {
-      get { return _unpauses; }
+      get { return _unpauses?? default(uint); }
       set { _unpauses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unpausesSpecified
+    {
+      get { return _unpauses != null; }
+      set { if (value == (_unpauses== null)) _unpauses = value ? this.unpauses : (uint?)null; }
+    }
+    private bool ShouldSerializeunpauses() { return unpausesSpecified; }
+    private void Resetunpauses() { unpausesSpecified = false; }
+    
 
-    private uint _lines_drawn = default(uint);
+    private uint? _lines_drawn;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"lines_drawn", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lines_drawn
     {
-      get { return _lines_drawn; }
+      get { return _lines_drawn?? default(uint); }
       set { _lines_drawn = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lines_drawnSpecified
+    {
+      get { return _lines_drawn != null; }
+      set { if (value == (_lines_drawn== null)) _lines_drawn = value ? this.lines_drawn : (uint?)null; }
+    }
+    private bool ShouldSerializelines_drawn() { return lines_drawnSpecified; }
+    private void Resetlines_drawn() { lines_drawnSpecified = false; }
+    
 
-    private uint _voice_chat_seconds = default(uint);
+    private uint? _voice_chat_seconds;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"voice_chat_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint voice_chat_seconds
     {
-      get { return _voice_chat_seconds; }
+      get { return _voice_chat_seconds?? default(uint); }
       set { _voice_chat_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voice_chat_secondsSpecified
+    {
+      get { return _voice_chat_seconds != null; }
+      set { if (value == (_voice_chat_seconds== null)) _voice_chat_seconds = value ? this.voice_chat_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializevoice_chat_seconds() { return voice_chat_secondsSpecified; }
+    private void Resetvoice_chat_seconds() { voice_chat_secondsSpecified = false; }
+    
 
-    private uint _chat_mutes = default(uint);
+    private uint? _chat_mutes;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"chat_mutes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint chat_mutes
     {
-      get { return _chat_mutes; }
+      get { return _chat_mutes?? default(uint); }
       set { _chat_mutes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_mutesSpecified
+    {
+      get { return _chat_mutes != null; }
+      set { if (value == (_chat_mutes== null)) _chat_mutes = value ? this.chat_mutes : (uint?)null; }
+    }
+    private bool ShouldSerializechat_mutes() { return chat_mutesSpecified; }
+    private void Resetchat_mutes() { chat_mutesSpecified = false; }
+    
 
-    private uint _voice_mutes = default(uint);
+    private uint? _voice_mutes;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"voice_mutes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint voice_mutes
     {
-      get { return _voice_mutes; }
+      get { return _voice_mutes?? default(uint); }
       set { _voice_mutes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voice_mutesSpecified
+    {
+      get { return _voice_mutes != null; }
+      set { if (value == (_voice_mutes== null)) _voice_mutes = value ? this.voice_mutes : (uint?)null; }
+    }
+    private bool ShouldSerializevoice_mutes() { return voice_mutesSpecified; }
+    private void Resetvoice_mutes() { voice_mutesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2177,23 +3772,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameMatchSignoutResponse() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _replay_salt = default(uint);
+    private uint? _replay_salt;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"replay_salt", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_salt
     {
-      get { return _replay_salt; }
+      get { return _replay_salt?? default(uint); }
       set { _replay_salt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_saltSpecified
+    {
+      get { return _replay_salt != null; }
+      set { if (value == (_replay_salt== null)) _replay_salt = value ? this.replay_salt : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_salt() { return replay_saltSpecified; }
+    private void Resetreplay_salt() { replay_saltSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CLobbyTimedRewardDetails> _timed_reward_details = new global::System.Collections.Generic.List<CLobbyTimedRewardDetails>();
     [global::ProtoBuf.ProtoMember(3, Name=@"timed_reward_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CLobbyTimedRewardDetails> timed_reward_details
@@ -2209,14 +3822,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _leagueid = default(uint);
+    private uint? _leagueid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"leagueid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leagueid
     {
-      get { return _leagueid; }
+      get { return _leagueid?? default(uint); }
       set { _leagueid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leagueidSpecified
+    {
+      get { return _leagueid != null; }
+      set { if (value == (_leagueid== null)) _leagueid = value ? this.leagueid : (uint?)null; }
+    }
+    private bool ShouldSerializeleagueid() { return leagueidSpecified; }
+    private void Resetleagueid() { leagueidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGameMatchSignoutResponse.CAdditionalSignoutMsg> _additional_msgs = new global::System.Collections.Generic.List<CMsgGameMatchSignoutResponse.CAdditionalSignoutMsg>();
     [global::ProtoBuf.ProtoMember(6, Name=@"additional_msgs", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGameMatchSignoutResponse.CAdditionalSignoutMsg> additional_msgs
@@ -2225,14 +3847,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _metadata_private_key = default(uint);
+    private uint? _metadata_private_key;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"metadata_private_key", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint metadata_private_key
     {
-      get { return _metadata_private_key; }
+      get { return _metadata_private_key?? default(uint); }
       set { _metadata_private_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadata_private_keySpecified
+    {
+      get { return _metadata_private_key != null; }
+      set { if (value == (_metadata_private_key== null)) _metadata_private_key = value ? this.metadata_private_key : (uint?)null; }
+    }
+    private bool ShouldSerializemetadata_private_key() { return metadata_private_keySpecified; }
+    private void Resetmetadata_private_key() { metadata_private_keySpecified = false; }
+    
 
     private CMsgDOTAMatch _match_details = null;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2255,23 +3886,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CAdditionalSignoutMsg() {}
     
 
-    private uint _id = default(uint);
+    private uint? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint id
     {
-      get { return _id; }
+      get { return _id?? default(uint); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (uint?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private byte[] _contents = null;
+    private byte[] _contents;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"contents", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] contents
     {
-      get { return _contents; }
+      get { return _contents?? null; }
       set { _contents = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contentsSpecified
+    {
+      get { return _contents != null; }
+      set { if (value == (_contents== null)) _contents = value ? this.contents : (byte[])null; }
+    }
+    private bool ShouldSerializecontents() { return contentsSpecified; }
+    private void Resetcontents() { contentsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2283,122 +3932,239 @@ namespace SteamKit2.GC.Dota.Internal
     public PlayerMetadata() {}
     
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _avg_kills_x16 = default(uint);
+    private uint? _avg_kills_x16;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"avg_kills_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_kills_x16
     {
-      get { return _avg_kills_x16; }
+      get { return _avg_kills_x16?? default(uint); }
       set { _avg_kills_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_kills_x16Specified
+    {
+      get { return _avg_kills_x16 != null; }
+      set { if (value == (_avg_kills_x16== null)) _avg_kills_x16 = value ? this.avg_kills_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_kills_x16() { return avg_kills_x16Specified; }
+    private void Resetavg_kills_x16() { avg_kills_x16Specified = false; }
+    
 
-    private uint _avg_deaths_x16 = default(uint);
+    private uint? _avg_deaths_x16;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"avg_deaths_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_deaths_x16
     {
-      get { return _avg_deaths_x16; }
+      get { return _avg_deaths_x16?? default(uint); }
       set { _avg_deaths_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_deaths_x16Specified
+    {
+      get { return _avg_deaths_x16 != null; }
+      set { if (value == (_avg_deaths_x16== null)) _avg_deaths_x16 = value ? this.avg_deaths_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_deaths_x16() { return avg_deaths_x16Specified; }
+    private void Resetavg_deaths_x16() { avg_deaths_x16Specified = false; }
+    
 
-    private uint _avg_assists_x16 = default(uint);
+    private uint? _avg_assists_x16;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"avg_assists_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_assists_x16
     {
-      get { return _avg_assists_x16; }
+      get { return _avg_assists_x16?? default(uint); }
       set { _avg_assists_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_assists_x16Specified
+    {
+      get { return _avg_assists_x16 != null; }
+      set { if (value == (_avg_assists_x16== null)) _avg_assists_x16 = value ? this.avg_assists_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_assists_x16() { return avg_assists_x16Specified; }
+    private void Resetavg_assists_x16() { avg_assists_x16Specified = false; }
+    
 
-    private uint _avg_gpm_x16 = default(uint);
+    private uint? _avg_gpm_x16;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"avg_gpm_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_gpm_x16
     {
-      get { return _avg_gpm_x16; }
+      get { return _avg_gpm_x16?? default(uint); }
       set { _avg_gpm_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_gpm_x16Specified
+    {
+      get { return _avg_gpm_x16 != null; }
+      set { if (value == (_avg_gpm_x16== null)) _avg_gpm_x16 = value ? this.avg_gpm_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_gpm_x16() { return avg_gpm_x16Specified; }
+    private void Resetavg_gpm_x16() { avg_gpm_x16Specified = false; }
+    
 
-    private uint _avg_xpm_x16 = default(uint);
+    private uint? _avg_xpm_x16;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"avg_xpm_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_xpm_x16
     {
-      get { return _avg_xpm_x16; }
+      get { return _avg_xpm_x16?? default(uint); }
       set { _avg_xpm_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_xpm_x16Specified
+    {
+      get { return _avg_xpm_x16 != null; }
+      set { if (value == (_avg_xpm_x16== null)) _avg_xpm_x16 = value ? this.avg_xpm_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_xpm_x16() { return avg_xpm_x16Specified; }
+    private void Resetavg_xpm_x16() { avg_xpm_x16Specified = false; }
+    
 
-    private uint _best_kills_x16 = default(uint);
+    private uint? _best_kills_x16;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"best_kills_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_kills_x16
     {
-      get { return _best_kills_x16; }
+      get { return _best_kills_x16?? default(uint); }
       set { _best_kills_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_kills_x16Specified
+    {
+      get { return _best_kills_x16 != null; }
+      set { if (value == (_best_kills_x16== null)) _best_kills_x16 = value ? this.best_kills_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializebest_kills_x16() { return best_kills_x16Specified; }
+    private void Resetbest_kills_x16() { best_kills_x16Specified = false; }
+    
 
-    private uint _best_assists_x16 = default(uint);
+    private uint? _best_assists_x16;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"best_assists_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_assists_x16
     {
-      get { return _best_assists_x16; }
+      get { return _best_assists_x16?? default(uint); }
       set { _best_assists_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_assists_x16Specified
+    {
+      get { return _best_assists_x16 != null; }
+      set { if (value == (_best_assists_x16== null)) _best_assists_x16 = value ? this.best_assists_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializebest_assists_x16() { return best_assists_x16Specified; }
+    private void Resetbest_assists_x16() { best_assists_x16Specified = false; }
+    
 
-    private uint _best_gpm_x16 = default(uint);
+    private uint? _best_gpm_x16;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"best_gpm_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_gpm_x16
     {
-      get { return _best_gpm_x16; }
+      get { return _best_gpm_x16?? default(uint); }
       set { _best_gpm_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_gpm_x16Specified
+    {
+      get { return _best_gpm_x16 != null; }
+      set { if (value == (_best_gpm_x16== null)) _best_gpm_x16 = value ? this.best_gpm_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializebest_gpm_x16() { return best_gpm_x16Specified; }
+    private void Resetbest_gpm_x16() { best_gpm_x16Specified = false; }
+    
 
-    private uint _best_xpm_x16 = default(uint);
+    private uint? _best_xpm_x16;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"best_xpm_x16", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_xpm_x16
     {
-      get { return _best_xpm_x16; }
+      get { return _best_xpm_x16?? default(uint); }
       set { _best_xpm_x16 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_xpm_x16Specified
+    {
+      get { return _best_xpm_x16 != null; }
+      set { if (value == (_best_xpm_x16== null)) _best_xpm_x16 = value ? this.best_xpm_x16 : (uint?)null; }
+    }
+    private bool ShouldSerializebest_xpm_x16() { return best_xpm_x16Specified; }
+    private void Resetbest_xpm_x16() { best_xpm_x16Specified = false; }
+    
 
-    private uint _win_streak = default(uint);
+    private uint? _win_streak;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"win_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint win_streak
     {
-      get { return _win_streak; }
+      get { return _win_streak?? default(uint); }
       set { _win_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool win_streakSpecified
+    {
+      get { return _win_streak != null; }
+      set { if (value == (_win_streak== null)) _win_streak = value ? this.win_streak : (uint?)null; }
+    }
+    private bool ShouldSerializewin_streak() { return win_streakSpecified; }
+    private void Resetwin_streak() { win_streakSpecified = false; }
+    
 
-    private uint _best_win_streak = default(uint);
+    private uint? _best_win_streak;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"best_win_streak", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint best_win_streak
     {
-      get { return _best_win_streak; }
+      get { return _best_win_streak?? default(uint); }
       set { _best_win_streak = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool best_win_streakSpecified
+    {
+      get { return _best_win_streak != null; }
+      set { if (value == (_best_win_streak== null)) _best_win_streak = value ? this.best_win_streak : (uint?)null; }
+    }
+    private bool ShouldSerializebest_win_streak() { return best_win_streakSpecified; }
+    private void Resetbest_win_streak() { best_win_streakSpecified = false; }
+    
 
-    private uint _games_played = default(uint);
+    private uint? _games_played;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"games_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games_played
     {
-      get { return _games_played; }
+      get { return _games_played?? default(uint); }
       set { _games_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool games_playedSpecified
+    {
+      get { return _games_played != null; }
+      set { if (value == (_games_played== null)) _games_played = value ? this.games_played : (uint?)null; }
+    }
+    private bool ShouldSerializegames_played() { return games_playedSpecified; }
+    private void Resetgames_played() { games_playedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2432,41 +4198,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameMatchSignOutPermissionRequest() {}
     
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
-    private uint _local_attempt = default(uint);
+    private uint? _local_attempt;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"local_attempt", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint local_attempt
     {
-      get { return _local_attempt; }
+      get { return _local_attempt?? default(uint); }
       set { _local_attempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool local_attemptSpecified
+    {
+      get { return _local_attempt != null; }
+      set { if (value == (_local_attempt== null)) _local_attempt = value ? this.local_attempt : (uint?)null; }
+    }
+    private bool ShouldSerializelocal_attempt() { return local_attemptSpecified; }
+    private void Resetlocal_attempt() { local_attemptSpecified = false; }
+    
 
-    private uint _total_attempt = default(uint);
+    private uint? _total_attempt;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_attempt", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_attempt
     {
-      get { return _total_attempt; }
+      get { return _total_attempt?? default(uint); }
       set { _total_attempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_attemptSpecified
+    {
+      get { return _total_attempt != null; }
+      set { if (value == (_total_attempt== null)) _total_attempt = value ? this.total_attempt : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_attempt() { return total_attemptSpecified; }
+    private void Resettotal_attempt() { total_attemptSpecified = false; }
+    
 
-    private uint _seconds_waited = default(uint);
+    private uint? _seconds_waited;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"seconds_waited", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds_waited
     {
-      get { return _seconds_waited; }
+      get { return _seconds_waited?? default(uint); }
       set { _seconds_waited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_waitedSpecified
+    {
+      get { return _seconds_waited != null; }
+      set { if (value == (_seconds_waited== null)) _seconds_waited = value ? this.seconds_waited : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds_waited() { return seconds_waitedSpecified; }
+    private void Resetseconds_waited() { seconds_waitedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2478,32 +4280,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameMatchSignOutPermissionResponse() {}
     
 
-    private bool _permission_granted = (bool)false;
+    private bool? _permission_granted;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"permission_granted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool permission_granted
     {
-      get { return _permission_granted; }
+      get { return _permission_granted?? (bool)false; }
       set { _permission_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permission_grantedSpecified
+    {
+      get { return _permission_granted != null; }
+      set { if (value == (_permission_granted== null)) _permission_granted = value ? this.permission_granted : (bool?)null; }
+    }
+    private bool ShouldSerializepermission_granted() { return permission_grantedSpecified; }
+    private void Resetpermission_granted() { permission_grantedSpecified = false; }
+    
 
-    private bool _abandon_signout = (bool)false;
+    private bool? _abandon_signout;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"abandon_signout", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool abandon_signout
     {
-      get { return _abandon_signout; }
+      get { return _abandon_signout?? (bool)false; }
       set { _abandon_signout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abandon_signoutSpecified
+    {
+      get { return _abandon_signout != null; }
+      set { if (value == (_abandon_signout== null)) _abandon_signout = value ? this.abandon_signout : (bool?)null; }
+    }
+    private bool ShouldSerializeabandon_signout() { return abandon_signoutSpecified; }
+    private void Resetabandon_signout() { abandon_signoutSpecified = false; }
+    
 
-    private uint _retry_delay_seconds = (uint)0;
+    private uint? _retry_delay_seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"retry_delay_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint retry_delay_seconds
     {
-      get { return _retry_delay_seconds; }
+      get { return _retry_delay_seconds?? (uint)0; }
       set { _retry_delay_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool retry_delay_secondsSpecified
+    {
+      get { return _retry_delay_seconds != null; }
+      set { if (value == (_retry_delay_seconds== null)) _retry_delay_seconds = value ? this.retry_delay_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializeretry_delay_seconds() { return retry_delay_secondsSpecified; }
+    private void Resetretry_delay_seconds() { retry_delay_secondsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2515,41 +4344,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTALiveScoreboardUpdate() {}
     
 
-    private uint _tournament_id = default(uint);
+    private uint? _tournament_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tournament_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_id
     {
-      get { return _tournament_id; }
+      get { return _tournament_id?? default(uint); }
       set { _tournament_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_idSpecified
+    {
+      get { return _tournament_id != null; }
+      set { if (value == (_tournament_id== null)) _tournament_id = value ? this.tournament_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_id() { return tournament_idSpecified; }
+    private void Resettournament_id() { tournament_idSpecified = false; }
+    
 
-    private uint _tournament_game_id = default(uint);
+    private uint? _tournament_game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tournament_game_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tournament_game_id
     {
-      get { return _tournament_game_id; }
+      get { return _tournament_game_id?? default(uint); }
       set { _tournament_game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tournament_game_idSpecified
+    {
+      get { return _tournament_game_id != null; }
+      set { if (value == (_tournament_game_id== null)) _tournament_game_id = value ? this.tournament_game_id : (uint?)null; }
+    }
+    private bool ShouldSerializetournament_game_id() { return tournament_game_idSpecified; }
+    private void Resettournament_game_id() { tournament_game_idSpecified = false; }
+    
 
-    private float _duration = default(float);
+    private float? _duration;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float duration
     {
-      get { return _duration; }
+      get { return _duration?? default(float); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (float?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private int _hltv_delay = default(int);
+    private int? _hltv_delay;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hltv_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int hltv_delay
     {
-      get { return _hltv_delay; }
+      get { return _hltv_delay?? default(int); }
       set { _hltv_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hltv_delaySpecified
+    {
+      get { return _hltv_delay != null; }
+      set { if (value == (_hltv_delay== null)) _hltv_delay = value ? this.hltv_delay : (int?)null; }
+    }
+    private bool ShouldSerializehltv_delay() { return hltv_delaySpecified; }
+    private void Resethltv_delay() { hltv_delaySpecified = false; }
+    
 
     private CMsgDOTALiveScoreboardUpdate.Team _team_good = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_good", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2569,32 +4434,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _team_bad = value; }
     }
 
-    private uint _roshan_respawn_timer = default(uint);
+    private uint? _roshan_respawn_timer;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"roshan_respawn_timer", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint roshan_respawn_timer
     {
-      get { return _roshan_respawn_timer; }
+      get { return _roshan_respawn_timer?? default(uint); }
       set { _roshan_respawn_timer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool roshan_respawn_timerSpecified
+    {
+      get { return _roshan_respawn_timer != null; }
+      set { if (value == (_roshan_respawn_timer== null)) _roshan_respawn_timer = value ? this.roshan_respawn_timer : (uint?)null; }
+    }
+    private bool ShouldSerializeroshan_respawn_timer() { return roshan_respawn_timerSpecified; }
+    private void Resetroshan_respawn_timer() { roshan_respawn_timerSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Team")]
   public partial class Team : global::ProtoBuf.IExtensible
   {
@@ -2608,32 +4500,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _tower_state = default(uint);
+    private uint? _tower_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tower_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tower_state
     {
-      get { return _tower_state; }
+      get { return _tower_state?? default(uint); }
       set { _tower_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tower_stateSpecified
+    {
+      get { return _tower_state != null; }
+      set { if (value == (_tower_state== null)) _tower_state = value ? this.tower_state : (uint?)null; }
+    }
+    private bool ShouldSerializetower_state() { return tower_stateSpecified; }
+    private void Resettower_state() { tower_stateSpecified = false; }
+    
 
-    private uint _barracks_state = default(uint);
+    private uint? _barracks_state;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"barracks_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint barracks_state
     {
-      get { return _barracks_state; }
+      get { return _barracks_state?? default(uint); }
       set { _barracks_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool barracks_stateSpecified
+    {
+      get { return _barracks_state != null; }
+      set { if (value == (_barracks_state== null)) _barracks_state = value ? this.barracks_state : (uint?)null; }
+    }
+    private bool ShouldSerializebarracks_state() { return barracks_stateSpecified; }
+    private void Resetbarracks_state() { barracks_stateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _hero_picks = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"hero_picks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> hero_picks
@@ -2654,239 +4573,473 @@ namespace SteamKit2.GC.Dota.Internal
     public Player() {}
     
 
-    private uint _player_slot = default(uint);
+    private uint? _player_slot;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_slot
     {
-      get { return _player_slot; }
+      get { return _player_slot?? default(uint); }
       set { _player_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_slotSpecified
+    {
+      get { return _player_slot != null; }
+      set { if (value == (_player_slot== null)) _player_slot = value ? this.player_slot : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_slot() { return player_slotSpecified; }
+    private void Resetplayer_slot() { player_slotSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private string _hero_name = "";
+    private string _hero_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string hero_name
     {
-      get { return _hero_name; }
+      get { return _hero_name?? ""; }
       set { _hero_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_nameSpecified
+    {
+      get { return _hero_name != null; }
+      set { if (value == (_hero_name== null)) _hero_name = value ? this.hero_name : (string)null; }
+    }
+    private bool ShouldSerializehero_name() { return hero_nameSpecified; }
+    private void Resethero_name() { hero_nameSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _assists = default(uint);
+    private uint? _assists;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"assists", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint assists
     {
-      get { return _assists; }
+      get { return _assists?? default(uint); }
       set { _assists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assistsSpecified
+    {
+      get { return _assists != null; }
+      set { if (value == (_assists== null)) _assists = value ? this.assists : (uint?)null; }
+    }
+    private bool ShouldSerializeassists() { return assistsSpecified; }
+    private void Resetassists() { assistsSpecified = false; }
+    
 
-    private uint _last_hits = default(uint);
+    private uint? _last_hits;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"last_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_hits
     {
-      get { return _last_hits; }
+      get { return _last_hits?? default(uint); }
       set { _last_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_hitsSpecified
+    {
+      get { return _last_hits != null; }
+      set { if (value == (_last_hits== null)) _last_hits = value ? this.last_hits : (uint?)null; }
+    }
+    private bool ShouldSerializelast_hits() { return last_hitsSpecified; }
+    private void Resetlast_hits() { last_hitsSpecified = false; }
+    
 
-    private uint _denies = default(uint);
+    private uint? _denies;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"denies", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint denies
     {
-      get { return _denies; }
+      get { return _denies?? default(uint); }
       set { _denies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deniesSpecified
+    {
+      get { return _denies != null; }
+      set { if (value == (_denies== null)) _denies = value ? this.denies : (uint?)null; }
+    }
+    private bool ShouldSerializedenies() { return deniesSpecified; }
+    private void Resetdenies() { deniesSpecified = false; }
+    
 
-    private uint _gold = default(uint);
+    private uint? _gold;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gold
     {
-      get { return _gold; }
+      get { return _gold?? default(uint); }
       set { _gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool goldSpecified
+    {
+      get { return _gold != null; }
+      set { if (value == (_gold== null)) _gold = value ? this.gold : (uint?)null; }
+    }
+    private bool ShouldSerializegold() { return goldSpecified; }
+    private void Resetgold() { goldSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private float _gold_per_min = default(float);
+    private float? _gold_per_min;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"gold_per_min", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float gold_per_min
     {
-      get { return _gold_per_min; }
+      get { return _gold_per_min?? default(float); }
       set { _gold_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gold_per_minSpecified
+    {
+      get { return _gold_per_min != null; }
+      set { if (value == (_gold_per_min== null)) _gold_per_min = value ? this.gold_per_min : (float?)null; }
+    }
+    private bool ShouldSerializegold_per_min() { return gold_per_minSpecified; }
+    private void Resetgold_per_min() { gold_per_minSpecified = false; }
+    
 
-    private float _xp_per_min = default(float);
+    private float? _xp_per_min;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"xp_per_min", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float xp_per_min
     {
-      get { return _xp_per_min; }
+      get { return _xp_per_min?? default(float); }
       set { _xp_per_min = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_per_minSpecified
+    {
+      get { return _xp_per_min != null; }
+      set { if (value == (_xp_per_min== null)) _xp_per_min = value ? this.xp_per_min : (float?)null; }
+    }
+    private bool ShouldSerializexp_per_min() { return xp_per_minSpecified; }
+    private void Resetxp_per_min() { xp_per_minSpecified = false; }
+    
 
-    private CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState _ultimate_state = CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState.k_EDOTAUltimateStateNotLearned;
+    private CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState? _ultimate_state;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"ultimate_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState.k_EDOTAUltimateStateNotLearned)]
     public CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState ultimate_state
     {
-      get { return _ultimate_state; }
+      get { return _ultimate_state?? CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState.k_EDOTAUltimateStateNotLearned; }
       set { _ultimate_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ultimate_stateSpecified
+    {
+      get { return _ultimate_state != null; }
+      set { if (value == (_ultimate_state== null)) _ultimate_state = value ? this.ultimate_state : (CMsgDOTALiveScoreboardUpdate.Team.Player.DOTAUltimateState?)null; }
+    }
+    private bool ShouldSerializeultimate_state() { return ultimate_stateSpecified; }
+    private void Resetultimate_state() { ultimate_stateSpecified = false; }
+    
 
-    private float _ultimate_cooldown = default(float);
+    private float? _ultimate_cooldown;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"ultimate_cooldown", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ultimate_cooldown
     {
-      get { return _ultimate_cooldown; }
+      get { return _ultimate_cooldown?? default(float); }
       set { _ultimate_cooldown = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ultimate_cooldownSpecified
+    {
+      get { return _ultimate_cooldown != null; }
+      set { if (value == (_ultimate_cooldown== null)) _ultimate_cooldown = value ? this.ultimate_cooldown : (float?)null; }
+    }
+    private bool ShouldSerializeultimate_cooldown() { return ultimate_cooldownSpecified; }
+    private void Resetultimate_cooldown() { ultimate_cooldownSpecified = false; }
+    
 
-    private uint _item0 = default(uint);
+    private uint? _item0;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"item0", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item0
     {
-      get { return _item0; }
+      get { return _item0?? default(uint); }
       set { _item0 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item0Specified
+    {
+      get { return _item0 != null; }
+      set { if (value == (_item0== null)) _item0 = value ? this.item0 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem0() { return item0Specified; }
+    private void Resetitem0() { item0Specified = false; }
+    
 
-    private uint _item1 = default(uint);
+    private uint? _item1;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"item1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item1
     {
-      get { return _item1; }
+      get { return _item1?? default(uint); }
       set { _item1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item1Specified
+    {
+      get { return _item1 != null; }
+      set { if (value == (_item1== null)) _item1 = value ? this.item1 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem1() { return item1Specified; }
+    private void Resetitem1() { item1Specified = false; }
+    
 
-    private uint _item2 = default(uint);
+    private uint? _item2;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"item2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item2
     {
-      get { return _item2; }
+      get { return _item2?? default(uint); }
       set { _item2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item2Specified
+    {
+      get { return _item2 != null; }
+      set { if (value == (_item2== null)) _item2 = value ? this.item2 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem2() { return item2Specified; }
+    private void Resetitem2() { item2Specified = false; }
+    
 
-    private uint _item3 = default(uint);
+    private uint? _item3;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"item3", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item3
     {
-      get { return _item3; }
+      get { return _item3?? default(uint); }
       set { _item3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item3Specified
+    {
+      get { return _item3 != null; }
+      set { if (value == (_item3== null)) _item3 = value ? this.item3 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem3() { return item3Specified; }
+    private void Resetitem3() { item3Specified = false; }
+    
 
-    private uint _item4 = default(uint);
+    private uint? _item4;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"item4", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item4
     {
-      get { return _item4; }
+      get { return _item4?? default(uint); }
       set { _item4 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item4Specified
+    {
+      get { return _item4 != null; }
+      set { if (value == (_item4== null)) _item4 = value ? this.item4 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem4() { return item4Specified; }
+    private void Resetitem4() { item4Specified = false; }
+    
 
-    private uint _item5 = default(uint);
+    private uint? _item5;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"item5", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item5
     {
-      get { return _item5; }
+      get { return _item5?? default(uint); }
       set { _item5 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item5Specified
+    {
+      get { return _item5 != null; }
+      set { if (value == (_item5== null)) _item5 = value ? this.item5 : (uint?)null; }
+    }
+    private bool ShouldSerializeitem5() { return item5Specified; }
+    private void Resetitem5() { item5Specified = false; }
+    
 
-    private uint _respawn_timer = default(uint);
+    private uint? _respawn_timer;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"respawn_timer", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint respawn_timer
     {
-      get { return _respawn_timer; }
+      get { return _respawn_timer?? default(uint); }
       set { _respawn_timer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool respawn_timerSpecified
+    {
+      get { return _respawn_timer != null; }
+      set { if (value == (_respawn_timer== null)) _respawn_timer = value ? this.respawn_timer : (uint?)null; }
+    }
+    private bool ShouldSerializerespawn_timer() { return respawn_timerSpecified; }
+    private void Resetrespawn_timer() { respawn_timerSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _position_x = default(float);
+    private float? _position_x;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"position_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float position_x
     {
-      get { return _position_x; }
+      get { return _position_x?? default(float); }
       set { _position_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool position_xSpecified
+    {
+      get { return _position_x != null; }
+      set { if (value == (_position_x== null)) _position_x = value ? this.position_x : (float?)null; }
+    }
+    private bool ShouldSerializeposition_x() { return position_xSpecified; }
+    private void Resetposition_x() { position_xSpecified = false; }
+    
 
-    private float _position_y = default(float);
+    private float? _position_y;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"position_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float position_y
     {
-      get { return _position_y; }
+      get { return _position_y?? default(float); }
       set { _position_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool position_ySpecified
+    {
+      get { return _position_y != null; }
+      set { if (value == (_position_y== null)) _position_y = value ? this.position_y : (float?)null; }
+    }
+    private bool ShouldSerializeposition_y() { return position_ySpecified; }
+    private void Resetposition_y() { position_ySpecified = false; }
+    
 
-    private uint _net_worth = default(uint);
+    private uint? _net_worth;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"net_worth", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint net_worth
     {
-      get { return _net_worth; }
+      get { return _net_worth?? default(uint); }
       set { _net_worth = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_worthSpecified
+    {
+      get { return _net_worth != null; }
+      set { if (value == (_net_worth== null)) _net_worth = value ? this.net_worth : (uint?)null; }
+    }
+    private bool ShouldSerializenet_worth() { return net_worthSpecified; }
+    private void Resetnet_worth() { net_worthSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTALiveScoreboardUpdate.Team.Player.HeroAbility> _abilities = new global::System.Collections.Generic.List<CMsgDOTALiveScoreboardUpdate.Team.Player.HeroAbility>();
     [global::ProtoBuf.ProtoMember(27, Name=@"abilities", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTALiveScoreboardUpdate.Team.Player.HeroAbility> abilities
@@ -2900,23 +5053,41 @@ namespace SteamKit2.GC.Dota.Internal
     public HeroAbility() {}
     
 
-    private uint _ability_id = default(uint);
+    private uint? _ability_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ability_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ability_id
     {
-      get { return _ability_id; }
+      get { return _ability_id?? default(uint); }
       set { _ability_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ability_idSpecified
+    {
+      get { return _ability_id != null; }
+      set { if (value == (_ability_id== null)) _ability_id = value ? this.ability_id : (uint?)null; }
+    }
+    private bool ShouldSerializeability_id() { return ability_idSpecified; }
+    private void Resetability_id() { ability_idSpecified = false; }
+    
 
-    private uint _ability_level = default(uint);
+    private uint? _ability_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ability_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ability_level
     {
-      get { return _ability_level; }
+      get { return _ability_level?? default(uint); }
       set { _ability_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ability_levelSpecified
+    {
+      get { return _ability_level != null; }
+      set { if (value == (_ability_level== null)) _ability_level = value ? this.ability_level : (uint?)null; }
+    }
+    private bool ShouldSerializeability_level() { return ability_levelSpecified; }
+    private void Resetability_level() { ability_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2960,23 +5131,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARequestPlayerResources() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _player_id = default(uint);
+    private uint? _player_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_id
     {
-      get { return _player_id; }
+      get { return _player_id?? default(uint); }
       set { _player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_idSpecified
+    {
+      get { return _player_id != null; }
+      set { if (value == (_player_id== null)) _player_id = value ? this.player_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_id() { return player_idSpecified; }
+    private void Resetplayer_id() { player_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2988,59 +5177,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARequestPlayerResourcesResponse() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _player_id = default(uint);
+    private uint? _player_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"player_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_id
     {
-      get { return _player_id; }
+      get { return _player_id?? default(uint); }
       set { _player_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_idSpecified
+    {
+      get { return _player_id != null; }
+      set { if (value == (_player_id== null)) _player_id = value ? this.player_id : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_id() { return player_idSpecified; }
+    private void Resetplayer_id() { player_idSpecified = false; }
+    
 
-    private bool _prevent_text_chat = default(bool);
+    private bool? _prevent_text_chat;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"prevent_text_chat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prevent_text_chat
     {
-      get { return _prevent_text_chat; }
+      get { return _prevent_text_chat?? default(bool); }
       set { _prevent_text_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_text_chatSpecified
+    {
+      get { return _prevent_text_chat != null; }
+      set { if (value == (_prevent_text_chat== null)) _prevent_text_chat = value ? this.prevent_text_chat : (bool?)null; }
+    }
+    private bool ShouldSerializeprevent_text_chat() { return prevent_text_chatSpecified; }
+    private void Resetprevent_text_chat() { prevent_text_chatSpecified = false; }
+    
 
-    private bool _prevent_voice_chat = default(bool);
+    private bool? _prevent_voice_chat;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"prevent_voice_chat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prevent_voice_chat
     {
-      get { return _prevent_voice_chat; }
+      get { return _prevent_voice_chat?? default(bool); }
       set { _prevent_voice_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_voice_chatSpecified
+    {
+      get { return _prevent_voice_chat != null; }
+      set { if (value == (_prevent_voice_chat== null)) _prevent_voice_chat = value ? this.prevent_voice_chat : (bool?)null; }
+    }
+    private bool ShouldSerializeprevent_voice_chat() { return prevent_voice_chatSpecified; }
+    private void Resetprevent_voice_chat() { prevent_voice_chatSpecified = false; }
+    
 
-    private bool _low_priority = default(bool);
+    private bool? _low_priority;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority
     {
-      get { return _low_priority; }
+      get { return _low_priority?? default(bool); }
       set { _low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_prioritySpecified
+    {
+      get { return _low_priority != null; }
+      set { if (value == (_low_priority== null)) _low_priority = value ? this.low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority() { return low_prioritySpecified; }
+    private void Resetlow_priority() { low_prioritySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3088,59 +5331,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Result() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _prevent_text_chat = default(bool);
+    private bool? _prevent_text_chat;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prevent_text_chat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prevent_text_chat
     {
-      get { return _prevent_text_chat; }
+      get { return _prevent_text_chat?? default(bool); }
       set { _prevent_text_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_text_chatSpecified
+    {
+      get { return _prevent_text_chat != null; }
+      set { if (value == (_prevent_text_chat== null)) _prevent_text_chat = value ? this.prevent_text_chat : (bool?)null; }
+    }
+    private bool ShouldSerializeprevent_text_chat() { return prevent_text_chatSpecified; }
+    private void Resetprevent_text_chat() { prevent_text_chatSpecified = false; }
+    
 
-    private bool _prevent_voice_chat = default(bool);
+    private bool? _prevent_voice_chat;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"prevent_voice_chat", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prevent_voice_chat
     {
-      get { return _prevent_voice_chat; }
+      get { return _prevent_voice_chat?? default(bool); }
       set { _prevent_voice_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prevent_voice_chatSpecified
+    {
+      get { return _prevent_voice_chat != null; }
+      set { if (value == (_prevent_voice_chat== null)) _prevent_voice_chat = value ? this.prevent_voice_chat : (bool?)null; }
+    }
+    private bool ShouldSerializeprevent_voice_chat() { return prevent_voice_chatSpecified; }
+    private void Resetprevent_voice_chat() { prevent_voice_chatSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private bool _rank_calibrated = default(bool);
+    private bool? _rank_calibrated;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rank_calibrated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool rank_calibrated
     {
-      get { return _rank_calibrated; }
+      get { return _rank_calibrated?? default(bool); }
       set { _rank_calibrated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rank_calibratedSpecified
+    {
+      get { return _rank_calibrated != null; }
+      set { if (value == (_rank_calibrated== null)) _rank_calibrated = value ? this.rank_calibrated : (bool?)null; }
+    }
+    private bool ShouldSerializerank_calibrated() { return rank_calibratedSpecified; }
+    private void Resetrank_calibrated() { rank_calibratedSpecified = false; }
+    
 
-    private bool _low_priority = default(bool);
+    private bool? _low_priority;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority
     {
-      get { return _low_priority; }
+      get { return _low_priority?? default(bool); }
       set { _low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_prioritySpecified
+    {
+      get { return _low_priority != null; }
+      set { if (value == (_low_priority== null)) _low_priority = value ? this.low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority() { return low_prioritySpecified; }
+    private void Resetlow_priority() { low_prioritySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3181,68 +5478,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToRelayConnect() {}
     
 
-    private uint _source_tv_public_addr = default(uint);
+    private uint? _source_tv_public_addr;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source_tv_public_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_public_addr
     {
-      get { return _source_tv_public_addr; }
+      get { return _source_tv_public_addr?? default(uint); }
       set { _source_tv_public_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_public_addrSpecified
+    {
+      get { return _source_tv_public_addr != null; }
+      set { if (value == (_source_tv_public_addr== null)) _source_tv_public_addr = value ? this.source_tv_public_addr : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_public_addr() { return source_tv_public_addrSpecified; }
+    private void Resetsource_tv_public_addr() { source_tv_public_addrSpecified = false; }
+    
 
-    private uint _source_tv_private_addr = default(uint);
+    private uint? _source_tv_private_addr;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"source_tv_private_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_private_addr
     {
-      get { return _source_tv_private_addr; }
+      get { return _source_tv_private_addr?? default(uint); }
       set { _source_tv_private_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_private_addrSpecified
+    {
+      get { return _source_tv_private_addr != null; }
+      set { if (value == (_source_tv_private_addr== null)) _source_tv_private_addr = value ? this.source_tv_private_addr : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_private_addr() { return source_tv_private_addrSpecified; }
+    private void Resetsource_tv_private_addr() { source_tv_private_addrSpecified = false; }
+    
 
-    private uint _source_tv_port = default(uint);
+    private uint? _source_tv_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_tv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_tv_port
     {
-      get { return _source_tv_port; }
+      get { return _source_tv_port?? default(uint); }
       set { _source_tv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_portSpecified
+    {
+      get { return _source_tv_port != null; }
+      set { if (value == (_source_tv_port== null)) _source_tv_port = value ? this.source_tv_port : (uint?)null; }
+    }
+    private bool ShouldSerializesource_tv_port() { return source_tv_portSpecified; }
+    private void Resetsource_tv_port() { source_tv_portSpecified = false; }
+    
 
-    private ulong _game_server_steam_id = default(ulong);
+    private ulong? _game_server_steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_server_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_server_steam_id
     {
-      get { return _game_server_steam_id; }
+      get { return _game_server_steam_id?? default(ulong); }
       set { _game_server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_steam_idSpecified
+    {
+      get { return _game_server_steam_id != null; }
+      set { if (value == (_game_server_steam_id== null)) _game_server_steam_id = value ? this.game_server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_server_steam_id() { return game_server_steam_idSpecified; }
+    private void Resetgame_server_steam_id() { game_server_steam_idSpecified = false; }
+    
 
-    private uint _parent_count = default(uint);
+    private uint? _parent_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"parent_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint parent_count
     {
-      get { return _parent_count; }
+      get { return _parent_count?? default(uint); }
       set { _parent_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parent_countSpecified
+    {
+      get { return _parent_count != null; }
+      set { if (value == (_parent_count== null)) _parent_count = value ? this.parent_count : (uint?)null; }
+    }
+    private bool ShouldSerializeparent_count() { return parent_countSpecified; }
+    private void Resetparent_count() { parent_countSpecified = false; }
+    
 
-    private ulong _tv_unique_secret_code = default(ulong);
+    private ulong? _tv_unique_secret_code;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tv_unique_secret_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tv_unique_secret_code
     {
-      get { return _tv_unique_secret_code; }
+      get { return _tv_unique_secret_code?? default(ulong); }
       set { _tv_unique_secret_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_unique_secret_codeSpecified
+    {
+      get { return _tv_unique_secret_code != null; }
+      set { if (value == (_tv_unique_secret_code== null)) _tv_unique_secret_code = value ? this.tv_unique_secret_code : (ulong?)null; }
+    }
+    private bool ShouldSerializetv_unique_secret_code() { return tv_unique_secret_codeSpecified; }
+    private void Resettv_unique_secret_code() { tv_unique_secret_codeSpecified = false; }
+    
 
-    private ulong _source_tv_steamid = default(ulong);
+    private ulong? _source_tv_steamid;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"source_tv_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong source_tv_steamid
     {
-      get { return _source_tv_steamid; }
+      get { return _source_tv_steamid?? default(ulong); }
       set { _source_tv_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_tv_steamidSpecified
+    {
+      get { return _source_tv_steamid != null; }
+      set { if (value == (_source_tv_steamid== null)) _source_tv_steamid = value ? this.source_tv_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesource_tv_steamid() { return source_tv_steamidSpecified; }
+    private void Resetsource_tv_steamid() { source_tv_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3254,14 +5614,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGCToLANServerRelayConnect() {}
     
 
-    private ulong _relay_steamid = default(ulong);
+    private ulong? _relay_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"relay_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong relay_steamid
     {
-      get { return _relay_steamid; }
+      get { return _relay_steamid?? default(ulong); }
       set { _relay_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool relay_steamidSpecified
+    {
+      get { return _relay_steamid != null; }
+      set { if (value == (_relay_steamid== null)) _relay_steamid = value ? this.relay_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializerelay_steamid() { return relay_steamidSpecified; }
+    private void Resetrelay_steamid() { relay_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3283,14 +5652,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCBanStatusRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3302,41 +5680,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCBanStatusResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private bool _low_priority = default(bool);
+    private bool? _low_priority;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool low_priority
     {
-      get { return _low_priority; }
+      get { return _low_priority?? default(bool); }
       set { _low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool low_prioritySpecified
+    {
+      get { return _low_priority != null; }
+      set { if (value == (_low_priority== null)) _low_priority = value ? this.low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializelow_priority() { return low_prioritySpecified; }
+    private void Resetlow_priority() { low_prioritySpecified = false; }
+    
 
-    private bool _text_chat_banned = default(bool);
+    private bool? _text_chat_banned;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"text_chat_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool text_chat_banned
     {
-      get { return _text_chat_banned; }
+      get { return _text_chat_banned?? default(bool); }
       set { _text_chat_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool text_chat_bannedSpecified
+    {
+      get { return _text_chat_banned != null; }
+      set { if (value == (_text_chat_banned== null)) _text_chat_banned = value ? this.text_chat_banned : (bool?)null; }
+    }
+    private bool ShouldSerializetext_chat_banned() { return text_chat_bannedSpecified; }
+    private void Resettext_chat_banned() { text_chat_bannedSpecified = false; }
+    
 
-    private bool _voice_chat_banned = default(bool);
+    private bool? _voice_chat_banned;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"voice_chat_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool voice_chat_banned
     {
-      get { return _voice_chat_banned; }
+      get { return _voice_chat_banned?? default(bool); }
       set { _voice_chat_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voice_chat_bannedSpecified
+    {
+      get { return _voice_chat_banned != null; }
+      set { if (value == (_voice_chat_banned== null)) _voice_chat_banned = value ? this.voice_chat_banned : (bool?)null; }
+    }
+    private bool ShouldSerializevoice_chat_banned() { return voice_chat_bannedSpecified; }
+    private void Resetvoice_chat_banned() { voice_chat_bannedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3348,104 +5762,203 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgTournamentItemEvent() {}
     
 
-    private uint _killer_account_id = default(uint);
+    private uint? _killer_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_account_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_account_id
     {
-      get { return _killer_account_id; }
+      get { return _killer_account_id?? default(uint); }
       set { _killer_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_account_idSpecified
+    {
+      get { return _killer_account_id != null; }
+      set { if (value == (_killer_account_id== null)) _killer_account_id = value ? this.killer_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_account_id() { return killer_account_idSpecified; }
+    private void Resetkiller_account_id() { killer_account_idSpecified = false; }
+    
 
-    private uint _victim_account_id = default(uint);
+    private uint? _victim_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"victim_account_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint victim_account_id
     {
-      get { return _victim_account_id; }
+      get { return _victim_account_id?? default(uint); }
       set { _victim_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victim_account_idSpecified
+    {
+      get { return _victim_account_id != null; }
+      set { if (value == (_victim_account_id== null)) _victim_account_id = value ? this.victim_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializevictim_account_id() { return victim_account_idSpecified; }
+    private void Resetvictim_account_id() { victim_account_idSpecified = false; }
+    
 
-    private DOTA_TournamentEvents _event_type = DOTA_TournamentEvents.TE_FIRST_BLOOD;
+    private DOTA_TournamentEvents? _event_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_TournamentEvents.TE_FIRST_BLOOD)]
     public DOTA_TournamentEvents event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? DOTA_TournamentEvents.TE_FIRST_BLOOD; }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (DOTA_TournamentEvents?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private int _tv_delay = default(int);
+    private int? _tv_delay;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tv_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int tv_delay
     {
-      get { return _tv_delay; }
+      get { return _tv_delay?? default(int); }
       set { _tv_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tv_delaySpecified
+    {
+      get { return _tv_delay != null; }
+      set { if (value == (_tv_delay== null)) _tv_delay = value ? this.tv_delay : (int?)null; }
+    }
+    private bool ShouldSerializetv_delay() { return tv_delaySpecified; }
+    private void Resettv_delay() { tv_delaySpecified = false; }
+    
 
-    private int _dota_time = default(int);
+    private int? _dota_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"dota_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int dota_time
     {
-      get { return _dota_time; }
+      get { return _dota_time?? default(int); }
       set { _dota_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dota_timeSpecified
+    {
+      get { return _dota_time != null; }
+      set { if (value == (_dota_time== null)) _dota_time = value ? this.dota_time : (int?)null; }
+    }
+    private bool ShouldSerializedota_time() { return dota_timeSpecified; }
+    private void Resetdota_time() { dota_timeSpecified = false; }
+    
 
-    private float _replay_time = default(float);
+    private float? _replay_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"replay_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float replay_time
     {
-      get { return _replay_time; }
+      get { return _replay_time?? default(float); }
       set { _replay_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_timeSpecified
+    {
+      get { return _replay_time != null; }
+      set { if (value == (_replay_time== null)) _replay_time = value ? this.replay_time : (float?)null; }
+    }
+    private bool ShouldSerializereplay_time() { return replay_timeSpecified; }
+    private void Resetreplay_time() { replay_timeSpecified = false; }
+    
 
-    private string _loot_list = "";
+    private string _loot_list;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"loot_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loot_list
     {
-      get { return _loot_list; }
+      get { return _loot_list?? ""; }
       set { _loot_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_listSpecified
+    {
+      get { return _loot_list != null; }
+      set { if (value == (_loot_list== null)) _loot_list = value ? this.loot_list : (string)null; }
+    }
+    private bool ShouldSerializeloot_list() { return loot_listSpecified; }
+    private void Resetloot_list() { loot_listSpecified = false; }
+    
 
-    private uint _event_team = default(uint);
+    private uint? _event_team;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"event_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_team
     {
-      get { return _event_team; }
+      get { return _event_team?? default(uint); }
       set { _event_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_teamSpecified
+    {
+      get { return _event_team != null; }
+      set { if (value == (_event_team== null)) _event_team = value ? this.event_team : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_team() { return event_teamSpecified; }
+    private void Resetevent_team() { event_teamSpecified = false; }
+    
 
-    private uint _multi_kill_count = default(uint);
+    private uint? _multi_kill_count;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"multi_kill_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint multi_kill_count
     {
-      get { return _multi_kill_count; }
+      get { return _multi_kill_count?? default(uint); }
       set { _multi_kill_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool multi_kill_countSpecified
+    {
+      get { return _multi_kill_count != null; }
+      set { if (value == (_multi_kill_count== null)) _multi_kill_count = value ? this.multi_kill_count : (uint?)null; }
+    }
+    private bool ShouldSerializemulti_kill_count() { return multi_kill_countSpecified; }
+    private void Resetmulti_kill_count() { multi_kill_countSpecified = false; }
+    
 
-    private uint _winner_score = default(uint);
+    private uint? _winner_score;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"winner_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint winner_score
     {
-      get { return _winner_score; }
+      get { return _winner_score?? default(uint); }
       set { _winner_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winner_scoreSpecified
+    {
+      get { return _winner_score != null; }
+      set { if (value == (_winner_score== null)) _winner_score = value ? this.winner_score : (uint?)null; }
+    }
+    private bool ShouldSerializewinner_score() { return winner_scoreSpecified; }
+    private void Resetwinner_score() { winner_scoreSpecified = false; }
+    
 
-    private uint _loser_score = default(uint);
+    private uint? _loser_score;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"loser_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint loser_score
     {
-      get { return _loser_score; }
+      get { return _loser_score?? default(uint); }
       set { _loser_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loser_scoreSpecified
+    {
+      get { return _loser_score != null; }
+      set { if (value == (_loser_score== null)) _loser_score = value ? this.loser_score : (uint?)null; }
+    }
+    private bool ShouldSerializeloser_score() { return loser_scoreSpecified; }
+    private void Resetloser_score() { loser_scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CProtoItemHeroStatue> _hero_statues = new global::System.Collections.Generic.List<CProtoItemHeroStatue>();
     [global::ProtoBuf.ProtoMember(12, Name=@"hero_statues", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CProtoItemHeroStatue> hero_statues
@@ -3464,23 +5977,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgTournamentItemEventResponse() {}
     
 
-    private DOTA_TournamentEvents _event_type = DOTA_TournamentEvents.TE_FIRST_BLOOD;
+    private DOTA_TournamentEvents? _event_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_TournamentEvents.TE_FIRST_BLOOD)]
     public DOTA_TournamentEvents event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? DOTA_TournamentEvents.TE_FIRST_BLOOD; }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (DOTA_TournamentEvents?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private uint _viewers_granted = default(uint);
+    private uint? _viewers_granted;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"viewers_granted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint viewers_granted
     {
-      get { return _viewers_granted; }
+      get { return _viewers_granted?? default(uint); }
       set { _viewers_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewers_grantedSpecified
+    {
+      get { return _viewers_granted != null; }
+      set { if (value == (_viewers_granted== null)) _viewers_granted = value ? this.viewers_granted : (uint?)null; }
+    }
+    private bool ShouldSerializeviewers_granted() { return viewers_grantedSpecified; }
+    private void Resetviewers_granted() { viewers_grantedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3492,14 +6023,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgTeamFanfare() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3511,23 +6051,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgResponseTeamFanfare() {}
     
 
-    private uint _fanfare_goodguys = default(uint);
+    private uint? _fanfare_goodguys;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"fanfare_goodguys", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fanfare_goodguys
     {
-      get { return _fanfare_goodguys; }
+      get { return _fanfare_goodguys?? default(uint); }
       set { _fanfare_goodguys = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fanfare_goodguysSpecified
+    {
+      get { return _fanfare_goodguys != null; }
+      set { if (value == (_fanfare_goodguys== null)) _fanfare_goodguys = value ? this.fanfare_goodguys : (uint?)null; }
+    }
+    private bool ShouldSerializefanfare_goodguys() { return fanfare_goodguysSpecified; }
+    private void Resetfanfare_goodguys() { fanfare_goodguysSpecified = false; }
+    
 
-    private uint _fanfare_badguys = default(uint);
+    private uint? _fanfare_badguys;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fanfare_badguys", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fanfare_badguys
     {
-      get { return _fanfare_badguys; }
+      get { return _fanfare_badguys?? default(uint); }
       set { _fanfare_badguys = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fanfare_badguysSpecified
+    {
+      get { return _fanfare_badguys != null; }
+      set { if (value == (_fanfare_badguys== null)) _fanfare_badguys = value ? this.fanfare_badguys : (uint?)null; }
+    }
+    private bool ShouldSerializefanfare_badguys() { return fanfare_badguysSpecified; }
+    private void Resetfanfare_badguys() { fanfare_badguysSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3539,32 +6097,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameServerUploadSaveGame() {}
     
 
-    private uint _game_time = default(uint);
+    private uint? _game_time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(uint); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (uint?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private byte[] _save_game_data = null;
+    private byte[] _save_game_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"save_game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] save_game_data
     {
-      get { return _save_game_data; }
+      get { return _save_game_data?? null; }
       set { _save_game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_game_dataSpecified
+    {
+      get { return _save_game_data != null; }
+      set { if (value == (_save_game_data== null)) _save_game_data = value ? this.save_game_data : (byte[])null; }
+    }
+    private bool ShouldSerializesave_game_data() { return save_game_dataSpecified; }
+    private void Resetsave_game_data() { save_game_dataSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _player_steam_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(4, Name=@"player_steam_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> player_steam_ids
@@ -3583,14 +6168,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameServerSaveGameResult() {}
     
 
-    private CMsgGameServerSaveGameResult.Result _result = CMsgGameServerSaveGameResult.Result.SaveSuccessful;
+    private CMsgGameServerSaveGameResult.Result? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerSaveGameResult.Result.SaveSuccessful)]
     public CMsgGameServerSaveGameResult.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgGameServerSaveGameResult.Result.SaveSuccessful; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGameServerSaveGameResult.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -3619,14 +6213,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameServerGetLoadGame() {}
     
 
-    private uint _save_id = default(uint);
+    private uint? _save_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"save_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint save_id
     {
-      get { return _save_id; }
+      get { return _save_id?? default(uint); }
       set { _save_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_idSpecified
+    {
+      get { return _save_id != null; }
+      set { if (value == (_save_id== null)) _save_id = value ? this.save_id : (uint?)null; }
+    }
+    private bool ShouldSerializesave_id() { return save_idSpecified; }
+    private void Resetsave_id() { save_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3638,14 +6241,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGameServerGetLoadGameResult() {}
     
 
-    private byte[] _save_game_data = null;
+    private byte[] _save_game_data;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"save_game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] save_game_data
     {
-      get { return _save_game_data; }
+      get { return _save_game_data?? null; }
       set { _save_game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_game_dataSpecified
+    {
+      get { return _save_game_data != null; }
+      set { if (value == (_save_game_data== null)) _save_game_data = value ? this.save_game_data : (byte[])null; }
+    }
+    private bool ShouldSerializesave_game_data() { return save_game_dataSpecified; }
+    private void Resetsave_game_data() { save_game_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3657,23 +6269,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAGenerateDiretidePrizeList() {}
     
 
-    private uint _prize_list = default(uint);
+    private uint? _prize_list;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prize_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_list
     {
-      get { return _prize_list; }
+      get { return _prize_list?? default(uint); }
       set { _prize_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_listSpecified
+    {
+      get { return _prize_list != null; }
+      set { if (value == (_prize_list== null)) _prize_list = value ? this.prize_list : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_list() { return prize_listSpecified; }
+    private void Resetprize_list() { prize_listSpecified = false; }
+    
 
-    private uint _highest_roshan_level = default(uint);
+    private uint? _highest_roshan_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"highest_roshan_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint highest_roshan_level
     {
-      get { return _highest_roshan_level; }
+      get { return _highest_roshan_level?? default(uint); }
       set { _highest_roshan_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool highest_roshan_levelSpecified
+    {
+      get { return _highest_roshan_level != null; }
+      set { if (value == (_highest_roshan_level== null)) _highest_roshan_level = value ? this.highest_roshan_level : (uint?)null; }
+    }
+    private bool ShouldSerializehighest_roshan_level() { return highest_roshan_levelSpecified; }
+    private void Resethighest_roshan_level() { highest_roshan_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3699,14 +6329,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _prize_list = default(uint);
+    private uint? _prize_list;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"prize_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_list
     {
-      get { return _prize_list; }
+      get { return _prize_list?? default(uint); }
       set { _prize_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_listSpecified
+    {
+      get { return _prize_list != null; }
+      set { if (value == (_prize_list== null)) _prize_list = value ? this.prize_list : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_list() { return prize_listSpecified; }
+    private void Resetprize_list() { prize_listSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3718,23 +6357,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTARewardDiretidePrizes() {}
     
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _prize_list = default(uint);
+    private uint? _prize_list;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prize_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_list
     {
-      get { return _prize_list; }
+      get { return _prize_list?? default(uint); }
       set { _prize_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_listSpecified
+    {
+      get { return _prize_list != null; }
+      set { if (value == (_prize_list== null)) _prize_list = value ? this.prize_list : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_list() { return prize_listSpecified; }
+    private void Resetprize_list() { prize_listSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3746,14 +6403,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTADiretidePrizesRewardedResponse() {}
     
 
-    private uint _prize_list = default(uint);
+    private uint? _prize_list;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prize_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prize_list
     {
-      get { return _prize_list; }
+      get { return _prize_list?? default(uint); }
       set { _prize_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prize_listSpecified
+    {
+      get { return _prize_list != null; }
+      set { if (value == (_prize_list== null)) _prize_list = value ? this.prize_list : (uint?)null; }
+    }
+    private bool ShouldSerializeprize_list() { return prize_listSpecified; }
+    private void Resetprize_list() { prize_listSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3772,82 +6438,154 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _audit_action = default(uint);
+    private uint? _audit_action;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"audit_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint audit_action
     {
-      get { return _audit_action; }
+      get { return _audit_action?? default(uint); }
       set { _audit_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_actionSpecified
+    {
+      get { return _audit_action != null; }
+      set { if (value == (_audit_action== null)) _audit_action = value ? this.audit_action : (uint?)null; }
+    }
+    private bool ShouldSerializeaudit_action() { return audit_actionSpecified; }
+    private void Resetaudit_action() { audit_actionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"AwardPoints")]
   public partial class AwardPoints : global::ProtoBuf.IExtensible
   {
     public AwardPoints() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private int _points = default(int);
+    private int? _points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int points
     {
-      get { return _points; }
+      get { return _points?? default(int); }
       set { _points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pointsSpecified
+    {
+      get { return _points != null; }
+      set { if (value == (_points== null)) _points = value ? this.points : (int?)null; }
+    }
+    private bool ShouldSerializepoints() { return pointsSpecified; }
+    private void Resetpoints() { pointsSpecified = false; }
+    
 
-    private int _premium_points = default(int);
+    private int? _premium_points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"premium_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int premium_points
     {
-      get { return _premium_points; }
+      get { return _premium_points?? default(int); }
       set { _premium_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool premium_pointsSpecified
+    {
+      get { return _premium_points != null; }
+      set { if (value == (_premium_points== null)) _premium_points = value ? this.premium_points : (int?)null; }
+    }
+    private bool ShouldSerializepremium_points() { return premium_pointsSpecified; }
+    private void Resetpremium_points() { premium_pointsSpecified = false; }
+    
 
-    private uint _trade_ban_time = default(uint);
+    private uint? _trade_ban_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"trade_ban_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_time
     {
-      get { return _trade_ban_time; }
+      get { return _trade_ban_time?? default(uint); }
       set { _trade_ban_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_timeSpecified
+    {
+      get { return _trade_ban_time != null; }
+      set { if (value == (_trade_ban_time== null)) _trade_ban_time = value ? this.trade_ban_time : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_time() { return trade_ban_timeSpecified; }
+    private void Resettrade_ban_time() { trade_ban_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3871,28 +6609,46 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"AdditionalDrops")]
   public partial class AdditionalDrops : global::ProtoBuf.IExtensible
   {
     public AdditionalDrops() {}
     
 
-    private string _loot_list = "";
+    private string _loot_list;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"loot_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loot_list
     {
-      get { return _loot_list; }
+      get { return _loot_list?? ""; }
       set { _loot_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_listSpecified
+    {
+      get { return _loot_list != null; }
+      set { if (value == (_loot_list== null)) _loot_list = value ? this.loot_list : (string)null; }
+    }
+    private bool ShouldSerializeloot_list() { return loot_listSpecified; }
+    private void Resetloot_list() { loot_listSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _player_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"player_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> player_account_ids
@@ -3901,23 +6657,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _no_trade = default(bool);
+    private bool? _no_trade;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"no_trade", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool no_trade
     {
-      get { return _no_trade; }
+      get { return _no_trade?? default(bool); }
       set { _no_trade = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool no_tradeSpecified
+    {
+      get { return _no_trade != null; }
+      set { if (value == (_no_trade== null)) _no_trade = value ? this.no_trade : (bool?)null; }
+    }
+    private bool ShouldSerializeno_trade() { return no_tradeSpecified; }
+    private void Resetno_trade() { no_tradeSpecified = false; }
+    
 
-    private bool _randomize_reward = default(bool);
+    private bool? _randomize_reward;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"randomize_reward", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool randomize_reward
     {
-      get { return _randomize_reward; }
+      get { return _randomize_reward?? default(bool); }
       set { _randomize_reward = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool randomize_rewardSpecified
+    {
+      get { return _randomize_reward != null; }
+      set { if (value == (_randomize_reward== null)) _randomize_reward = value ? this.randomize_reward : (bool?)null; }
+    }
+    private bool ShouldSerializerandomize_reward() { return randomize_rewardSpecified; }
+    private void Resetrandomize_reward() { randomize_rewardSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3934,14 +6708,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDOTAFrostivusTimeElapsed() {}
     
 
-    private uint _seconds = default(uint);
+    private uint? _seconds;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds
     {
-      get { return _seconds; }
+      get { return _seconds?? default(uint); }
       set { _seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secondsSpecified
+    {
+      get { return _seconds != null; }
+      set { if (value == (_seconds== null)) _seconds = value ? this.seconds : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds() { return secondsSpecified; }
+    private void Resetseconds() { secondsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDOTAFrostivusTimeElapsed.User> _users = new global::System.Collections.Generic.List<CMsgDOTAFrostivusTimeElapsed.User>();
     [global::ProtoBuf.ProtoMember(2, Name=@"users", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDOTAFrostivusTimeElapsed.User> users
@@ -3950,37 +6733,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"User")]
   public partial class User : global::ProtoBuf.IExtensible
   {
     public User() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _time_elapsed_s = default(uint);
+    private uint? _time_elapsed_s;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_elapsed_s", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_elapsed_s
     {
-      get { return _time_elapsed_s; }
+      get { return _time_elapsed_s?? default(uint); }
       set { _time_elapsed_s = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_elapsed_sSpecified
+    {
+      get { return _time_elapsed_s != null; }
+      set { if (value == (_time_elapsed_s== null)) _time_elapsed_s = value ? this.time_elapsed_s : (uint?)null; }
+    }
+    private bool ShouldSerializetime_elapsed_s() { return time_elapsed_sSpecified; }
+    private void Resettime_elapsed_s() { time_elapsed_sSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3997,23 +6807,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerPingRequest() {}
     
 
-    private ulong _request_id = default(ulong);
+    private ulong? _request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(ulong); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
 
-    private ulong _request_time = default(ulong);
+    private ulong? _request_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"request_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong request_time
     {
-      get { return _request_time; }
+      get { return _request_time?? default(ulong); }
       set { _request_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_timeSpecified
+    {
+      get { return _request_time != null; }
+      set { if (value == (_request_time== null)) _request_time = value ? this.request_time : (ulong?)null; }
+    }
+    private bool ShouldSerializerequest_time() { return request_timeSpecified; }
+    private void Resetrequest_time() { request_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4025,32 +6853,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerPingResponse() {}
     
 
-    private ulong _request_id = default(ulong);
+    private ulong? _request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong request_id
     {
-      get { return _request_id; }
+      get { return _request_id?? default(ulong); }
       set { _request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_idSpecified
+    {
+      get { return _request_id != null; }
+      set { if (value == (_request_id== null)) _request_id = value ? this.request_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerequest_id() { return request_idSpecified; }
+    private void Resetrequest_id() { request_idSpecified = false; }
+    
 
-    private ulong _request_time = default(ulong);
+    private ulong? _request_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"request_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong request_time
     {
-      get { return _request_time; }
+      get { return _request_time?? default(ulong); }
       set { _request_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_timeSpecified
+    {
+      get { return _request_time != null; }
+      set { if (value == (_request_time== null)) _request_time = value ? this.request_time : (ulong?)null; }
+    }
+    private bool ShouldSerializerequest_time() { return request_timeSpecified; }
+    private void Resetrequest_time() { request_timeSpecified = false; }
+    
 
-    private uint _cluster = default(uint);
+    private uint? _cluster;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cluster", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cluster
     {
-      get { return _cluster; }
+      get { return _cluster?? default(uint); }
       set { _cluster = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clusterSpecified
+    {
+      get { return _cluster != null; }
+      set { if (value == (_cluster== null)) _cluster = value ? this.cluster : (uint?)null; }
+    }
+    private bool ShouldSerializecluster() { return clusterSpecified; }
+    private void Resetcluster() { clusterSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4062,14 +6917,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerConsoleCommand() {}
     
 
-    private string _console_command = "";
+    private string _console_command;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"console_command", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string console_command
     {
-      get { return _console_command; }
+      get { return _console_command?? ""; }
       set { _console_command = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool console_commandSpecified
+    {
+      get { return _console_command != null; }
+      set { if (value == (_console_command== null)) _console_command = value ? this.console_command : (string)null; }
+    }
+    private bool ShouldSerializeconsole_command() { return console_commandSpecified; }
+    private void Resetconsole_command() { console_commandSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4081,14 +6945,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerGetEventPoints() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _account_id = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> account_id
@@ -4107,14 +6980,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerGetEventPointsResponse() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgServerGetEventPointsResponse.Points> _points = new global::System.Collections.Generic.List<CMsgServerGetEventPointsResponse.Points>();
     [global::ProtoBuf.ProtoMember(2, Name=@"points", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgServerGetEventPointsResponse.Points> points
@@ -4128,32 +7010,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Points() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _points_total = default(uint);
+    private uint? _points_total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points_total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_total
     {
-      get { return _points_total; }
+      get { return _points_total?? default(uint); }
       set { _points_total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_totalSpecified
+    {
+      get { return _points_total != null; }
+      set { if (value == (_points_total== null)) _points_total = value ? this.points_total : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_total() { return points_totalSpecified; }
+    private void Resetpoints_total() { points_totalSpecified = false; }
+    
 
-    private bool _owned = default(bool);
+    private bool? _owned;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool owned
     {
-      get { return _owned; }
+      get { return _owned?? default(bool); }
       set { _owned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownedSpecified
+    {
+      get { return _owned != null; }
+      set { if (value == (_owned== null)) _owned = value ? this.owned : (bool?)null; }
+    }
+    private bool ShouldSerializeowned() { return ownedSpecified; }
+    private void Resetowned() { ownedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4182,59 +7091,113 @@ namespace SteamKit2.GC.Dota.Internal
     public Survey() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _question_id = default(uint);
+    private uint? _question_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"question_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint question_id
     {
-      get { return _question_id; }
+      get { return _question_id?? default(uint); }
       set { _question_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool question_idSpecified
+    {
+      get { return _question_id != null; }
+      set { if (value == (_question_id== null)) _question_id = value ? this.question_id : (uint?)null; }
+    }
+    private bool ShouldSerializequestion_id() { return question_idSpecified; }
+    private void Resetquestion_id() { question_idSpecified = false; }
+    
 
-    private uint _expire_time = default(uint);
+    private uint? _expire_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expire_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expire_time
     {
-      get { return _expire_time; }
+      get { return _expire_time?? default(uint); }
       set { _expire_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expire_timeSpecified
+    {
+      get { return _expire_time != null; }
+      set { if (value == (_expire_time== null)) _expire_time = value ? this.expire_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpire_time() { return expire_timeSpecified; }
+    private void Resetexpire_time() { expire_timeSpecified = false; }
+    
 
-    private ulong _survey_key = default(ulong);
+    private ulong? _survey_key;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"survey_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong survey_key
     {
-      get { return _survey_key; }
+      get { return _survey_key?? default(ulong); }
       set { _survey_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_keySpecified
+    {
+      get { return _survey_key != null; }
+      set { if (value == (_survey_key== null)) _survey_key = value ? this.survey_key : (ulong?)null; }
+    }
+    private bool ShouldSerializesurvey_key() { return survey_keySpecified; }
+    private void Resetsurvey_key() { survey_keySpecified = false; }
+    
 
-    private ulong _extra_data = default(ulong);
+    private ulong? _extra_data;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"extra_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong extra_data
     {
-      get { return _extra_data; }
+      get { return _extra_data?? default(ulong); }
       set { _extra_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool extra_dataSpecified
+    {
+      get { return _extra_data != null; }
+      set { if (value == (_extra_data== null)) _extra_data = value ? this.extra_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeextra_data() { return extra_dataSpecified; }
+    private void Resetextra_data() { extra_dataSpecified = false; }
+    
 
-    private ulong _extra_data_32 = default(ulong);
+    private ulong? _extra_data_32;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"extra_data_32", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong extra_data_32
     {
-      get { return _extra_data_32; }
+      get { return _extra_data_32?? default(ulong); }
       set { _extra_data_32 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool extra_data_32Specified
+    {
+      get { return _extra_data_32 != null; }
+      set { if (value == (_extra_data_32== null)) _extra_data_32 = value ? this.extra_data_32 : (ulong?)null; }
+    }
+    private bool ShouldSerializeextra_data_32() { return extra_data_32Specified; }
+    private void Resetextra_data_32() { extra_data_32Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4251,14 +7214,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerGrantSurveyPermissionResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4270,32 +7242,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCMatchConnectionStats() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _region_id = default(uint);
+    private uint? _region_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"region_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_id
     {
-      get { return _region_id; }
+      get { return _region_id?? default(uint); }
       set { _region_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_idSpecified
+    {
+      get { return _region_id != null; }
+      set { if (value == (_region_id== null)) _region_id = value ? this.region_id : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_id() { return region_idSpecified; }
+    private void Resetregion_id() { region_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgServerToGCMatchConnectionStats.Player> _players = new global::System.Collections.Generic.List<CMsgServerToGCMatchConnectionStats.Player>();
     [global::ProtoBuf.ProtoMember(4, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgServerToGCMatchConnectionStats.Player> players
@@ -4304,73 +7303,136 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _cluster_id = default(uint);
+    private uint? _cluster_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cluster_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cluster_id
     {
-      get { return _cluster_id; }
+      get { return _cluster_id?? default(uint); }
       set { _cluster_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cluster_idSpecified
+    {
+      get { return _cluster_id != null; }
+      set { if (value == (_cluster_id== null)) _cluster_id = value ? this.cluster_id : (uint?)null; }
+    }
+    private bool ShouldSerializecluster_id() { return cluster_idSpecified; }
+    private void Resetcluster_id() { cluster_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _avg_ping_ms = default(uint);
+    private uint? _avg_ping_ms;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"avg_ping_ms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_ping_ms
     {
-      get { return _avg_ping_ms; }
+      get { return _avg_ping_ms?? default(uint); }
       set { _avg_ping_ms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_ping_msSpecified
+    {
+      get { return _avg_ping_ms != null; }
+      set { if (value == (_avg_ping_ms== null)) _avg_ping_ms = value ? this.avg_ping_ms : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_ping_ms() { return avg_ping_msSpecified; }
+    private void Resetavg_ping_ms() { avg_ping_msSpecified = false; }
+    
 
-    private float _packet_loss = default(float);
+    private float? _packet_loss;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"packet_loss", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float packet_loss
     {
-      get { return _packet_loss; }
+      get { return _packet_loss?? default(float); }
       set { _packet_loss = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packet_lossSpecified
+    {
+      get { return _packet_loss != null; }
+      set { if (value == (_packet_loss== null)) _packet_loss = value ? this.packet_loss : (float?)null; }
+    }
+    private bool ShouldSerializepacket_loss() { return packet_lossSpecified; }
+    private void Resetpacket_loss() { packet_lossSpecified = false; }
+    
 
-    private float _ping_deviation = default(float);
+    private float? _ping_deviation;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ping_deviation", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ping_deviation
     {
-      get { return _ping_deviation; }
+      get { return _ping_deviation?? default(float); }
       set { _ping_deviation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ping_deviationSpecified
+    {
+      get { return _ping_deviation != null; }
+      set { if (value == (_ping_deviation== null)) _ping_deviation = value ? this.ping_deviation : (float?)null; }
+    }
+    private bool ShouldSerializeping_deviation() { return ping_deviationSpecified; }
+    private void Resetping_deviation() { ping_deviationSpecified = false; }
+    
 
-    private uint _full_resends = default(uint);
+    private uint? _full_resends;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"full_resends", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint full_resends
     {
-      get { return _full_resends; }
+      get { return _full_resends?? default(uint); }
       set { _full_resends = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool full_resendsSpecified
+    {
+      get { return _full_resends != null; }
+      set { if (value == (_full_resends== null)) _full_resends = value ? this.full_resends : (uint?)null; }
+    }
+    private bool ShouldSerializefull_resends() { return full_resendsSpecified; }
+    private void Resetfull_resends() { full_resendsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4387,14 +7449,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerGCUpdateSpectatorCount() {}
     
 
-    private uint _spectator_count = default(uint);
+    private uint? _spectator_count;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"spectator_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spectator_count
     {
-      get { return _spectator_count; }
+      get { return _spectator_count?? default(uint); }
       set { _spectator_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spectator_countSpecified
+    {
+      get { return _spectator_count != null; }
+      set { if (value == (_spectator_count== null)) _spectator_count = value ? this.spectator_count : (uint?)null; }
+    }
+    private bool ShouldSerializespectator_count() { return spectator_countSpecified; }
+    private void Resetspectator_count() { spectator_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4406,14 +7477,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CSerializedCombatLog() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CSerializedCombatLog.Dictionary _dictionary = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"dictionary", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -4511,14 +7591,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CUserEquips() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CAdditionalEquipSlot> _equips = new global::System.Collections.Generic.List<CAdditionalEquipSlot>();
     [global::ProtoBuf.ProtoMember(2, Name=@"equips", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CAdditionalEquipSlot> equips
@@ -4588,23 +7677,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Record() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(5, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -4628,50 +7735,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSuspiciousActivity() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ESuspiciousActivity _activity = ESuspiciousActivity.k_ESuspiciousActivity_VAC_MultipleInstances;
+    private ESuspiciousActivity? _activity;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"activity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ESuspiciousActivity.k_ESuspiciousActivity_VAC_MultipleInstances)]
     public ESuspiciousActivity activity
     {
-      get { return _activity; }
+      get { return _activity?? ESuspiciousActivity.k_ESuspiciousActivity_VAC_MultipleInstances; }
       set { _activity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activitySpecified
+    {
+      get { return _activity != null; }
+      set { if (value == (_activity== null)) _activity = value ? this.activity : (ESuspiciousActivity?)null; }
+    }
+    private bool ShouldSerializeactivity() { return activitySpecified; }
+    private void Resetactivity() { activitySpecified = false; }
+    
 
-    private int _intdata1 = default(int);
+    private int? _intdata1;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"intdata1", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int intdata1
     {
-      get { return _intdata1; }
+      get { return _intdata1?? default(int); }
       set { _intdata1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool intdata1Specified
+    {
+      get { return _intdata1 != null; }
+      set { if (value == (_intdata1== null)) _intdata1 = value ? this.intdata1 : (int?)null; }
+    }
+    private bool ShouldSerializeintdata1() { return intdata1Specified; }
+    private void Resetintdata1() { intdata1Specified = false; }
+    
 
-    private int _intdata2 = default(int);
+    private int? _intdata2;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"intdata2", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int intdata2
     {
-      get { return _intdata2; }
+      get { return _intdata2?? default(int); }
       set { _intdata2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool intdata2Specified
+    {
+      get { return _intdata2 != null; }
+      set { if (value == (_intdata2== null)) _intdata2 = value ? this.intdata2 : (int?)null; }
+    }
+    private bool ShouldSerializeintdata2() { return intdata2Specified; }
+    private void Resetintdata2() { intdata2Specified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4693,14 +7845,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCRequestStatus_Response() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4733,50 +7894,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _assassin_won = default(bool);
+    private bool? _assassin_won;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"assassin_won", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool assassin_won
     {
-      get { return _assassin_won; }
+      get { return _assassin_won?? default(bool); }
       set { _assassin_won = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool assassin_wonSpecified
+    {
+      get { return _assassin_won != null; }
+      set { if (value == (_assassin_won== null)) _assassin_won = value ? this.assassin_won : (bool?)null; }
+    }
+    private bool ShouldSerializeassassin_won() { return assassin_wonSpecified; }
+    private void Resetassassin_won() { assassin_wonSpecified = false; }
+    
 
-    private uint _target_hero_id = default(uint);
+    private uint? _target_hero_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"target_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_hero_id
     {
-      get { return _target_hero_id; }
+      get { return _target_hero_id?? default(uint); }
       set { _target_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_hero_idSpecified
+    {
+      get { return _target_hero_id != null; }
+      set { if (value == (_target_hero_id== null)) _target_hero_id = value ? this.target_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_hero_id() { return target_hero_idSpecified; }
+    private void Resettarget_hero_id() { target_hero_idSpecified = false; }
+    
 
-    private bool _contract_completed = default(bool);
+    private bool? _contract_completed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"contract_completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool contract_completed
     {
-      get { return _contract_completed; }
+      get { return _contract_completed?? default(bool); }
       set { _contract_completed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contract_completedSpecified
+    {
+      get { return _contract_completed != null; }
+      set { if (value == (_contract_completed== null)) _contract_completed = value ? this.contract_completed : (bool?)null; }
+    }
+    private bool ShouldSerializecontract_completed() { return contract_completedSpecified; }
+    private void Resetcontract_completed() { contract_completedSpecified = false; }
+    
 
-    private float _contract_complete_time = default(float);
+    private float? _contract_complete_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"contract_complete_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float contract_complete_time
     {
-      get { return _contract_complete_time; }
+      get { return _contract_complete_time?? default(float); }
       set { _contract_complete_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contract_complete_timeSpecified
+    {
+      get { return _contract_complete_time != null; }
+      set { if (value == (_contract_complete_time== null)) _contract_complete_time = value ? this.contract_complete_time : (float?)null; }
+    }
+    private bool ShouldSerializecontract_complete_time() { return contract_complete_timeSpecified; }
+    private void Resetcontract_complete_time() { contract_complete_timeSpecified = false; }
+    
 
-    private bool _pa_is_radiant = default(bool);
+    private bool? _pa_is_radiant;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"pa_is_radiant", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool pa_is_radiant
     {
-      get { return _pa_is_radiant; }
+      get { return _pa_is_radiant?? default(bool); }
       set { _pa_is_radiant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pa_is_radiantSpecified
+    {
+      get { return _pa_is_radiant != null; }
+      set { if (value == (_pa_is_radiant== null)) _pa_is_radiant = value ? this.pa_is_radiant : (bool?)null; }
+    }
+    private bool ShouldSerializepa_is_radiant() { return pa_is_radiantSpecified; }
+    private void Resetpa_is_radiant() { pa_is_radiantSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4788,14 +7994,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCGetIngameEventData() {}
     
 
-    private EEvent _event = EEvent.EVENT_ID_NONE;
+    private EEvent? _event;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EEvent.EVENT_ID_NONE)]
     public EEvent @event
     {
-      get { return _event; }
+      get { return _event?? EEvent.EVENT_ID_NONE; }
       set { _event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventSpecified
+    {
+      get { return _event != null; }
+      set { if (value == (_event== null)) _event = value ? this.@event : (EEvent?)null; }
+    }
+    private bool ShouldSerializeevent() { return eventSpecified; }
+    private void Resetevent() { eventSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4824,14 +8039,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCKillSummaries() {}
     
 
-    private uint _ingameevent_id = default(uint);
+    private uint? _ingameevent_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ingameevent_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ingameevent_id
     {
-      get { return _ingameevent_id; }
+      get { return _ingameevent_id?? default(uint); }
       set { _ingameevent_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ingameevent_idSpecified
+    {
+      get { return _ingameevent_id != null; }
+      set { if (value == (_ingameevent_id== null)) _ingameevent_id = value ? this.ingameevent_id : (uint?)null; }
+    }
+    private bool ShouldSerializeingameevent_id() { return ingameevent_idSpecified; }
+    private void Resetingameevent_id() { ingameevent_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgServerToGCKillSummaries.KillSummary> _summaries = new global::System.Collections.Generic.List<CMsgServerToGCKillSummaries.KillSummary>();
     [global::ProtoBuf.ProtoMember(2, Name=@"summaries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgServerToGCKillSummaries.KillSummary> summaries
@@ -4845,32 +8069,59 @@ namespace SteamKit2.GC.Dota.Internal
     public KillSummary() {}
     
 
-    private uint _killer_hero_id = default(uint);
+    private uint? _killer_hero_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_hero_id
     {
-      get { return _killer_hero_id; }
+      get { return _killer_hero_id?? default(uint); }
       set { _killer_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_hero_idSpecified
+    {
+      get { return _killer_hero_id != null; }
+      set { if (value == (_killer_hero_id== null)) _killer_hero_id = value ? this.killer_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_hero_id() { return killer_hero_idSpecified; }
+    private void Resetkiller_hero_id() { killer_hero_idSpecified = false; }
+    
 
-    private uint _victim_hero_id = default(uint);
+    private uint? _victim_hero_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"victim_hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint victim_hero_id
     {
-      get { return _victim_hero_id; }
+      get { return _victim_hero_id?? default(uint); }
       set { _victim_hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victim_hero_idSpecified
+    {
+      get { return _victim_hero_id != null; }
+      set { if (value == (_victim_hero_id== null)) _victim_hero_id = value ? this.victim_hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializevictim_hero_id() { return victim_hero_idSpecified; }
+    private void Resetvictim_hero_id() { victim_hero_idSpecified = false; }
+    
 
-    private uint _kill_count = default(uint);
+    private uint? _kill_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"kill_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kill_count
     {
-      get { return _kill_count; }
+      get { return _kill_count?? default(uint); }
       set { _kill_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kill_countSpecified
+    {
+      get { return _kill_count != null; }
+      set { if (value == (_kill_count== null)) _kill_count = value ? this.kill_count : (uint?)null; }
+    }
+    private bool ShouldSerializekill_count() { return kill_countSpecified; }
+    private void Resetkill_count() { kill_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4887,32 +8138,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerPredictionResult() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private bool _correct = default(bool);
+    private bool? _correct;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"correct", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool correct
     {
-      get { return _correct; }
+      get { return _correct?? default(bool); }
       set { _correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool correctSpecified
+    {
+      get { return _correct != null; }
+      set { if (value == (_correct== null)) _correct = value ? this.correct : (bool?)null; }
+    }
+    private bool ShouldSerializecorrect() { return correctSpecified; }
+    private void Resetcorrect() { correctSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToServerPredictionResult.Prediction> _predictions = new global::System.Collections.Generic.List<CMsgGCToServerPredictionResult.Prediction>();
     [global::ProtoBuf.ProtoMember(4, Name=@"predictions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToServerPredictionResult.Prediction> predictions
@@ -4926,41 +8204,77 @@ namespace SteamKit2.GC.Dota.Internal
     public Prediction() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _num_correct = default(uint);
+    private uint? _num_correct;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_correct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_correct
     {
-      get { return _num_correct; }
+      get { return _num_correct?? default(uint); }
       set { _num_correct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_correctSpecified
+    {
+      get { return _num_correct != null; }
+      set { if (value == (_num_correct== null)) _num_correct = value ? this.num_correct : (uint?)null; }
+    }
+    private bool ShouldSerializenum_correct() { return num_correctSpecified; }
+    private void Resetnum_correct() { num_correctSpecified = false; }
+    
 
-    private uint _num_fails = default(uint);
+    private uint? _num_fails;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_fails", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_fails
     {
-      get { return _num_fails; }
+      get { return _num_fails?? default(uint); }
       set { _num_fails = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_failsSpecified
+    {
+      get { return _num_fails != null; }
+      set { if (value == (_num_fails== null)) _num_fails = value ? this.num_fails : (uint?)null; }
+    }
+    private bool ShouldSerializenum_fails() { return num_failsSpecified; }
+    private void Resetnum_fails() { num_failsSpecified = false; }
+    
 
-    private CMsgGCToServerPredictionResult.Prediction.EResult _result = CMsgGCToServerPredictionResult.Prediction.EResult.k_eResult_ItemGranted;
+    private CMsgGCToServerPredictionResult.Prediction.EResult? _result;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCToServerPredictionResult.Prediction.EResult.k_eResult_ItemGranted)]
     public CMsgGCToServerPredictionResult.Prediction.EResult result
     {
-      get { return _result; }
+      get { return _result?? CMsgGCToServerPredictionResult.Prediction.EResult.k_eResult_ItemGranted; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgGCToServerPredictionResult.Prediction.EResult?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _granted_item_defs = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"granted_item_defs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> granted_item_defs
@@ -4995,23 +8309,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCLockCharmTrading() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5023,14 +8355,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSignOutUpdatePlayerChallenge() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSignOutUpdatePlayerChallenge.Challenge> _completed = new global::System.Collections.Generic.List<CMsgSignOutUpdatePlayerChallenge.Challenge>();
     [global::ProtoBuf.ProtoMember(2, Name=@"completed", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSignOutUpdatePlayerChallenge.Challenge> completed
@@ -5046,64 +8387,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _hero_id = default(uint);
+    private uint? _hero_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"hero_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hero_id
     {
-      get { return _hero_id; }
+      get { return _hero_id?? default(uint); }
       set { _hero_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hero_idSpecified
+    {
+      get { return _hero_id != null; }
+      set { if (value == (_hero_id== null)) _hero_id = value ? this.hero_id : (uint?)null; }
+    }
+    private bool ShouldSerializehero_id() { return hero_idSpecified; }
+    private void Resethero_id() { hero_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Challenge")]
   public partial class Challenge : global::ProtoBuf.IExtensible
   {
     public Challenge() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private uint _sequence_id = default(uint);
+    private uint? _sequence_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sequence_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sequence_id
     {
-      get { return _sequence_id; }
+      get { return _sequence_id?? default(uint); }
       set { _sequence_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequence_idSpecified
+    {
+      get { return _sequence_id != null; }
+      set { if (value == (_sequence_id== null)) _sequence_id = value ? this.sequence_id : (uint?)null; }
+    }
+    private bool ShouldSerializesequence_id() { return sequence_idSpecified; }
+    private void Resetsequence_id() { sequence_idSpecified = false; }
+    
 
-    private uint _progress = default(uint);
+    private uint? _progress;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"progress", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint progress
     {
-      get { return _progress; }
+      get { return _progress?? default(uint); }
       set { _progress = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool progressSpecified
+    {
+      get { return _progress != null; }
+      set { if (value == (_progress== null)) _progress = value ? this.progress : (uint?)null; }
+    }
+    private bool ShouldSerializeprogress() { return progressSpecified; }
+    private void Resetprogress() { progressSpecified = false; }
+    
 
-    private uint _challenge_rank = default(uint);
+    private uint? _challenge_rank;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"challenge_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint challenge_rank
     {
-      get { return _challenge_rank; }
+      get { return _challenge_rank?? default(uint); }
       set { _challenge_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_rankSpecified
+    {
+      get { return _challenge_rank != null; }
+      set { if (value == (_challenge_rank== null)) _challenge_rank = value ? this.challenge_rank : (uint?)null; }
+    }
+    private bool ShouldSerializechallenge_rank() { return challenge_rankSpecified; }
+    private void Resetchallenge_rank() { challenge_rankSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5120,14 +8515,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCRerollPlayerChallenge() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
     private CMsgClientToGCRerollPlayerChallenge _reroll_msg = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reroll_msg", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -5155,64 +8559,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _hold_key = default(ulong);
+    private ulong? _hold_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hold_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong hold_key
     {
-      get { return _hold_key; }
+      get { return _hold_key?? default(ulong); }
       set { _hold_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hold_keySpecified
+    {
+      get { return _hold_key != null; }
+      set { if (value == (_hold_key== null)) _hold_key = value ? this.hold_key : (ulong?)null; }
+    }
+    private bool ShouldSerializehold_key() { return hold_keySpecified; }
+    private void Resethold_key() { hold_keySpecified = false; }
+    
 
-    private uint _hold_until = default(uint);
+    private uint? _hold_until;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hold_until", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hold_until
     {
-      get { return _hold_until; }
+      get { return _hold_until?? default(uint); }
       set { _hold_until = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hold_untilSpecified
+    {
+      get { return _hold_until != null; }
+      set { if (value == (_hold_until== null)) _hold_until = value ? this.hold_until : (uint?)null; }
+    }
+    private bool ShouldSerializehold_until() { return hold_untilSpecified; }
+    private void Resethold_until() { hold_untilSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"HoldRequest")]
   public partial class HoldRequest : global::ProtoBuf.IExtensible
   {
     public HoldRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _points_held = default(uint);
+    private uint? _points_held;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"points_held", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_held
     {
-      get { return _points_held; }
+      get { return _points_held?? default(uint); }
       set { _points_held = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_heldSpecified
+    {
+      get { return _points_held != null; }
+      set { if (value == (_points_held== null)) _points_held = value ? this.points_held : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_held() { return points_heldSpecified; }
+    private void Resetpoints_held() { points_heldSpecified = false; }
+    
 
-    private uint _premium_held = default(uint);
+    private uint? _premium_held;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"premium_held", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint premium_held
     {
-      get { return _premium_held; }
+      get { return _premium_held?? default(uint); }
       set { _premium_held = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool premium_heldSpecified
+    {
+      get { return _premium_held != null; }
+      set { if (value == (_premium_held== null)) _premium_held = value ? this.premium_held : (uint?)null; }
+    }
+    private bool ShouldSerializepremium_held() { return premium_heldSpecified; }
+    private void Resetpremium_held() { premium_heldSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5236,23 +8694,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _hold_key = default(ulong);
+    private ulong? _hold_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hold_key", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong hold_key
     {
-      get { return _hold_key; }
+      get { return _hold_key?? default(ulong); }
       set { _hold_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hold_keySpecified
+    {
+      get { return _hold_key != null; }
+      set { if (value == (_hold_key== null)) _hold_key = value ? this.hold_key : (ulong?)null; }
+    }
+    private bool ShouldSerializehold_key() { return hold_keySpecified; }
+    private void Resethold_key() { hold_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5264,32 +8740,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToServerUpdateBroadcastCheers() {}
     
 
-    private uint _time_stamp = default(uint);
+    private uint? _time_stamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(uint); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (uint?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private uint _team_1_cheers = default(uint);
+    private uint? _team_1_cheers;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"team_1_cheers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_1_cheers
     {
-      get { return _team_1_cheers; }
+      get { return _team_1_cheers?? default(uint); }
       set { _team_1_cheers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_1_cheersSpecified
+    {
+      get { return _team_1_cheers != null; }
+      set { if (value == (_team_1_cheers== null)) _team_1_cheers = value ? this.team_1_cheers : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_1_cheers() { return team_1_cheersSpecified; }
+    private void Resetteam_1_cheers() { team_1_cheersSpecified = false; }
+    
 
-    private uint _team_2_cheers = default(uint);
+    private uint? _team_2_cheers;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_2_cheers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_2_cheers
     {
-      get { return _team_2_cheers; }
+      get { return _team_2_cheers?? default(uint); }
       set { _team_2_cheers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_2_cheersSpecified
+    {
+      get { return _team_2_cheers != null; }
+      set { if (value == (_team_2_cheers== null)) _team_2_cheers = value ? this.team_2_cheers : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_2_cheers() { return team_2_cheersSpecified; }
+    private void Resetteam_2_cheers() { team_2_cheersSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5308,55 +8811,100 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _winnings = default(uint);
+    private uint? _winnings;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"winnings", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint winnings
     {
-      get { return _winnings; }
+      get { return _winnings?? default(uint); }
       set { _winnings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winningsSpecified
+    {
+      get { return _winnings != null; }
+      set { if (value == (_winnings== null)) _winnings = value ? this.winnings : (uint?)null; }
+    }
+    private bool ShouldSerializewinnings() { return winningsSpecified; }
+    private void Resetwinnings() { winningsSpecified = false; }
+    
 
-    private uint _max_wager = default(uint);
+    private uint? _max_wager;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"max_wager", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_wager
     {
-      get { return _max_wager; }
+      get { return _max_wager?? default(uint); }
       set { _max_wager = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_wagerSpecified
+    {
+      get { return _max_wager != null; }
+      set { if (value == (_max_wager== null)) _max_wager = value ? this.max_wager : (uint?)null; }
+    }
+    private bool ShouldSerializemax_wager() { return max_wagerSpecified; }
+    private void Resetmax_wager() { max_wagerSpecified = false; }
+    
 
-    private uint _wager = default(uint);
+    private uint? _wager;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"wager", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint wager
     {
-      get { return _wager; }
+      get { return _wager?? default(uint); }
       set { _wager = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wagerSpecified
+    {
+      get { return _wager != null; }
+      set { if (value == (_wager== null)) _wager = value ? this.wager : (uint?)null; }
+    }
+    private bool ShouldSerializewager() { return wagerSpecified; }
+    private void Resetwager() { wagerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5380,64 +8928,118 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _xp_gained = default(uint);
+    private uint? _xp_gained;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"xp_gained", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint xp_gained
     {
-      get { return _xp_gained; }
+      get { return _xp_gained?? default(uint); }
       set { _xp_gained = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xp_gainedSpecified
+    {
+      get { return _xp_gained != null; }
+      set { if (value == (_xp_gained== null)) _xp_gained = value ? this.xp_gained : (uint?)null; }
+    }
+    private bool ShouldSerializexp_gained() { return xp_gainedSpecified; }
+    private void Resetxp_gained() { xp_gainedSpecified = false; }
+    
 
-    private uint _coins_spent = default(uint);
+    private uint? _coins_spent;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"coins_spent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint coins_spent
     {
-      get { return _coins_spent; }
+      get { return _coins_spent?? default(uint); }
       set { _coins_spent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coins_spentSpecified
+    {
+      get { return _coins_spent != null; }
+      set { if (value == (_coins_spent== null)) _coins_spent = value ? this.coins_spent : (uint?)null; }
+    }
+    private bool ShouldSerializecoins_spent() { return coins_spentSpecified; }
+    private void Resetcoins_spent() { coins_spentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5454,14 +9056,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSignOutCommunityGoalProgress() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSignOutCommunityGoalProgress.EventGoalIncrement> _event_increments = new global::System.Collections.Generic.List<CMsgSignOutCommunityGoalProgress.EventGoalIncrement>();
     [global::ProtoBuf.ProtoMember(2, Name=@"event_increments", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSignOutCommunityGoalProgress.EventGoalIncrement> event_increments
@@ -5475,23 +9086,41 @@ namespace SteamKit2.GC.Dota.Internal
     public EventGoalIncrement() {}
     
 
-    private uint _event_goal_id = default(uint);
+    private uint? _event_goal_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_goal_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_goal_id
     {
-      get { return _event_goal_id; }
+      get { return _event_goal_id?? default(uint); }
       set { _event_goal_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_goal_idSpecified
+    {
+      get { return _event_goal_id != null; }
+      set { if (value == (_event_goal_id== null)) _event_goal_id = value ? this.event_goal_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_goal_id() { return event_goal_idSpecified; }
+    private void Resetevent_goal_id() { event_goal_idSpecified = false; }
+    
 
-    private uint _increment_amount = default(uint);
+    private uint? _increment_amount;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"increment_amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint increment_amount
     {
-      get { return _increment_amount; }
+      get { return _increment_amount?? default(uint); }
       set { _increment_amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool increment_amountSpecified
+    {
+      get { return _increment_amount != null; }
+      set { if (value == (_increment_amount== null)) _increment_amount = value ? this.increment_amount : (uint?)null; }
+    }
+    private bool ShouldSerializeincrement_amount() { return increment_amountSpecified; }
+    private void Resetincrement_amount() { increment_amountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5508,50 +9137,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCPostMatchTip() {}
     
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _tipper_account_id = default(uint);
+    private uint? _tipper_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"tipper_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tipper_account_id
     {
-      get { return _tipper_account_id; }
+      get { return _tipper_account_id?? default(uint); }
       set { _tipper_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tipper_account_idSpecified
+    {
+      get { return _tipper_account_id != null; }
+      set { if (value == (_tipper_account_id== null)) _tipper_account_id = value ? this.tipper_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetipper_account_id() { return tipper_account_idSpecified; }
+    private void Resettipper_account_id() { tipper_account_idSpecified = false; }
+    
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
 
-    private uint _tip_amount = default(uint);
+    private uint? _tip_amount;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tip_amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tip_amount
     {
-      get { return _tip_amount; }
+      get { return _tip_amount?? default(uint); }
       set { _tip_amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tip_amountSpecified
+    {
+      get { return _tip_amount != null; }
+      set { if (value == (_tip_amount== null)) _tip_amount = value ? this.tip_amount : (uint?)null; }
+    }
+    private bool ShouldSerializetip_amount() { return tip_amountSpecified; }
+    private void Resettip_amount() { tip_amountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5563,41 +9237,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCPostMatchTipResponse() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _tipper_account_id = default(uint);
+    private uint? _tipper_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tipper_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tipper_account_id
     {
-      get { return _tipper_account_id; }
+      get { return _tipper_account_id?? default(uint); }
       set { _tipper_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tipper_account_idSpecified
+    {
+      get { return _tipper_account_id != null; }
+      set { if (value == (_tipper_account_id== null)) _tipper_account_id = value ? this.tipper_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializetipper_account_id() { return tipper_account_idSpecified; }
+    private void Resettipper_account_id() { tipper_account_idSpecified = false; }
+    
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
 
-    private CMsgServerToGCPostMatchTipResponse.Result _result = CMsgServerToGCPostMatchTipResponse.Result.SUCCESS;
+    private CMsgServerToGCPostMatchTipResponse.Result? _result;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgServerToGCPostMatchTipResponse.Result.SUCCESS)]
     public CMsgServerToGCPostMatchTipResponse.Result result
     {
-      get { return _result; }
+      get { return _result?? CMsgServerToGCPostMatchTipResponse.Result.SUCCESS; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (CMsgServerToGCPostMatchTipResponse.Result?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"Result", EnumPassthru=true)]
     public enum Result
     {
@@ -5620,32 +9330,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCStartCompendiumInGamePredictions() {}
     
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private float _hltv_delay = default(float);
+    private float? _hltv_delay;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hltv_delay", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float hltv_delay
     {
-      get { return _hltv_delay; }
+      get { return _hltv_delay?? default(float); }
       set { _hltv_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hltv_delaySpecified
+    {
+      get { return _hltv_delay != null; }
+      set { if (value == (_hltv_delay== null)) _hltv_delay = value ? this.hltv_delay : (float?)null; }
+    }
+    private bool ShouldSerializehltv_delay() { return hltv_delaySpecified; }
+    private void Resethltv_delay() { hltv_delaySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _prediction_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"prediction_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> prediction_ids
@@ -5664,14 +9401,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCStartCompendiumInGamePredictionsResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5683,14 +9429,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCCloseCompendiumInGamePredictionVoting() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5702,14 +9457,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCCloseCompendiumInGamePredictionVotingResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5721,14 +9485,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCEndCompendiumInGamePredictions() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5740,14 +9513,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCEndCompendiumInGamePredictionsResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5759,14 +9541,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCCompendiumInGamePredictionResults() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgServerToGCCompendiumInGamePredictionResults.PredictionResult> _results = new global::System.Collections.Generic.List<CMsgServerToGCCompendiumInGamePredictionResults.PredictionResult>();
     [global::ProtoBuf.ProtoMember(2, Name=@"results", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgServerToGCCompendiumInGamePredictionResults.PredictionResult> results
@@ -5780,32 +9571,59 @@ namespace SteamKit2.GC.Dota.Internal
     public PredictionResult() {}
     
 
-    private uint _prediction_id = default(uint);
+    private uint? _prediction_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"prediction_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_id
     {
-      get { return _prediction_id; }
+      get { return _prediction_id?? default(uint); }
       set { _prediction_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_idSpecified
+    {
+      get { return _prediction_id != null; }
+      set { if (value == (_prediction_id== null)) _prediction_id = value ? this.prediction_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_id() { return prediction_idSpecified; }
+    private void Resetprediction_id() { prediction_idSpecified = false; }
+    
 
-    private uint _prediction_value = default(uint);
+    private uint? _prediction_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prediction_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prediction_value
     {
-      get { return _prediction_value; }
+      get { return _prediction_value?? default(uint); }
       set { _prediction_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_valueSpecified
+    {
+      get { return _prediction_value != null; }
+      set { if (value == (_prediction_value== null)) _prediction_value = value ? this.prediction_value : (uint?)null; }
+    }
+    private bool ShouldSerializeprediction_value() { return prediction_valueSpecified; }
+    private void Resetprediction_value() { prediction_valueSpecified = false; }
+    
 
-    private bool _prediction_value_is_mask = default(bool);
+    private bool? _prediction_value_is_mask;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"prediction_value_is_mask", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prediction_value_is_mask
     {
-      get { return _prediction_value_is_mask; }
+      get { return _prediction_value_is_mask?? default(bool); }
       set { _prediction_value_is_mask = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prediction_value_is_maskSpecified
+    {
+      get { return _prediction_value_is_mask != null; }
+      set { if (value == (_prediction_value_is_mask== null)) _prediction_value_is_mask = value ? this.prediction_value_is_mask : (bool?)null; }
+    }
+    private bool ShouldSerializeprediction_value_is_mask() { return prediction_value_is_maskSpecified; }
+    private void Resetprediction_value_is_mask() { prediction_value_is_maskSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5822,14 +9640,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerToGCCompendiumInGamePredictionResultsResponse() {}
     
 
-    private bool _result = default(bool);
+    private bool? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool result
     {
-      get { return _result; }
+      get { return _result?? default(bool); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (bool?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgSharedEnums.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/MsgSharedEnums.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: dota_shared_enums.proto
 namespace SteamKit2.GC.Dota.Internal
 {
@@ -17,59 +19,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CDOTAClientHardwareSpecs() {}
     
 
-    private uint _logical_processors = default(uint);
+    private uint? _logical_processors;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"logical_processors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logical_processors
     {
-      get { return _logical_processors; }
+      get { return _logical_processors?? default(uint); }
       set { _logical_processors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logical_processorsSpecified
+    {
+      get { return _logical_processors != null; }
+      set { if (value == (_logical_processors== null)) _logical_processors = value ? this.logical_processors : (uint?)null; }
+    }
+    private bool ShouldSerializelogical_processors() { return logical_processorsSpecified; }
+    private void Resetlogical_processors() { logical_processorsSpecified = false; }
+    
 
-    private ulong _cpu_cycles_per_second = default(ulong);
+    private ulong? _cpu_cycles_per_second;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cpu_cycles_per_second", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cpu_cycles_per_second
     {
-      get { return _cpu_cycles_per_second; }
+      get { return _cpu_cycles_per_second?? default(ulong); }
       set { _cpu_cycles_per_second = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cpu_cycles_per_secondSpecified
+    {
+      get { return _cpu_cycles_per_second != null; }
+      set { if (value == (_cpu_cycles_per_second== null)) _cpu_cycles_per_second = value ? this.cpu_cycles_per_second : (ulong?)null; }
+    }
+    private bool ShouldSerializecpu_cycles_per_second() { return cpu_cycles_per_secondSpecified; }
+    private void Resetcpu_cycles_per_second() { cpu_cycles_per_secondSpecified = false; }
+    
 
-    private ulong _total_physical_memory = default(ulong);
+    private ulong? _total_physical_memory;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_physical_memory", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong total_physical_memory
     {
-      get { return _total_physical_memory; }
+      get { return _total_physical_memory?? default(ulong); }
       set { _total_physical_memory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_physical_memorySpecified
+    {
+      get { return _total_physical_memory != null; }
+      set { if (value == (_total_physical_memory== null)) _total_physical_memory = value ? this.total_physical_memory : (ulong?)null; }
+    }
+    private bool ShouldSerializetotal_physical_memory() { return total_physical_memorySpecified; }
+    private void Resettotal_physical_memory() { total_physical_memorySpecified = false; }
+    
 
-    private bool _is_64_bit_os = default(bool);
+    private bool? _is_64_bit_os;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_64_bit_os", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_64_bit_os
     {
-      get { return _is_64_bit_os; }
+      get { return _is_64_bit_os?? default(bool); }
       set { _is_64_bit_os = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_64_bit_osSpecified
+    {
+      get { return _is_64_bit_os != null; }
+      set { if (value == (_is_64_bit_os== null)) _is_64_bit_os = value ? this.is_64_bit_os : (bool?)null; }
+    }
+    private bool ShouldSerializeis_64_bit_os() { return is_64_bit_osSpecified; }
+    private void Resetis_64_bit_os() { is_64_bit_osSpecified = false; }
+    
 
-    private ulong _upload_measurement = default(ulong);
+    private ulong? _upload_measurement;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"upload_measurement", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upload_measurement
     {
-      get { return _upload_measurement; }
+      get { return _upload_measurement?? default(ulong); }
       set { _upload_measurement = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_measurementSpecified
+    {
+      get { return _upload_measurement != null; }
+      set { if (value == (_upload_measurement== null)) _upload_measurement = value ? this.upload_measurement : (ulong?)null; }
+    }
+    private bool ShouldSerializeupload_measurement() { return upload_measurementSpecified; }
+    private void Resetupload_measurement() { upload_measurementSpecified = false; }
+    
 
-    private bool _prefer_not_host = default(bool);
+    private bool? _prefer_not_host;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"prefer_not_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prefer_not_host
     {
-      get { return _prefer_not_host; }
+      get { return _prefer_not_host?? default(bool); }
       set { _prefer_not_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prefer_not_hostSpecified
+    {
+      get { return _prefer_not_host != null; }
+      set { if (value == (_prefer_not_host== null)) _prefer_not_host = value ? this.prefer_not_host : (bool?)null; }
+    }
+    private bool ShouldSerializeprefer_not_host() { return prefer_not_hostSpecified; }
+    private void Resetprefer_not_host() { prefer_not_hostSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -81,23 +137,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CDOTASaveGame() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _save_time = default(uint);
+    private uint? _save_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"save_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint save_time
     {
-      get { return _save_time; }
+      get { return _save_time?? default(uint); }
       set { _save_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_timeSpecified
+    {
+      get { return _save_time != null; }
+      set { if (value == (_save_time== null)) _save_time = value ? this.save_time : (uint?)null; }
+    }
+    private bool ShouldSerializesave_time() { return save_timeSpecified; }
+    private void Resetsave_time() { save_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDOTASaveGame.Player> _players = new global::System.Collections.Generic.List<CDOTASaveGame.Player>();
     [global::ProtoBuf.ProtoMember(3, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDOTASaveGame.Player> players
@@ -118,32 +192,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Player() {}
     
 
-    private DOTA_GC_TEAM _team = DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    private DOTA_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS)]
     public DOTA_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (DOTA_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _hero = "";
+    private string _hero;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"hero", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string hero
     {
-      get { return _hero; }
+      get { return _hero?? ""; }
       set { _hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heroSpecified
+    {
+      get { return _hero != null; }
+      set { if (value == (_hero== null)) _hero = value ? this.hero : (string)null; }
+    }
+    private bool ShouldSerializehero() { return heroSpecified; }
+    private void Resethero() { heroSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -155,32 +256,59 @@ namespace SteamKit2.GC.Dota.Internal
     public SaveInstance() {}
     
 
-    private uint _game_time = default(uint);
+    private uint? _game_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_time
     {
-      get { return _game_time; }
+      get { return _game_time?? default(uint); }
       set { _game_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_timeSpecified
+    {
+      get { return _game_time != null; }
+      set { if (value == (_game_time== null)) _game_time = value ? this.game_time : (uint?)null; }
+    }
+    private bool ShouldSerializegame_time() { return game_timeSpecified; }
+    private void Resetgame_time() { game_timeSpecified = false; }
+    
 
-    private uint _team1_score = default(uint);
+    private uint? _team1_score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team1_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team1_score
     {
-      get { return _team1_score; }
+      get { return _team1_score?? default(uint); }
       set { _team1_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team1_scoreSpecified
+    {
+      get { return _team1_score != null; }
+      set { if (value == (_team1_score== null)) _team1_score = value ? this.team1_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam1_score() { return team1_scoreSpecified; }
+    private void Resetteam1_score() { team1_scoreSpecified = false; }
+    
 
-    private uint _team2_score = default(uint);
+    private uint? _team2_score;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team2_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team2_score
     {
-      get { return _team2_score; }
+      get { return _team2_score?? default(uint); }
       set { _team2_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team2_scoreSpecified
+    {
+      get { return _team2_score != null; }
+      set { if (value == (_team2_score== null)) _team2_score = value ? this.team2_score : (uint?)null; }
+    }
+    private bool ShouldSerializeteam2_score() { return team2_scoreSpecified; }
+    private void Resetteam2_score() { team2_scoreSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CDOTASaveGame.SaveInstance.PlayerPositions> _player_positions = new global::System.Collections.Generic.List<CDOTASaveGame.SaveInstance.PlayerPositions>();
     [global::ProtoBuf.ProtoMember(5, Name=@"player_positions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CDOTASaveGame.SaveInstance.PlayerPositions> player_positions
@@ -189,46 +317,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _save_id = default(uint);
+    private uint? _save_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"save_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint save_id
     {
-      get { return _save_id; }
+      get { return _save_id?? default(uint); }
       set { _save_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_idSpecified
+    {
+      get { return _save_id != null; }
+      set { if (value == (_save_id== null)) _save_id = value ? this.save_id : (uint?)null; }
+    }
+    private bool ShouldSerializesave_id() { return save_idSpecified; }
+    private void Resetsave_id() { save_idSpecified = false; }
+    
 
-    private uint _save_time = default(uint);
+    private uint? _save_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"save_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint save_time
     {
-      get { return _save_time; }
+      get { return _save_time?? default(uint); }
       set { _save_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_timeSpecified
+    {
+      get { return _save_time != null; }
+      set { if (value == (_save_time== null)) _save_time = value ? this.save_time : (uint?)null; }
+    }
+    private bool ShouldSerializesave_time() { return save_timeSpecified; }
+    private void Resetsave_time() { save_timeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PlayerPositions")]
   public partial class PlayerPositions : global::ProtoBuf.IExtensible
   {
     public PlayerPositions() {}
     
 
-    private float _x = default(float);
+    private float? _x;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float x
     {
-      get { return _x; }
+      get { return _x?? default(float); }
       set { _x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool xSpecified
+    {
+      get { return _x != null; }
+      set { if (value == (_x== null)) _x = value ? this.x : (float?)null; }
+    }
+    private bool ShouldSerializex() { return xSpecified; }
+    private void Resetx() { xSpecified = false; }
+    
 
-    private float _y = default(float);
+    private float? _y;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float y
     {
-      get { return _y; }
+      get { return _y?? default(float); }
       set { _y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ySpecified
+    {
+      get { return _y != null; }
+      set { if (value == (_y== null)) _y = value ? this.y : (float?)null; }
+    }
+    private bool ShouldSerializey() { return ySpecified; }
+    private void Resety() { ySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/NetworkConnection.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/NetworkConnection.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: network_connection.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.GC.Dota.Internal

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgBase.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -18,95 +20,185 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgProtoBufHeader() {}
     
 
-    private ulong _client_steam_id = default(ulong);
+    private ulong? _client_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_steam_id
     {
-      get { return _client_steam_id; }
+      get { return _client_steam_id?? default(ulong); }
       set { _client_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_steam_idSpecified
+    {
+      get { return _client_steam_id != null; }
+      set { if (value == (_client_steam_id== null)) _client_steam_id = value ? this.client_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_steam_id() { return client_steam_idSpecified; }
+    private void Resetclient_steam_id() { client_steam_idSpecified = false; }
+    
 
-    private int _client_session_id = default(int);
+    private int? _client_session_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int client_session_id
     {
-      get { return _client_session_id; }
+      get { return _client_session_id?? default(int); }
       set { _client_session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_idSpecified
+    {
+      get { return _client_session_id != null; }
+      set { if (value == (_client_session_id== null)) _client_session_id = value ? this.client_session_id : (int?)null; }
+    }
+    private bool ShouldSerializeclient_session_id() { return client_session_idSpecified; }
+    private void Resetclient_session_id() { client_session_idSpecified = false; }
+    
 
-    private uint _source_app_id = default(uint);
+    private uint? _source_app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_app_id
     {
-      get { return _source_app_id; }
+      get { return _source_app_id?? default(uint); }
       set { _source_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_app_idSpecified
+    {
+      get { return _source_app_id != null; }
+      set { if (value == (_source_app_id== null)) _source_app_id = value ? this.source_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializesource_app_id() { return source_app_idSpecified; }
+    private void Resetsource_app_id() { source_app_idSpecified = false; }
+    
 
-    private ulong _job_id_source = (ulong)18446744073709551615;
+    private ulong? _job_id_source;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"job_id_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_source
     {
-      get { return _job_id_source; }
+      get { return _job_id_source?? (ulong)18446744073709551615; }
       set { _job_id_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_sourceSpecified
+    {
+      get { return _job_id_source != null; }
+      set { if (value == (_job_id_source== null)) _job_id_source = value ? this.job_id_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_source() { return job_id_sourceSpecified; }
+    private void Resetjob_id_source() { job_id_sourceSpecified = false; }
+    
 
-    private ulong _job_id_target = (ulong)18446744073709551615;
+    private ulong? _job_id_target;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"job_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_target
     {
-      get { return _job_id_target; }
+      get { return _job_id_target?? (ulong)18446744073709551615; }
       set { _job_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_targetSpecified
+    {
+      get { return _job_id_target != null; }
+      set { if (value == (_job_id_target== null)) _job_id_target = value ? this.job_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_target() { return job_id_targetSpecified; }
+    private void Resetjob_id_target() { job_id_targetSpecified = false; }
+    
 
-    private string _target_job_name = "";
+    private string _target_job_name;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"target_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string target_job_name
     {
-      get { return _target_job_name; }
+      get { return _target_job_name?? ""; }
       set { _target_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_job_nameSpecified
+    {
+      get { return _target_job_name != null; }
+      set { if (value == (_target_job_name== null)) _target_job_name = value ? this.target_job_name : (string)null; }
+    }
+    private bool ShouldSerializetarget_job_name() { return target_job_nameSpecified; }
+    private void Resettarget_job_name() { target_job_nameSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
 
-    private GCProtoBufMsgSrc _gc_msg_src = GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified;
+    private GCProtoBufMsgSrc? _gc_msg_src;
     [global::ProtoBuf.ProtoMember(200, IsRequired = false, Name=@"gc_msg_src", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified)]
     public GCProtoBufMsgSrc gc_msg_src
     {
-      get { return _gc_msg_src; }
+      get { return _gc_msg_src?? GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified; }
       set { _gc_msg_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_msg_srcSpecified
+    {
+      get { return _gc_msg_src != null; }
+      set { if (value == (_gc_msg_src== null)) _gc_msg_src = value ? this.gc_msg_src : (GCProtoBufMsgSrc?)null; }
+    }
+    private bool ShouldSerializegc_msg_src() { return gc_msg_srcSpecified; }
+    private void Resetgc_msg_src() { gc_msg_srcSpecified = false; }
+    
 
-    private uint _gc_dir_index_source = default(uint);
+    private uint? _gc_dir_index_source;
     [global::ProtoBuf.ProtoMember(201, IsRequired = false, Name=@"gc_dir_index_source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_dir_index_source
     {
-      get { return _gc_dir_index_source; }
+      get { return _gc_dir_index_source?? default(uint); }
       set { _gc_dir_index_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_dir_index_sourceSpecified
+    {
+      get { return _gc_dir_index_source != null; }
+      set { if (value == (_gc_dir_index_source== null)) _gc_dir_index_source = value ? this.gc_dir_index_source : (uint?)null; }
+    }
+    private bool ShouldSerializegc_dir_index_source() { return gc_dir_index_sourceSpecified; }
+    private void Resetgc_dir_index_source() { gc_dir_index_sourceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -118,50 +210,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgWebAPIKey() {}
     
 
-    private uint _status = (uint)255;
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)255)]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? (uint)255; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _account_id = (uint)0;
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? (uint)0; }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _publisher_group_id = (uint)0;
+    private uint? _publisher_group_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"publisher_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint publisher_group_id
     {
-      get { return _publisher_group_id; }
+      get { return _publisher_group_id?? (uint)0; }
       set { _publisher_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publisher_group_idSpecified
+    {
+      get { return _publisher_group_id != null; }
+      set { if (value == (_publisher_group_id== null)) _publisher_group_id = value ? this.publisher_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializepublisher_group_id() { return publisher_group_idSpecified; }
+    private void Resetpublisher_group_id() { publisher_group_idSpecified = false; }
+    
 
-    private uint _key_id = default(uint);
+    private uint? _key_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"key_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint key_id
     {
-      get { return _key_id; }
+      get { return _key_id?? default(uint); }
       set { _key_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_idSpecified
+    {
+      get { return _key_id != null; }
+      set { if (value == (_key_id== null)) _key_id = value ? this.key_id : (uint?)null; }
+    }
+    private bool ShouldSerializekey_id() { return key_idSpecified; }
+    private void Resetkey_id() { key_idSpecified = false; }
+    
 
-    private string _domain = "";
+    private string _domain;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"domain", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string domain
     {
-      get { return _domain; }
+      get { return _domain?? ""; }
       set { _domain = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool domainSpecified
+    {
+      get { return _domain != null; }
+      set { if (value == (_domain== null)) _domain = value ? this.domain : (string)null; }
+    }
+    private bool ShouldSerializedomain() { return domainSpecified; }
+    private void Resetdomain() { domainSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,32 +310,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgHttpRequest() {}
     
 
-    private uint _request_method = default(uint);
+    private uint? _request_method;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_method
     {
-      get { return _request_method; }
+      get { return _request_method?? default(uint); }
       set { _request_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_methodSpecified
+    {
+      get { return _request_method != null; }
+      set { if (value == (_request_method== null)) _request_method = value ? this.request_method : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_method() { return request_methodSpecified; }
+    private void Resetrequest_method() { request_methodSpecified = false; }
+    
 
-    private string _hostname = "";
+    private string _hostname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hostname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string hostname
     {
-      get { return _hostname; }
+      get { return _hostname?? ""; }
       set { _hostname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hostnameSpecified
+    {
+      get { return _hostname != null; }
+      set { if (value == (_hostname== null)) _hostname = value ? this.hostname : (string)null; }
+    }
+    private bool ShouldSerializehostname() { return hostnameSpecified; }
+    private void Resethostname() { hostnameSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader>();
     [global::ProtoBuf.ProtoMember(4, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> headers
@@ -221,46 +385,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
 
-    private uint _absolute_timeout = default(uint);
+    private uint? _absolute_timeout;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"absolute_timeout", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint absolute_timeout
     {
-      get { return _absolute_timeout; }
+      get { return _absolute_timeout?? default(uint); }
       set { _absolute_timeout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool absolute_timeoutSpecified
+    {
+      get { return _absolute_timeout != null; }
+      set { if (value == (_absolute_timeout== null)) _absolute_timeout = value ? this.absolute_timeout : (uint?)null; }
+    }
+    private bool ShouldSerializeabsolute_timeout() { return absolute_timeoutSpecified; }
+    private void Resetabsolute_timeout() { absolute_timeoutSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"RequestHeader")]
   public partial class RequestHeader : global::ProtoBuf.IExtensible
   {
     public RequestHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -272,23 +472,41 @@ namespace SteamKit2.GC.Dota.Internal
     public QueryParam() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -305,41 +523,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgWebAPIRequest() {}
     
 
-    private string _UNUSED_job_name = "";
+    private string _UNUSED_job_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"UNUSED_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string UNUSED_job_name
     {
-      get { return _UNUSED_job_name; }
+      get { return _UNUSED_job_name?? ""; }
       set { _UNUSED_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool UNUSED_job_nameSpecified
+    {
+      get { return _UNUSED_job_name != null; }
+      set { if (value == (_UNUSED_job_name== null)) _UNUSED_job_name = value ? this.UNUSED_job_name : (string)null; }
+    }
+    private bool ShouldSerializeUNUSED_job_name() { return UNUSED_job_nameSpecified; }
+    private void ResetUNUSED_job_name() { UNUSED_job_nameSpecified = false; }
+    
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgWebAPIKey _api_key = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"api_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -359,14 +613,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _request = value; }
     }
 
-    private uint _routing_app_id = default(uint);
+    private uint? _routing_app_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"routing_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint routing_app_id
     {
-      get { return _routing_app_id; }
+      get { return _routing_app_id?? default(uint); }
       set { _routing_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_app_idSpecified
+    {
+      get { return _routing_app_id != null; }
+      set { if (value == (_routing_app_id== null)) _routing_app_id = value ? this.routing_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializerouting_app_id() { return routing_app_idSpecified; }
+    private void Resetrouting_app_id() { routing_app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -378,14 +641,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgHttpResponse() {}
     
 
-    private uint _status_code = default(uint);
+    private uint? _status_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_code
     {
-      get { return _status_code; }
+      get { return _status_code?? default(uint); }
       set { _status_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_codeSpecified
+    {
+      get { return _status_code != null; }
+      set { if (value == (_status_code== null)) _status_code = value ? this.status_code : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_code() { return status_codeSpecified; }
+    private void Resetstatus_code() { status_codeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader>();
     [global::ProtoBuf.ProtoMember(2, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> headers
@@ -394,37 +666,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ResponseHeader")]
   public partial class ResponseHeader : global::ProtoBuf.IExtensible
   {
     public ResponseHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -441,23 +740,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMFindAccounts() {}
     
 
-    private uint _search_type = default(uint);
+    private uint? _search_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_type
     {
-      get { return _search_type; }
+      get { return _search_type?? default(uint); }
       set { _search_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_typeSpecified
+    {
+      get { return _search_type != null; }
+      set { if (value == (_search_type== null)) _search_type = value ? this.search_type : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_type() { return search_typeSpecified; }
+    private void Resetsearch_type() { search_typeSpecified = false; }
+    
 
-    private string _search_string = "";
+    private string _search_string;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"search_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_string
     {
-      get { return _search_string; }
+      get { return _search_string?? ""; }
       set { _search_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_stringSpecified
+    {
+      get { return _search_string != null; }
+      set { if (value == (_search_string== null)) _search_string = value ? this.search_string : (string)null; }
+    }
+    private bool ShouldSerializesearch_string() { return search_stringSpecified; }
+    private void Resetsearch_string() { search_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -486,68 +803,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgNotifyWatchdog() {}
     
 
-    private uint _source = default(uint);
+    private uint? _source;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source
     {
-      get { return _source; }
+      get { return _source?? default(uint); }
       set { _source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sourceSpecified
+    {
+      get { return _source != null; }
+      set { if (value == (_source== null)) _source = value ? this.source : (uint?)null; }
+    }
+    private bool ShouldSerializesource() { return sourceSpecified; }
+    private void Resetsource() { sourceSpecified = false; }
+    
 
-    private uint _alert_type = default(uint);
+    private uint? _alert_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"alert_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint alert_type
     {
-      get { return _alert_type; }
+      get { return _alert_type?? default(uint); }
       set { _alert_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool alert_typeSpecified
+    {
+      get { return _alert_type != null; }
+      set { if (value == (_alert_type== null)) _alert_type = value ? this.alert_type : (uint?)null; }
+    }
+    private bool ShouldSerializealert_type() { return alert_typeSpecified; }
+    private void Resetalert_type() { alert_typeSpecified = false; }
+    
 
-    private bool _critical = default(bool);
+    private bool? _critical;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"critical", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool critical
     {
-      get { return _critical; }
+      get { return _critical?? default(bool); }
       set { _critical = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool criticalSpecified
+    {
+      get { return _critical != null; }
+      set { if (value == (_critical== null)) _critical = value ? this.critical : (bool?)null; }
+    }
+    private bool ShouldSerializecritical() { return criticalSpecified; }
+    private void Resetcritical() { criticalSpecified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
 
-    private string _recipient = "";
+    private string _recipient;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"recipient", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string recipient
     {
-      get { return _recipient; }
+      get { return _recipient?? ""; }
       set { _recipient = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipientSpecified
+    {
+      get { return _recipient != null; }
+      set { if (value == (_recipient== null)) _recipient = value ? this.recipient : (string)null; }
+    }
+    private bool ShouldSerializerecipient() { return recipientSpecified; }
+    private void Resetrecipient() { recipientSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -559,14 +939,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMGetLicenses() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -578,32 +967,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPackageLicense() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -622,14 +1038,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -641,23 +1066,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMGetUserGameStats() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _stats = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> stats
@@ -676,32 +1119,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMGetUserGameStatsResponse() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> _stats = new global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats>();
     [global::ProtoBuf.ProtoMember(4, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> stats
@@ -722,23 +1192,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -750,32 +1238,59 @@ namespace SteamKit2.GC.Dota.Internal
     public Achievement_Blocks() {}
     
 
-    private uint _achievement_id = default(uint);
+    private uint? _achievement_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"achievement_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_id
     {
-      get { return _achievement_id; }
+      get { return _achievement_id?? default(uint); }
       set { _achievement_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_idSpecified
+    {
+      get { return _achievement_id != null; }
+      set { if (value == (_achievement_id== null)) _achievement_id = value ? this.achievement_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_id() { return achievement_idSpecified; }
+    private void Resetachievement_id() { achievement_idSpecified = false; }
+    
 
-    private uint _achievement_bit_id = default(uint);
+    private uint? _achievement_bit_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"achievement_bit_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_bit_id
     {
-      get { return _achievement_bit_id; }
+      get { return _achievement_bit_id?? default(uint); }
       set { _achievement_bit_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_bit_idSpecified
+    {
+      get { return _achievement_bit_id != null; }
+      set { if (value == (_achievement_bit_id== null)) _achievement_bit_id = value ? this.achievement_bit_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_bit_id() { return achievement_bit_idSpecified; }
+    private void Resetachievement_bit_id() { achievement_bit_idSpecified = false; }
+    
 
-    private uint _unlock_time = default(uint);
+    private uint? _unlock_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"unlock_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unlock_time
     {
-      get { return _unlock_time; }
+      get { return _unlock_time?? default(uint); }
       set { _unlock_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unlock_timeSpecified
+    {
+      get { return _unlock_time != null; }
+      set { if (value == (_unlock_time== null)) _unlock_time = value ? this.unlock_time : (uint?)null; }
+    }
+    private bool ShouldSerializeunlock_time() { return unlock_timeSpecified; }
+    private void Resetunlock_time() { unlock_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -792,23 +1307,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetCommandList() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _command_prefix = "";
+    private string _command_prefix;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"command_prefix", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_prefix
     {
-      get { return _command_prefix; }
+      get { return _command_prefix?? ""; }
       set { _command_prefix = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_prefixSpecified
+    {
+      get { return _command_prefix != null; }
+      set { if (value == (_command_prefix== null)) _command_prefix = value ? this.command_prefix : (string)null; }
+    }
+    private bool ShouldSerializecommand_prefix() { return command_prefixSpecified; }
+    private void Resetcommand_prefix() { command_prefixSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -866,23 +1399,41 @@ namespace SteamKit2.GC.Dota.Internal
     public ValueTag() {}
     
 
-    private bool _found = default(bool);
+    private bool? _found;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"found", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found
     {
-      get { return _found; }
+      get { return _found?? default(bool); }
       set { _found = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool foundSpecified
+    {
+      get { return _found != null; }
+      set { if (value == (_found== null)) _found = value ? this.found : (bool?)null; }
+    }
+    private bool ShouldSerializefound() { return foundSpecified; }
+    private void Resetfound() { foundSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -911,23 +1462,41 @@ namespace SteamKit2.GC.Dota.Internal
     public KeyPair() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -971,131 +1540,257 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCMsgMemCachedStatsResponse() {}
     
 
-    private ulong _curr_connections = default(ulong);
+    private ulong? _curr_connections;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"curr_connections", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_connections
     {
-      get { return _curr_connections; }
+      get { return _curr_connections?? default(ulong); }
       set { _curr_connections = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_connectionsSpecified
+    {
+      get { return _curr_connections != null; }
+      set { if (value == (_curr_connections== null)) _curr_connections = value ? this.curr_connections : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_connections() { return curr_connectionsSpecified; }
+    private void Resetcurr_connections() { curr_connectionsSpecified = false; }
+    
 
-    private ulong _cmd_get = default(ulong);
+    private ulong? _cmd_get;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cmd_get", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_get
     {
-      get { return _cmd_get; }
+      get { return _cmd_get?? default(ulong); }
       set { _cmd_get = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_getSpecified
+    {
+      get { return _cmd_get != null; }
+      set { if (value == (_cmd_get== null)) _cmd_get = value ? this.cmd_get : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_get() { return cmd_getSpecified; }
+    private void Resetcmd_get() { cmd_getSpecified = false; }
+    
 
-    private ulong _cmd_set = default(ulong);
+    private ulong? _cmd_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cmd_set", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_set
     {
-      get { return _cmd_set; }
+      get { return _cmd_set?? default(ulong); }
       set { _cmd_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_setSpecified
+    {
+      get { return _cmd_set != null; }
+      set { if (value == (_cmd_set== null)) _cmd_set = value ? this.cmd_set : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_set() { return cmd_setSpecified; }
+    private void Resetcmd_set() { cmd_setSpecified = false; }
+    
 
-    private ulong _cmd_flush = default(ulong);
+    private ulong? _cmd_flush;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cmd_flush", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_flush
     {
-      get { return _cmd_flush; }
+      get { return _cmd_flush?? default(ulong); }
       set { _cmd_flush = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_flushSpecified
+    {
+      get { return _cmd_flush != null; }
+      set { if (value == (_cmd_flush== null)) _cmd_flush = value ? this.cmd_flush : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_flush() { return cmd_flushSpecified; }
+    private void Resetcmd_flush() { cmd_flushSpecified = false; }
+    
 
-    private ulong _get_hits = default(ulong);
+    private ulong? _get_hits;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"get_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_hits
     {
-      get { return _get_hits; }
+      get { return _get_hits?? default(ulong); }
       set { _get_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_hitsSpecified
+    {
+      get { return _get_hits != null; }
+      set { if (value == (_get_hits== null)) _get_hits = value ? this.get_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_hits() { return get_hitsSpecified; }
+    private void Resetget_hits() { get_hitsSpecified = false; }
+    
 
-    private ulong _get_misses = default(ulong);
+    private ulong? _get_misses;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"get_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_misses
     {
-      get { return _get_misses; }
+      get { return _get_misses?? default(ulong); }
       set { _get_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_missesSpecified
+    {
+      get { return _get_misses != null; }
+      set { if (value == (_get_misses== null)) _get_misses = value ? this.get_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_misses() { return get_missesSpecified; }
+    private void Resetget_misses() { get_missesSpecified = false; }
+    
 
-    private ulong _delete_hits = default(ulong);
+    private ulong? _delete_hits;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"delete_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_hits
     {
-      get { return _delete_hits; }
+      get { return _delete_hits?? default(ulong); }
       set { _delete_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_hitsSpecified
+    {
+      get { return _delete_hits != null; }
+      set { if (value == (_delete_hits== null)) _delete_hits = value ? this.delete_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_hits() { return delete_hitsSpecified; }
+    private void Resetdelete_hits() { delete_hitsSpecified = false; }
+    
 
-    private ulong _delete_misses = default(ulong);
+    private ulong? _delete_misses;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"delete_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_misses
     {
-      get { return _delete_misses; }
+      get { return _delete_misses?? default(ulong); }
       set { _delete_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_missesSpecified
+    {
+      get { return _delete_misses != null; }
+      set { if (value == (_delete_misses== null)) _delete_misses = value ? this.delete_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_misses() { return delete_missesSpecified; }
+    private void Resetdelete_misses() { delete_missesSpecified = false; }
+    
 
-    private ulong _bytes_read = default(ulong);
+    private ulong? _bytes_read;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"bytes_read", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_read
     {
-      get { return _bytes_read; }
+      get { return _bytes_read?? default(ulong); }
       set { _bytes_read = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_readSpecified
+    {
+      get { return _bytes_read != null; }
+      set { if (value == (_bytes_read== null)) _bytes_read = value ? this.bytes_read : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_read() { return bytes_readSpecified; }
+    private void Resetbytes_read() { bytes_readSpecified = false; }
+    
 
-    private ulong _bytes_written = default(ulong);
+    private ulong? _bytes_written;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"bytes_written", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_written
     {
-      get { return _bytes_written; }
+      get { return _bytes_written?? default(ulong); }
       set { _bytes_written = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_writtenSpecified
+    {
+      get { return _bytes_written != null; }
+      set { if (value == (_bytes_written== null)) _bytes_written = value ? this.bytes_written : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_written() { return bytes_writtenSpecified; }
+    private void Resetbytes_written() { bytes_writtenSpecified = false; }
+    
 
-    private ulong _limit_maxbytes = default(ulong);
+    private ulong? _limit_maxbytes;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"limit_maxbytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong limit_maxbytes
     {
-      get { return _limit_maxbytes; }
+      get { return _limit_maxbytes?? default(ulong); }
       set { _limit_maxbytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool limit_maxbytesSpecified
+    {
+      get { return _limit_maxbytes != null; }
+      set { if (value == (_limit_maxbytes== null)) _limit_maxbytes = value ? this.limit_maxbytes : (ulong?)null; }
+    }
+    private bool ShouldSerializelimit_maxbytes() { return limit_maxbytesSpecified; }
+    private void Resetlimit_maxbytes() { limit_maxbytesSpecified = false; }
+    
 
-    private ulong _curr_items = default(ulong);
+    private ulong? _curr_items;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"curr_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_items
     {
-      get { return _curr_items; }
+      get { return _curr_items?? default(ulong); }
       set { _curr_items = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_itemsSpecified
+    {
+      get { return _curr_items != null; }
+      set { if (value == (_curr_items== null)) _curr_items = value ? this.curr_items : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_items() { return curr_itemsSpecified; }
+    private void Resetcurr_items() { curr_itemsSpecified = false; }
+    
 
-    private ulong _evictions = default(ulong);
+    private ulong? _evictions;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"evictions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong evictions
     {
-      get { return _evictions; }
+      get { return _evictions?? default(ulong); }
       set { _evictions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool evictionsSpecified
+    {
+      get { return _evictions != null; }
+      set { if (value == (_evictions== null)) _evictions = value ? this.evictions : (ulong?)null; }
+    }
+    private bool ShouldSerializeevictions() { return evictionsSpecified; }
+    private void Resetevictions() { evictionsSpecified = false; }
+    
 
-    private ulong _bytes = default(ulong);
+    private ulong? _bytes;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes
     {
-      get { return _bytes; }
+      get { return _bytes?? default(ulong); }
       set { _bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytesSpecified
+    {
+      get { return _bytes != null; }
+      set { if (value == (_bytes== null)) _bytes = value ? this.bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes() { return bytesSpecified; }
+    private void Resetbytes() { bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1107,14 +1802,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCMsgSQLStats() {}
     
 
-    private uint _schema_catalog = default(uint);
+    private uint? _schema_catalog;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"schema_catalog", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint schema_catalog
     {
-      get { return _schema_catalog; }
+      get { return _schema_catalog?? default(uint); }
       set { _schema_catalog = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_catalogSpecified
+    {
+      get { return _schema_catalog != null; }
+      set { if (value == (_schema_catalog== null)) _schema_catalog = value ? this.schema_catalog : (uint?)null; }
+    }
+    private bool ShouldSerializeschema_catalog() { return schema_catalogSpecified; }
+    private void Resetschema_catalog() { schema_catalogSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1126,86 +1830,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCMsgSQLStatsResponse() {}
     
 
-    private uint _threads = default(uint);
+    private uint? _threads;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"threads", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads
     {
-      get { return _threads; }
+      get { return _threads?? default(uint); }
       set { _threads = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threadsSpecified
+    {
+      get { return _threads != null; }
+      set { if (value == (_threads== null)) _threads = value ? this.threads : (uint?)null; }
+    }
+    private bool ShouldSerializethreads() { return threadsSpecified; }
+    private void Resetthreads() { threadsSpecified = false; }
+    
 
-    private uint _threads_connected = default(uint);
+    private uint? _threads_connected;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"threads_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_connected
     {
-      get { return _threads_connected; }
+      get { return _threads_connected?? default(uint); }
       set { _threads_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_connectedSpecified
+    {
+      get { return _threads_connected != null; }
+      set { if (value == (_threads_connected== null)) _threads_connected = value ? this.threads_connected : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_connected() { return threads_connectedSpecified; }
+    private void Resetthreads_connected() { threads_connectedSpecified = false; }
+    
 
-    private uint _threads_active = default(uint);
+    private uint? _threads_active;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"threads_active", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_active
     {
-      get { return _threads_active; }
+      get { return _threads_active?? default(uint); }
       set { _threads_active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_activeSpecified
+    {
+      get { return _threads_active != null; }
+      set { if (value == (_threads_active== null)) _threads_active = value ? this.threads_active : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_active() { return threads_activeSpecified; }
+    private void Resetthreads_active() { threads_activeSpecified = false; }
+    
 
-    private uint _operations_submitted = default(uint);
+    private uint? _operations_submitted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"operations_submitted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_submitted
     {
-      get { return _operations_submitted; }
+      get { return _operations_submitted?? default(uint); }
       set { _operations_submitted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_submittedSpecified
+    {
+      get { return _operations_submitted != null; }
+      set { if (value == (_operations_submitted== null)) _operations_submitted = value ? this.operations_submitted : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_submitted() { return operations_submittedSpecified; }
+    private void Resetoperations_submitted() { operations_submittedSpecified = false; }
+    
 
-    private uint _prepared_statements_executed = default(uint);
+    private uint? _prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prepared_statements_executed
     {
-      get { return _prepared_statements_executed; }
+      get { return _prepared_statements_executed?? default(uint); }
       set { _prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prepared_statements_executedSpecified
+    {
+      get { return _prepared_statements_executed != null; }
+      set { if (value == (_prepared_statements_executed== null)) _prepared_statements_executed = value ? this.prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializeprepared_statements_executed() { return prepared_statements_executedSpecified; }
+    private void Resetprepared_statements_executed() { prepared_statements_executedSpecified = false; }
+    
 
-    private uint _non_prepared_statements_executed = default(uint);
+    private uint? _non_prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"non_prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint non_prepared_statements_executed
     {
-      get { return _non_prepared_statements_executed; }
+      get { return _non_prepared_statements_executed?? default(uint); }
       set { _non_prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool non_prepared_statements_executedSpecified
+    {
+      get { return _non_prepared_statements_executed != null; }
+      set { if (value == (_non_prepared_statements_executed== null)) _non_prepared_statements_executed = value ? this.non_prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializenon_prepared_statements_executed() { return non_prepared_statements_executedSpecified; }
+    private void Resetnon_prepared_statements_executed() { non_prepared_statements_executedSpecified = false; }
+    
 
-    private uint _deadlock_retries = default(uint);
+    private uint? _deadlock_retries;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deadlock_retries", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deadlock_retries
     {
-      get { return _deadlock_retries; }
+      get { return _deadlock_retries?? default(uint); }
       set { _deadlock_retries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deadlock_retriesSpecified
+    {
+      get { return _deadlock_retries != null; }
+      set { if (value == (_deadlock_retries== null)) _deadlock_retries = value ? this.deadlock_retries : (uint?)null; }
+    }
+    private bool ShouldSerializedeadlock_retries() { return deadlock_retriesSpecified; }
+    private void Resetdeadlock_retries() { deadlock_retriesSpecified = false; }
+    
 
-    private uint _operations_timed_out_in_queue = default(uint);
+    private uint? _operations_timed_out_in_queue;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"operations_timed_out_in_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_timed_out_in_queue
     {
-      get { return _operations_timed_out_in_queue; }
+      get { return _operations_timed_out_in_queue?? default(uint); }
       set { _operations_timed_out_in_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_timed_out_in_queueSpecified
+    {
+      get { return _operations_timed_out_in_queue != null; }
+      set { if (value == (_operations_timed_out_in_queue== null)) _operations_timed_out_in_queue = value ? this.operations_timed_out_in_queue : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_timed_out_in_queue() { return operations_timed_out_in_queueSpecified; }
+    private void Resetoperations_timed_out_in_queue() { operations_timed_out_in_queueSpecified = false; }
+    
 
-    private uint _errors = default(uint);
+    private uint? _errors;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"errors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint errors
     {
-      get { return _errors; }
+      get { return _errors?? default(uint); }
       set { _errors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorsSpecified
+    {
+      get { return _errors != null; }
+      set { if (value == (_errors== null)) _errors = value ? this.errors : (uint?)null; }
+    }
+    private bool ShouldSerializeerrors() { return errorsSpecified; }
+    private void Reseterrors() { errorsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1217,41 +2002,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMAddFreeLicense() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip_public = default(uint);
+    private uint? _ip_public;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip_public", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip_public
     {
-      get { return _ip_public; }
+      get { return _ip_public?? default(uint); }
       set { _ip_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_publicSpecified
+    {
+      get { return _ip_public != null; }
+      set { if (value == (_ip_public== null)) _ip_public = value ? this.ip_public : (uint?)null; }
+    }
+    private bool ShouldSerializeip_public() { return ip_publicSpecified; }
+    private void Resetip_public() { ip_publicSpecified = false; }
+    
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private string _store_country_code = "";
+    private string _store_country_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"store_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string store_country_code
     {
-      get { return _store_country_code; }
+      get { return _store_country_code?? ""; }
       set { _store_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_country_codeSpecified
+    {
+      get { return _store_country_code != null; }
+      set { if (value == (_store_country_code== null)) _store_country_code = value ? this.store_country_code : (string)null; }
+    }
+    private bool ShouldSerializestore_country_code() { return store_country_codeSpecified; }
+    private void Resetstore_country_code() { store_country_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1263,32 +2084,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMAddFreeLicenseResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _purchase_result_detail = default(int);
+    private int? _purchase_result_detail;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"purchase_result_detail", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int purchase_result_detail
     {
-      get { return _purchase_result_detail; }
+      get { return _purchase_result_detail?? default(int); }
       set { _purchase_result_detail = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_result_detailSpecified
+    {
+      get { return _purchase_result_detail != null; }
+      set { if (value == (_purchase_result_detail== null)) _purchase_result_detail = value ? this.purchase_result_detail : (int?)null; }
+    }
+    private bool ShouldSerializepurchase_result_detail() { return purchase_result_detailSpecified; }
+    private void Resetpurchase_result_detail() { purchase_result_detailSpecified = false; }
+    
 
-    private ulong _transid = default(ulong);
+    private ulong? _transid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"transid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong transid
     {
-      get { return _transid; }
+      get { return _transid?? default(ulong); }
       set { _transid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transidSpecified
+    {
+      get { return _transid != null; }
+      set { if (value == (_transid== null)) _transid = value ? this.transid : (ulong?)null; }
+    }
+    private bool ShouldSerializetransid() { return transidSpecified; }
+    private void Resettransid() { transidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1317,59 +2165,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CIPLocationInfo() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private float _latitude = default(float);
+    private float? _latitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float latitude
     {
-      get { return _latitude; }
+      get { return _latitude?? default(float); }
       set { _latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latitudeSpecified
+    {
+      get { return _latitude != null; }
+      set { if (value == (_latitude== null)) _latitude = value ? this.latitude : (float?)null; }
+    }
+    private bool ShouldSerializelatitude() { return latitudeSpecified; }
+    private void Resetlatitude() { latitudeSpecified = false; }
+    
 
-    private float _longitude = default(float);
+    private float? _longitude;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float longitude
     {
-      get { return _longitude; }
+      get { return _longitude?? default(float); }
       set { _longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool longitudeSpecified
+    {
+      get { return _longitude != null; }
+      set { if (value == (_longitude== null)) _longitude = value ? this.longitude : (float?)null; }
+    }
+    private bool ShouldSerializelongitude() { return longitudeSpecified; }
+    private void Resetlongitude() { longitudeSpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private string _state = "";
+    private string _state;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string state
     {
-      get { return _state; }
+      get { return _state?? ""; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (string)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _city = "";
+    private string _city;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"city", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string city
     {
-      get { return _city; }
+      get { return _city?? ""; }
       set { _city = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool citySpecified
+    {
+      get { return _city != null; }
+      set { if (value == (_city== null)) _city = value ? this.city : (string)null; }
+    }
+    private bool ShouldSerializecity() { return citySpecified; }
+    private void Resetcity() { citySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1415,23 +2317,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CIPASNInfo() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _asn = default(uint);
+    private uint? _asn;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"asn", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint asn
     {
-      get { return _asn; }
+      get { return _asn?? default(uint); }
       set { _asn = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool asnSpecified
+    {
+      get { return _asn != null; }
+      set { if (value == (_asn== null)) _asn = value ? this.asn : (uint?)null; }
+    }
+    private bool ShouldSerializeasn() { return asnSpecified; }
+    private void Resetasn() { asnSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1460,23 +2380,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCMsgSystemStatsSchema() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _schema_kv = null;
+    private byte[] _schema_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"schema_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] schema_kv
     {
-      get { return _schema_kv; }
+      get { return _schema_kv?? null; }
       set { _schema_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_kvSpecified
+    {
+      get { return _schema_kv != null; }
+      set { if (value == (_schema_kv== null)) _schema_kv = value ? this.schema_kv : (byte[])null; }
+    }
+    private bool ShouldSerializeschema_kv() { return schema_kvSpecified; }
+    private void Resetschema_kv() { schema_kvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1498,122 +2436,239 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCMsgGetSystemStatsResponse() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _stats_kv = null;
+    private byte[] _stats_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stats_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] stats_kv
     {
-      get { return _stats_kv; }
+      get { return _stats_kv?? null; }
       set { _stats_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_kvSpecified
+    {
+      get { return _stats_kv != null; }
+      set { if (value == (_stats_kv== null)) _stats_kv = value ? this.stats_kv : (byte[])null; }
+    }
+    private bool ShouldSerializestats_kv() { return stats_kvSpecified; }
+    private void Resetstats_kv() { stats_kvSpecified = false; }
+    
 
-    private uint _active_jobs = default(uint);
+    private uint? _active_jobs;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"active_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_jobs
     {
-      get { return _active_jobs; }
+      get { return _active_jobs?? default(uint); }
       set { _active_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_jobsSpecified
+    {
+      get { return _active_jobs != null; }
+      set { if (value == (_active_jobs== null)) _active_jobs = value ? this.active_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_jobs() { return active_jobsSpecified; }
+    private void Resetactive_jobs() { active_jobsSpecified = false; }
+    
 
-    private uint _yielding_jobs = default(uint);
+    private uint? _yielding_jobs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"yielding_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint yielding_jobs
     {
-      get { return _yielding_jobs; }
+      get { return _yielding_jobs?? default(uint); }
       set { _yielding_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool yielding_jobsSpecified
+    {
+      get { return _yielding_jobs != null; }
+      set { if (value == (_yielding_jobs== null)) _yielding_jobs = value ? this.yielding_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeyielding_jobs() { return yielding_jobsSpecified; }
+    private void Resetyielding_jobs() { yielding_jobsSpecified = false; }
+    
 
-    private uint _user_sessions = default(uint);
+    private uint? _user_sessions;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"user_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_sessions
     {
-      get { return _user_sessions; }
+      get { return _user_sessions?? default(uint); }
       set { _user_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_sessionsSpecified
+    {
+      get { return _user_sessions != null; }
+      set { if (value == (_user_sessions== null)) _user_sessions = value ? this.user_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_sessions() { return user_sessionsSpecified; }
+    private void Resetuser_sessions() { user_sessionsSpecified = false; }
+    
 
-    private uint _game_server_sessions = default(uint);
+    private uint? _game_server_sessions;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_server_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_sessions
     {
-      get { return _game_server_sessions; }
+      get { return _game_server_sessions?? default(uint); }
       set { _game_server_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_sessionsSpecified
+    {
+      get { return _game_server_sessions != null; }
+      set { if (value == (_game_server_sessions== null)) _game_server_sessions = value ? this.game_server_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_sessions() { return game_server_sessionsSpecified; }
+    private void Resetgame_server_sessions() { game_server_sessionsSpecified = false; }
+    
 
-    private uint _socaches = default(uint);
+    private uint? _socaches;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"socaches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches
     {
-      get { return _socaches; }
+      get { return _socaches?? default(uint); }
       set { _socaches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socachesSpecified
+    {
+      get { return _socaches != null; }
+      set { if (value == (_socaches== null)) _socaches = value ? this.socaches : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches() { return socachesSpecified; }
+    private void Resetsocaches() { socachesSpecified = false; }
+    
 
-    private uint _socaches_to_unload = default(uint);
+    private uint? _socaches_to_unload;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"socaches_to_unload", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_to_unload
     {
-      get { return _socaches_to_unload; }
+      get { return _socaches_to_unload?? default(uint); }
       set { _socaches_to_unload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_to_unloadSpecified
+    {
+      get { return _socaches_to_unload != null; }
+      set { if (value == (_socaches_to_unload== null)) _socaches_to_unload = value ? this.socaches_to_unload : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_to_unload() { return socaches_to_unloadSpecified; }
+    private void Resetsocaches_to_unload() { socaches_to_unloadSpecified = false; }
+    
 
-    private uint _socaches_loading = default(uint);
+    private uint? _socaches_loading;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"socaches_loading", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_loading
     {
-      get { return _socaches_loading; }
+      get { return _socaches_loading?? default(uint); }
       set { _socaches_loading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_loadingSpecified
+    {
+      get { return _socaches_loading != null; }
+      set { if (value == (_socaches_loading== null)) _socaches_loading = value ? this.socaches_loading : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_loading() { return socaches_loadingSpecified; }
+    private void Resetsocaches_loading() { socaches_loadingSpecified = false; }
+    
 
-    private uint _writeback_queue = default(uint);
+    private uint? _writeback_queue;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"writeback_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint writeback_queue
     {
-      get { return _writeback_queue; }
+      get { return _writeback_queue?? default(uint); }
       set { _writeback_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool writeback_queueSpecified
+    {
+      get { return _writeback_queue != null; }
+      set { if (value == (_writeback_queue== null)) _writeback_queue = value ? this.writeback_queue : (uint?)null; }
+    }
+    private bool ShouldSerializewriteback_queue() { return writeback_queueSpecified; }
+    private void Resetwriteback_queue() { writeback_queueSpecified = false; }
+    
 
-    private uint _steamid_locks = default(uint);
+    private uint? _steamid_locks;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"steamid_locks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamid_locks
     {
-      get { return _steamid_locks; }
+      get { return _steamid_locks?? default(uint); }
       set { _steamid_locks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_locksSpecified
+    {
+      get { return _steamid_locks != null; }
+      set { if (value == (_steamid_locks== null)) _steamid_locks = value ? this.steamid_locks : (uint?)null; }
+    }
+    private bool ShouldSerializesteamid_locks() { return steamid_locksSpecified; }
+    private void Resetsteamid_locks() { steamid_locksSpecified = false; }
+    
 
-    private uint _logon_queue = default(uint);
+    private uint? _logon_queue;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"logon_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_queue
     {
-      get { return _logon_queue; }
+      get { return _logon_queue?? default(uint); }
       set { _logon_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_queueSpecified
+    {
+      get { return _logon_queue != null; }
+      set { if (value == (_logon_queue== null)) _logon_queue = value ? this.logon_queue : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_queue() { return logon_queueSpecified; }
+    private void Resetlogon_queue() { logon_queueSpecified = false; }
+    
 
-    private uint _logon_jobs = default(uint);
+    private uint? _logon_jobs;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"logon_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_jobs
     {
-      get { return _logon_jobs; }
+      get { return _logon_jobs?? default(uint); }
       set { _logon_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_jobsSpecified
+    {
+      get { return _logon_jobs != null; }
+      set { if (value == (_logon_jobs== null)) _logon_jobs = value ? this.logon_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_jobs() { return logon_jobsSpecified; }
+    private void Resetlogon_jobs() { logon_jobsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1625,32 +2680,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMSendEmail() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private uint _email_format = default(uint);
+    private uint? _email_format;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(uint); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> _persona_name_tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken>();
     [global::ProtoBuf.ProtoMember(5, Name=@"persona_name_tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> persona_name_tokens
@@ -1659,14 +2741,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _source_gc = default(uint);
+    private uint? _source_gc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"source_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_gc
     {
-      get { return _source_gc; }
+      get { return _source_gc?? default(uint); }
       set { _source_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_gcSpecified
+    {
+      get { return _source_gc != null; }
+      set { if (value == (_source_gc== null)) _source_gc = value ? this.source_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesource_gc() { return source_gcSpecified; }
+    private void Resetsource_gc() { source_gcSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> _tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken>();
     [global::ProtoBuf.ProtoMember(7, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> tokens
@@ -1680,23 +2771,41 @@ namespace SteamKit2.GC.Dota.Internal
     public ReplacementToken() {}
     
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
 
-    private string _token_value = "";
+    private string _token_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_value
     {
-      get { return _token_value; }
+      get { return _token_value?? ""; }
       set { _token_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_valueSpecified
+    {
+      get { return _token_value != null; }
+      set { if (value == (_token_value== null)) _token_value = value ? this.token_value : (string)null; }
+    }
+    private bool ShouldSerializetoken_value() { return token_valueSpecified; }
+    private void Resettoken_value() { token_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1708,23 +2817,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PersonaNameReplacementToken() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1741,14 +2868,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMSendEmailResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1760,41 +2896,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetEmailTemplate() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private int _email_lang = default(int);
+    private int? _email_lang;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_lang", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_lang
     {
-      get { return _email_lang; }
+      get { return _email_lang?? default(int); }
       set { _email_lang = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_langSpecified
+    {
+      get { return _email_lang != null; }
+      set { if (value == (_email_lang== null)) _email_lang = value ? this.email_lang : (int?)null; }
+    }
+    private bool ShouldSerializeemail_lang() { return email_langSpecified; }
+    private void Resetemail_lang() { email_langSpecified = false; }
+    
 
-    private int _email_format = default(int);
+    private int? _email_format;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(int); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (int?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1806,32 +2978,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetEmailTemplateResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _template_exists = default(bool);
+    private bool? _template_exists;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"template_exists", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool template_exists
     {
-      get { return _template_exists; }
+      get { return _template_exists?? default(bool); }
       set { _template_exists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool template_existsSpecified
+    {
+      get { return _template_exists != null; }
+      set { if (value == (_template_exists== null)) _template_exists = value ? this.template_exists : (bool?)null; }
+    }
+    private bool ShouldSerializetemplate_exists() { return template_existsSpecified; }
+    private void Resettemplate_exists() { template_existsSpecified = false; }
+    
 
-    private string _template = "";
+    private string _template;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"template", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string template
     {
-      get { return _template; }
+      get { return _template?? ""; }
       set { _template = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool templateSpecified
+    {
+      get { return _template != null; }
+      set { if (value == (_template== null)) _template = value ? this.template : (string)null; }
+    }
+    private bool ShouldSerializetemplate() { return templateSpecified; }
+    private void Resettemplate() { templateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1843,50 +3042,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMGrantGuestPasses2() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private int _passes_to_grant = default(int);
+    private int? _passes_to_grant;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"passes_to_grant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int passes_to_grant
     {
-      get { return _passes_to_grant; }
+      get { return _passes_to_grant?? default(int); }
       set { _passes_to_grant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_to_grantSpecified
+    {
+      get { return _passes_to_grant != null; }
+      set { if (value == (_passes_to_grant== null)) _passes_to_grant = value ? this.passes_to_grant : (int?)null; }
+    }
+    private bool ShouldSerializepasses_to_grant() { return passes_to_grantSpecified; }
+    private void Resetpasses_to_grant() { passes_to_grantSpecified = false; }
+    
 
-    private int _days_to_expiration = default(int);
+    private int? _days_to_expiration;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"days_to_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int days_to_expiration
     {
-      get { return _days_to_expiration; }
+      get { return _days_to_expiration?? default(int); }
       set { _days_to_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool days_to_expirationSpecified
+    {
+      get { return _days_to_expiration != null; }
+      set { if (value == (_days_to_expiration== null)) _days_to_expiration = value ? this.days_to_expiration : (int?)null; }
+    }
+    private bool ShouldSerializedays_to_expiration() { return days_to_expirationSpecified; }
+    private void Resetdays_to_expiration() { days_to_expirationSpecified = false; }
+    
 
-    private int _action = default(int);
+    private int? _action;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int action
     {
-      get { return _action; }
+      get { return _action?? default(int); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (int?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1898,23 +3142,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAMGrantGuestPasses2Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _passes_granted = (int)0;
+    private int? _passes_granted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"passes_granted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int passes_granted
     {
-      get { return _passes_granted; }
+      get { return _passes_granted?? (int)0; }
       set { _passes_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_grantedSpecified
+    {
+      get { return _passes_granted != null; }
+      set { if (value == (_passes_granted== null)) _passes_granted = value ? this.passes_granted : (int?)null; }
+    }
+    private bool ShouldSerializepasses_granted() { return passes_grantedSpecified; }
+    private void Resetpasses_granted() { passes_grantedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1926,23 +3188,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCSystemMsg_GetAccountDetails() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1954,293 +3234,581 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCSystemMsg_GetAccountDetails_Response() {}
     
 
-    private uint _eresult_deprecated = (uint)2;
+    private uint? _eresult_deprecated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult_deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult_deprecated
     {
-      get { return _eresult_deprecated; }
+      get { return _eresult_deprecated?? (uint)2; }
       set { _eresult_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_deprecatedSpecified
+    {
+      get { return _eresult_deprecated != null; }
+      set { if (value == (_eresult_deprecated== null)) _eresult_deprecated = value ? this.eresult_deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult_deprecated() { return eresult_deprecatedSpecified; }
+    private void Reseteresult_deprecated() { eresult_deprecatedSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private bool _is_profile_created = default(bool);
+    private bool? _is_profile_created;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"is_profile_created", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_profile_created
     {
-      get { return _is_profile_created; }
+      get { return _is_profile_created?? default(bool); }
       set { _is_profile_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_profile_createdSpecified
+    {
+      get { return _is_profile_created != null; }
+      set { if (value == (_is_profile_created== null)) _is_profile_created = value ? this.is_profile_created : (bool?)null; }
+    }
+    private bool ShouldSerializeis_profile_created() { return is_profile_createdSpecified; }
+    private void Resetis_profile_created() { is_profile_createdSpecified = false; }
+    
 
-    private bool _is_profile_public = default(bool);
+    private bool? _is_profile_public;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_profile_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_profile_public
     {
-      get { return _is_profile_public; }
+      get { return _is_profile_public?? default(bool); }
       set { _is_profile_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_profile_publicSpecified
+    {
+      get { return _is_profile_public != null; }
+      set { if (value == (_is_profile_public== null)) _is_profile_public = value ? this.is_profile_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_profile_public() { return is_profile_publicSpecified; }
+    private void Resetis_profile_public() { is_profile_publicSpecified = false; }
+    
 
-    private bool _is_inventory_public = default(bool);
+    private bool? _is_inventory_public;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_inventory_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_inventory_public
     {
-      get { return _is_inventory_public; }
+      get { return _is_inventory_public?? default(bool); }
       set { _is_inventory_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_inventory_publicSpecified
+    {
+      get { return _is_inventory_public != null; }
+      set { if (value == (_is_inventory_public== null)) _is_inventory_public = value ? this.is_inventory_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_inventory_public() { return is_inventory_publicSpecified; }
+    private void Resetis_inventory_public() { is_inventory_publicSpecified = false; }
+    
 
-    private bool _is_vac_banned = default(bool);
+    private bool? _is_vac_banned;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_vac_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_vac_banned
     {
-      get { return _is_vac_banned; }
+      get { return _is_vac_banned?? default(bool); }
       set { _is_vac_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_vac_bannedSpecified
+    {
+      get { return _is_vac_banned != null; }
+      set { if (value == (_is_vac_banned== null)) _is_vac_banned = value ? this.is_vac_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_vac_banned() { return is_vac_bannedSpecified; }
+    private void Resetis_vac_banned() { is_vac_bannedSpecified = false; }
+    
 
-    private bool _is_cyber_cafe = default(bool);
+    private bool? _is_cyber_cafe;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_cyber_cafe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_cyber_cafe
     {
-      get { return _is_cyber_cafe; }
+      get { return _is_cyber_cafe?? default(bool); }
       set { _is_cyber_cafe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_cyber_cafeSpecified
+    {
+      get { return _is_cyber_cafe != null; }
+      set { if (value == (_is_cyber_cafe== null)) _is_cyber_cafe = value ? this.is_cyber_cafe : (bool?)null; }
+    }
+    private bool ShouldSerializeis_cyber_cafe() { return is_cyber_cafeSpecified; }
+    private void Resetis_cyber_cafe() { is_cyber_cafeSpecified = false; }
+    
 
-    private bool _is_school_account = default(bool);
+    private bool? _is_school_account;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_school_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_school_account
     {
-      get { return _is_school_account; }
+      get { return _is_school_account?? default(bool); }
       set { _is_school_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_school_accountSpecified
+    {
+      get { return _is_school_account != null; }
+      set { if (value == (_is_school_account== null)) _is_school_account = value ? this.is_school_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_school_account() { return is_school_accountSpecified; }
+    private void Resetis_school_account() { is_school_accountSpecified = false; }
+    
 
-    private bool _is_limited = default(bool);
+    private bool? _is_limited;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_limited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_limited
     {
-      get { return _is_limited; }
+      get { return _is_limited?? default(bool); }
       set { _is_limited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_limitedSpecified
+    {
+      get { return _is_limited != null; }
+      set { if (value == (_is_limited== null)) _is_limited = value ? this.is_limited : (bool?)null; }
+    }
+    private bool ShouldSerializeis_limited() { return is_limitedSpecified; }
+    private void Resetis_limited() { is_limitedSpecified = false; }
+    
 
-    private bool _is_subscribed = default(bool);
+    private bool? _is_subscribed;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_subscribed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_subscribed
     {
-      get { return _is_subscribed; }
+      get { return _is_subscribed?? default(bool); }
       set { _is_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_subscribedSpecified
+    {
+      get { return _is_subscribed != null; }
+      set { if (value == (_is_subscribed== null)) _is_subscribed = value ? this.is_subscribed : (bool?)null; }
+    }
+    private bool ShouldSerializeis_subscribed() { return is_subscribedSpecified; }
+    private void Resetis_subscribed() { is_subscribedSpecified = false; }
+    
 
-    private uint _package = default(uint);
+    private uint? _package;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"package", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package
     {
-      get { return _package; }
+      get { return _package?? default(uint); }
       set { _package = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageSpecified
+    {
+      get { return _package != null; }
+      set { if (value == (_package== null)) _package = value ? this.package : (uint?)null; }
+    }
+    private bool ShouldSerializepackage() { return packageSpecified; }
+    private void Resetpackage() { packageSpecified = false; }
+    
 
-    private bool _is_free_trial_account = default(bool);
+    private bool? _is_free_trial_account;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"is_free_trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_free_trial_account
     {
-      get { return _is_free_trial_account; }
+      get { return _is_free_trial_account?? default(bool); }
       set { _is_free_trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_free_trial_accountSpecified
+    {
+      get { return _is_free_trial_account != null; }
+      set { if (value == (_is_free_trial_account== null)) _is_free_trial_account = value ? this.is_free_trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_free_trial_account() { return is_free_trial_accountSpecified; }
+    private void Resetis_free_trial_account() { is_free_trial_accountSpecified = false; }
+    
 
-    private uint _free_trial_expiration = default(uint);
+    private uint? _free_trial_expiration;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"free_trial_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint free_trial_expiration
     {
-      get { return _free_trial_expiration; }
+      get { return _free_trial_expiration?? default(uint); }
       set { _free_trial_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool free_trial_expirationSpecified
+    {
+      get { return _free_trial_expiration != null; }
+      set { if (value == (_free_trial_expiration== null)) _free_trial_expiration = value ? this.free_trial_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializefree_trial_expiration() { return free_trial_expirationSpecified; }
+    private void Resetfree_trial_expiration() { free_trial_expirationSpecified = false; }
+    
 
-    private bool _is_low_violence = default(bool);
+    private bool? _is_low_violence;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"is_low_violence", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_low_violence
     {
-      get { return _is_low_violence; }
+      get { return _is_low_violence?? default(bool); }
       set { _is_low_violence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_low_violenceSpecified
+    {
+      get { return _is_low_violence != null; }
+      set { if (value == (_is_low_violence== null)) _is_low_violence = value ? this.is_low_violence : (bool?)null; }
+    }
+    private bool ShouldSerializeis_low_violence() { return is_low_violenceSpecified; }
+    private void Resetis_low_violence() { is_low_violenceSpecified = false; }
+    
 
-    private bool _is_account_locked_down = default(bool);
+    private bool? _is_account_locked_down;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"is_account_locked_down", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_account_locked_down
     {
-      get { return _is_account_locked_down; }
+      get { return _is_account_locked_down?? default(bool); }
       set { _is_account_locked_down = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_account_locked_downSpecified
+    {
+      get { return _is_account_locked_down != null; }
+      set { if (value == (_is_account_locked_down== null)) _is_account_locked_down = value ? this.is_account_locked_down : (bool?)null; }
+    }
+    private bool ShouldSerializeis_account_locked_down() { return is_account_locked_downSpecified; }
+    private void Resetis_account_locked_down() { is_account_locked_downSpecified = false; }
+    
 
-    private bool _is_community_banned = default(bool);
+    private bool? _is_community_banned;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"is_community_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_community_banned
     {
-      get { return _is_community_banned; }
+      get { return _is_community_banned?? default(bool); }
       set { _is_community_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_community_bannedSpecified
+    {
+      get { return _is_community_banned != null; }
+      set { if (value == (_is_community_banned== null)) _is_community_banned = value ? this.is_community_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_community_banned() { return is_community_bannedSpecified; }
+    private void Resetis_community_banned() { is_community_bannedSpecified = false; }
+    
 
-    private bool _is_trade_banned = default(bool);
+    private bool? _is_trade_banned;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"is_trade_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_trade_banned
     {
-      get { return _is_trade_banned; }
+      get { return _is_trade_banned?? default(bool); }
       set { _is_trade_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_trade_bannedSpecified
+    {
+      get { return _is_trade_banned != null; }
+      set { if (value == (_is_trade_banned== null)) _is_trade_banned = value ? this.is_trade_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_trade_banned() { return is_trade_bannedSpecified; }
+    private void Resetis_trade_banned() { is_trade_bannedSpecified = false; }
+    
 
-    private uint _trade_ban_expiration = default(uint);
+    private uint? _trade_ban_expiration;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"trade_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_expiration
     {
-      get { return _trade_ban_expiration; }
+      get { return _trade_ban_expiration?? default(uint); }
       set { _trade_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_expirationSpecified
+    {
+      get { return _trade_ban_expiration != null; }
+      set { if (value == (_trade_ban_expiration== null)) _trade_ban_expiration = value ? this.trade_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_expiration() { return trade_ban_expirationSpecified; }
+    private void Resettrade_ban_expiration() { trade_ban_expirationSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _suspension_end_time = default(uint);
+    private uint? _suspension_end_time;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"suspension_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suspension_end_time
     {
-      get { return _suspension_end_time; }
+      get { return _suspension_end_time?? default(uint); }
       set { _suspension_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suspension_end_timeSpecified
+    {
+      get { return _suspension_end_time != null; }
+      set { if (value == (_suspension_end_time== null)) _suspension_end_time = value ? this.suspension_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializesuspension_end_time() { return suspension_end_timeSpecified; }
+    private void Resetsuspension_end_time() { suspension_end_timeSpecified = false; }
+    
 
-    private string _currency = "";
+    private string _currency;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string currency
     {
-      get { return _currency; }
+      get { return _currency?? ""; }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (string)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private uint _steam_level = default(uint);
+    private uint? _steam_level;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"steam_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steam_level
     {
-      get { return _steam_level; }
+      get { return _steam_level?? default(uint); }
       set { _steam_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_levelSpecified
+    {
+      get { return _steam_level != null; }
+      set { if (value == (_steam_level== null)) _steam_level = value ? this.steam_level : (uint?)null; }
+    }
+    private bool ShouldSerializesteam_level() { return steam_levelSpecified; }
+    private void Resetsteam_level() { steam_levelSpecified = false; }
+    
 
-    private uint _friend_count = default(uint);
+    private uint? _friend_count;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"friend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friend_count
     {
-      get { return _friend_count; }
+      get { return _friend_count?? default(uint); }
       set { _friend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_countSpecified
+    {
+      get { return _friend_count != null; }
+      set { if (value == (_friend_count== null)) _friend_count = value ? this.friend_count : (uint?)null; }
+    }
+    private bool ShouldSerializefriend_count() { return friend_countSpecified; }
+    private void Resetfriend_count() { friend_countSpecified = false; }
+    
 
-    private uint _account_creation_time = default(uint);
+    private uint? _account_creation_time;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"account_creation_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_creation_time
     {
-      get { return _account_creation_time; }
+      get { return _account_creation_time?? default(uint); }
       set { _account_creation_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_creation_timeSpecified
+    {
+      get { return _account_creation_time != null; }
+      set { if (value == (_account_creation_time== null)) _account_creation_time = value ? this.account_creation_time : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_creation_time() { return account_creation_timeSpecified; }
+    private void Resetaccount_creation_time() { account_creation_timeSpecified = false; }
+    
 
-    private bool _is_steamguard_enabled = default(bool);
+    private bool? _is_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"is_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_steamguard_enabled
     {
-      get { return _is_steamguard_enabled; }
+      get { return _is_steamguard_enabled?? default(bool); }
       set { _is_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_steamguard_enabledSpecified
+    {
+      get { return _is_steamguard_enabled != null; }
+      set { if (value == (_is_steamguard_enabled== null)) _is_steamguard_enabled = value ? this.is_steamguard_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_steamguard_enabled() { return is_steamguard_enabledSpecified; }
+    private void Resetis_steamguard_enabled() { is_steamguard_enabledSpecified = false; }
+    
 
-    private bool _is_phone_verified = default(bool);
+    private bool? _is_phone_verified;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"is_phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_verified
     {
-      get { return _is_phone_verified; }
+      get { return _is_phone_verified?? default(bool); }
       set { _is_phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_verifiedSpecified
+    {
+      get { return _is_phone_verified != null; }
+      set { if (value == (_is_phone_verified== null)) _is_phone_verified = value ? this.is_phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_verified() { return is_phone_verifiedSpecified; }
+    private void Resetis_phone_verified() { is_phone_verifiedSpecified = false; }
+    
 
-    private bool _is_two_factor_auth_enabled = default(bool);
+    private bool? _is_two_factor_auth_enabled;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"is_two_factor_auth_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_two_factor_auth_enabled
     {
-      get { return _is_two_factor_auth_enabled; }
+      get { return _is_two_factor_auth_enabled?? default(bool); }
       set { _is_two_factor_auth_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_two_factor_auth_enabledSpecified
+    {
+      get { return _is_two_factor_auth_enabled != null; }
+      set { if (value == (_is_two_factor_auth_enabled== null)) _is_two_factor_auth_enabled = value ? this.is_two_factor_auth_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_two_factor_auth_enabled() { return is_two_factor_auth_enabledSpecified; }
+    private void Resetis_two_factor_auth_enabled() { is_two_factor_auth_enabledSpecified = false; }
+    
 
-    private uint _two_factor_enabled_time = default(uint);
+    private uint? _two_factor_enabled_time;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"two_factor_enabled_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint two_factor_enabled_time
     {
-      get { return _two_factor_enabled_time; }
+      get { return _two_factor_enabled_time?? default(uint); }
       set { _two_factor_enabled_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool two_factor_enabled_timeSpecified
+    {
+      get { return _two_factor_enabled_time != null; }
+      set { if (value == (_two_factor_enabled_time== null)) _two_factor_enabled_time = value ? this.two_factor_enabled_time : (uint?)null; }
+    }
+    private bool ShouldSerializetwo_factor_enabled_time() { return two_factor_enabled_timeSpecified; }
+    private void Resettwo_factor_enabled_time() { two_factor_enabled_timeSpecified = false; }
+    
 
-    private uint _phone_verification_time = default(uint);
+    private uint? _phone_verification_time;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"phone_verification_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phone_verification_time
     {
-      get { return _phone_verification_time; }
+      get { return _phone_verification_time?? default(uint); }
       set { _phone_verification_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_verification_timeSpecified
+    {
+      get { return _phone_verification_time != null; }
+      set { if (value == (_phone_verification_time== null)) _phone_verification_time = value ? this.phone_verification_time : (uint?)null; }
+    }
+    private bool ShouldSerializephone_verification_time() { return phone_verification_timeSpecified; }
+    private void Resetphone_verification_time() { phone_verification_timeSpecified = false; }
+    
 
-    private ulong _phone_id = default(ulong);
+    private ulong? _phone_id;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"phone_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong phone_id
     {
-      get { return _phone_id; }
+      get { return _phone_id?? default(ulong); }
       set { _phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_idSpecified
+    {
+      get { return _phone_id != null; }
+      set { if (value == (_phone_id== null)) _phone_id = value ? this.phone_id : (ulong?)null; }
+    }
+    private bool ShouldSerializephone_id() { return phone_idSpecified; }
+    private void Resetphone_id() { phone_idSpecified = false; }
+    
 
-    private bool _is_phone_identifying = default(bool);
+    private bool? _is_phone_identifying;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"is_phone_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_identifying
     {
-      get { return _is_phone_identifying; }
+      get { return _is_phone_identifying?? default(bool); }
       set { _is_phone_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_identifyingSpecified
+    {
+      get { return _is_phone_identifying != null; }
+      set { if (value == (_is_phone_identifying== null)) _is_phone_identifying = value ? this.is_phone_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_identifying() { return is_phone_identifyingSpecified; }
+    private void Resetis_phone_identifying() { is_phone_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2288,23 +3856,41 @@ namespace SteamKit2.GC.Dota.Internal
     public PersonaName() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2321,23 +3907,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCCheckFriendship() {}
     
 
-    private ulong _steamid_left = default(ulong);
+    private ulong? _steamid_left;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_left", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_left
     {
-      get { return _steamid_left; }
+      get { return _steamid_left?? default(ulong); }
       set { _steamid_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_leftSpecified
+    {
+      get { return _steamid_left != null; }
+      set { if (value == (_steamid_left== null)) _steamid_left = value ? this.steamid_left : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_left() { return steamid_leftSpecified; }
+    private void Resetsteamid_left() { steamid_leftSpecified = false; }
+    
 
-    private ulong _steamid_right = default(ulong);
+    private ulong? _steamid_right;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_right", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_right
     {
-      get { return _steamid_right; }
+      get { return _steamid_right?? default(ulong); }
       set { _steamid_right = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_rightSpecified
+    {
+      get { return _steamid_right != null; }
+      set { if (value == (_steamid_right== null)) _steamid_right = value ? this.steamid_right : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_right() { return steamid_rightSpecified; }
+    private void Resetsteamid_right() { steamid_rightSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2349,23 +3953,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCCheckFriendship_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private bool _found_friendship = default(bool);
+    private bool? _found_friendship;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"found_friendship", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found_friendship
     {
-      get { return _found_friendship; }
+      get { return _found_friendship?? default(bool); }
       set { _found_friendship = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool found_friendshipSpecified
+    {
+      get { return _found_friendship != null; }
+      set { if (value == (_found_friendship== null)) _found_friendship = value ? this.found_friendship : (bool?)null; }
+    }
+    private bool ShouldSerializefound_friendship() { return found_friendshipSpecified; }
+    private void Resetfound_friendship() { found_friendshipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2377,23 +3999,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetAppFriendsList() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _include_friendship_timestamps = default(bool);
+    private bool? _include_friendship_timestamps;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"include_friendship_timestamps", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_friendship_timestamps
     {
-      get { return _include_friendship_timestamps; }
+      get { return _include_friendship_timestamps?? default(bool); }
       set { _include_friendship_timestamps = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_friendship_timestampsSpecified
+    {
+      get { return _include_friendship_timestamps != null; }
+      set { if (value == (_include_friendship_timestamps== null)) _include_friendship_timestamps = value ? this.include_friendship_timestamps : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_friendship_timestamps() { return include_friendship_timestampsSpecified; }
+    private void Resetinclude_friendship_timestamps() { include_friendship_timestampsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2405,14 +4045,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetAppFriendsList_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamids
@@ -2438,14 +4087,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMsgMasterSetDirectory() {}
     
 
-    private uint _master_dir_index = default(uint);
+    private uint? _master_dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"master_dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint master_dir_index
     {
-      get { return _master_dir_index; }
+      get { return _master_dir_index?? default(uint); }
       set { _master_dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool master_dir_indexSpecified
+    {
+      get { return _master_dir_index != null; }
+      set { if (value == (_master_dir_index== null)) _master_dir_index = value ? this.master_dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializemaster_dir_index() { return master_dir_indexSpecified; }
+    private void Resetmaster_dir_index() { master_dir_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> _dir = new global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC>();
     [global::ProtoBuf.ProtoMember(2, Name=@"dir", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> dir
@@ -2459,50 +4117,95 @@ namespace SteamKit2.GC.Dota.Internal
     public SubGC() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _box = "";
+    private string _box;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"box", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string box
     {
-      get { return _box; }
+      get { return _box?? ""; }
       set { _box = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boxSpecified
+    {
+      get { return _box != null; }
+      set { if (value == (_box== null)) _box = value ? this.box : (string)null; }
+    }
+    private bool ShouldSerializebox() { return boxSpecified; }
+    private void Resetbox() { boxSpecified = false; }
+    
 
-    private string _command_line = "";
+    private string _command_line;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"command_line", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_line
     {
-      get { return _command_line; }
+      get { return _command_line?? ""; }
       set { _command_line = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_lineSpecified
+    {
+      get { return _command_line != null; }
+      set { if (value == (_command_line== null)) _command_line = value ? this.command_line : (string)null; }
+    }
+    private bool ShouldSerializecommand_line() { return command_lineSpecified; }
+    private void Resetcommand_line() { command_lineSpecified = false; }
+    
 
-    private string _gc_binary = "";
+    private string _gc_binary;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gc_binary", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gc_binary
     {
-      get { return _gc_binary; }
+      get { return _gc_binary?? ""; }
       set { _gc_binary = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_binarySpecified
+    {
+      get { return _gc_binary != null; }
+      set { if (value == (_gc_binary== null)) _gc_binary = value ? this.gc_binary : (string)null; }
+    }
+    private bool ShouldSerializegc_binary() { return gc_binarySpecified; }
+    private void Resetgc_binary() { gc_binarySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2519,23 +4222,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMsgMasterSetDirectory_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2547,14 +4268,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMsgWebAPIJobRequestForwardResponse() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2566,14 +4296,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCSystemMsg_GetPurchaseTrust_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2585,41 +4324,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCSystemMsg_GetPurchaseTrust_Response() {}
     
 
-    private bool _has_prior_purchase_history = default(bool);
+    private bool? _has_prior_purchase_history;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_prior_purchase_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_prior_purchase_history
     {
-      get { return _has_prior_purchase_history; }
+      get { return _has_prior_purchase_history?? default(bool); }
       set { _has_prior_purchase_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_prior_purchase_historySpecified
+    {
+      get { return _has_prior_purchase_history != null; }
+      set { if (value == (_has_prior_purchase_history== null)) _has_prior_purchase_history = value ? this.has_prior_purchase_history : (bool?)null; }
+    }
+    private bool ShouldSerializehas_prior_purchase_history() { return has_prior_purchase_historySpecified; }
+    private void Resethas_prior_purchase_history() { has_prior_purchase_historySpecified = false; }
+    
 
-    private bool _has_no_recent_password_resets = default(bool);
+    private bool? _has_no_recent_password_resets;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"has_no_recent_password_resets", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_no_recent_password_resets
     {
-      get { return _has_no_recent_password_resets; }
+      get { return _has_no_recent_password_resets?? default(bool); }
       set { _has_no_recent_password_resets = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_no_recent_password_resetsSpecified
+    {
+      get { return _has_no_recent_password_resets != null; }
+      set { if (value == (_has_no_recent_password_resets== null)) _has_no_recent_password_resets = value ? this.has_no_recent_password_resets : (bool?)null; }
+    }
+    private bool ShouldSerializehas_no_recent_password_resets() { return has_no_recent_password_resetsSpecified; }
+    private void Resethas_no_recent_password_resets() { has_no_recent_password_resetsSpecified = false; }
+    
 
-    private bool _is_wallet_cash_trusted = default(bool);
+    private bool? _is_wallet_cash_trusted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_wallet_cash_trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_wallet_cash_trusted
     {
-      get { return _is_wallet_cash_trusted; }
+      get { return _is_wallet_cash_trusted?? default(bool); }
       set { _is_wallet_cash_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_wallet_cash_trustedSpecified
+    {
+      get { return _is_wallet_cash_trusted != null; }
+      set { if (value == (_is_wallet_cash_trusted== null)) _is_wallet_cash_trusted = value ? this.is_wallet_cash_trusted : (bool?)null; }
+    }
+    private bool ShouldSerializeis_wallet_cash_trusted() { return is_wallet_cash_trustedSpecified; }
+    private void Resetis_wallet_cash_trusted() { is_wallet_cash_trustedSpecified = false; }
+    
 
-    private uint _time_all_trusted = default(uint);
+    private uint? _time_all_trusted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_all_trusted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_all_trusted
     {
-      get { return _time_all_trusted; }
+      get { return _time_all_trusted?? default(uint); }
       set { _time_all_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_all_trustedSpecified
+    {
+      get { return _time_all_trusted != null; }
+      set { if (value == (_time_all_trusted== null)) _time_all_trusted = value ? this.time_all_trusted : (uint?)null; }
+    }
+    private bool ShouldSerializetime_all_trusted() { return time_all_trustedSpecified; }
+    private void Resettime_all_trusted() { time_all_trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2631,50 +4406,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCHAccountVacStatusChange() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _rtime_vacban_starts = default(uint);
+    private uint? _rtime_vacban_starts;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rtime_vacban_starts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime_vacban_starts
     {
-      get { return _rtime_vacban_starts; }
+      get { return _rtime_vacban_starts?? default(uint); }
       set { _rtime_vacban_starts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_vacban_startsSpecified
+    {
+      get { return _rtime_vacban_starts != null; }
+      set { if (value == (_rtime_vacban_starts== null)) _rtime_vacban_starts = value ? this.rtime_vacban_starts : (uint?)null; }
+    }
+    private bool ShouldSerializertime_vacban_starts() { return rtime_vacban_startsSpecified; }
+    private void Resetrtime_vacban_starts() { rtime_vacban_startsSpecified = false; }
+    
 
-    private bool _is_banned_now = default(bool);
+    private bool? _is_banned_now;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_banned_now", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_now
     {
-      get { return _is_banned_now; }
+      get { return _is_banned_now?? default(bool); }
       set { _is_banned_now = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_nowSpecified
+    {
+      get { return _is_banned_now != null; }
+      set { if (value == (_is_banned_now== null)) _is_banned_now = value ? this.is_banned_now : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_now() { return is_banned_nowSpecified; }
+    private void Resetis_banned_now() { is_banned_nowSpecified = false; }
+    
 
-    private bool _is_banned_future = default(bool);
+    private bool? _is_banned_future;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_banned_future", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_future
     {
-      get { return _is_banned_future; }
+      get { return _is_banned_future?? default(bool); }
       set { _is_banned_future = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_futureSpecified
+    {
+      get { return _is_banned_future != null; }
+      set { if (value == (_is_banned_future== null)) _is_banned_future = value ? this.is_banned_future : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_future() { return is_banned_futureSpecified; }
+    private void Resetis_banned_future() { is_banned_futureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2686,14 +4506,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetPartnerAccountLink() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2705,23 +4534,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCGetPartnerAccountLink_Response() {}
     
 
-    private uint _pwid = default(uint);
+    private uint? _pwid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"pwid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pwid
     {
-      get { return _pwid; }
+      get { return _pwid?? default(uint); }
       set { _pwid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pwidSpecified
+    {
+      get { return _pwid != null; }
+      set { if (value == (_pwid== null)) _pwid = value ? this.pwid : (uint?)null; }
+    }
+    private bool ShouldSerializepwid() { return pwidSpecified; }
+    private void Resetpwid() { pwidSpecified = false; }
+    
 
-    private uint _nexonid = default(uint);
+    private uint? _nexonid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"nexonid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint nexonid
     {
-      get { return _nexonid; }
+      get { return _nexonid?? default(uint); }
       set { _nexonid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nexonidSpecified
+    {
+      get { return _nexonid != null; }
+      set { if (value == (_nexonid== null)) _nexonid = value ? this.nexonid : (uint?)null; }
+    }
+    private bool ShouldSerializenexonid() { return nexonidSpecified; }
+    private void Resetnexonid() { nexonidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2740,41 +4587,77 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgGCRoutingInfo.RoutingMethod _method = CMsgGCRoutingInfo.RoutingMethod.RANDOM;
+    private CMsgGCRoutingInfo.RoutingMethod? _method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.RANDOM)]
     public CMsgGCRoutingInfo.RoutingMethod method
     {
-      get { return _method; }
+      get { return _method?? CMsgGCRoutingInfo.RoutingMethod.RANDOM; }
       set { _method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool methodSpecified
+    {
+      get { return _method != null; }
+      set { if (value == (_method== null)) _method = value ? this.method : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializemethod() { return methodSpecified; }
+    private void Resetmethod() { methodSpecified = false; }
+    
 
-    private CMsgGCRoutingInfo.RoutingMethod _fallback = CMsgGCRoutingInfo.RoutingMethod.DISCARD;
+    private CMsgGCRoutingInfo.RoutingMethod? _fallback;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fallback", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.DISCARD)]
     public CMsgGCRoutingInfo.RoutingMethod fallback
     {
-      get { return _fallback; }
+      get { return _fallback?? CMsgGCRoutingInfo.RoutingMethod.DISCARD; }
       set { _fallback = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fallbackSpecified
+    {
+      get { return _fallback != null; }
+      set { if (value == (_fallback== null)) _fallback = value ? this.fallback : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializefallback() { return fallbackSpecified; }
+    private void Resetfallback() { fallbackSpecified = false; }
+    
 
-    private uint _protobuf_field = default(uint);
+    private uint? _protobuf_field;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"protobuf_field", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protobuf_field
     {
-      get { return _protobuf_field; }
+      get { return _protobuf_field?? default(uint); }
       set { _protobuf_field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protobuf_fieldSpecified
+    {
+      get { return _protobuf_field != null; }
+      set { if (value == (_protobuf_field== null)) _protobuf_field = value ? this.protobuf_field : (uint?)null; }
+    }
+    private bool ShouldSerializeprotobuf_field() { return protobuf_fieldSpecified; }
+    private void Resetprotobuf_field() { protobuf_fieldSpecified = false; }
+    
 
-    private string _webapi_param = "";
+    private string _webapi_param;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"webapi_param", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webapi_param
     {
-      get { return _webapi_param; }
+      get { return _webapi_param?? ""; }
       set { _webapi_param = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_paramSpecified
+    {
+      get { return _webapi_param != null; }
+      set { if (value == (_webapi_param== null)) _webapi_param = value ? this.webapi_param : (string)null; }
+    }
+    private bool ShouldSerializewebapi_param() { return webapi_paramSpecified; }
+    private void Resetwebapi_param() { webapi_paramSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"RoutingMethod", EnumPassthru=true)]
     public enum RoutingMethod
     {
@@ -2821,23 +4704,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Entry() {}
     
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2875,14 +4776,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Entry() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2908,14 +4818,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMsgMasterSetWebAPIRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2927,14 +4846,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMsgMasterSetClientMsgRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2960,14 +4888,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgGCMsgSetOptions.GCSQLVersion _gcsql_version = CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE;
+    private CMsgGCMsgSetOptions.GCSQLVersion? _gcsql_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gcsql_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE)]
     public CMsgGCMsgSetOptions.GCSQLVersion gcsql_version
     {
-      get { return _gcsql_version; }
+      get { return _gcsql_version?? CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE; }
       set { _gcsql_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gcsql_versionSpecified
+    {
+      get { return _gcsql_version != null; }
+      set { if (value == (_gcsql_version== null)) _gcsql_version = value ? this.gcsql_version : (CMsgGCMsgSetOptions.GCSQLVersion?)null; }
+    }
+    private bool ShouldSerializegcsql_version() { return gcsql_versionSpecified; }
+    private void Resetgcsql_version() { gcsql_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"MessageRange")]
   public partial class MessageRange : global::ProtoBuf.IExtensible
   {
@@ -3031,77 +4968,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCHUpdateSession() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private bool _online = default(bool);
+    private bool? _online;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"online", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool online
     {
-      get { return _online; }
+      get { return _online?? default(bool); }
       set { _online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onlineSpecified
+    {
+      get { return _online != null; }
+      set { if (value == (_online== null)) _online = value ? this.online : (bool?)null; }
+    }
+    private bool ShouldSerializeonline() { return onlineSpecified; }
+    private void Resetonline() { onlineSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private uint _server_addr = default(uint);
+    private uint? _server_addr;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_addr
     {
-      get { return _server_addr; }
+      get { return _server_addr?? default(uint); }
       set { _server_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addrSpecified
+    {
+      get { return _server_addr != null; }
+      set { if (value == (_server_addr== null)) _server_addr = value ? this.server_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_addr() { return server_addrSpecified; }
+    private void Resetserver_addr() { server_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _os_type = default(uint);
+    private uint? _os_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint os_type
     {
-      get { return _os_type; }
+      get { return _os_type?? default(uint); }
       set { _os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_typeSpecified
+    {
+      get { return _os_type != null; }
+      set { if (value == (_os_type== null)) _os_type = value ? this.os_type : (uint?)null; }
+    }
+    private bool ShouldSerializeos_type() { return os_typeSpecified; }
+    private void Resetos_type() { os_typeSpecified = false; }
+    
 
-    private uint _client_addr = default(uint);
+    private uint? _client_addr;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"client_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_addr
     {
-      get { return _client_addr; }
+      get { return _client_addr?? default(uint); }
       set { _client_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_addrSpecified
+    {
+      get { return _client_addr != null; }
+      set { if (value == (_client_addr== null)) _client_addr = value ? this.client_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_addr() { return client_addrSpecified; }
+    private void Resetclient_addr() { client_addrSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> _extra_fields = new global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField>();
     [global::ProtoBuf.ProtoMember(9, Name=@"extra_fields", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> extra_fields
@@ -3115,23 +5124,41 @@ namespace SteamKit2.GC.Dota.Internal
     public ExtraField() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3148,23 +5175,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgNotificationOfSuspiciousActivity() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
     private CMsgNotificationOfSuspiciousActivity.MultipleGameInstances _multiple_instances = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"multiple_instances", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3180,14 +5225,23 @@ namespace SteamKit2.GC.Dota.Internal
     public MultipleGameInstances() {}
     
 
-    private uint _app_instance_count = default(uint);
+    private uint? _app_instance_count;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_instance_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_instance_count
     {
-      get { return _app_instance_count; }
+      get { return _app_instance_count?? default(uint); }
       set { _app_instance_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_instance_countSpecified
+    {
+      get { return _app_instance_count != null; }
+      set { if (value == (_app_instance_count== null)) _app_instance_count = value ? this.app_instance_count : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_instance_count() { return app_instance_countSpecified; }
+    private void Resetapp_instance_count() { app_instance_countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _other_steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"other_steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> other_steamids
@@ -3211,23 +5265,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDPPartnerMicroTxns() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _gc_name = "";
+    private string _gc_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gc_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gc_name
     {
-      get { return _gc_name; }
+      get { return _gc_name?? ""; }
       set { _gc_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_nameSpecified
+    {
+      get { return _gc_name != null; }
+      set { if (value == (_gc_name== null)) _gc_name = value ? this.gc_name : (string)null; }
+    }
+    private bool ShouldSerializegc_name() { return gc_nameSpecified; }
+    private void Resetgc_name() { gc_nameSpecified = false; }
+    
 
     private CMsgDPPartnerMicroTxns.PartnerInfo _partner = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"partner", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3250,158 +5322,311 @@ namespace SteamKit2.GC.Dota.Internal
     public PartnerMicroTxn() {}
     
 
-    private uint _init_time = default(uint);
+    private uint? _init_time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"init_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint init_time
     {
-      get { return _init_time; }
+      get { return _init_time?? default(uint); }
       set { _init_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool init_timeSpecified
+    {
+      get { return _init_time != null; }
+      set { if (value == (_init_time== null)) _init_time = value ? this.init_time : (uint?)null; }
+    }
+    private bool ShouldSerializeinit_time() { return init_timeSpecified; }
+    private void Resetinit_time() { init_timeSpecified = false; }
+    
 
-    private uint _last_update_time = default(uint);
+    private uint? _last_update_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_update_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_update_time
     {
-      get { return _last_update_time; }
+      get { return _last_update_time?? default(uint); }
       set { _last_update_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_update_timeSpecified
+    {
+      get { return _last_update_time != null; }
+      set { if (value == (_last_update_time== null)) _last_update_time = value ? this.last_update_time : (uint?)null; }
+    }
+    private bool ShouldSerializelast_update_time() { return last_update_timeSpecified; }
+    private void Resetlast_update_time() { last_update_timeSpecified = false; }
+    
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _line_item = default(uint);
+    private uint? _line_item;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"line_item", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint line_item
     {
-      get { return _line_item; }
+      get { return _line_item?? default(uint); }
       set { _line_item = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool line_itemSpecified
+    {
+      get { return _line_item != null; }
+      set { if (value == (_line_item== null)) _line_item = value ? this.line_item : (uint?)null; }
+    }
+    private bool ShouldSerializeline_item() { return line_itemSpecified; }
+    private void Resetline_item() { line_itemSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _price = default(uint);
+    private uint? _price;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"price", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price
     {
-      get { return _price; }
+      get { return _price?? default(uint); }
       set { _price = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool priceSpecified
+    {
+      get { return _price != null; }
+      set { if (value == (_price== null)) _price = value ? this.price : (uint?)null; }
+    }
+    private bool ShouldSerializeprice() { return priceSpecified; }
+    private void Resetprice() { priceSpecified = false; }
+    
 
-    private uint _tax = default(uint);
+    private uint? _tax;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"tax", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tax
     {
-      get { return _tax; }
+      get { return _tax?? default(uint); }
       set { _tax = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool taxSpecified
+    {
+      get { return _tax != null; }
+      set { if (value == (_tax== null)) _tax = value ? this.tax : (uint?)null; }
+    }
+    private bool ShouldSerializetax() { return taxSpecified; }
+    private void Resettax() { taxSpecified = false; }
+    
 
-    private uint _price_usd = default(uint);
+    private uint? _price_usd;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"price_usd", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_usd
     {
-      get { return _price_usd; }
+      get { return _price_usd?? default(uint); }
       set { _price_usd = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_usdSpecified
+    {
+      get { return _price_usd != null; }
+      set { if (value == (_price_usd== null)) _price_usd = value ? this.price_usd : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_usd() { return price_usdSpecified; }
+    private void Resetprice_usd() { price_usdSpecified = false; }
+    
 
-    private uint _tax_usd = default(uint);
+    private uint? _tax_usd;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"tax_usd", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tax_usd
     {
-      get { return _tax_usd; }
+      get { return _tax_usd?? default(uint); }
       set { _tax_usd = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tax_usdSpecified
+    {
+      get { return _tax_usd != null; }
+      set { if (value == (_tax_usd== null)) _tax_usd = value ? this.tax_usd : (uint?)null; }
+    }
+    private bool ShouldSerializetax_usd() { return tax_usdSpecified; }
+    private void Resettax_usd() { tax_usdSpecified = false; }
+    
 
-    private uint _purchase_type = default(uint);
+    private uint? _purchase_type;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"purchase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint purchase_type
     {
-      get { return _purchase_type; }
+      get { return _purchase_type?? default(uint); }
       set { _purchase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_typeSpecified
+    {
+      get { return _purchase_type != null; }
+      set { if (value == (_purchase_type== null)) _purchase_type = value ? this.purchase_type : (uint?)null; }
+    }
+    private bool ShouldSerializepurchase_type() { return purchase_typeSpecified; }
+    private void Resetpurchase_type() { purchase_typeSpecified = false; }
+    
 
-    private uint _steam_txn_type = default(uint);
+    private uint? _steam_txn_type;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"steam_txn_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steam_txn_type
     {
-      get { return _steam_txn_type; }
+      get { return _steam_txn_type?? default(uint); }
       set { _steam_txn_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_txn_typeSpecified
+    {
+      get { return _steam_txn_type != null; }
+      set { if (value == (_steam_txn_type== null)) _steam_txn_type = value ? this.steam_txn_type : (uint?)null; }
+    }
+    private bool ShouldSerializesteam_txn_type() { return steam_txn_typeSpecified; }
+    private void Resetsteam_txn_type() { steam_txn_typeSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private string _region_code = "";
+    private string _region_code;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"region_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string region_code
     {
-      get { return _region_code; }
+      get { return _region_code?? ""; }
       set { _region_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_codeSpecified
+    {
+      get { return _region_code != null; }
+      set { if (value == (_region_code== null)) _region_code = value ? this.region_code : (string)null; }
+    }
+    private bool ShouldSerializeregion_code() { return region_codeSpecified; }
+    private void Resetregion_code() { region_codeSpecified = false; }
+    
 
-    private int _quantity = default(int);
+    private int? _quantity;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(int); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (int?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private ulong _ref_trans_id = default(ulong);
+    private ulong? _ref_trans_id;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"ref_trans_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ref_trans_id
     {
-      get { return _ref_trans_id; }
+      get { return _ref_trans_id?? default(ulong); }
       set { _ref_trans_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ref_trans_idSpecified
+    {
+      get { return _ref_trans_id != null; }
+      set { if (value == (_ref_trans_id== null)) _ref_trans_id = value ? this.ref_trans_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeref_trans_id() { return ref_trans_idSpecified; }
+    private void Resetref_trans_id() { ref_trans_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3413,41 +5638,77 @@ namespace SteamKit2.GC.Dota.Internal
     public PartnerInfo() {}
     
 
-    private uint _partner_id = default(uint);
+    private uint? _partner_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"partner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint partner_id
     {
-      get { return _partner_id; }
+      get { return _partner_id?? default(uint); }
       set { _partner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_idSpecified
+    {
+      get { return _partner_id != null; }
+      set { if (value == (_partner_id== null)) _partner_id = value ? this.partner_id : (uint?)null; }
+    }
+    private bool ShouldSerializepartner_id() { return partner_idSpecified; }
+    private void Resetpartner_id() { partner_idSpecified = false; }
+    
 
-    private string _partner_name = "";
+    private string _partner_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"partner_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string partner_name
     {
-      get { return _partner_name; }
+      get { return _partner_name?? ""; }
       set { _partner_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_nameSpecified
+    {
+      get { return _partner_name != null; }
+      set { if (value == (_partner_name== null)) _partner_name = value ? this.partner_name : (string)null; }
+    }
+    private bool ShouldSerializepartner_name() { return partner_nameSpecified; }
+    private void Resetpartner_name() { partner_nameSpecified = false; }
+    
 
-    private string _currency_code = "";
+    private string _currency_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"currency_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string currency_code
     {
-      get { return _currency_code; }
+      get { return _currency_code?? ""; }
       set { _currency_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currency_codeSpecified
+    {
+      get { return _currency_code != null; }
+      set { if (value == (_currency_code== null)) _currency_code = value ? this.currency_code : (string)null; }
+    }
+    private bool ShouldSerializecurrency_code() { return currency_codeSpecified; }
+    private void Resetcurrency_code() { currency_codeSpecified = false; }
+    
 
-    private string _currency_name = "";
+    private string _currency_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"currency_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string currency_name
     {
-      get { return _currency_name; }
+      get { return _currency_name?? ""; }
       set { _currency_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currency_nameSpecified
+    {
+      get { return _currency_name != null; }
+      set { if (value == (_currency_name== null)) _currency_name = value ? this.currency_name : (string)null; }
+    }
+    private bool ShouldSerializecurrency_name() { return currency_nameSpecified; }
+    private void Resetcurrency_name() { currency_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3464,23 +5725,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDPPartnerMicroTxnsResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private CMsgDPPartnerMicroTxnsResponse.EErrorCode _eerrorcode = CMsgDPPartnerMicroTxnsResponse.EErrorCode.k_MsgValid;
+    private CMsgDPPartnerMicroTxnsResponse.EErrorCode? _eerrorcode;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eerrorcode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgDPPartnerMicroTxnsResponse.EErrorCode.k_MsgValid)]
     public CMsgDPPartnerMicroTxnsResponse.EErrorCode eerrorcode
     {
-      get { return _eerrorcode; }
+      get { return _eerrorcode?? CMsgDPPartnerMicroTxnsResponse.EErrorCode.k_MsgValid; }
       set { _eerrorcode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eerrorcodeSpecified
+    {
+      get { return _eerrorcode != null; }
+      set { if (value == (_eerrorcode== null)) _eerrorcode = value ? this.eerrorcode : (CMsgDPPartnerMicroTxnsResponse.EErrorCode?)null; }
+    }
+    private bool ShouldSerializeeerrorcode() { return eerrorcodeSpecified; }
+    private void Reseteerrorcode() { eerrorcodeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EErrorCode", EnumPassthru=true)]
     public enum EErrorCode
     {
@@ -3524,32 +5803,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCHVacVerificationChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_verified = default(bool);
+    private bool? _is_verified;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_verified
     {
-      get { return _is_verified; }
+      get { return _is_verified?? default(bool); }
       set { _is_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_verifiedSpecified
+    {
+      get { return _is_verified != null; }
+      set { if (value == (_is_verified== null)) _is_verified = value ? this.is_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_verified() { return is_verifiedSpecified; }
+    private void Resetis_verified() { is_verifiedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: base_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -18,50 +20,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCStorePurchaseInit_LineItem() {}
     
 
-    private uint _item_def_id = default(uint);
+    private uint? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(uint); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _cost_in_local_currency = default(uint);
+    private uint? _cost_in_local_currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cost_in_local_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cost_in_local_currency
     {
-      get { return _cost_in_local_currency; }
+      get { return _cost_in_local_currency?? default(uint); }
       set { _cost_in_local_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cost_in_local_currencySpecified
+    {
+      get { return _cost_in_local_currency != null; }
+      set { if (value == (_cost_in_local_currency== null)) _cost_in_local_currency = value ? this.cost_in_local_currency : (uint?)null; }
+    }
+    private bool ShouldSerializecost_in_local_currency() { return cost_in_local_currencySpecified; }
+    private void Resetcost_in_local_currency() { cost_in_local_currencySpecified = false; }
+    
 
-    private uint _purchase_type = default(uint);
+    private uint? _purchase_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"purchase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint purchase_type
     {
-      get { return _purchase_type; }
+      get { return _purchase_type?? default(uint); }
       set { _purchase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_typeSpecified
+    {
+      get { return _purchase_type != null; }
+      set { if (value == (_purchase_type== null)) _purchase_type = value ? this.purchase_type : (uint?)null; }
+    }
+    private bool ShouldSerializepurchase_type() { return purchase_typeSpecified; }
+    private void Resetpurchase_type() { purchase_typeSpecified = false; }
+    
 
-    private ulong _source_reference_id = default(ulong);
+    private ulong? _source_reference_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"source_reference_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong source_reference_id
     {
-      get { return _source_reference_id; }
+      get { return _source_reference_id?? default(ulong); }
       set { _source_reference_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_reference_idSpecified
+    {
+      get { return _source_reference_id != null; }
+      set { if (value == (_source_reference_id== null)) _source_reference_id = value ? this.source_reference_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesource_reference_id() { return source_reference_idSpecified; }
+    private void Resetsource_reference_id() { source_reference_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -73,32 +120,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseInit() {}
     
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> _line_items = new global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem>();
     [global::ProtoBuf.ProtoMember(4, Name=@"line_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> line_items
@@ -117,23 +191,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseInitResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -145,14 +237,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSystemBroadcast() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -192,14 +293,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _region_ping_failed_bitmask = default(uint);
+    private uint? _region_ping_failed_bitmask;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"region_ping_failed_bitmask", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_ping_failed_bitmask
     {
-      get { return _region_ping_failed_bitmask; }
+      get { return _region_ping_failed_bitmask?? default(uint); }
       set { _region_ping_failed_bitmask = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_ping_failed_bitmaskSpecified
+    {
+      get { return _region_ping_failed_bitmask != null; }
+      set { if (value == (_region_ping_failed_bitmask== null)) _region_ping_failed_bitmask = value ? this.region_ping_failed_bitmask : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_ping_failed_bitmask() { return region_ping_failed_bitmaskSpecified; }
+    private void Resetregion_ping_failed_bitmask() { region_ping_failed_bitmaskSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -211,41 +321,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgInviteToParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private bool _as_coach = default(bool);
+    private bool? _as_coach;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"as_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool as_coach
     {
-      get { return _as_coach; }
+      get { return _as_coach?? default(bool); }
       set { _as_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool as_coachSpecified
+    {
+      get { return _as_coach != null; }
+      set { if (value == (_as_coach== null)) _as_coach = value ? this.as_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeas_coach() { return as_coachSpecified; }
+    private void Resetas_coach() { as_coachSpecified = false; }
+    
 
     private CMsgClientPingData _ping_data = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ping_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -266,23 +412,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgInviteToLobby() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -294,32 +458,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgInvitationCreated() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private bool _user_offline = default(bool);
+    private bool? _user_offline;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"user_offline", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool user_offline
     {
-      get { return _user_offline; }
+      get { return _user_offline?? default(bool); }
       set { _user_offline = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_offlineSpecified
+    {
+      get { return _user_offline != null; }
+      set { if (value == (_user_offline== null)) _user_offline = value ? this.user_offline : (bool?)null; }
+    }
+    private bool ShouldSerializeuser_offline() { return user_offlineSpecified; }
+    private void Resetuser_offline() { user_offlineSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -331,32 +522,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgPartyInviteResponse() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private bool _accept = default(bool);
+    private bool? _accept;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accept", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept
     {
-      get { return _accept; }
+      get { return _accept?? default(bool); }
       set { _accept = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptSpecified
+    {
+      get { return _accept != null; }
+      set { if (value == (_accept== null)) _accept = value ? this.accept : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept() { return acceptSpecified; }
+    private void Resetaccept() { acceptSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
     private CMsgClientPingData _ping_data = null;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"ping_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -377,50 +595,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLobbyInviteResponse() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private bool _accept = default(bool);
+    private bool? _accept;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accept", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept
     {
-      get { return _accept; }
+      get { return _accept?? default(bool); }
       set { _accept = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptSpecified
+    {
+      get { return _accept != null; }
+      set { if (value == (_accept== null)) _accept = value ? this.accept : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept() { return acceptSpecified; }
+    private void Resetaccept() { acceptSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private ulong _custom_game_crc = default(ulong);
+    private ulong? _custom_game_crc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"custom_game_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong custom_game_crc
     {
-      get { return _custom_game_crc; }
+      get { return _custom_game_crc?? default(ulong); }
       set { _custom_game_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_crcSpecified
+    {
+      get { return _custom_game_crc != null; }
+      set { if (value == (_custom_game_crc== null)) _custom_game_crc = value ? this.custom_game_crc : (ulong?)null; }
+    }
+    private bool ShouldSerializecustom_game_crc() { return custom_game_crcSpecified; }
+    private void Resetcustom_game_crc() { custom_game_crcSpecified = false; }
+    
 
-    private uint _custom_game_timestamp = default(uint);
+    private uint? _custom_game_timestamp;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"custom_game_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_game_timestamp
     {
-      get { return _custom_game_timestamp; }
+      get { return _custom_game_timestamp?? default(uint); }
       set { _custom_game_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_game_timestampSpecified
+    {
+      get { return _custom_game_timestamp != null; }
+      set { if (value == (_custom_game_timestamp== null)) _custom_game_timestamp = value ? this.custom_game_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_game_timestamp() { return custom_game_timestampSpecified; }
+    private void Resetcustom_game_timestamp() { custom_game_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -432,14 +695,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgKickFromParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -461,32 +733,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgCustomGameInstallStatus() {}
     
 
-    private ECustomGameInstallStatus _status = ECustomGameInstallStatus.k_ECustomGameInstallStatus_Unknown;
+    private ECustomGameInstallStatus? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ECustomGameInstallStatus.k_ECustomGameInstallStatus_Unknown)]
     public ECustomGameInstallStatus status
     {
-      get { return _status; }
+      get { return _status?? ECustomGameInstallStatus.k_ECustomGameInstallStatus_Unknown; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (ECustomGameInstallStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _latest_timestamp_from_steam = default(uint);
+    private uint? _latest_timestamp_from_steam;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"latest_timestamp_from_steam", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint latest_timestamp_from_steam
     {
-      get { return _latest_timestamp_from_steam; }
+      get { return _latest_timestamp_from_steam?? default(uint); }
       set { _latest_timestamp_from_steam = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latest_timestamp_from_steamSpecified
+    {
+      get { return _latest_timestamp_from_steam != null; }
+      set { if (value == (_latest_timestamp_from_steam== null)) _latest_timestamp_from_steam = value ? this.latest_timestamp_from_steam : (uint?)null; }
+    }
+    private bool ShouldSerializelatest_timestamp_from_steam() { return latest_timestamp_from_steamSpecified; }
+    private void Resetlatest_timestamp_from_steam() { latest_timestamp_from_steamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -517,14 +816,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgLANServerAvailable() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -536,77 +844,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconGameAccountClient() {}
     
 
-    private uint _additional_backpack_slots = (uint)0;
+    private uint? _additional_backpack_slots;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"additional_backpack_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint additional_backpack_slots
     {
-      get { return _additional_backpack_slots; }
+      get { return _additional_backpack_slots?? (uint)0; }
       set { _additional_backpack_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool additional_backpack_slotsSpecified
+    {
+      get { return _additional_backpack_slots != null; }
+      set { if (value == (_additional_backpack_slots== null)) _additional_backpack_slots = value ? this.additional_backpack_slots : (uint?)null; }
+    }
+    private bool ShouldSerializeadditional_backpack_slots() { return additional_backpack_slotsSpecified; }
+    private void Resetadditional_backpack_slots() { additional_backpack_slotsSpecified = false; }
+    
 
-    private bool _trial_account = (bool)false;
+    private bool? _trial_account;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool trial_account
     {
-      get { return _trial_account; }
+      get { return _trial_account?? (bool)false; }
       set { _trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trial_accountSpecified
+    {
+      get { return _trial_account != null; }
+      set { if (value == (_trial_account== null)) _trial_account = value ? this.trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializetrial_account() { return trial_accountSpecified; }
+    private void Resettrial_account() { trial_accountSpecified = false; }
+    
 
-    private bool _eligible_for_online_play = (bool)true;
+    private bool? _eligible_for_online_play;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eligible_for_online_play", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool eligible_for_online_play
     {
-      get { return _eligible_for_online_play; }
+      get { return _eligible_for_online_play?? (bool)true; }
       set { _eligible_for_online_play = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eligible_for_online_playSpecified
+    {
+      get { return _eligible_for_online_play != null; }
+      set { if (value == (_eligible_for_online_play== null)) _eligible_for_online_play = value ? this.eligible_for_online_play : (bool?)null; }
+    }
+    private bool ShouldSerializeeligible_for_online_play() { return eligible_for_online_playSpecified; }
+    private void Reseteligible_for_online_play() { eligible_for_online_playSpecified = false; }
+    
 
-    private bool _need_to_choose_most_helpful_friend = default(bool);
+    private bool? _need_to_choose_most_helpful_friend;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"need_to_choose_most_helpful_friend", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool need_to_choose_most_helpful_friend
     {
-      get { return _need_to_choose_most_helpful_friend; }
+      get { return _need_to_choose_most_helpful_friend?? default(bool); }
       set { _need_to_choose_most_helpful_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool need_to_choose_most_helpful_friendSpecified
+    {
+      get { return _need_to_choose_most_helpful_friend != null; }
+      set { if (value == (_need_to_choose_most_helpful_friend== null)) _need_to_choose_most_helpful_friend = value ? this.need_to_choose_most_helpful_friend : (bool?)null; }
+    }
+    private bool ShouldSerializeneed_to_choose_most_helpful_friend() { return need_to_choose_most_helpful_friendSpecified; }
+    private void Resetneed_to_choose_most_helpful_friend() { need_to_choose_most_helpful_friendSpecified = false; }
+    
 
-    private bool _in_coaches_list = default(bool);
+    private bool? _in_coaches_list;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"in_coaches_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_coaches_list
     {
-      get { return _in_coaches_list; }
+      get { return _in_coaches_list?? default(bool); }
       set { _in_coaches_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_coaches_listSpecified
+    {
+      get { return _in_coaches_list != null; }
+      set { if (value == (_in_coaches_list== null)) _in_coaches_list = value ? this.in_coaches_list : (bool?)null; }
+    }
+    private bool ShouldSerializein_coaches_list() { return in_coaches_listSpecified; }
+    private void Resetin_coaches_list() { in_coaches_listSpecified = false; }
+    
 
-    private uint _trade_ban_expiration = default(uint);
+    private uint? _trade_ban_expiration;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"trade_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_expiration
     {
-      get { return _trade_ban_expiration; }
+      get { return _trade_ban_expiration?? default(uint); }
       set { _trade_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_expirationSpecified
+    {
+      get { return _trade_ban_expiration != null; }
+      set { if (value == (_trade_ban_expiration== null)) _trade_ban_expiration = value ? this.trade_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_expiration() { return trade_ban_expirationSpecified; }
+    private void Resettrade_ban_expiration() { trade_ban_expirationSpecified = false; }
+    
 
-    private uint _duel_ban_expiration = default(uint);
+    private uint? _duel_ban_expiration;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"duel_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel_ban_expiration
     {
-      get { return _duel_ban_expiration; }
+      get { return _duel_ban_expiration?? default(uint); }
       set { _duel_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel_ban_expirationSpecified
+    {
+      get { return _duel_ban_expiration != null; }
+      set { if (value == (_duel_ban_expiration== null)) _duel_ban_expiration = value ? this.duel_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializeduel_ban_expiration() { return duel_ban_expirationSpecified; }
+    private void Resetduel_ban_expiration() { duel_ban_expirationSpecified = false; }
+    
 
-    private bool _made_first_purchase = (bool)false;
+    private bool? _made_first_purchase;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"made_first_purchase", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool made_first_purchase
     {
-      get { return _made_first_purchase; }
+      get { return _made_first_purchase?? (bool)false; }
       set { _made_first_purchase = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool made_first_purchaseSpecified
+    {
+      get { return _made_first_purchase != null; }
+      set { if (value == (_made_first_purchase== null)) _made_first_purchase = value ? this.made_first_purchase : (bool?)null; }
+    }
+    private bool ShouldSerializemade_first_purchase() { return made_first_purchaseSpecified; }
+    private void Resetmade_first_purchase() { made_first_purchaseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -618,50 +998,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOItemCriteriaCondition() {}
     
 
-    private int _op = default(int);
+    private int? _op;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"op", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int op
     {
-      get { return _op; }
+      get { return _op?? default(int); }
       set { _op = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opSpecified
+    {
+      get { return _op != null; }
+      set { if (value == (_op== null)) _op = value ? this.op : (int?)null; }
+    }
+    private bool ShouldSerializeop() { return opSpecified; }
+    private void Resetop() { opSpecified = false; }
+    
 
-    private string _field = "";
+    private string _field;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"field", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string field
     {
-      get { return _field; }
+      get { return _field?? ""; }
       set { _field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fieldSpecified
+    {
+      get { return _field != null; }
+      set { if (value == (_field== null)) _field = value ? this.field : (string)null; }
+    }
+    private bool ShouldSerializefield() { return fieldSpecified; }
+    private void Resetfield() { fieldSpecified = false; }
+    
 
-    private bool _required = default(bool);
+    private bool? _required;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"required", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool required
     {
-      get { return _required; }
+      get { return _required?? default(bool); }
       set { _required = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requiredSpecified
+    {
+      get { return _required != null; }
+      set { if (value == (_required== null)) _required = value ? this.required : (bool?)null; }
+    }
+    private bool ShouldSerializerequired() { return requiredSpecified; }
+    private void Resetrequired() { requiredSpecified = false; }
+    
 
-    private float _float_value = default(float);
+    private float? _float_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"float_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float float_value
     {
-      get { return _float_value; }
+      get { return _float_value?? default(float); }
       set { _float_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool float_valueSpecified
+    {
+      get { return _float_value != null; }
+      set { if (value == (_float_value== null)) _float_value = value ? this.float_value : (float?)null; }
+    }
+    private bool ShouldSerializefloat_value() { return float_valueSpecified; }
+    private void Resetfloat_value() { float_valueSpecified = false; }
+    
 
-    private string _string_value = "";
+    private string _string_value;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"string_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string string_value
     {
-      get { return _string_value; }
+      get { return _string_value?? ""; }
       set { _string_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool string_valueSpecified
+    {
+      get { return _string_value != null; }
+      set { if (value == (_string_value== null)) _string_value = value ? this.string_value : (string)null; }
+    }
+    private bool ShouldSerializestring_value() { return string_valueSpecified; }
+    private void Resetstring_value() { string_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -673,68 +1098,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOItemCriteria() {}
     
 
-    private uint _item_level = default(uint);
+    private uint? _item_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_level
     {
-      get { return _item_level; }
+      get { return _item_level?? default(uint); }
       set { _item_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_levelSpecified
+    {
+      get { return _item_level != null; }
+      set { if (value == (_item_level== null)) _item_level = value ? this.item_level : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_level() { return item_levelSpecified; }
+    private void Resetitem_level() { item_levelSpecified = false; }
+    
 
-    private int _item_quality = default(int);
+    private int? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(int); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (int?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private bool _item_level_set = default(bool);
+    private bool? _item_level_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_level_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_level_set
     {
-      get { return _item_level_set; }
+      get { return _item_level_set?? default(bool); }
       set { _item_level_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_level_setSpecified
+    {
+      get { return _item_level_set != null; }
+      set { if (value == (_item_level_set== null)) _item_level_set = value ? this.item_level_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_level_set() { return item_level_setSpecified; }
+    private void Resetitem_level_set() { item_level_setSpecified = false; }
+    
 
-    private bool _item_quality_set = default(bool);
+    private bool? _item_quality_set;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"item_quality_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_quality_set
     {
-      get { return _item_quality_set; }
+      get { return _item_quality_set?? default(bool); }
       set { _item_quality_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_quality_setSpecified
+    {
+      get { return _item_quality_set != null; }
+      set { if (value == (_item_quality_set== null)) _item_quality_set = value ? this.item_quality_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_quality_set() { return item_quality_setSpecified; }
+    private void Resetitem_quality_set() { item_quality_setSpecified = false; }
+    
 
-    private uint _initial_inventory = default(uint);
+    private uint? _initial_inventory;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initial_inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_inventory
     {
-      get { return _initial_inventory; }
+      get { return _initial_inventory?? default(uint); }
       set { _initial_inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_inventorySpecified
+    {
+      get { return _initial_inventory != null; }
+      set { if (value == (_initial_inventory== null)) _initial_inventory = value ? this.initial_inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_inventory() { return initial_inventorySpecified; }
+    private void Resetinitial_inventory() { initial_inventorySpecified = false; }
+    
 
-    private uint _initial_quantity = default(uint);
+    private uint? _initial_quantity;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"initial_quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_quantity
     {
-      get { return _initial_quantity; }
+      get { return _initial_quantity?? default(uint); }
       set { _initial_quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_quantitySpecified
+    {
+      get { return _initial_quantity != null; }
+      set { if (value == (_initial_quantity== null)) _initial_quantity = value ? this.initial_quantity : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_quantity() { return initial_quantitySpecified; }
+    private void Resetinitial_quantity() { initial_quantitySpecified = false; }
+    
 
-    private bool _ignore_enabled_flag = default(bool);
+    private bool? _ignore_enabled_flag;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"ignore_enabled_flag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ignore_enabled_flag
     {
-      get { return _ignore_enabled_flag; }
+      get { return _ignore_enabled_flag?? default(bool); }
       set { _ignore_enabled_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ignore_enabled_flagSpecified
+    {
+      get { return _ignore_enabled_flag != null; }
+      set { if (value == (_ignore_enabled_flag== null)) _ignore_enabled_flag = value ? this.ignore_enabled_flag : (bool?)null; }
+    }
+    private bool ShouldSerializeignore_enabled_flag() { return ignore_enabled_flagSpecified; }
+    private void Resetignore_enabled_flag() { ignore_enabled_flagSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteriaCondition> _conditions = new global::System.Collections.Generic.List<CSOItemCriteriaCondition>();
     [global::ProtoBuf.ProtoMember(9, Name=@"conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteriaCondition> conditions
@@ -743,14 +1231,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _recent_only = default(bool);
+    private bool? _recent_only;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"recent_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool recent_only
     {
-      get { return _recent_only; }
+      get { return _recent_only?? default(bool); }
       set { _recent_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recent_onlySpecified
+    {
+      get { return _recent_only != null; }
+      set { if (value == (_recent_only== null)) _recent_only = value ? this.recent_only : (bool?)null; }
+    }
+    private bool ShouldSerializerecent_only() { return recent_onlySpecified; }
+    private void Resetrecent_only() { recent_onlySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -762,149 +1259,293 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOItemRecipe() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _n_a = "";
+    private string _n_a;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"n_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string n_a
     {
-      get { return _n_a; }
+      get { return _n_a?? ""; }
       set { _n_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool n_aSpecified
+    {
+      get { return _n_a != null; }
+      set { if (value == (_n_a== null)) _n_a = value ? this.n_a : (string)null; }
+    }
+    private bool ShouldSerializen_a() { return n_aSpecified; }
+    private void Resetn_a() { n_aSpecified = false; }
+    
 
-    private string _desc_inputs = "";
+    private string _desc_inputs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"desc_inputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_inputs
     {
-      get { return _desc_inputs; }
+      get { return _desc_inputs?? ""; }
       set { _desc_inputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_inputsSpecified
+    {
+      get { return _desc_inputs != null; }
+      set { if (value == (_desc_inputs== null)) _desc_inputs = value ? this.desc_inputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_inputs() { return desc_inputsSpecified; }
+    private void Resetdesc_inputs() { desc_inputsSpecified = false; }
+    
 
-    private string _desc_outputs = "";
+    private string _desc_outputs;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"desc_outputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_outputs
     {
-      get { return _desc_outputs; }
+      get { return _desc_outputs?? ""; }
       set { _desc_outputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_outputsSpecified
+    {
+      get { return _desc_outputs != null; }
+      set { if (value == (_desc_outputs== null)) _desc_outputs = value ? this.desc_outputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_outputs() { return desc_outputsSpecified; }
+    private void Resetdesc_outputs() { desc_outputsSpecified = false; }
+    
 
-    private string _di_a = "";
+    private string _di_a;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"di_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_a
     {
-      get { return _di_a; }
+      get { return _di_a?? ""; }
       set { _di_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_aSpecified
+    {
+      get { return _di_a != null; }
+      set { if (value == (_di_a== null)) _di_a = value ? this.di_a : (string)null; }
+    }
+    private bool ShouldSerializedi_a() { return di_aSpecified; }
+    private void Resetdi_a() { di_aSpecified = false; }
+    
 
-    private string _di_b = "";
+    private string _di_b;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"di_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_b
     {
-      get { return _di_b; }
+      get { return _di_b?? ""; }
       set { _di_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_bSpecified
+    {
+      get { return _di_b != null; }
+      set { if (value == (_di_b== null)) _di_b = value ? this.di_b : (string)null; }
+    }
+    private bool ShouldSerializedi_b() { return di_bSpecified; }
+    private void Resetdi_b() { di_bSpecified = false; }
+    
 
-    private string _di_c = "";
+    private string _di_c;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"di_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_c
     {
-      get { return _di_c; }
+      get { return _di_c?? ""; }
       set { _di_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_cSpecified
+    {
+      get { return _di_c != null; }
+      set { if (value == (_di_c== null)) _di_c = value ? this.di_c : (string)null; }
+    }
+    private bool ShouldSerializedi_c() { return di_cSpecified; }
+    private void Resetdi_c() { di_cSpecified = false; }
+    
 
-    private string _do_a = "";
+    private string _do_a;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"do_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_a
     {
-      get { return _do_a; }
+      get { return _do_a?? ""; }
       set { _do_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_aSpecified
+    {
+      get { return _do_a != null; }
+      set { if (value == (_do_a== null)) _do_a = value ? this.do_a : (string)null; }
+    }
+    private bool ShouldSerializedo_a() { return do_aSpecified; }
+    private void Resetdo_a() { do_aSpecified = false; }
+    
 
-    private string _do_b = "";
+    private string _do_b;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"do_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_b
     {
-      get { return _do_b; }
+      get { return _do_b?? ""; }
       set { _do_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_bSpecified
+    {
+      get { return _do_b != null; }
+      set { if (value == (_do_b== null)) _do_b = value ? this.do_b : (string)null; }
+    }
+    private bool ShouldSerializedo_b() { return do_bSpecified; }
+    private void Resetdo_b() { do_bSpecified = false; }
+    
 
-    private string _do_c = "";
+    private string _do_c;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"do_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_c
     {
-      get { return _do_c; }
+      get { return _do_c?? ""; }
       set { _do_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_cSpecified
+    {
+      get { return _do_c != null; }
+      set { if (value == (_do_c== null)) _do_c = value ? this.do_c : (string)null; }
+    }
+    private bool ShouldSerializedo_c() { return do_cSpecified; }
+    private void Resetdo_c() { do_cSpecified = false; }
+    
 
-    private bool _requires_all_same_class = default(bool);
+    private bool? _requires_all_same_class;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"requires_all_same_class", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_class
     {
-      get { return _requires_all_same_class; }
+      get { return _requires_all_same_class?? default(bool); }
       set { _requires_all_same_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_classSpecified
+    {
+      get { return _requires_all_same_class != null; }
+      set { if (value == (_requires_all_same_class== null)) _requires_all_same_class = value ? this.requires_all_same_class : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_class() { return requires_all_same_classSpecified; }
+    private void Resetrequires_all_same_class() { requires_all_same_classSpecified = false; }
+    
 
-    private bool _requires_all_same_slot = default(bool);
+    private bool? _requires_all_same_slot;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"requires_all_same_slot", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_slot
     {
-      get { return _requires_all_same_slot; }
+      get { return _requires_all_same_slot?? default(bool); }
       set { _requires_all_same_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_slotSpecified
+    {
+      get { return _requires_all_same_slot != null; }
+      set { if (value == (_requires_all_same_slot== null)) _requires_all_same_slot = value ? this.requires_all_same_slot : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_slot() { return requires_all_same_slotSpecified; }
+    private void Resetrequires_all_same_slot() { requires_all_same_slotSpecified = false; }
+    
 
-    private int _class_usage_for_output = default(int);
+    private int? _class_usage_for_output;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"class_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int class_usage_for_output
     {
-      get { return _class_usage_for_output; }
+      get { return _class_usage_for_output?? default(int); }
       set { _class_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_usage_for_outputSpecified
+    {
+      get { return _class_usage_for_output != null; }
+      set { if (value == (_class_usage_for_output== null)) _class_usage_for_output = value ? this.class_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeclass_usage_for_output() { return class_usage_for_outputSpecified; }
+    private void Resetclass_usage_for_output() { class_usage_for_outputSpecified = false; }
+    
 
-    private int _slot_usage_for_output = default(int);
+    private int? _slot_usage_for_output;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"slot_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int slot_usage_for_output
     {
-      get { return _slot_usage_for_output; }
+      get { return _slot_usage_for_output?? default(int); }
       set { _slot_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_usage_for_outputSpecified
+    {
+      get { return _slot_usage_for_output != null; }
+      set { if (value == (_slot_usage_for_output== null)) _slot_usage_for_output = value ? this.slot_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeslot_usage_for_output() { return slot_usage_for_outputSpecified; }
+    private void Resetslot_usage_for_output() { slot_usage_for_outputSpecified = false; }
+    
 
-    private int _set_for_output = default(int);
+    private int? _set_for_output;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"set_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int set_for_output
     {
-      get { return _set_for_output; }
+      get { return _set_for_output?? default(int); }
       set { _set_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool set_for_outputSpecified
+    {
+      get { return _set_for_output != null; }
+      set { if (value == (_set_for_output== null)) _set_for_output = value ? this.set_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeset_for_output() { return set_for_outputSpecified; }
+    private void Resetset_for_output() { set_for_outputSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteria> _input_items_criteria = new global::System.Collections.Generic.List<CSOItemCriteria>();
     [global::ProtoBuf.ProtoMember(20, Name=@"input_items_criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteria> input_items_criteria
@@ -937,23 +1578,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgApplyStrangePart() {}
     
 
-    private ulong _strange_part_item_id = default(ulong);
+    private ulong? _strange_part_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"strange_part_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong strange_part_item_id
     {
-      get { return _strange_part_item_id; }
+      get { return _strange_part_item_id?? default(ulong); }
       set { _strange_part_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_part_item_idSpecified
+    {
+      get { return _strange_part_item_id != null; }
+      set { if (value == (_strange_part_item_id== null)) _strange_part_item_id = value ? this.strange_part_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestrange_part_item_id() { return strange_part_item_idSpecified; }
+    private void Resetstrange_part_item_id() { strange_part_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -965,23 +1624,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgApplyPennantUpgrade() {}
     
 
-    private ulong _upgrade_item_id = default(ulong);
+    private ulong? _upgrade_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upgrade_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upgrade_item_id
     {
-      get { return _upgrade_item_id; }
+      get { return _upgrade_item_id?? default(ulong); }
       set { _upgrade_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upgrade_item_idSpecified
+    {
+      get { return _upgrade_item_id != null; }
+      set { if (value == (_upgrade_item_id== null)) _upgrade_item_id = value ? this.upgrade_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeupgrade_item_id() { return upgrade_item_idSpecified; }
+    private void Resetupgrade_item_id() { upgrade_item_idSpecified = false; }
+    
 
-    private ulong _pennant_item_id = default(ulong);
+    private ulong? _pennant_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pennant_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pennant_item_id
     {
-      get { return _pennant_item_id; }
+      get { return _pennant_item_id?? default(ulong); }
       set { _pennant_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pennant_item_idSpecified
+    {
+      get { return _pennant_item_id != null; }
+      set { if (value == (_pennant_item_id== null)) _pennant_item_id = value ? this.pennant_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepennant_item_id() { return pennant_item_idSpecified; }
+    private void Resetpennant_item_id() { pennant_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -993,23 +1670,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgApplyEggEssence() {}
     
 
-    private ulong _essence_item_id = default(ulong);
+    private ulong? _essence_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"essence_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong essence_item_id
     {
-      get { return _essence_item_id; }
+      get { return _essence_item_id?? default(ulong); }
       set { _essence_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool essence_item_idSpecified
+    {
+      get { return _essence_item_id != null; }
+      set { if (value == (_essence_item_id== null)) _essence_item_id = value ? this.essence_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeessence_item_id() { return essence_item_idSpecified; }
+    private void Resetessence_item_id() { essence_item_idSpecified = false; }
+    
 
-    private ulong _egg_item_id = default(ulong);
+    private ulong? _egg_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"egg_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong egg_item_id
     {
-      get { return _egg_item_id; }
+      get { return _egg_item_id?? default(ulong); }
       set { _egg_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool egg_item_idSpecified
+    {
+      get { return _egg_item_id != null; }
+      set { if (value == (_egg_item_id== null)) _egg_item_id = value ? this.egg_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeegg_item_id() { return egg_item_idSpecified; }
+    private void Resetegg_item_id() { egg_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1021,32 +1716,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemAttribute() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private byte[] _value_bytes = null;
+    private byte[] _value_bytes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"value_bytes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value_bytes
     {
-      get { return _value_bytes; }
+      get { return _value_bytes?? null; }
       set { _value_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_bytesSpecified
+    {
+      get { return _value_bytes != null; }
+      set { if (value == (_value_bytes== null)) _value_bytes = value ? this.value_bytes : (byte[])null; }
+    }
+    private bool ShouldSerializevalue_bytes() { return value_bytesSpecified; }
+    private void Resetvalue_bytes() { value_bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1058,23 +1780,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemEquipped() {}
     
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1086,86 +1826,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItem() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quantity = (uint)1;
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? (uint)1; }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _level = (uint)1;
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? (uint)1; }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _quality = (uint)4;
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4)]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? (uint)4; }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _flags = (uint)0;
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? (uint)0; }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _origin = (uint)0;
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? (uint)0; }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemAttribute> _attribute = new global::System.Collections.Generic.List<CSOEconItemAttribute>();
     [global::ProtoBuf.ProtoMember(12, Name=@"attribute", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemAttribute> attribute
@@ -1183,32 +2004,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _interior_item = value; }
     }
 
-    private bool _in_use = (bool)false;
+    private bool? _in_use;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"in_use", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool in_use
     {
-      get { return _in_use; }
+      get { return _in_use?? (bool)false; }
       set { _in_use = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_useSpecified
+    {
+      get { return _in_use != null; }
+      set { if (value == (_in_use== null)) _in_use = value ? this.in_use : (bool?)null; }
+    }
+    private bool ShouldSerializein_use() { return in_useSpecified; }
+    private void Resetin_use() { in_useSpecified = false; }
+    
 
-    private uint _style = (uint)0;
+    private uint? _style;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"style", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint style
     {
-      get { return _style; }
+      get { return _style?? (uint)0; }
       set { _style = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool styleSpecified
+    {
+      get { return _style != null; }
+      set { if (value == (_style== null)) _style = value ? this.style : (uint?)null; }
+    }
+    private bool ShouldSerializestyle() { return styleSpecified; }
+    private void Resetstyle() { styleSpecified = false; }
+    
 
-    private ulong _original_id = (ulong)0;
+    private ulong? _original_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"original_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong original_id
     {
-      get { return _original_id; }
+      get { return _original_id?? (ulong)0; }
       set { _original_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_idSpecified
+    {
+      get { return _original_id != null; }
+      set { if (value == (_original_id== null)) _original_id = value ? this.original_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeoriginal_id() { return original_idSpecified; }
+    private void Resetoriginal_id() { original_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemEquipped> _equipped_state = new global::System.Collections.Generic.List<CSOEconItemEquipped>();
     [global::ProtoBuf.ProtoMember(18, Name=@"equipped_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemEquipped> equipped_state
@@ -1227,14 +2075,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSortItems() {}
     
 
-    private uint _sort_type = default(uint);
+    private uint? _sort_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sort_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_type
     {
-      get { return _sort_type; }
+      get { return _sort_type?? default(uint); }
       set { _sort_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_typeSpecified
+    {
+      get { return _sort_type != null; }
+      set { if (value == (_sort_type== null)) _sort_type = value ? this.sort_type : (uint?)null; }
+    }
+    private bool ShouldSerializesort_type() { return sort_typeSpecified; }
+    private void Resetsort_type() { sort_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1246,41 +2103,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconClaimCode() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _code_type = default(uint);
+    private uint? _code_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"code_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint code_type
     {
-      get { return _code_type; }
+      get { return _code_type?? default(uint); }
       set { _code_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool code_typeSpecified
+    {
+      get { return _code_type != null; }
+      set { if (value == (_code_type== null)) _code_type = value ? this.code_type : (uint?)null; }
+    }
+    private bool ShouldSerializecode_type() { return code_typeSpecified; }
+    private void Resetcode_type() { code_typeSpecified = false; }
+    
 
-    private uint _time_acquired = default(uint);
+    private uint? _time_acquired;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_acquired", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_acquired
     {
-      get { return _time_acquired; }
+      get { return _time_acquired?? default(uint); }
       set { _time_acquired = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_acquiredSpecified
+    {
+      get { return _time_acquired != null; }
+      set { if (value == (_time_acquired== null)) _time_acquired = value ? this.time_acquired : (uint?)null; }
+    }
+    private bool ShouldSerializetime_acquired() { return time_acquiredSpecified; }
+    private void Resettime_acquired() { time_acquiredSpecified = false; }
+    
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1292,14 +2185,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgStoreGetUserData() {}
     
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1311,86 +2213,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgStoreGetUserDataResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
 
-    private ulong _experiment_data = (ulong)0;
+    private ulong? _experiment_data;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"experiment_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong experiment_data
     {
-      get { return _experiment_data; }
+      get { return _experiment_data?? (ulong)0; }
       set { _experiment_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experiment_dataSpecified
+    {
+      get { return _experiment_data != null; }
+      set { if (value == (_experiment_data== null)) _experiment_data = value ? this.experiment_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeexperiment_data() { return experiment_dataSpecified; }
+    private void Resetexperiment_data() { experiment_dataSpecified = false; }
+    
 
-    private int _featured_item_idx = default(int);
+    private int? _featured_item_idx;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"featured_item_idx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int featured_item_idx
     {
-      get { return _featured_item_idx; }
+      get { return _featured_item_idx?? default(int); }
       set { _featured_item_idx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool featured_item_idxSpecified
+    {
+      get { return _featured_item_idx != null; }
+      set { if (value == (_featured_item_idx== null)) _featured_item_idx = value ? this.featured_item_idx : (int?)null; }
+    }
+    private bool ShouldSerializefeatured_item_idx() { return featured_item_idxSpecified; }
+    private void Resetfeatured_item_idx() { featured_item_idxSpecified = false; }
+    
 
-    private bool _show_hat_descriptions = (bool)true;
+    private bool? _show_hat_descriptions;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"show_hat_descriptions", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool show_hat_descriptions
     {
-      get { return _show_hat_descriptions; }
+      get { return _show_hat_descriptions?? (bool)true; }
       set { _show_hat_descriptions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool show_hat_descriptionsSpecified
+    {
+      get { return _show_hat_descriptions != null; }
+      set { if (value == (_show_hat_descriptions== null)) _show_hat_descriptions = value ? this.show_hat_descriptions : (bool?)null; }
+    }
+    private bool ShouldSerializeshow_hat_descriptions() { return show_hat_descriptionsSpecified; }
+    private void Resetshow_hat_descriptions() { show_hat_descriptionsSpecified = false; }
+    
 
-    private byte[] _price_sheet = null;
+    private byte[] _price_sheet;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"price_sheet", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] price_sheet
     {
-      get { return _price_sheet; }
+      get { return _price_sheet?? null; }
       set { _price_sheet = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheetSpecified
+    {
+      get { return _price_sheet != null; }
+      set { if (value == (_price_sheet== null)) _price_sheet = value ? this.price_sheet : (byte[])null; }
+    }
+    private bool ShouldSerializeprice_sheet() { return price_sheetSpecified; }
+    private void Resetprice_sheet() { price_sheetSpecified = false; }
+    
 
-    private int _default_item_sort = (int)0;
+    private int? _default_item_sort;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"default_item_sort", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int default_item_sort
     {
-      get { return _default_item_sort; }
+      get { return _default_item_sort?? (int)0; }
       set { _default_item_sort = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool default_item_sortSpecified
+    {
+      get { return _default_item_sort != null; }
+      set { if (value == (_default_item_sort== null)) _default_item_sort = value ? this.default_item_sort : (int?)null; }
+    }
+    private bool ShouldSerializedefault_item_sort() { return default_item_sortSpecified; }
+    private void Resetdefault_item_sort() { default_item_sortSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _popular_items = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(10, Name=@"popular_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> popular_items
@@ -1409,32 +2392,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgUpdateItemSchema() {}
     
 
-    private byte[] _items_game = null;
+    private byte[] _items_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"items_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] items_game
     {
-      get { return _items_game; }
+      get { return _items_game?? null; }
       set { _items_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_gameSpecified
+    {
+      get { return _items_game != null; }
+      set { if (value == (_items_game== null)) _items_game = value ? this.items_game : (byte[])null; }
+    }
+    private bool ShouldSerializeitems_game() { return items_gameSpecified; }
+    private void Resetitems_game() { items_gameSpecified = false; }
+    
 
-    private uint _item_schema_version = default(uint);
+    private uint? _item_schema_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_schema_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_schema_version
     {
-      get { return _item_schema_version; }
+      get { return _item_schema_version?? default(uint); }
       set { _item_schema_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_schema_versionSpecified
+    {
+      get { return _item_schema_version != null; }
+      set { if (value == (_item_schema_version== null)) _item_schema_version = value ? this.item_schema_version : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_schema_version() { return item_schema_versionSpecified; }
+    private void Resetitem_schema_version() { item_schema_versionSpecified = false; }
+    
 
-    private string _items_game_url = "";
+    private string _items_game_url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"items_game_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string items_game_url
     {
-      get { return _items_game_url; }
+      get { return _items_game_url?? ""; }
       set { _items_game_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_game_urlSpecified
+    {
+      get { return _items_game_url != null; }
+      set { if (value == (_items_game_url== null)) _items_game_url = value ? this.items_game_url : (string)null; }
+    }
+    private bool ShouldSerializeitems_game_url() { return items_game_urlSpecified; }
+    private void Resetitems_game_url() { items_game_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1446,14 +2456,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCError() {}
     
 
-    private string _error_text = "";
+    private string _error_text;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"error_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_text
     {
-      get { return _error_text; }
+      get { return _error_text?? ""; }
       set { _error_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_textSpecified
+    {
+      get { return _error_text != null; }
+      set { if (value == (_error_text== null)) _error_text = value ? this.error_text : (string)null; }
+    }
+    private bool ShouldSerializeerror_text() { return error_textSpecified; }
+    private void Reseterror_text() { error_textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1475,23 +2494,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgConVarValue() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1520,14 +2557,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgConsumableExhausted() {}
     
 
-    private int _item_def_id = default(int);
+    private int? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(int); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (int?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1539,59 +2585,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgItemAcknowledged() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _rarity = default(uint);
+    private uint? _rarity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rarity
     {
-      get { return _rarity; }
+      get { return _rarity?? default(uint); }
       set { _rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raritySpecified
+    {
+      get { return _rarity != null; }
+      set { if (value == (_rarity== null)) _rarity = value ? this.rarity : (uint?)null; }
+    }
+    private bool ShouldSerializerarity() { return raritySpecified; }
+    private void Resetrarity() { raritySpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1615,23 +2715,41 @@ namespace SteamKit2.GC.Dota.Internal
     public ItemPosition() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _position = default(uint);
+    private uint? _position;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint position
     {
-      get { return _position; }
+      get { return _position?? default(uint); }
       set { _position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool positionSpecified
+    {
+      get { return _position != null; }
+      set { if (value == (_position== null)) _position = value ? this.position : (uint?)null; }
+    }
+    private bool ShouldSerializeposition() { return positionSpecified; }
+    private void Resetposition() { positionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1648,32 +2766,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCNameItemNotification() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private string _item_name_custom = "";
+    private string _item_name_custom;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_name_custom", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_name_custom
     {
-      get { return _item_name_custom; }
+      get { return _item_name_custom?? ""; }
       set { _item_name_custom = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_name_customSpecified
+    {
+      get { return _item_name_custom != null; }
+      set { if (value == (_item_name_custom== null)) _item_name_custom = value ? this.item_name_custom : (string)null; }
+    }
+    private bool ShouldSerializeitem_name_custom() { return item_name_customSpecified; }
+    private void Resetitem_name_custom() { item_name_customSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1685,23 +2830,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCClientDisplayNotification() {}
     
 
-    private string _notification_title_localization_key = "";
+    private string _notification_title_localization_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"notification_title_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_title_localization_key
     {
-      get { return _notification_title_localization_key; }
+      get { return _notification_title_localization_key?? ""; }
       set { _notification_title_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_title_localization_keySpecified
+    {
+      get { return _notification_title_localization_key != null; }
+      set { if (value == (_notification_title_localization_key== null)) _notification_title_localization_key = value ? this.notification_title_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_title_localization_key() { return notification_title_localization_keySpecified; }
+    private void Resetnotification_title_localization_key() { notification_title_localization_keySpecified = false; }
+    
 
-    private string _notification_body_localization_key = "";
+    private string _notification_body_localization_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"notification_body_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_body_localization_key
     {
-      get { return _notification_body_localization_key; }
+      get { return _notification_body_localization_key?? ""; }
       set { _notification_body_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_body_localization_keySpecified
+    {
+      get { return _notification_body_localization_key != null; }
+      set { if (value == (_notification_body_localization_key== null)) _notification_body_localization_key = value ? this.notification_body_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_body_localization_key() { return notification_body_localization_keySpecified; }
+    private void Resetnotification_body_localization_key() { notification_body_localization_keySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _body_substring_keys = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"body_substring_keys", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> body_substring_keys
@@ -1727,14 +2890,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCShowItemsPickedUp() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1746,41 +2918,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCIncrementKillCountResponse() {}
     
 
-    private uint _killer_account_id = default(uint);
+    private uint? _killer_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_account_id
     {
-      get { return _killer_account_id; }
+      get { return _killer_account_id?? default(uint); }
       set { _killer_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_account_idSpecified
+    {
+      get { return _killer_account_id != null; }
+      set { if (value == (_killer_account_id== null)) _killer_account_id = value ? this.killer_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_account_id() { return killer_account_idSpecified; }
+    private void Resetkiller_account_id() { killer_account_idSpecified = false; }
+    
 
-    private uint _num_kills = default(uint);
+    private uint? _num_kills;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_kills
     {
-      get { return _num_kills; }
+      get { return _num_kills?? default(uint); }
       set { _num_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_killsSpecified
+    {
+      get { return _num_kills != null; }
+      set { if (value == (_num_kills== null)) _num_kills = value ? this.num_kills : (uint?)null; }
+    }
+    private bool ShouldSerializenum_kills() { return num_killsSpecified; }
+    private void Resetnum_kills() { num_killsSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _level_type = default(uint);
+    private uint? _level_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"level_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level_type
     {
-      get { return _level_type; }
+      get { return _level_type?? default(uint); }
       set { _level_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_typeSpecified
+    {
+      get { return _level_type != null; }
+      set { if (value == (_level_type== null)) _level_type = value ? this.level_type : (uint?)null; }
+    }
+    private bool ShouldSerializelevel_type() { return level_typeSpecified; }
+    private void Resetlevel_type() { level_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1792,77 +3000,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemDropRateBonus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _expiration_date = default(uint);
+    private uint? _expiration_date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"expiration_date", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_date
     {
-      get { return _expiration_date; }
+      get { return _expiration_date?? default(uint); }
       set { _expiration_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_dateSpecified
+    {
+      get { return _expiration_date != null; }
+      set { if (value == (_expiration_date== null)) _expiration_date = value ? this.expiration_date : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_date() { return expiration_dateSpecified; }
+    private void Resetexpiration_date() { expiration_dateSpecified = false; }
+    
 
-    private float _bonus = default(float);
+    private float? _bonus;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bonus", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float bonus
     {
-      get { return _bonus; }
+      get { return _bonus?? default(float); }
       set { _bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonusSpecified
+    {
+      get { return _bonus != null; }
+      set { if (value == (_bonus== null)) _bonus = value ? this.bonus : (float?)null; }
+    }
+    private bool ShouldSerializebonus() { return bonusSpecified; }
+    private void Resetbonus() { bonusSpecified = false; }
+    
 
-    private uint _bonus_count = default(uint);
+    private uint? _bonus_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bonus_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_count
     {
-      get { return _bonus_count; }
+      get { return _bonus_count?? default(uint); }
       set { _bonus_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_countSpecified
+    {
+      get { return _bonus_count != null; }
+      set { if (value == (_bonus_count== null)) _bonus_count = value ? this.bonus_count : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_count() { return bonus_countSpecified; }
+    private void Resetbonus_count() { bonus_countSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _seconds_left = default(uint);
+    private uint? _seconds_left;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"seconds_left", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds_left
     {
-      get { return _seconds_left; }
+      get { return _seconds_left?? default(uint); }
       set { _seconds_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_leftSpecified
+    {
+      get { return _seconds_left != null; }
+      set { if (value == (_seconds_left== null)) _seconds_left = value ? this.seconds_left : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds_left() { return seconds_leftSpecified; }
+    private void Resetseconds_left() { seconds_leftSpecified = false; }
+    
 
-    private uint _booster_type = default(uint);
+    private uint? _booster_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"booster_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint booster_type
     {
-      get { return _booster_type; }
+      get { return _booster_type?? default(uint); }
       set { _booster_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool booster_typeSpecified
+    {
+      get { return _booster_type != null; }
+      set { if (value == (_booster_type== null)) _booster_type = value ? this.booster_type : (uint?)null; }
+    }
+    private bool ShouldSerializebooster_type() { return booster_typeSpecified; }
+    private void Resetbooster_type() { booster_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1874,41 +3154,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemLeagueViewPass() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _itemindex = default(uint);
+    private uint? _itemindex;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"itemindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint itemindex
     {
-      get { return _itemindex; }
+      get { return _itemindex?? default(uint); }
       set { _itemindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemindexSpecified
+    {
+      get { return _itemindex != null; }
+      set { if (value == (_itemindex== null)) _itemindex = value ? this.itemindex : (uint?)null; }
+    }
+    private bool ShouldSerializeitemindex() { return itemindexSpecified; }
+    private void Resetitemindex() { itemindexSpecified = false; }
+    
 
-    private uint _grant_reason = default(uint);
+    private uint? _grant_reason;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"grant_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint grant_reason
     {
-      get { return _grant_reason; }
+      get { return _grant_reason?? default(uint); }
       set { _grant_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool grant_reasonSpecified
+    {
+      get { return _grant_reason != null; }
+      set { if (value == (_grant_reason== null)) _grant_reason = value ? this.grant_reason : (uint?)null; }
+    }
+    private bool ShouldSerializegrant_reason() { return grant_reasonSpecified; }
+    private void Resetgrant_reason() { grant_reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1920,32 +3236,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemEventTicket() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _event_id = default(uint);
+    private uint? _event_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_id
     {
-      get { return _event_id; }
+      get { return _event_id?? default(uint); }
       set { _event_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_idSpecified
+    {
+      get { return _event_id != null; }
+      set { if (value == (_event_id== null)) _event_id = value ? this.event_id : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_id() { return event_idSpecified; }
+    private void Resetevent_id() { event_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1957,77 +3300,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CSOEconItemTournamentPassport() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _original_purchaser_id = default(uint);
+    private uint? _original_purchaser_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"original_purchaser_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint original_purchaser_id
     {
-      get { return _original_purchaser_id; }
+      get { return _original_purchaser_id?? default(uint); }
       set { _original_purchaser_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_purchaser_idSpecified
+    {
+      get { return _original_purchaser_id != null; }
+      set { if (value == (_original_purchaser_id== null)) _original_purchaser_id = value ? this.original_purchaser_id : (uint?)null; }
+    }
+    private bool ShouldSerializeoriginal_purchaser_id() { return original_purchaser_idSpecified; }
+    private void Resetoriginal_purchaser_id() { original_purchaser_idSpecified = false; }
+    
 
-    private uint _passports_bought = default(uint);
+    private uint? _passports_bought;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"passports_bought", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint passports_bought
     {
-      get { return _passports_bought; }
+      get { return _passports_bought?? default(uint); }
       set { _passports_bought = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passports_boughtSpecified
+    {
+      get { return _passports_bought != null; }
+      set { if (value == (_passports_bought== null)) _passports_bought = value ? this.passports_bought : (uint?)null; }
+    }
+    private bool ShouldSerializepassports_bought() { return passports_boughtSpecified; }
+    private void Resetpassports_bought() { passports_boughtSpecified = false; }
+    
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _reward_flags = default(uint);
+    private uint? _reward_flags;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"reward_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reward_flags
     {
-      get { return _reward_flags; }
+      get { return _reward_flags?? default(uint); }
       set { _reward_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reward_flagsSpecified
+    {
+      get { return _reward_flags != null; }
+      set { if (value == (_reward_flags== null)) _reward_flags = value ? this.reward_flags : (uint?)null; }
+    }
+    private bool ShouldSerializereward_flags() { return reward_flagsSpecified; }
+    private void Resetreward_flags() { reward_flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2039,14 +3454,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseCancel() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2058,14 +3482,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseCancelResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2077,14 +3510,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseFinalize() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2096,14 +3538,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCStorePurchaseFinalizeResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -2122,23 +3573,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCBannedWordListRequest() {}
     
 
-    private uint _ban_list_group_id = default(uint);
+    private uint? _ban_list_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ban_list_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ban_list_group_id
     {
-      get { return _ban_list_group_id; }
+      get { return _ban_list_group_id?? default(uint); }
       set { _ban_list_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_list_group_idSpecified
+    {
+      get { return _ban_list_group_id != null; }
+      set { if (value == (_ban_list_group_id== null)) _ban_list_group_id = value ? this.ban_list_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializeban_list_group_id() { return ban_list_group_idSpecified; }
+    private void Resetban_list_group_id() { ban_list_group_idSpecified = false; }
+    
 
-    private uint _word_id = default(uint);
+    private uint? _word_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint word_id
     {
-      get { return _word_id; }
+      get { return _word_id?? default(uint); }
       set { _word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_idSpecified
+    {
+      get { return _word_id != null; }
+      set { if (value == (_word_id== null)) _word_id = value ? this.word_id : (uint?)null; }
+    }
+    private bool ShouldSerializeword_id() { return word_idSpecified; }
+    private void Resetword_id() { word_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2150,32 +3619,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCBannedWord() {}
     
 
-    private uint _word_id = default(uint);
+    private uint? _word_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint word_id
     {
-      get { return _word_id; }
+      get { return _word_id?? default(uint); }
       set { _word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_idSpecified
+    {
+      get { return _word_id != null; }
+      set { if (value == (_word_id== null)) _word_id = value ? this.word_id : (uint?)null; }
+    }
+    private bool ShouldSerializeword_id() { return word_idSpecified; }
+    private void Resetword_id() { word_idSpecified = false; }
+    
 
-    private GC_BannedWordType _word_type = GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD;
+    private GC_BannedWordType? _word_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"word_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD)]
     public GC_BannedWordType word_type
     {
-      get { return _word_type; }
+      get { return _word_type?? GC_BannedWordType.GC_BANNED_WORD_DISABLE_WORD; }
       set { _word_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_typeSpecified
+    {
+      get { return _word_type != null; }
+      set { if (value == (_word_type== null)) _word_type = value ? this.word_type : (GC_BannedWordType?)null; }
+    }
+    private bool ShouldSerializeword_type() { return word_typeSpecified; }
+    private void Resetword_type() { word_typeSpecified = false; }
+    
 
-    private string _word = "";
+    private string _word;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"word", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string word
     {
-      get { return _word; }
+      get { return _word?? ""; }
       set { _word = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wordSpecified
+    {
+      get { return _word != null; }
+      set { if (value == (_word== null)) _word = value ? this.word : (string)null; }
+    }
+    private bool ShouldSerializeword() { return wordSpecified; }
+    private void Resetword() { wordSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2187,14 +3683,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCBannedWordListResponse() {}
     
 
-    private uint _ban_list_group_id = default(uint);
+    private uint? _ban_list_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ban_list_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ban_list_group_id
     {
-      get { return _ban_list_group_id; }
+      get { return _ban_list_group_id?? default(uint); }
       set { _ban_list_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_list_group_idSpecified
+    {
+      get { return _ban_list_group_id != null; }
+      set { if (value == (_ban_list_group_id== null)) _ban_list_group_id = value ? this.ban_list_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializeban_list_group_id() { return ban_list_group_idSpecified; }
+    private void Resetban_list_group_id() { ban_list_group_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCBannedWord> _word_list = new global::System.Collections.Generic.List<CMsgGCBannedWord>();
     [global::ProtoBuf.ProtoMember(2, Name=@"word_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCBannedWord> word_list
@@ -2232,14 +3737,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCBannedWordListUpdated() {}
     
 
-    private uint _group_id = default(uint);
+    private uint? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(uint); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (uint?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2251,23 +3765,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCDirtySDOCache() {}
     
 
-    private uint _sdo_type = default(uint);
+    private uint? _sdo_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sdo_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sdo_type
     {
-      get { return _sdo_type; }
+      get { return _sdo_type?? default(uint); }
       set { _sdo_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sdo_typeSpecified
+    {
+      get { return _sdo_type != null; }
+      set { if (value == (_sdo_type== null)) _sdo_type = value ? this.sdo_type : (uint?)null; }
+    }
+    private bool ShouldSerializesdo_type() { return sdo_typeSpecified; }
+    private void Resetsdo_type() { sdo_typeSpecified = false; }
+    
 
-    private ulong _key_uint64 = default(ulong);
+    private ulong? _key_uint64;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"key_uint64", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong key_uint64
     {
-      get { return _key_uint64; }
+      get { return _key_uint64?? default(ulong); }
       set { _key_uint64 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_uint64Specified
+    {
+      get { return _key_uint64 != null; }
+      set { if (value == (_key_uint64== null)) _key_uint64 = value ? this.key_uint64 : (ulong?)null; }
+    }
+    private bool ShouldSerializekey_uint64() { return key_uint64Specified; }
+    private void Resetkey_uint64() { key_uint64Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2279,14 +3811,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCDirtyMultipleSDOCache() {}
     
 
-    private uint _sdo_type = default(uint);
+    private uint? _sdo_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sdo_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sdo_type
     {
-      get { return _sdo_type; }
+      get { return _sdo_type?? default(uint); }
       set { _sdo_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sdo_typeSpecified
+    {
+      get { return _sdo_type != null; }
+      set { if (value == (_sdo_type== null)) _sdo_type = value ? this.sdo_type : (uint?)null; }
+    }
+    private bool ShouldSerializesdo_type() { return sdo_typeSpecified; }
+    private void Resetsdo_type() { sdo_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _key_uint64 = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"key_uint64", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> key_uint64
@@ -2305,23 +3846,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCApplyLocalizationDiff() {}
     
 
-    private uint _language = default(uint);
+    private uint? _language;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint language
     {
-      get { return _language; }
+      get { return _language?? default(uint); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (uint?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private string _packed_diff = "";
+    private string _packed_diff;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"packed_diff", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string packed_diff
     {
-      get { return _packed_diff; }
+      get { return _packed_diff?? ""; }
       set { _packed_diff = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packed_diffSpecified
+    {
+      get { return _packed_diff != null; }
+      set { if (value == (_packed_diff== null)) _packed_diff = value ? this.packed_diff : (string)null; }
+    }
+    private bool ShouldSerializepacked_diff() { return packed_diffSpecified; }
+    private void Resetpacked_diff() { packed_diffSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2333,14 +3892,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCApplyLocalizationDiffResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2352,23 +3920,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCCollectItem() {}
     
 
-    private ulong _collection_item_id = default(ulong);
+    private ulong? _collection_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"collection_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong collection_item_id
     {
-      get { return _collection_item_id; }
+      get { return _collection_item_id?? default(ulong); }
       set { _collection_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool collection_item_idSpecified
+    {
+      get { return _collection_item_id != null; }
+      set { if (value == (_collection_item_id== null)) _collection_item_id = value ? this.collection_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecollection_item_id() { return collection_item_idSpecified; }
+    private void Resetcollection_item_id() { collection_item_idSpecified = false; }
+    
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2390,14 +3976,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCUpdateSQLKeyValue() {}
     
 
-    private string _key_name = "";
+    private string _key_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key_name
     {
-      get { return _key_name; }
+      get { return _key_name?? ""; }
       set { _key_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_nameSpecified
+    {
+      get { return _key_name != null; }
+      set { if (value == (_key_name== null)) _key_name = value ? this.key_name : (string)null; }
+    }
+    private bool ShouldSerializekey_name() { return key_nameSpecified; }
+    private void Resetkey_name() { key_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2409,14 +4004,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCServerVersionUpdated() {}
     
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2428,14 +4032,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCClientVersionUpdated() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2457,23 +4070,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRecipeComponent() {}
     
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
 
-    private ulong _attribute_index = default(ulong);
+    private ulong? _attribute_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"attribute_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong attribute_index
     {
-      get { return _attribute_index; }
+      get { return _attribute_index?? default(ulong); }
       set { _attribute_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attribute_indexSpecified
+    {
+      get { return _attribute_index != null; }
+      set { if (value == (_attribute_index== null)) _attribute_index = value ? this.attribute_index : (ulong?)null; }
+    }
+    private bool ShouldSerializeattribute_index() { return attribute_indexSpecified; }
+    private void Resetattribute_index() { attribute_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2485,14 +4116,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgFulfillDynamicRecipeComponent() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgRecipeComponent> _consumption_components = new global::System.Collections.Generic.List<CMsgRecipeComponent>();
     [global::ProtoBuf.ProtoMember(2, Name=@"consumption_components", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgRecipeComponent> consumption_components
@@ -2511,14 +4151,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCClientMarketDataRequest() {}
     
 
-    private uint _user_currency = default(uint);
+    private uint? _user_currency;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_currency
     {
-      get { return _user_currency; }
+      get { return _user_currency?? default(uint); }
       set { _user_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_currencySpecified
+    {
+      get { return _user_currency != null; }
+      set { if (value == (_user_currency== null)) _user_currency = value ? this.user_currency : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_currency() { return user_currencySpecified; }
+    private void Resetuser_currency() { user_currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2530,41 +4179,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCClientMarketDataEntry() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _item_quality = default(uint);
+    private uint? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(uint); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private uint _item_sell_listings = default(uint);
+    private uint? _item_sell_listings;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_sell_listings", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_sell_listings
     {
-      get { return _item_sell_listings; }
+      get { return _item_sell_listings?? default(uint); }
       set { _item_sell_listings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_sell_listingsSpecified
+    {
+      get { return _item_sell_listings != null; }
+      set { if (value == (_item_sell_listings== null)) _item_sell_listings = value ? this.item_sell_listings : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_sell_listings() { return item_sell_listingsSpecified; }
+    private void Resetitem_sell_listings() { item_sell_listingsSpecified = false; }
+    
 
-    private uint _price_in_local_currency = default(uint);
+    private uint? _price_in_local_currency;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_in_local_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_in_local_currency
     {
-      get { return _price_in_local_currency; }
+      get { return _price_in_local_currency?? default(uint); }
       set { _price_in_local_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_in_local_currencySpecified
+    {
+      get { return _price_in_local_currency != null; }
+      set { if (value == (_price_in_local_currency== null)) _price_in_local_currency = value ? this.price_in_local_currency : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_in_local_currency() { return price_in_local_currencySpecified; }
+    private void Resetprice_in_local_currency() { price_in_local_currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2593,32 +4278,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgExtractGems() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
 
-    private uint _item_socket_id = (uint)65535;
+    private uint? _item_socket_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_socket_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)65535)]
     public uint item_socket_id
     {
-      get { return _item_socket_id; }
+      get { return _item_socket_id?? (uint)65535; }
       set { _item_socket_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_socket_idSpecified
+    {
+      get { return _item_socket_id != null; }
+      set { if (value == (_item_socket_id== null)) _item_socket_id = value ? this.item_socket_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_socket_id() { return item_socket_idSpecified; }
+    private void Resetitem_socket_id() { item_socket_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2630,23 +4342,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgExtractGemsResponse() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private CMsgExtractGemsResponse.EExtractGems _response = CMsgExtractGemsResponse.EExtractGems.k_ExtractGems_Succeeded;
+    private CMsgExtractGemsResponse.EExtractGems? _response;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgExtractGemsResponse.EExtractGems.k_ExtractGems_Succeeded)]
     public CMsgExtractGemsResponse.EExtractGems response
     {
-      get { return _response; }
+      get { return _response?? CMsgExtractGemsResponse.EExtractGems.k_ExtractGems_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgExtractGemsResponse.EExtractGems?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EExtractGems", EnumPassthru=true)]
     public enum EExtractGems
     {
@@ -2678,32 +4408,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAddSocket() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
 
-    private bool _unusual = default(bool);
+    private bool? _unusual;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"unusual", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool unusual
     {
-      get { return _unusual; }
+      get { return _unusual?? default(bool); }
       set { _unusual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unusualSpecified
+    {
+      get { return _unusual != null; }
+      set { if (value == (_unusual== null)) _unusual = value ? this.unusual : (bool?)null; }
+    }
+    private bool ShouldSerializeunusual() { return unusualSpecified; }
+    private void Resetunusual() { unusualSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2715,14 +4472,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAddSocketResponse() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _updated_socket_index = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"updated_socket_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> updated_socket_index
@@ -2731,14 +4497,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgAddSocketResponse.EAddSocket _response = CMsgAddSocketResponse.EAddSocket.k_AddSocket_Succeeded;
+    private CMsgAddSocketResponse.EAddSocket? _response;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgAddSocketResponse.EAddSocket.k_AddSocket_Succeeded)]
     public CMsgAddSocketResponse.EAddSocket response
     {
-      get { return _response; }
+      get { return _response?? CMsgAddSocketResponse.EAddSocket.k_AddSocket_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgAddSocketResponse.EAddSocket?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EAddSocket", EnumPassthru=true)]
     public enum EAddSocket
     {
@@ -2767,23 +4542,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAddItemToSocketData() {}
     
 
-    private ulong _gem_item_id = default(ulong);
+    private ulong? _gem_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gem_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gem_item_id
     {
-      get { return _gem_item_id; }
+      get { return _gem_item_id?? default(ulong); }
       set { _gem_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gem_item_idSpecified
+    {
+      get { return _gem_item_id != null; }
+      set { if (value == (_gem_item_id== null)) _gem_item_id = value ? this.gem_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegem_item_id() { return gem_item_idSpecified; }
+    private void Resetgem_item_id() { gem_item_idSpecified = false; }
+    
 
-    private uint _socket_index = default(uint);
+    private uint? _socket_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"socket_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socket_index
     {
-      get { return _socket_index; }
+      get { return _socket_index?? default(uint); }
       set { _socket_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socket_indexSpecified
+    {
+      get { return _socket_index != null; }
+      set { if (value == (_socket_index== null)) _socket_index = value ? this.socket_index : (uint?)null; }
+    }
+    private bool ShouldSerializesocket_index() { return socket_indexSpecified; }
+    private void Resetsocket_index() { socket_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2795,14 +4588,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAddItemToSocket() {}
     
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAddItemToSocketData> _gems_to_socket = new global::System.Collections.Generic.List<CMsgAddItemToSocketData>();
     [global::ProtoBuf.ProtoMember(2, Name=@"gems_to_socket", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAddItemToSocketData> gems_to_socket
@@ -2821,14 +4623,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAddItemToSocketResponse() {}
     
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _updated_socket_index = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"updated_socket_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> updated_socket_index
@@ -2837,14 +4648,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgAddItemToSocketResponse.EAddGem _response = CMsgAddItemToSocketResponse.EAddGem.k_AddGem_Succeeded;
+    private CMsgAddItemToSocketResponse.EAddGem? _response;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgAddItemToSocketResponse.EAddGem.k_AddGem_Succeeded)]
     public CMsgAddItemToSocketResponse.EAddGem response
     {
-      get { return _response; }
+      get { return _response?? CMsgAddItemToSocketResponse.EAddGem.k_AddGem_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgAddItemToSocketResponse.EAddGem?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EAddGem", EnumPassthru=true)]
     public enum EAddGem
     {
@@ -2885,23 +4705,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgResetStrangeGemCount() {}
     
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
 
-    private uint _socket_index = default(uint);
+    private uint? _socket_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"socket_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socket_index
     {
-      get { return _socket_index; }
+      get { return _socket_index?? default(uint); }
       set { _socket_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socket_indexSpecified
+    {
+      get { return _socket_index != null; }
+      set { if (value == (_socket_index== null)) _socket_index = value ? this.socket_index : (uint?)null; }
+    }
+    private bool ShouldSerializesocket_index() { return socket_indexSpecified; }
+    private void Resetsocket_index() { socket_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2913,14 +4751,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgResetStrangeGemCountResponse() {}
     
 
-    private CMsgResetStrangeGemCountResponse.EResetGem _response = CMsgResetStrangeGemCountResponse.EResetGem.k_ResetGem_Succeeded;
+    private CMsgResetStrangeGemCountResponse.EResetGem? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgResetStrangeGemCountResponse.EResetGem.k_ResetGem_Succeeded)]
     public CMsgResetStrangeGemCountResponse.EResetGem response
     {
-      get { return _response; }
+      get { return _response?? CMsgResetStrangeGemCountResponse.EResetGem.k_ResetGem_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgResetStrangeGemCountResponse.EResetGem?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResetGem", EnumPassthru=true)]
     public enum EResetGem
     {
@@ -2952,32 +4799,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPollFileRequest() {}
     
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _poll_id = default(uint);
+    private uint? _poll_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"poll_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint poll_id
     {
-      get { return _poll_id; }
+      get { return _poll_id?? default(uint); }
       set { _poll_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool poll_idSpecified
+    {
+      get { return _poll_id != null; }
+      set { if (value == (_poll_id== null)) _poll_id = value ? this.poll_id : (uint?)null; }
+    }
+    private bool ShouldSerializepoll_id() { return poll_idSpecified; }
+    private void Resetpoll_id() { poll_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2989,23 +4863,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPollFileResponse() {}
     
 
-    private uint _poll_id = default(uint);
+    private uint? _poll_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"poll_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint poll_id
     {
-      get { return _poll_id; }
+      get { return _poll_id?? default(uint); }
       set { _poll_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool poll_idSpecified
+    {
+      get { return _poll_id != null; }
+      set { if (value == (_poll_id== null)) _poll_id = value ? this.poll_id : (uint?)null; }
+    }
+    private bool ShouldSerializepoll_id() { return poll_idSpecified; }
+    private void Resetpoll_id() { poll_idSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCEcon.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCEcon.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: econ_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: econ_shared_enums.proto
@@ -19,23 +21,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgApplyAutograph() {}
     
 
-    private ulong _autograph_item_id = default(ulong);
+    private ulong? _autograph_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"autograph_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong autograph_item_id
     {
-      get { return _autograph_item_id; }
+      get { return _autograph_item_id?? default(ulong); }
       set { _autograph_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autograph_item_idSpecified
+    {
+      get { return _autograph_item_id != null; }
+      set { if (value == (_autograph_item_id== null)) _autograph_item_id = value ? this.autograph_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeautograph_item_id() { return autograph_item_idSpecified; }
+    private void Resetautograph_item_id() { autograph_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -47,41 +67,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgAdjustItemEquippedState() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
 
-    private uint _style_index = default(uint);
+    private uint? _style_index;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"style_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint style_index
     {
-      get { return _style_index; }
+      get { return _style_index?? default(uint); }
       set { _style_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool style_indexSpecified
+    {
+      get { return _style_index != null; }
+      set { if (value == (_style_index== null)) _style_index = value ? this.style_index : (uint?)null; }
+    }
+    private bool ShouldSerializestyle_index() { return style_indexSpecified; }
+    private void Resetstyle_index() { style_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -93,14 +149,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgEconPlayerStrangeCountAdjustment() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment> _strange_count_adjustments = new global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment>();
     [global::ProtoBuf.ProtoMember(2, Name=@"strange_count_adjustments", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment> strange_count_adjustments
@@ -114,32 +179,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CStrangeCountAdjustment() {}
     
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _adjustment = default(uint);
+    private uint? _adjustment;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"adjustment", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint adjustment
     {
-      get { return _adjustment; }
+      get { return _adjustment?? default(uint); }
       set { _adjustment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool adjustmentSpecified
+    {
+      get { return _adjustment != null; }
+      set { if (value == (_adjustment== null)) _adjustment = value ? this.adjustment : (uint?)null; }
+    }
+    private bool ShouldSerializeadjustment() { return adjustmentSpecified; }
+    private void Resetadjustment() { adjustmentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,14 +265,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestItemPurgatory_FinalizePurchaseResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -216,14 +317,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestItemPurgatory_RefundPurchaseResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -252,23 +362,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCRequestStoreSalesData() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _currency = default(uint);
+    private uint? _currency;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currency
     {
-      get { return _currency; }
+      get { return _currency?? default(uint); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (uint?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -287,46 +415,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Price")]
   public partial class Price : global::ProtoBuf.IExtensible
   {
     public Price() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _price = default(uint);
+    private uint? _price;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"price", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price
     {
-      get { return _price; }
+      get { return _price?? default(uint); }
       set { _price = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool priceSpecified
+    {
+      get { return _price != null; }
+      set { if (value == (_price== null)) _price = value ? this.price : (uint?)null; }
+    }
+    private bool ShouldSerializeprice() { return priceSpecified; }
+    private void Resetprice() { priceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -343,23 +507,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCRequestStoreSalesDataUpToDateResponse() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -391,14 +573,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGetUserSessionServer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -410,14 +601,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGetUserSessionServerResponse() {}
     
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -429,23 +629,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGetUserServerMembers() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _max_spectators = default(uint);
+    private uint? _max_spectators;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_spectators
     {
-      get { return _max_spectators; }
+      get { return _max_spectators?? default(uint); }
       set { _max_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_spectatorsSpecified
+    {
+      get { return _max_spectators != null; }
+      set { if (value == (_max_spectators== null)) _max_spectators = value ? this.max_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializemax_spectators() { return max_spectatorsSpecified; }
+    private void Resetmax_spectators() { max_spectatorsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -503,23 +721,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Account() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private string _persona = "";
+    private string _persona;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona
     {
-      get { return _persona; }
+      get { return _persona?? ""; }
       set { _persona = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool personaSpecified
+    {
+      get { return _persona != null; }
+      set { if (value == (_persona== null)) _persona = value ? this.persona : (string)null; }
+    }
+    private bool ShouldSerializepersona() { return personaSpecified; }
+    private void Resetpersona() { personaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -536,14 +772,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGetUserPCBangNo() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -555,14 +800,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGetUserPCBangNoResponse() {}
     
 
-    private uint _pc_bang_no = default(uint);
+    private uint? _pc_bang_no;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"pc_bang_no", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pc_bang_no
     {
-      get { return _pc_bang_no; }
+      get { return _pc_bang_no?? default(uint); }
       set { _pc_bang_no = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pc_bang_noSpecified
+    {
+      get { return _pc_bang_no != null; }
+      set { if (value == (_pc_bang_no== null)) _pc_bang_no = value ? this.pc_bang_no : (uint?)null; }
+    }
+    private bool ShouldSerializepc_bang_no() { return pc_bang_noSpecified; }
+    private void Resetpc_bang_no() { pc_bang_noSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -574,14 +828,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestCrateItems() {}
     
 
-    private uint _crate_item_def = default(uint);
+    private uint? _crate_item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"crate_item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crate_item_def
     {
-      get { return _crate_item_def; }
+      get { return _crate_item_def?? default(uint); }
       set { _crate_item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crate_item_defSpecified
+    {
+      get { return _crate_item_def != null; }
+      set { if (value == (_crate_item_def== null)) _crate_item_def = value ? this.crate_item_def : (uint?)null; }
+    }
+    private bool ShouldSerializecrate_item_def() { return crate_item_defSpecified; }
+    private void Resetcrate_item_def() { crate_item_defSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -593,14 +856,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRequestCrateItemsResponse() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _item_defs = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_defs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> item_defs
@@ -609,14 +881,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _peek_item_def = default(uint);
+    private uint? _peek_item_def;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"peek_item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint peek_item_def
     {
-      get { return _peek_item_def; }
+      get { return _peek_item_def?? default(uint); }
       set { _peek_item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool peek_item_defSpecified
+    {
+      get { return _peek_item_def != null; }
+      set { if (value == (_peek_item_def== null)) _peek_item_def = value ? this.peek_item_def : (uint?)null; }
+    }
+    private bool ShouldSerializepeek_item_def() { return peek_item_defSpecified; }
+    private void Resetpeek_item_def() { peek_item_defSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResult", EnumPassthru=true)]
     public enum EResult
     {
@@ -639,50 +920,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCCanUseDropRateBonus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _drop_rate_bonus = default(float);
+    private float? _drop_rate_bonus;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"drop_rate_bonus", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float drop_rate_bonus
     {
-      get { return _drop_rate_bonus; }
+      get { return _drop_rate_bonus?? default(float); }
       set { _drop_rate_bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool drop_rate_bonusSpecified
+    {
+      get { return _drop_rate_bonus != null; }
+      set { if (value == (_drop_rate_bonus== null)) _drop_rate_bonus = value ? this.drop_rate_bonus : (float?)null; }
+    }
+    private bool ShouldSerializedrop_rate_bonus() { return drop_rate_bonusSpecified; }
+    private void Resetdrop_rate_bonus() { drop_rate_bonusSpecified = false; }
+    
 
-    private uint _booster_type = default(uint);
+    private uint? _booster_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"booster_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint booster_type
     {
-      get { return _booster_type; }
+      get { return _booster_type?? default(uint); }
       set { _booster_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool booster_typeSpecified
+    {
+      get { return _booster_type != null; }
+      set { if (value == (_booster_type== null)) _booster_type = value ? this.booster_type : (uint?)null; }
+    }
+    private bool ShouldSerializebooster_type() { return booster_typeSpecified; }
+    private void Resetbooster_type() { booster_typeSpecified = false; }
+    
 
-    private uint _exclusive_item_def = default(uint);
+    private uint? _exclusive_item_def;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"exclusive_item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint exclusive_item_def
     {
-      get { return _exclusive_item_def; }
+      get { return _exclusive_item_def?? default(uint); }
       set { _exclusive_item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool exclusive_item_defSpecified
+    {
+      get { return _exclusive_item_def != null; }
+      set { if (value == (_exclusive_item_def== null)) _exclusive_item_def = value ? this.exclusive_item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeexclusive_item_def() { return exclusive_item_defSpecified; }
+    private void Resetexclusive_item_def() { exclusive_item_defSpecified = false; }
+    
 
-    private bool _allow_equal_rate = default(bool);
+    private bool? _allow_equal_rate;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"allow_equal_rate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_equal_rate
     {
-      get { return _allow_equal_rate; }
+      get { return _allow_equal_rate?? default(bool); }
       set { _allow_equal_rate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_equal_rateSpecified
+    {
+      get { return _allow_equal_rate != null; }
+      set { if (value == (_allow_equal_rate== null)) _allow_equal_rate = value ? this.allow_equal_rate : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_equal_rate() { return allow_equal_rateSpecified; }
+    private void Resetallow_equal_rate() { allow_equal_rateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -694,68 +1020,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSQLAddDropRateBonus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private float _drop_rate_bonus = default(float);
+    private float? _drop_rate_bonus;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"drop_rate_bonus", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float drop_rate_bonus
     {
-      get { return _drop_rate_bonus; }
+      get { return _drop_rate_bonus?? default(float); }
       set { _drop_rate_bonus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool drop_rate_bonusSpecified
+    {
+      get { return _drop_rate_bonus != null; }
+      set { if (value == (_drop_rate_bonus== null)) _drop_rate_bonus = value ? this.drop_rate_bonus : (float?)null; }
+    }
+    private bool ShouldSerializedrop_rate_bonus() { return drop_rate_bonusSpecified; }
+    private void Resetdrop_rate_bonus() { drop_rate_bonusSpecified = false; }
+    
 
-    private uint _booster_type = default(uint);
+    private uint? _booster_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"booster_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint booster_type
     {
-      get { return _booster_type; }
+      get { return _booster_type?? default(uint); }
       set { _booster_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool booster_typeSpecified
+    {
+      get { return _booster_type != null; }
+      set { if (value == (_booster_type== null)) _booster_type = value ? this.booster_type : (uint?)null; }
+    }
+    private bool ShouldSerializebooster_type() { return booster_typeSpecified; }
+    private void Resetbooster_type() { booster_typeSpecified = false; }
+    
 
-    private uint _seconds_duration = default(uint);
+    private uint? _seconds_duration;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"seconds_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds_duration
     {
-      get { return _seconds_duration; }
+      get { return _seconds_duration?? default(uint); }
       set { _seconds_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_durationSpecified
+    {
+      get { return _seconds_duration != null; }
+      set { if (value == (_seconds_duration== null)) _seconds_duration = value ? this.seconds_duration : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds_duration() { return seconds_durationSpecified; }
+    private void Resetseconds_duration() { seconds_durationSpecified = false; }
+    
 
-    private uint _end_time_stamp = default(uint);
+    private uint? _end_time_stamp;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"end_time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint end_time_stamp
     {
-      get { return _end_time_stamp; }
+      get { return _end_time_stamp?? default(uint); }
       set { _end_time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool end_time_stampSpecified
+    {
+      get { return _end_time_stamp != null; }
+      set { if (value == (_end_time_stamp== null)) _end_time_stamp = value ? this.end_time_stamp : (uint?)null; }
+    }
+    private bool ShouldSerializeend_time_stamp() { return end_time_stampSpecified; }
+    private void Resetend_time_stamp() { end_time_stampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -767,41 +1156,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSQLUpgradeBattleBooster() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private float _bonus_to_add = default(float);
+    private float? _bonus_to_add;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bonus_to_add", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float bonus_to_add
     {
-      get { return _bonus_to_add; }
+      get { return _bonus_to_add?? default(float); }
       set { _bonus_to_add = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_to_addSpecified
+    {
+      get { return _bonus_to_add != null; }
+      set { if (value == (_bonus_to_add== null)) _bonus_to_add = value ? this.bonus_to_add : (float?)null; }
+    }
+    private bool ShouldSerializebonus_to_add() { return bonus_to_addSpecified; }
+    private void Resetbonus_to_add() { bonus_to_addSpecified = false; }
+    
 
-    private uint _booster_type = default(uint);
+    private uint? _booster_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"booster_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint booster_type
     {
-      get { return _booster_type; }
+      get { return _booster_type?? default(uint); }
       set { _booster_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool booster_typeSpecified
+    {
+      get { return _booster_type != null; }
+      set { if (value == (_booster_type== null)) _booster_type = value ? this.booster_type : (uint?)null; }
+    }
+    private bool ShouldSerializebooster_type() { return booster_typeSpecified; }
+    private void Resetbooster_type() { booster_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -813,23 +1238,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCRefreshSOCache() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _reload = default(bool);
+    private bool? _reload;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool reload
     {
-      get { return _reload; }
+      get { return _reload?? default(bool); }
       set { _reload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reloadSpecified
+    {
+      get { return _reload != null; }
+      set { if (value == (_reload== null)) _reload = value ? this.reload : (bool?)null; }
+    }
+    private bool ShouldSerializereload() { return reloadSpecified; }
+    private void Resetreload() { reloadSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -841,23 +1284,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCCheckAccountTradeStatus() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _initiator = default(bool);
+    private bool? _initiator;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"initiator", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool initiator
     {
-      get { return _initiator; }
+      get { return _initiator?? default(bool); }
       set { _initiator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiatorSpecified
+    {
+      get { return _initiator != null; }
+      set { if (value == (_initiator== null)) _initiator = value ? this.initiator : (bool?)null; }
+    }
+    private bool ShouldSerializeinitiator() { return initiatorSpecified; }
+    private void Resetinitiator() { initiatorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -869,23 +1330,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCCheckAccountTradeStatusResponse() {}
     
 
-    private bool _can_trade = default(bool);
+    private bool? _can_trade;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"can_trade", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_trade
     {
-      get { return _can_trade; }
+      get { return _can_trade?? default(bool); }
       set { _can_trade = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_tradeSpecified
+    {
+      get { return _can_trade != null; }
+      set { if (value == (_can_trade== null)) _can_trade = value ? this.can_trade : (bool?)null; }
+    }
+    private bool ShouldSerializecan_trade() { return can_tradeSpecified; }
+    private void Resetcan_trade() { can_tradeSpecified = false; }
+    
 
-    private uint _error_code = default(uint);
+    private uint? _error_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"error_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint error_code
     {
-      get { return _error_code; }
+      get { return _error_code?? default(uint); }
       set { _error_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_codeSpecified
+    {
+      get { return _error_code != null; }
+      set { if (value == (_error_code== null)) _error_code = value ? this.error_code : (uint?)null; }
+    }
+    private bool ShouldSerializeerror_code() { return error_codeSpecified; }
+    private void Reseterror_code() { error_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -897,14 +1376,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGrantAccountRolledItems() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item> _items = new global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item>();
     [global::ProtoBuf.ProtoMember(2, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item> items
@@ -913,37 +1401,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _audit_action = default(uint);
+    private uint? _audit_action;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"audit_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint audit_action
     {
-      get { return _audit_action; }
+      get { return _audit_action?? default(uint); }
       set { _audit_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_actionSpecified
+    {
+      get { return _audit_action != null; }
+      set { if (value == (_audit_action== null)) _audit_action = value ? this.audit_action : (uint?)null; }
+    }
+    private bool ShouldSerializeaudit_action() { return audit_actionSpecified; }
+    private void Resetaudit_action() { audit_actionSpecified = false; }
+    
 
-    private ulong _audit_data = default(ulong);
+    private ulong? _audit_data;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"audit_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong audit_data
     {
-      get { return _audit_data; }
+      get { return _audit_data?? default(ulong); }
       set { _audit_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_dataSpecified
+    {
+      get { return _audit_data != null; }
+      set { if (value == (_audit_data== null)) _audit_data = value ? this.audit_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeaudit_data() { return audit_dataSpecified; }
+    private void Resetaudit_data() { audit_dataSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Item")]
   public partial class Item : global::ProtoBuf.IExtensible
   {
     public Item() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _loot_lists = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(2, Name=@"loot_lists", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> loot_lists
@@ -952,23 +1467,41 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private bool _ignore_limit = default(bool);
+    private bool? _ignore_limit;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ignore_limit", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ignore_limit
     {
-      get { return _ignore_limit; }
+      get { return _ignore_limit?? default(bool); }
       set { _ignore_limit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ignore_limitSpecified
+    {
+      get { return _ignore_limit != null; }
+      set { if (value == (_ignore_limit== null)) _ignore_limit = value ? this.ignore_limit : (bool?)null; }
+    }
+    private bool ShouldSerializeignore_limit() { return ignore_limitSpecified; }
+    private void Resetignore_limit() { ignore_limitSpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item.DynamicAttribute> _dynamic_attributes = new global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item.DynamicAttribute>();
     [global::ProtoBuf.ProtoMember(5, Name=@"dynamic_attributes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToGCGrantAccountRolledItems.Item.DynamicAttribute> dynamic_attributes
@@ -984,46 +1517,82 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _inventory_token = default(uint);
+    private uint? _inventory_token;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"inventory_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory_token
     {
-      get { return _inventory_token; }
+      get { return _inventory_token?? default(uint); }
       set { _inventory_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventory_tokenSpecified
+    {
+      get { return _inventory_token != null; }
+      set { if (value == (_inventory_token== null)) _inventory_token = value ? this.inventory_token : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory_token() { return inventory_tokenSpecified; }
+    private void Resetinventory_token() { inventory_tokenSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"DynamicAttribute")]
   public partial class DynamicAttribute : global::ProtoBuf.IExtensible
   {
     public DynamicAttribute() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _value_uint32 = default(uint);
+    private uint? _value_uint32;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value_uint32", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value_uint32
     {
-      get { return _value_uint32; }
+      get { return _value_uint32?? default(uint); }
       set { _value_uint32 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_uint32Specified
+    {
+      get { return _value_uint32 != null; }
+      set { if (value == (_value_uint32== null)) _value_uint32 = value ? this.value_uint32 : (uint?)null; }
+    }
+    private bool ShouldSerializevalue_uint32() { return value_uint32Specified; }
+    private void Resetvalue_uint32() { value_uint32Specified = false; }
+    
 
-    private float _value_float = default(float);
+    private float? _value_float;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"value_float", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float value_float
     {
-      get { return _value_float; }
+      get { return _value_float?? default(float); }
       set { _value_float = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_floatSpecified
+    {
+      get { return _value_float != null; }
+      set { if (value == (_value_float== null)) _value_float = value ? this.value_float : (float?)null; }
+    }
+    private bool ShouldSerializevalue_float() { return value_floatSpecified; }
+    private void Resetvalue_float() { value_floatSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1035,32 +1604,59 @@ namespace SteamKit2.GC.Dota.Internal
     public AdditionalAuditEntry() {}
     
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private uint _audit_action = default(uint);
+    private uint? _audit_action;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"audit_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint audit_action
     {
-      get { return _audit_action; }
+      get { return _audit_action?? default(uint); }
       set { _audit_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_actionSpecified
+    {
+      get { return _audit_action != null; }
+      set { if (value == (_audit_action== null)) _audit_action = value ? this.audit_action : (uint?)null; }
+    }
+    private bool ShouldSerializeaudit_action() { return audit_actionSpecified; }
+    private void Resetaudit_action() { audit_actionSpecified = false; }
+    
 
-    private ulong _audit_data = default(ulong);
+    private ulong? _audit_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"audit_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong audit_data
     {
-      get { return _audit_data; }
+      get { return _audit_data?? default(ulong); }
       set { _audit_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_dataSpecified
+    {
+      get { return _audit_data != null; }
+      set { if (value == (_audit_data== null)) _audit_data = value ? this.audit_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeaudit_data() { return audit_dataSpecified; }
+    private void Resetaudit_data() { audit_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1082,23 +1678,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCGrantSelfMadeItemToAccount() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1110,23 +1724,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgUseItem() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _gift__potential_targets = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"gift__potential_targets", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> gift__potential_targets
@@ -1135,32 +1767,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _duel__class_lock = default(uint);
+    private uint? _duel__class_lock;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"duel__class_lock", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel__class_lock
     {
-      get { return _duel__class_lock; }
+      get { return _duel__class_lock?? default(uint); }
       set { _duel__class_lock = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel__class_lockSpecified
+    {
+      get { return _duel__class_lock != null; }
+      set { if (value == (_duel__class_lock== null)) _duel__class_lock = value ? this.duel__class_lock : (uint?)null; }
+    }
+    private bool ShouldSerializeduel__class_lock() { return duel__class_lockSpecified; }
+    private void Resetduel__class_lock() { duel__class_lockSpecified = false; }
+    
 
-    private ulong _initiator_steam_id = default(ulong);
+    private ulong? _initiator_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initiator_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong initiator_steam_id
     {
-      get { return _initiator_steam_id; }
+      get { return _initiator_steam_id?? default(ulong); }
       set { _initiator_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiator_steam_idSpecified
+    {
+      get { return _initiator_steam_id != null; }
+      set { if (value == (_initiator_steam_id== null)) _initiator_steam_id = value ? this.initiator_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeinitiator_steam_id() { return initiator_steam_idSpecified; }
+    private void Resetinitiator_steam_id() { initiator_steam_idSpecified = false; }
+    
 
-    private bool _itempack__ack_immediately = default(bool);
+    private bool? _itempack__ack_immediately;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"itempack__ack_immediately", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool itempack__ack_immediately
     {
-      get { return _itempack__ack_immediately; }
+      get { return _itempack__ack_immediately?? default(bool); }
       set { _itempack__ack_immediately = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itempack__ack_immediatelySpecified
+    {
+      get { return _itempack__ack_immediately != null; }
+      set { if (value == (_itempack__ack_immediately== null)) _itempack__ack_immediately = value ? this.itempack__ack_immediately : (bool?)null; }
+    }
+    private bool ShouldSerializeitempack__ack_immediately() { return itempack__ack_immediatelySpecified; }
+    private void Resetitempack__ack_immediately() { itempack__ack_immediatelySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1172,14 +1831,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgServerUseItem() {}
     
 
-    private uint _initiator_account_id = default(uint);
+    private uint? _initiator_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"initiator_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initiator_account_id
     {
-      get { return _initiator_account_id; }
+      get { return _initiator_account_id?? default(uint); }
       set { _initiator_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiator_account_idSpecified
+    {
+      get { return _initiator_account_id != null; }
+      set { if (value == (_initiator_account_id== null)) _initiator_account_id = value ? this.initiator_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeinitiator_account_id() { return initiator_account_idSpecified; }
+    private void Resetinitiator_account_id() { initiator_account_idSpecified = false; }
+    
 
     private CMsgUseItem _use_item_msg = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"use_item_msg", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1227,23 +1895,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCPartnerBalanceResponse() {}
     
 
-    private EGCPartnerRequestResponse _result = EGCPartnerRequestResponse.k_EPartnerRequestOK;
+    private EGCPartnerRequestResponse? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCPartnerRequestResponse.k_EPartnerRequestOK)]
     public EGCPartnerRequestResponse result
     {
-      get { return _result; }
+      get { return _result?? EGCPartnerRequestResponse.k_EPartnerRequestOK; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (EGCPartnerRequestResponse?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private uint _balance = default(uint);
+    private uint? _balance;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"balance", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint balance
     {
-      get { return _balance; }
+      get { return _balance?? default(uint); }
       set { _balance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool balanceSpecified
+    {
+      get { return _balance != null; }
+      set { if (value == (_balance== null)) _balance = value ? this.balance : (uint?)null; }
+    }
+    private bool ShouldSerializebalance() { return balanceSpecified; }
+    private void Resetbalance() { balanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1255,23 +1941,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCStoreRechargeRedirect_LineItem() {}
     
 
-    private uint _item_def_id = default(uint);
+    private uint? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(uint); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1300,23 +2004,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCPartnerRechargeRedirectURLResponse() {}
     
 
-    private EGCPartnerRequestResponse _result = EGCPartnerRequestResponse.k_EPartnerRequestOK;
+    private EGCPartnerRequestResponse? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCPartnerRequestResponse.k_EPartnerRequestOK)]
     public EGCPartnerRequestResponse result
     {
-      get { return _result; }
+      get { return _result?? EGCPartnerRequestResponse.k_EPartnerRequestOK; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (EGCPartnerRequestResponse?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1328,23 +2050,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCEconSQLWorkItemEmbeddedRollbackData() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _deleted_item_id = default(ulong);
+    private ulong? _deleted_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"deleted_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong deleted_item_id
     {
-      get { return _deleted_item_id; }
+      get { return _deleted_item_id?? default(ulong); }
       set { _deleted_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deleted_item_idSpecified
+    {
+      get { return _deleted_item_id != null; }
+      set { if (value == (_deleted_item_id== null)) _deleted_item_id = value ? this.deleted_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializedeleted_item_id() { return deleted_item_idSpecified; }
+    private void Resetdeleted_item_id() { deleted_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1356,59 +2096,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgCraftStatue() {}
     
 
-    private uint _heroid = default(uint);
+    private uint? _heroid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"heroid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint heroid
     {
-      get { return _heroid; }
+      get { return _heroid?? default(uint); }
       set { _heroid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heroidSpecified
+    {
+      get { return _heroid != null; }
+      set { if (value == (_heroid== null)) _heroid = value ? this.heroid : (uint?)null; }
+    }
+    private bool ShouldSerializeheroid() { return heroidSpecified; }
+    private void Resetheroid() { heroidSpecified = false; }
+    
 
-    private string _sequencename = "";
+    private string _sequencename;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sequencename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sequencename
     {
-      get { return _sequencename; }
+      get { return _sequencename?? ""; }
       set { _sequencename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sequencenameSpecified
+    {
+      get { return _sequencename != null; }
+      set { if (value == (_sequencename== null)) _sequencename = value ? this.sequencename : (string)null; }
+    }
+    private bool ShouldSerializesequencename() { return sequencenameSpecified; }
+    private void Resetsequencename() { sequencenameSpecified = false; }
+    
 
-    private float _cycle = default(float);
+    private float? _cycle;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cycle", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float cycle
     {
-      get { return _cycle; }
+      get { return _cycle?? default(float); }
       set { _cycle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cycleSpecified
+    {
+      get { return _cycle != null; }
+      set { if (value == (_cycle== null)) _cycle = value ? this.cycle : (float?)null; }
+    }
+    private bool ShouldSerializecycle() { return cycleSpecified; }
+    private void Resetcycle() { cycleSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private uint _pedestal_itemdef = default(uint);
+    private uint? _pedestal_itemdef;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"pedestal_itemdef", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pedestal_itemdef
     {
-      get { return _pedestal_itemdef; }
+      get { return _pedestal_itemdef?? default(uint); }
       set { _pedestal_itemdef = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pedestal_itemdefSpecified
+    {
+      get { return _pedestal_itemdef != null; }
+      set { if (value == (_pedestal_itemdef== null)) _pedestal_itemdef = value ? this.pedestal_itemdef : (uint?)null; }
+    }
+    private bool ShouldSerializepedestal_itemdef() { return pedestal_itemdefSpecified; }
+    private void Resetpedestal_itemdef() { pedestal_itemdefSpecified = false; }
+    
 
-    private ulong _toolid = default(ulong);
+    private ulong? _toolid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"toolid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong toolid
     {
-      get { return _toolid; }
+      get { return _toolid?? default(ulong); }
       set { _toolid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool toolidSpecified
+    {
+      get { return _toolid != null; }
+      set { if (value == (_toolid== null)) _toolid = value ? this.toolid : (ulong?)null; }
+    }
+    private bool ShouldSerializetoolid() { return toolidSpecified; }
+    private void Resettoolid() { toolidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1420,14 +2214,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRedeemCode() {}
     
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1439,23 +2242,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgRedeemCodeResponse() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EResultCode", EnumPassthru=true)]
     public enum EResultCode
     {
@@ -1484,23 +2305,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDevNewItemRequest() {}
     
 
-    private string _item_def_name = "";
+    private string _item_def_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_def_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_def_name
     {
-      get { return _item_def_name; }
+      get { return _item_def_name?? ""; }
       set { _item_def_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_nameSpecified
+    {
+      get { return _item_def_name != null; }
+      set { if (value == (_item_def_name== null)) _item_def_name = value ? this.item_def_name : (string)null; }
+    }
+    private bool ShouldSerializeitem_def_name() { return item_def_nameSpecified; }
+    private void Resetitem_def_name() { item_def_nameSpecified = false; }
+    
 
-    private string _loot_list_name = "";
+    private string _loot_list_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"loot_list_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loot_list_name
     {
-      get { return _loot_list_name; }
+      get { return _loot_list_name?? ""; }
       set { _loot_list_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_list_nameSpecified
+    {
+      get { return _loot_list_name != null; }
+      set { if (value == (_loot_list_name== null)) _loot_list_name = value ? this.loot_list_name : (string)null; }
+    }
+    private bool ShouldSerializeloot_list_name() { return loot_list_nameSpecified; }
+    private void Resetloot_list_name() { loot_list_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _attr_def_name = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(5, Name=@"attr_def_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> attr_def_name
@@ -1526,14 +2365,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgDevNewItemRequestResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1545,23 +2393,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCAddGiftItem() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1573,32 +2439,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCWrapAndDeliverGift() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _give_to_account_id = default(uint);
+    private uint? _give_to_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"give_to_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint give_to_account_id
     {
-      get { return _give_to_account_id; }
+      get { return _give_to_account_id?? default(uint); }
       set { _give_to_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool give_to_account_idSpecified
+    {
+      get { return _give_to_account_id != null; }
+      set { if (value == (_give_to_account_id== null)) _give_to_account_id = value ? this.give_to_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegive_to_account_id() { return give_to_account_idSpecified; }
+    private void Resetgive_to_account_id() { give_to_account_idSpecified = false; }
+    
 
-    private string _gift_message = "";
+    private string _gift_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gift_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gift_message
     {
-      get { return _gift_message; }
+      get { return _gift_message?? ""; }
       set { _gift_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gift_messageSpecified
+    {
+      get { return _gift_message != null; }
+      set { if (value == (_gift_message== null)) _gift_message = value ? this.gift_message : (string)null; }
+    }
+    private bool ShouldSerializegift_message() { return gift_messageSpecified; }
+    private void Resetgift_message() { gift_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1610,68 +2503,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCWrapAndDeliverGiftResponse() {}
     
 
-    private EGCMsgResponse _response = EGCMsgResponse.k_EGCMsgResponseOK;
+    private EGCMsgResponse? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCMsgResponse.k_EGCMsgResponseOK)]
     public EGCMsgResponse response
     {
-      get { return _response; }
+      get { return _response?? EGCMsgResponse.k_EGCMsgResponseOK; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (EGCMsgResponse?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private uint _gifting_charge_uses = default(uint);
+    private uint? _gifting_charge_uses;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gifting_charge_uses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gifting_charge_uses
     {
-      get { return _gifting_charge_uses; }
+      get { return _gifting_charge_uses?? default(uint); }
       set { _gifting_charge_uses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifting_charge_usesSpecified
+    {
+      get { return _gifting_charge_uses != null; }
+      set { if (value == (_gifting_charge_uses== null)) _gifting_charge_uses = value ? this.gifting_charge_uses : (uint?)null; }
+    }
+    private bool ShouldSerializegifting_charge_uses() { return gifting_charge_usesSpecified; }
+    private void Resetgifting_charge_uses() { gifting_charge_usesSpecified = false; }
+    
 
-    private int _gifting_charge_max = default(int);
+    private int? _gifting_charge_max;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gifting_charge_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int gifting_charge_max
     {
-      get { return _gifting_charge_max; }
+      get { return _gifting_charge_max?? default(int); }
       set { _gifting_charge_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifting_charge_maxSpecified
+    {
+      get { return _gifting_charge_max != null; }
+      set { if (value == (_gifting_charge_max== null)) _gifting_charge_max = value ? this.gifting_charge_max : (int?)null; }
+    }
+    private bool ShouldSerializegifting_charge_max() { return gifting_charge_maxSpecified; }
+    private void Resetgifting_charge_max() { gifting_charge_maxSpecified = false; }
+    
 
-    private uint _gifting_uses = default(uint);
+    private uint? _gifting_uses;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"gifting_uses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gifting_uses
     {
-      get { return _gifting_uses; }
+      get { return _gifting_uses?? default(uint); }
       set { _gifting_uses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifting_usesSpecified
+    {
+      get { return _gifting_uses != null; }
+      set { if (value == (_gifting_uses== null)) _gifting_uses = value ? this.gifting_uses : (uint?)null; }
+    }
+    private bool ShouldSerializegifting_uses() { return gifting_usesSpecified; }
+    private void Resetgifting_uses() { gifting_usesSpecified = false; }
+    
 
-    private int _gifting_max = default(int);
+    private int? _gifting_max;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gifting_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int gifting_max
     {
-      get { return _gifting_max; }
+      get { return _gifting_max?? default(int); }
       set { _gifting_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifting_maxSpecified
+    {
+      get { return _gifting_max != null; }
+      set { if (value == (_gifting_max== null)) _gifting_max = value ? this.gifting_max : (int?)null; }
+    }
+    private bool ShouldSerializegifting_max() { return gifting_maxSpecified; }
+    private void Resetgifting_max() { gifting_maxSpecified = false; }
+    
 
-    private uint _gifting_window_hours = default(uint);
+    private uint? _gifting_window_hours;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"gifting_window_hours", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gifting_window_hours
     {
-      get { return _gifting_window_hours; }
+      get { return _gifting_window_hours?? default(uint); }
       set { _gifting_window_hours = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifting_window_hoursSpecified
+    {
+      get { return _gifting_window_hours != null; }
+      set { if (value == (_gifting_window_hours== null)) _gifting_window_hours = value ? this.gifting_window_hours : (uint?)null; }
+    }
+    private bool ShouldSerializegifting_window_hours() { return gifting_window_hoursSpecified; }
+    private void Resetgifting_window_hours() { gifting_window_hoursSpecified = false; }
+    
 
-    private EGCMsgInitiateTradeResponse _trade_restriction = EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted;
+    private EGCMsgInitiateTradeResponse? _trade_restriction;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"trade_restriction", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted)]
     public EGCMsgInitiateTradeResponse trade_restriction
     {
-      get { return _trade_restriction; }
+      get { return _trade_restriction?? EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted; }
       set { _trade_restriction = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_restrictionSpecified
+    {
+      get { return _trade_restriction != null; }
+      set { if (value == (_trade_restriction== null)) _trade_restriction = value ? this.trade_restriction : (EGCMsgInitiateTradeResponse?)null; }
+    }
+    private bool ShouldSerializetrade_restriction() { return trade_restrictionSpecified; }
+    private void Resettrade_restriction() { trade_restrictionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1683,14 +2639,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnwrapGift() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1712,50 +2677,95 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCGetGiftPermissionsResponse() {}
     
 
-    private bool _is_unlimited = default(bool);
+    private bool? _is_unlimited;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_unlimited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_unlimited
     {
-      get { return _is_unlimited; }
+      get { return _is_unlimited?? default(bool); }
       set { _is_unlimited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_unlimitedSpecified
+    {
+      get { return _is_unlimited != null; }
+      set { if (value == (_is_unlimited== null)) _is_unlimited = value ? this.is_unlimited : (bool?)null; }
+    }
+    private bool ShouldSerializeis_unlimited() { return is_unlimitedSpecified; }
+    private void Resetis_unlimited() { is_unlimitedSpecified = false; }
+    
 
-    private bool _has_two_factor = default(bool);
+    private bool? _has_two_factor;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"has_two_factor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_two_factor
     {
-      get { return _has_two_factor; }
+      get { return _has_two_factor?? default(bool); }
       set { _has_two_factor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_two_factorSpecified
+    {
+      get { return _has_two_factor != null; }
+      set { if (value == (_has_two_factor== null)) _has_two_factor = value ? this.has_two_factor : (bool?)null; }
+    }
+    private bool ShouldSerializehas_two_factor() { return has_two_factorSpecified; }
+    private void Resethas_two_factor() { has_two_factorSpecified = false; }
+    
 
-    private EGCMsgInitiateTradeResponse _sender_permission = EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted;
+    private EGCMsgInitiateTradeResponse? _sender_permission;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sender_permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted)]
     public EGCMsgInitiateTradeResponse sender_permission
     {
-      get { return _sender_permission; }
+      get { return _sender_permission?? EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted; }
       set { _sender_permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_permissionSpecified
+    {
+      get { return _sender_permission != null; }
+      set { if (value == (_sender_permission== null)) _sender_permission = value ? this.sender_permission : (EGCMsgInitiateTradeResponse?)null; }
+    }
+    private bool ShouldSerializesender_permission() { return sender_permissionSpecified; }
+    private void Resetsender_permission() { sender_permissionSpecified = false; }
+    
 
-    private uint _friendship_age_requirement = default(uint);
+    private uint? _friendship_age_requirement;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"friendship_age_requirement", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friendship_age_requirement
     {
-      get { return _friendship_age_requirement; }
+      get { return _friendship_age_requirement?? default(uint); }
       set { _friendship_age_requirement = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendship_age_requirementSpecified
+    {
+      get { return _friendship_age_requirement != null; }
+      set { if (value == (_friendship_age_requirement== null)) _friendship_age_requirement = value ? this.friendship_age_requirement : (uint?)null; }
+    }
+    private bool ShouldSerializefriendship_age_requirement() { return friendship_age_requirementSpecified; }
+    private void Resetfriendship_age_requirement() { friendship_age_requirementSpecified = false; }
+    
 
-    private uint _friendship_age_requirement_two_factor = default(uint);
+    private uint? _friendship_age_requirement_two_factor;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"friendship_age_requirement_two_factor", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friendship_age_requirement_two_factor
     {
-      get { return _friendship_age_requirement_two_factor; }
+      get { return _friendship_age_requirement_two_factor?? default(uint); }
       set { _friendship_age_requirement_two_factor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendship_age_requirement_two_factorSpecified
+    {
+      get { return _friendship_age_requirement_two_factor != null; }
+      set { if (value == (_friendship_age_requirement_two_factor== null)) _friendship_age_requirement_two_factor = value ? this.friendship_age_requirement_two_factor : (uint?)null; }
+    }
+    private bool ShouldSerializefriendship_age_requirement_two_factor() { return friendship_age_requirement_two_factorSpecified; }
+    private void Resetfriendship_age_requirement_two_factor() { friendship_age_requirement_two_factorSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCGetGiftPermissionsResponse.FriendPermission> _friend_permissions = new global::System.Collections.Generic.List<CMsgClientToGCGetGiftPermissionsResponse.FriendPermission>();
     [global::ProtoBuf.ProtoMember(9, Name=@"friend_permissions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCGetGiftPermissionsResponse.FriendPermission> friend_permissions
@@ -1769,23 +2779,41 @@ namespace SteamKit2.GC.Dota.Internal
     public FriendPermission() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private EGCMsgInitiateTradeResponse _permission = EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted;
+    private EGCMsgInitiateTradeResponse? _permission;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted)]
     public EGCMsgInitiateTradeResponse permission
     {
-      get { return _permission; }
+      get { return _permission?? EGCMsgInitiateTradeResponse.k_EGCMsgInitiateTradeResponse_Accepted; }
       set { _permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionSpecified
+    {
+      get { return _permission != null; }
+      set { if (value == (_permission== null)) _permission = value ? this.permission : (EGCMsgInitiateTradeResponse?)null; }
+    }
+    private bool ShouldSerializepermission() { return permissionSpecified; }
+    private void Resetpermission() { permissionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1802,14 +2830,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnpackBundle() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1828,14 +2865,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private CMsgClientToGCUnpackBundleResponse.EUnpackBundle _response = CMsgClientToGCUnpackBundleResponse.EUnpackBundle.k_UnpackBundle_Succeeded;
+    private CMsgClientToGCUnpackBundleResponse.EUnpackBundle? _response;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCUnpackBundleResponse.EUnpackBundle.k_UnpackBundle_Succeeded)]
     public CMsgClientToGCUnpackBundleResponse.EUnpackBundle response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCUnpackBundleResponse.EUnpackBundle.k_UnpackBundle_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCUnpackBundleResponse.EUnpackBundle?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EUnpackBundle", EnumPassthru=true)]
     public enum EUnpackBundle
     {
@@ -1873,14 +2919,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientStoreTransactionCompleted() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -1916,14 +2971,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCEquipItemsResponse() {}
     
 
-    private ulong _so_cache_version_id = default(ulong);
+    private ulong? _so_cache_version_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"so_cache_version_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong so_cache_version_id
     {
-      get { return _so_cache_version_id; }
+      get { return _so_cache_version_id?? default(ulong); }
       set { _so_cache_version_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool so_cache_version_idSpecified
+    {
+      get { return _so_cache_version_id != null; }
+      set { if (value == (_so_cache_version_id== null)) _so_cache_version_id = value ? this.so_cache_version_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeso_cache_version_id() { return so_cache_version_idSpecified; }
+    private void Resetso_cache_version_id() { so_cache_version_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1935,23 +2999,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSetItemStyle() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _style_index = default(uint);
+    private uint? _style_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"style_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint style_index
     {
-      get { return _style_index; }
+      get { return _style_index?? default(uint); }
       set { _style_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool style_indexSpecified
+    {
+      get { return _style_index != null; }
+      set { if (value == (_style_index== null)) _style_index = value ? this.style_index : (uint?)null; }
+    }
+    private bool ShouldSerializestyle_index() { return style_indexSpecified; }
+    private void Resetstyle_index() { style_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1963,14 +3045,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCSetItemStyleResponse() {}
     
 
-    private CMsgClientToGCSetItemStyleResponse.ESetStyle _response = CMsgClientToGCSetItemStyleResponse.ESetStyle.k_SetStyle_Succeeded;
+    private CMsgClientToGCSetItemStyleResponse.ESetStyle? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCSetItemStyleResponse.ESetStyle.k_SetStyle_Succeeded)]
     public CMsgClientToGCSetItemStyleResponse.ESetStyle response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCSetItemStyleResponse.ESetStyle.k_SetStyle_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCSetItemStyleResponse.ESetStyle?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ESetStyle", EnumPassthru=true)]
     public enum ESetStyle
     {
@@ -1996,23 +3087,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnlockItemStyle() {}
     
 
-    private ulong _item_to_unlock = default(ulong);
+    private ulong? _item_to_unlock;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_to_unlock", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_to_unlock
     {
-      get { return _item_to_unlock; }
+      get { return _item_to_unlock?? default(ulong); }
       set { _item_to_unlock = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_to_unlockSpecified
+    {
+      get { return _item_to_unlock != null; }
+      set { if (value == (_item_to_unlock== null)) _item_to_unlock = value ? this.item_to_unlock : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_to_unlock() { return item_to_unlockSpecified; }
+    private void Resetitem_to_unlock() { item_to_unlockSpecified = false; }
+    
 
-    private uint _style_index = default(uint);
+    private uint? _style_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"style_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint style_index
     {
-      get { return _style_index; }
+      get { return _style_index?? default(uint); }
       set { _style_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool style_indexSpecified
+    {
+      get { return _style_index != null; }
+      set { if (value == (_style_index== null)) _style_index = value ? this.style_index : (uint?)null; }
+    }
+    private bool ShouldSerializestyle_index() { return style_indexSpecified; }
+    private void Resetstyle_index() { style_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _consumable_item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"consumable_item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> consumable_item_ids
@@ -2031,41 +3140,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnlockItemStyleResponse() {}
     
 
-    private CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle _response = CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle.k_UnlockStyle_Succeeded;
+    private CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle.k_UnlockStyle_Succeeded)]
     public CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle.k_UnlockStyle_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _style_index = default(uint);
+    private uint? _style_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"style_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint style_index
     {
-      get { return _style_index; }
+      get { return _style_index?? default(uint); }
       set { _style_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool style_indexSpecified
+    {
+      get { return _style_index != null; }
+      set { if (value == (_style_index== null)) _style_index = value ? this.style_index : (uint?)null; }
+    }
+    private bool ShouldSerializestyle_index() { return style_indexSpecified; }
+    private void Resetstyle_index() { style_indexSpecified = false; }
+    
 
-    private uint _style_prereq = default(uint);
+    private uint? _style_prereq;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"style_prereq", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint style_prereq
     {
-      get { return _style_prereq; }
+      get { return _style_prereq?? default(uint); }
       set { _style_prereq = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool style_prereqSpecified
+    {
+      get { return _style_prereq != null; }
+      set { if (value == (_style_prereq== null)) _style_prereq = value ? this.style_prereq : (uint?)null; }
+    }
+    private bool ShouldSerializestyle_prereq() { return style_prereqSpecified; }
+    private void Resetstyle_prereq() { style_prereqSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EUnlockStyle", EnumPassthru=true)]
     public enum EUnlockStyle
     {
@@ -2125,32 +3270,59 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _set_to_value = default(uint);
+    private uint? _set_to_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"set_to_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint set_to_value
     {
-      get { return _set_to_value; }
+      get { return _set_to_value?? default(uint); }
       set { _set_to_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool set_to_valueSpecified
+    {
+      get { return _set_to_value != null; }
+      set { if (value == (_set_to_value== null)) _set_to_value = value ? this.set_to_value : (uint?)null; }
+    }
+    private bool ShouldSerializeset_to_value() { return set_to_valueSpecified; }
+    private void Resetset_to_value() { set_to_valueSpecified = false; }
+    
 
-    private uint _remove_categories = default(uint);
+    private uint? _remove_categories;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"remove_categories", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint remove_categories
     {
-      get { return _remove_categories; }
+      get { return _remove_categories?? default(uint); }
       set { _remove_categories = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool remove_categoriesSpecified
+    {
+      get { return _remove_categories != null; }
+      set { if (value == (_remove_categories== null)) _remove_categories = value ? this.remove_categories : (uint?)null; }
+    }
+    private bool ShouldSerializeremove_categories() { return remove_categoriesSpecified; }
+    private void Resetremove_categories() { remove_categoriesSpecified = false; }
+    
 
-    private uint _add_categories = default(uint);
+    private uint? _add_categories;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"add_categories", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint add_categories
     {
-      get { return _add_categories; }
+      get { return _add_categories?? default(uint); }
       set { _add_categories = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool add_categoriesSpecified
+    {
+      get { return _add_categories != null; }
+      set { if (value == (_add_categories== null)) _add_categories = value ? this.add_categories : (uint?)null; }
+    }
+    private bool ShouldSerializeadd_categories() { return add_categoriesSpecified; }
+    private void Resetadd_categories() { add_categoriesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2162,23 +3334,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnlockCrate() {}
     
 
-    private ulong _crate_item_id = default(ulong);
+    private ulong? _crate_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"crate_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong crate_item_id
     {
-      get { return _crate_item_id; }
+      get { return _crate_item_id?? default(ulong); }
       set { _crate_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crate_item_idSpecified
+    {
+      get { return _crate_item_id != null; }
+      set { if (value == (_crate_item_id== null)) _crate_item_id = value ? this.crate_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecrate_item_id() { return crate_item_idSpecified; }
+    private void Resetcrate_item_id() { crate_item_idSpecified = false; }
+    
 
-    private ulong _key_item_id = default(ulong);
+    private ulong? _key_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"key_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong key_item_id
     {
-      get { return _key_item_id; }
+      get { return _key_item_id?? default(ulong); }
       set { _key_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_item_idSpecified
+    {
+      get { return _key_item_id != null; }
+      set { if (value == (_key_item_id== null)) _key_item_id = value ? this.key_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializekey_item_id() { return key_item_idSpecified; }
+    private void Resetkey_item_id() { key_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2190,14 +3380,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCUnlockCrateResponse() {}
     
 
-    private EGCMsgResponse _result = EGCMsgResponse.k_EGCMsgResponseOK;
+    private EGCMsgResponse? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EGCMsgResponse.k_EGCMsgResponseOK)]
     public EGCMsgResponse result
     {
-      get { return _result; }
+      get { return _result?? EGCMsgResponse.k_EGCMsgResponseOK; }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (EGCMsgResponse?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCUnlockCrateResponse.Item> _granted_items = new global::System.Collections.Generic.List<CMsgClientToGCUnlockCrateResponse.Item>();
     [global::ProtoBuf.ProtoMember(2, Name=@"granted_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCUnlockCrateResponse.Item> granted_items
@@ -2211,23 +3410,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Item() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2244,14 +3461,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRemoveItemAttribute() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2263,23 +3489,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCRemoveItemAttributeResponse() {}
     
 
-    private CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute _response = CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute.k_RemoveItemAttribute_Succeeded;
+    private CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute.k_RemoveItemAttribute_Succeeded)]
     public CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute.k_RemoveItemAttribute_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ERemoveItemAttribute", EnumPassthru=true)]
     public enum ERemoveItemAttribute
     {
@@ -2311,32 +3555,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCNameItem() {}
     
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2348,23 +3619,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCNameItemResponse() {}
     
 
-    private CMsgClientToGCNameItemResponse.ENameItem _response = CMsgClientToGCNameItemResponse.ENameItem.k_NameItem_Succeeded;
+    private CMsgClientToGCNameItemResponse.ENameItem? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCNameItemResponse.ENameItem.k_NameItem_Succeeded)]
     public CMsgClientToGCNameItemResponse.ENameItem response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCNameItemResponse.ENameItem.k_NameItem_Succeeded; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCNameItemResponse.ENameItem?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ENameItem", EnumPassthru=true)]
     public enum ENameItem
     {
@@ -2396,23 +3685,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCSetItemPosition() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _new_position = default(uint);
+    private uint? _new_position;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_position
     {
-      get { return _new_position; }
+      get { return _new_position?? default(uint); }
       set { _new_position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_positionSpecified
+    {
+      get { return _new_position != null; }
+      set { if (value == (_new_position== null)) _new_position = value ? this.new_position : (uint?)null; }
+    }
+    private bool ShouldSerializenew_position() { return new_positionSpecified; }
+    private void Resetnew_position() { new_positionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2424,86 +3731,167 @@ namespace SteamKit2.GC.Dota.Internal
     public CAttribute_ItemDynamicRecipeComponent() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _item_quality = default(uint);
+    private uint? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(uint); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private uint _item_flags = default(uint);
+    private uint? _item_flags;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_flags
     {
-      get { return _item_flags; }
+      get { return _item_flags?? default(uint); }
       set { _item_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_flagsSpecified
+    {
+      get { return _item_flags != null; }
+      set { if (value == (_item_flags== null)) _item_flags = value ? this.item_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_flags() { return item_flagsSpecified; }
+    private void Resetitem_flags() { item_flagsSpecified = false; }
+    
 
-    private string _attributes_string = "";
+    private string _attributes_string;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"attributes_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string attributes_string
     {
-      get { return _attributes_string; }
+      get { return _attributes_string?? ""; }
       set { _attributes_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attributes_stringSpecified
+    {
+      get { return _attributes_string != null; }
+      set { if (value == (_attributes_string== null)) _attributes_string = value ? this.attributes_string : (string)null; }
+    }
+    private bool ShouldSerializeattributes_string() { return attributes_stringSpecified; }
+    private void Resetattributes_string() { attributes_stringSpecified = false; }
+    
 
-    private uint _item_count = default(uint);
+    private uint? _item_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_count
     {
-      get { return _item_count; }
+      get { return _item_count?? default(uint); }
       set { _item_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_countSpecified
+    {
+      get { return _item_count != null; }
+      set { if (value == (_item_count== null)) _item_count = value ? this.item_count : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_count() { return item_countSpecified; }
+    private void Resetitem_count() { item_countSpecified = false; }
+    
 
-    private uint _items_fulfilled = default(uint);
+    private uint? _items_fulfilled;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"items_fulfilled", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint items_fulfilled
     {
-      get { return _items_fulfilled; }
+      get { return _items_fulfilled?? default(uint); }
       set { _items_fulfilled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_fulfilledSpecified
+    {
+      get { return _items_fulfilled != null; }
+      set { if (value == (_items_fulfilled== null)) _items_fulfilled = value ? this.items_fulfilled : (uint?)null; }
+    }
+    private bool ShouldSerializeitems_fulfilled() { return items_fulfilledSpecified; }
+    private void Resetitems_fulfilled() { items_fulfilledSpecified = false; }
+    
 
-    private uint _item_rarity = default(uint);
+    private uint? _item_rarity;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"item_rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_rarity
     {
-      get { return _item_rarity; }
+      get { return _item_rarity?? default(uint); }
       set { _item_rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_raritySpecified
+    {
+      get { return _item_rarity != null; }
+      set { if (value == (_item_rarity== null)) _item_rarity = value ? this.item_rarity : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_rarity() { return item_raritySpecified; }
+    private void Resetitem_rarity() { item_raritySpecified = false; }
+    
 
-    private string _lootlist = "";
+    private string _lootlist;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"lootlist", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string lootlist
     {
-      get { return _lootlist; }
+      get { return _lootlist?? ""; }
       set { _lootlist = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lootlistSpecified
+    {
+      get { return _lootlist != null; }
+      set { if (value == (_lootlist== null)) _lootlist = value ? this.lootlist : (string)null; }
+    }
+    private bool ShouldSerializelootlist() { return lootlistSpecified; }
+    private void Resetlootlist() { lootlistSpecified = false; }
+    
 
-    private ulong _fulfilled_item_id = default(ulong);
+    private ulong? _fulfilled_item_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"fulfilled_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong fulfilled_item_id
     {
-      get { return _fulfilled_item_id; }
+      get { return _fulfilled_item_id?? default(ulong); }
       set { _fulfilled_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fulfilled_item_idSpecified
+    {
+      get { return _fulfilled_item_id != null; }
+      set { if (value == (_fulfilled_item_id== null)) _fulfilled_item_id = value ? this.fulfilled_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefulfilled_item_id() { return fulfilled_item_idSpecified; }
+    private void Resetfulfilled_item_id() { fulfilled_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2515,68 +3903,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CProtoItemSocket() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _attr_def_index = default(uint);
+    private uint? _attr_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"attr_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attr_def_index
     {
-      get { return _attr_def_index; }
+      get { return _attr_def_index?? default(uint); }
       set { _attr_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attr_def_indexSpecified
+    {
+      get { return _attr_def_index != null; }
+      set { if (value == (_attr_def_index== null)) _attr_def_index = value ? this.attr_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeattr_def_index() { return attr_def_indexSpecified; }
+    private void Resetattr_def_index() { attr_def_indexSpecified = false; }
+    
 
-    private uint _required_type = default(uint);
+    private uint? _required_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"required_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint required_type
     {
-      get { return _required_type; }
+      get { return _required_type?? default(uint); }
       set { _required_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool required_typeSpecified
+    {
+      get { return _required_type != null; }
+      set { if (value == (_required_type== null)) _required_type = value ? this.required_type : (uint?)null; }
+    }
+    private bool ShouldSerializerequired_type() { return required_typeSpecified; }
+    private void Resetrequired_type() { required_typeSpecified = false; }
+    
 
-    private string _required_hero = "";
+    private string _required_hero;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"required_hero", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string required_hero
     {
-      get { return _required_hero; }
+      get { return _required_hero?? ""; }
       set { _required_hero = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool required_heroSpecified
+    {
+      get { return _required_hero != null; }
+      set { if (value == (_required_hero== null)) _required_hero = value ? this.required_hero : (string)null; }
+    }
+    private bool ShouldSerializerequired_hero() { return required_heroSpecified; }
+    private void Resetrequired_hero() { required_heroSpecified = false; }
+    
 
-    private uint _gem_def_index = default(uint);
+    private uint? _gem_def_index;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gem_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gem_def_index
     {
-      get { return _gem_def_index; }
+      get { return _gem_def_index?? default(uint); }
       set { _gem_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gem_def_indexSpecified
+    {
+      get { return _gem_def_index != null; }
+      set { if (value == (_gem_def_index== null)) _gem_def_index = value ? this.gem_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializegem_def_index() { return gem_def_indexSpecified; }
+    private void Resetgem_def_index() { gem_def_indexSpecified = false; }
+    
 
-    private bool _not_tradable = default(bool);
+    private bool? _not_tradable;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"not_tradable", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool not_tradable
     {
-      get { return _not_tradable; }
+      get { return _not_tradable?? default(bool); }
       set { _not_tradable = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool not_tradableSpecified
+    {
+      get { return _not_tradable != null; }
+      set { if (value == (_not_tradable== null)) _not_tradable = value ? this.not_tradable : (bool?)null; }
+    }
+    private bool ShouldSerializenot_tradable() { return not_tradableSpecified; }
+    private void Resetnot_tradable() { not_tradableSpecified = false; }
+    
 
-    private string _required_item_slot = "";
+    private string _required_item_slot;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"required_item_slot", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string required_item_slot
     {
-      get { return _required_item_slot; }
+      get { return _required_item_slot?? ""; }
       set { _required_item_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool required_item_slotSpecified
+    {
+      get { return _required_item_slot != null; }
+      set { if (value == (_required_item_slot== null)) _required_item_slot = value ? this.required_item_slot : (string)null; }
+    }
+    private bool ShouldSerializerequired_item_slot() { return required_item_slotSpecified; }
+    private void Resetrequired_item_slot() { required_item_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2616,14 +4067,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _effect = default(uint);
+    private uint? _effect;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"effect", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint effect
     {
-      get { return _effect; }
+      get { return _effect?? default(uint); }
       set { _effect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool effectSpecified
+    {
+      get { return _effect != null; }
+      set { if (value == (_effect== null)) _effect = value ? this.effect : (uint?)null; }
+    }
+    private bool ShouldSerializeeffect() { return effectSpecified; }
+    private void Reseteffect() { effectSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2644,32 +4104,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _red = default(uint);
+    private uint? _red;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"red", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint red
     {
-      get { return _red; }
+      get { return _red?? default(uint); }
       set { _red = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool redSpecified
+    {
+      get { return _red != null; }
+      set { if (value == (_red== null)) _red = value ? this.red : (uint?)null; }
+    }
+    private bool ShouldSerializered() { return redSpecified; }
+    private void Resetred() { redSpecified = false; }
+    
 
-    private uint _green = default(uint);
+    private uint? _green;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"green", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint green
     {
-      get { return _green; }
+      get { return _green?? default(uint); }
       set { _green = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool greenSpecified
+    {
+      get { return _green != null; }
+      set { if (value == (_green== null)) _green = value ? this.green : (uint?)null; }
+    }
+    private bool ShouldSerializegreen() { return greenSpecified; }
+    private void Resetgreen() { greenSpecified = false; }
+    
 
-    private uint _blue = default(uint);
+    private uint? _blue;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"blue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint blue
     {
-      get { return _blue; }
+      get { return _blue?? default(uint); }
       set { _blue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool blueSpecified
+    {
+      get { return _blue != null; }
+      set { if (value == (_blue== null)) _blue = value ? this.blue : (uint?)null; }
+    }
+    private bool ShouldSerializeblue() { return blueSpecified; }
+    private void Resetblue() { blueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2690,23 +4177,41 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _strange_type = default(uint);
+    private uint? _strange_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"strange_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strange_type
     {
-      get { return _strange_type; }
+      get { return _strange_type?? default(uint); }
       set { _strange_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_typeSpecified
+    {
+      get { return _strange_type != null; }
+      set { if (value == (_strange_type== null)) _strange_type = value ? this.strange_type : (uint?)null; }
+    }
+    private bool ShouldSerializestrange_type() { return strange_typeSpecified; }
+    private void Resetstrange_type() { strange_typeSpecified = false; }
+    
 
-    private uint _strange_value = default(uint);
+    private uint? _strange_value;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"strange_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strange_value
     {
-      get { return _strange_value; }
+      get { return _strange_value?? default(uint); }
       set { _strange_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_valueSpecified
+    {
+      get { return _strange_value != null; }
+      set { if (value == (_strange_value== null)) _strange_value = value ? this.strange_value : (uint?)null; }
+    }
+    private bool ShouldSerializestrange_value() { return strange_valueSpecified; }
+    private void Resetstrange_value() { strange_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2727,41 +4232,77 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _games_viewed = default(uint);
+    private uint? _games_viewed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"games_viewed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games_viewed
     {
-      get { return _games_viewed; }
+      get { return _games_viewed?? default(uint); }
       set { _games_viewed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool games_viewedSpecified
+    {
+      get { return _games_viewed != null; }
+      set { if (value == (_games_viewed== null)) _games_viewed = value ? this.games_viewed : (uint?)null; }
+    }
+    private bool ShouldSerializegames_viewed() { return games_viewedSpecified; }
+    private void Resetgames_viewed() { games_viewedSpecified = false; }
+    
 
-    private uint _corporation_id = default(uint);
+    private uint? _corporation_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"corporation_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint corporation_id
     {
-      get { return _corporation_id; }
+      get { return _corporation_id?? default(uint); }
       set { _corporation_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool corporation_idSpecified
+    {
+      get { return _corporation_id != null; }
+      set { if (value == (_corporation_id== null)) _corporation_id = value ? this.corporation_id : (uint?)null; }
+    }
+    private bool ShouldSerializecorporation_id() { return corporation_idSpecified; }
+    private void Resetcorporation_id() { corporation_idSpecified = false; }
+    
 
-    private uint _league_id = default(uint);
+    private uint? _league_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"league_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint league_id
     {
-      get { return _league_id; }
+      get { return _league_id?? default(uint); }
       set { _league_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool league_idSpecified
+    {
+      get { return _league_id != null; }
+      set { if (value == (_league_id== null)) _league_id = value ? this.league_id : (uint?)null; }
+    }
+    private bool ShouldSerializeleague_id() { return league_idSpecified; }
+    private void Resetleague_id() { league_idSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2782,14 +4323,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _asset_modifier = default(uint);
+    private uint? _asset_modifier;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"asset_modifier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint asset_modifier
     {
-      get { return _asset_modifier; }
+      get { return _asset_modifier?? default(uint); }
       set { _asset_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool asset_modifierSpecified
+    {
+      get { return _asset_modifier != null; }
+      set { if (value == (_asset_modifier== null)) _asset_modifier = value ? this.asset_modifier : (uint?)null; }
+    }
+    private bool ShouldSerializeasset_modifier() { return asset_modifierSpecified; }
+    private void Resetasset_modifier() { asset_modifierSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2810,32 +4360,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private uint _asset_modifier = default(uint);
+    private uint? _asset_modifier;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"asset_modifier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint asset_modifier
     {
-      get { return _asset_modifier; }
+      get { return _asset_modifier?? default(uint); }
       set { _asset_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool asset_modifierSpecified
+    {
+      get { return _asset_modifier != null; }
+      set { if (value == (_asset_modifier== null)) _asset_modifier = value ? this.asset_modifier : (uint?)null; }
+    }
+    private bool ShouldSerializeasset_modifier() { return asset_modifierSpecified; }
+    private void Resetasset_modifier() { asset_modifierSpecified = false; }
+    
 
-    private uint _anim_modifier = default(uint);
+    private uint? _anim_modifier;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"anim_modifier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint anim_modifier
     {
-      get { return _anim_modifier; }
+      get { return _anim_modifier?? default(uint); }
       set { _anim_modifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool anim_modifierSpecified
+    {
+      get { return _anim_modifier != null; }
+      set { if (value == (_anim_modifier== null)) _anim_modifier = value ? this.anim_modifier : (uint?)null; }
+    }
+    private bool ShouldSerializeanim_modifier() { return anim_modifierSpecified; }
+    private void Resetanim_modifier() { anim_modifierSpecified = false; }
+    
 
-    private uint _ability_effect = default(uint);
+    private uint? _ability_effect;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ability_effect", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ability_effect
     {
-      get { return _ability_effect; }
+      get { return _ability_effect?? default(uint); }
       set { _ability_effect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ability_effectSpecified
+    {
+      get { return _ability_effect != null; }
+      set { if (value == (_ability_effect== null)) _ability_effect = value ? this.ability_effect : (uint?)null; }
+    }
+    private bool ShouldSerializeability_effect() { return ability_effectSpecified; }
+    private void Resetability_effect() { ability_effectSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2856,32 +4433,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _socket = value; }
     }
 
-    private string _autograph = "";
+    private string _autograph;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"autograph", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string autograph
     {
-      get { return _autograph; }
+      get { return _autograph?? ""; }
       set { _autograph = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autographSpecified
+    {
+      get { return _autograph != null; }
+      set { if (value == (_autograph== null)) _autograph = value ? this.autograph : (string)null; }
+    }
+    private bool ShouldSerializeautograph() { return autographSpecified; }
+    private void Resetautograph() { autographSpecified = false; }
+    
 
-    private uint _autograph_id = default(uint);
+    private uint? _autograph_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"autograph_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint autograph_id
     {
-      get { return _autograph_id; }
+      get { return _autograph_id?? default(uint); }
       set { _autograph_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autograph_idSpecified
+    {
+      get { return _autograph_id != null; }
+      set { if (value == (_autograph_id== null)) _autograph_id = value ? this.autograph_id : (uint?)null; }
+    }
+    private bool ShouldSerializeautograph_id() { return autograph_idSpecified; }
+    private void Resetautograph_id() { autograph_idSpecified = false; }
+    
 
-    private uint _autograph_score = default(uint);
+    private uint? _autograph_score;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"autograph_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint autograph_score
     {
-      get { return _autograph_score; }
+      get { return _autograph_score?? default(uint); }
       set { _autograph_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autograph_scoreSpecified
+    {
+      get { return _autograph_score != null; }
+      set { if (value == (_autograph_score== null)) _autograph_score = value ? this.autograph_score : (uint?)null; }
+    }
+    private bool ShouldSerializeautograph_score() { return autograph_scoreSpecified; }
+    private void Resetautograph_score() { autograph_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2912,14 +4516,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CAttribute_String() {}
     
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2931,41 +4544,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CWorkshop_GetItemDailyRevenue_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _item_id = default(uint);
+    private uint? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(uint); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _date_start = default(uint);
+    private uint? _date_start;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"date_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date_start
     {
-      get { return _date_start; }
+      get { return _date_start?? default(uint); }
       set { _date_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool date_startSpecified
+    {
+      get { return _date_start != null; }
+      set { if (value == (_date_start== null)) _date_start = value ? this.date_start : (uint?)null; }
+    }
+    private bool ShouldSerializedate_start() { return date_startSpecified; }
+    private void Resetdate_start() { date_startSpecified = false; }
+    
 
-    private uint _date_end = default(uint);
+    private uint? _date_end;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"date_end", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date_end
     {
-      get { return _date_end; }
+      get { return _date_end?? default(uint); }
       set { _date_end = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool date_endSpecified
+    {
+      get { return _date_end != null; }
+      set { if (value == (_date_end== null)) _date_end = value ? this.date_end : (uint?)null; }
+    }
+    private bool ShouldSerializedate_end() { return date_endSpecified; }
+    private void Resetdate_end() { date_endSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2989,41 +4638,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CountryDailyRevenue() {}
     
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private uint _date = default(uint);
+    private uint? _date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date
     {
-      get { return _date; }
+      get { return _date?? default(uint); }
       set { _date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dateSpecified
+    {
+      get { return _date != null; }
+      set { if (value == (_date== null)) _date = value ? this.date : (uint?)null; }
+    }
+    private bool ShouldSerializedate() { return dateSpecified; }
+    private void Resetdate() { dateSpecified = false; }
+    
 
-    private long _revenue_usd = default(long);
+    private long? _revenue_usd;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"revenue_usd", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(long))]
     public long revenue_usd
     {
-      get { return _revenue_usd; }
+      get { return _revenue_usd?? default(long); }
       set { _revenue_usd = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_usdSpecified
+    {
+      get { return _revenue_usd != null; }
+      set { if (value == (_revenue_usd== null)) _revenue_usd = value ? this.revenue_usd : (long?)null; }
+    }
+    private bool ShouldSerializerevenue_usd() { return revenue_usdSpecified; }
+    private void Resetrevenue_usd() { revenue_usdSpecified = false; }
+    
 
-    private int _units = default(int);
+    private int? _units;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"units", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int units
     {
-      get { return _units; }
+      get { return _units?? default(int); }
       set { _units = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unitsSpecified
+    {
+      get { return _units != null; }
+      set { if (value == (_units== null)) _units = value ? this.units : (int?)null; }
+    }
+    private bool ShouldSerializeunits() { return unitsSpecified; }
+    private void Resetunits() { unitsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3040,23 +4725,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSQLGCToGCGrantBackpackSlots() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _add_slots = default(uint);
+    private uint? _add_slots;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"add_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint add_slots
     {
-      get { return _add_slots; }
+      get { return _add_slots?? default(uint); }
       set { _add_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool add_slotsSpecified
+    {
+      get { return _add_slots != null; }
+      set { if (value == (_add_slots== null)) _add_slots = value ? this.add_slots : (uint?)null; }
+    }
+    private bool ShouldSerializeadd_slots() { return add_slotsSpecified; }
+    private void Resetadd_slots() { add_slotsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3068,14 +4771,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCLookupAccountName() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3087,23 +4799,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCLookupAccountNameResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3115,32 +4845,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCDevRevokeUserItems() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _audit_data = default(ulong);
+    private ulong? _audit_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"audit_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong audit_data
     {
-      get { return _audit_data; }
+      get { return _audit_data?? default(ulong); }
       set { _audit_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audit_dataSpecified
+    {
+      get { return _audit_data != null; }
+      set { if (value == (_audit_data== null)) _audit_data = value ? this.audit_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeaudit_data() { return audit_dataSpecified; }
+    private void Resetaudit_data() { audit_dataSpecified = false; }
+    
 
-    private bool _delete_audit_history = default(bool);
+    private bool? _delete_audit_history;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"delete_audit_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool delete_audit_history
     {
-      get { return _delete_audit_history; }
+      get { return _delete_audit_history?? default(bool); }
       set { _delete_audit_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_audit_historySpecified
+    {
+      get { return _delete_audit_history != null; }
+      set { if (value == (_delete_audit_history== null)) _delete_audit_history = value ? this.delete_audit_history : (bool?)null; }
+    }
+    private bool ShouldSerializedelete_audit_history() { return delete_audit_historySpecified; }
+    private void Resetdelete_audit_history() { delete_audit_historySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3159,37 +4916,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _recipe_def_index = default(uint);
+    private uint? _recipe_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"recipe_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipe_def_index
     {
-      get { return _recipe_def_index; }
+      get { return _recipe_def_index?? default(uint); }
       set { _recipe_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipe_def_indexSpecified
+    {
+      get { return _recipe_def_index != null; }
+      set { if (value == (_recipe_def_index== null)) _recipe_def_index = value ? this.recipe_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializerecipe_def_index() { return recipe_def_indexSpecified; }
+    private void Resetrecipe_def_index() { recipe_def_indexSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Item")]
   public partial class Item : global::ProtoBuf.IExtensible
   {
     public Item() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3206,14 +4990,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientToGCCreateStaticRecipeResponse() {}
     
 
-    private CMsgClientToGCCreateStaticRecipeResponse.EResponse _response = CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success;
+    private CMsgClientToGCCreateStaticRecipeResponse.EResponse? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success)]
     public CMsgClientToGCCreateStaticRecipeResponse.EResponse response
     {
-      get { return _response; }
+      get { return _response?? CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CMsgClientToGCCreateStaticRecipeResponse.EResponse?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientToGCCreateStaticRecipeResponse.OutputItem> _output_items = new global::System.Collections.Generic.List<CMsgClientToGCCreateStaticRecipeResponse.OutputItem>();
     [global::ProtoBuf.ProtoMember(2, Name=@"output_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientToGCCreateStaticRecipeResponse.OutputItem> output_items
@@ -3241,32 +5034,59 @@ namespace SteamKit2.GC.Dota.Internal
     public OutputItem() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3278,23 +5098,41 @@ namespace SteamKit2.GC.Dota.Internal
     public InputError() {}
     
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private CMsgClientToGCCreateStaticRecipeResponse.EResponse _error = CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success;
+    private CMsgClientToGCCreateStaticRecipeResponse.EResponse? _error;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success)]
     public CMsgClientToGCCreateStaticRecipeResponse.EResponse error
     {
-      get { return _error; }
+      get { return _error?? CMsgClientToGCCreateStaticRecipeResponse.EResponse.eResponse_Success; }
       set { _error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorSpecified
+    {
+      get { return _error != null; }
+      set { if (value == (_error== null)) _error = value ? this.error : (CMsgClientToGCCreateStaticRecipeResponse.EResponse?)null; }
+    }
+    private bool ShouldSerializeerror() { return errorSpecified; }
+    private void Reseterror() { errorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3306,23 +5144,41 @@ namespace SteamKit2.GC.Dota.Internal
     public AdditionalOutput() {}
     
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private ulong _value = default(ulong);
+    private ulong? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong value
     {
-      get { return _value; }
+      get { return _value?? default(ulong); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (ulong?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3359,77 +5215,149 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgProcessTransactionOrder() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
 
-    private ulong _steam_txn_id = default(ulong);
+    private ulong? _steam_txn_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_txn_id
     {
-      get { return _steam_txn_id; }
+      get { return _steam_txn_id?? default(ulong); }
       set { _steam_txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_txn_idSpecified
+    {
+      get { return _steam_txn_id != null; }
+      set { if (value == (_steam_txn_id== null)) _steam_txn_id = value ? this.steam_txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_txn_id() { return steam_txn_idSpecified; }
+    private void Resetsteam_txn_id() { steam_txn_idSpecified = false; }
+    
 
-    private ulong _partner_txn_id = default(ulong);
+    private ulong? _partner_txn_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"partner_txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong partner_txn_id
     {
-      get { return _partner_txn_id; }
+      get { return _partner_txn_id?? default(ulong); }
       set { _partner_txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partner_txn_idSpecified
+    {
+      get { return _partner_txn_id != null; }
+      set { if (value == (_partner_txn_id== null)) _partner_txn_id = value ? this.partner_txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepartner_txn_id() { return partner_txn_idSpecified; }
+    private void Resetpartner_txn_id() { partner_txn_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _time_stamp = default(uint);
+    private uint? _time_stamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(uint); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (uint?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private ulong _watermark = default(ulong);
+    private ulong? _watermark;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"watermark", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong watermark
     {
-      get { return _watermark; }
+      get { return _watermark?? default(ulong); }
       set { _watermark = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool watermarkSpecified
+    {
+      get { return _watermark != null; }
+      set { if (value == (_watermark== null)) _watermark = value ? this.watermark : (ulong?)null; }
+    }
+    private bool ShouldSerializewatermark() { return watermarkSpecified; }
+    private void Resetwatermark() { watermarkSpecified = false; }
+    
 
-    private int _purchase_report_status = default(int);
+    private int? _purchase_report_status;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"purchase_report_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int purchase_report_status
     {
-      get { return _purchase_report_status; }
+      get { return _purchase_report_status?? default(int); }
       set { _purchase_report_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_report_statusSpecified
+    {
+      get { return _purchase_report_status != null; }
+      set { if (value == (_purchase_report_status== null)) _purchase_report_status = value ? this.purchase_report_status : (int?)null; }
+    }
+    private bool ShouldSerializepurchase_report_status() { return purchase_report_statusSpecified; }
+    private void Resetpurchase_report_status() { purchase_report_statusSpecified = false; }
+    
 
-    private uint _currency = default(uint);
+    private uint? _currency;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currency
     {
-      get { return _currency; }
+      get { return _currency?? default(uint); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (uint?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgProcessTransactionOrder.Item> _items = new global::System.Collections.Generic.List<CMsgProcessTransactionOrder.Item>();
     [global::ProtoBuf.ProtoMember(9, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgProcessTransactionOrder.Item> items
@@ -3443,86 +5371,167 @@ namespace SteamKit2.GC.Dota.Internal
     public Item() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _item_price = default(uint);
+    private uint? _item_price;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_price", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_price
     {
-      get { return _item_price; }
+      get { return _item_price?? default(uint); }
       set { _item_price = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_priceSpecified
+    {
+      get { return _item_price != null; }
+      set { if (value == (_item_price== null)) _item_price = value ? this.item_price : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_price() { return item_priceSpecified; }
+    private void Resetitem_price() { item_priceSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private string _category_desc = "";
+    private string _category_desc;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"category_desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string category_desc
     {
-      get { return _category_desc; }
+      get { return _category_desc?? ""; }
       set { _category_desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool category_descSpecified
+    {
+      get { return _category_desc != null; }
+      set { if (value == (_category_desc== null)) _category_desc = value ? this.category_desc : (string)null; }
+    }
+    private bool ShouldSerializecategory_desc() { return category_descSpecified; }
+    private void Resetcategory_desc() { category_descSpecified = false; }
+    
 
-    private uint _store_purchase_type = default(uint);
+    private uint? _store_purchase_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"store_purchase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint store_purchase_type
     {
-      get { return _store_purchase_type; }
+      get { return _store_purchase_type?? default(uint); }
       set { _store_purchase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_purchase_typeSpecified
+    {
+      get { return _store_purchase_type != null; }
+      set { if (value == (_store_purchase_type== null)) _store_purchase_type = value ? this.store_purchase_type : (uint?)null; }
+    }
+    private bool ShouldSerializestore_purchase_type() { return store_purchase_typeSpecified; }
+    private void Resetstore_purchase_type() { store_purchase_typeSpecified = false; }
+    
 
-    private ulong _source_reference_id = default(ulong);
+    private ulong? _source_reference_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"source_reference_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong source_reference_id
     {
-      get { return _source_reference_id; }
+      get { return _source_reference_id?? default(ulong); }
       set { _source_reference_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_reference_idSpecified
+    {
+      get { return _source_reference_id != null; }
+      set { if (value == (_source_reference_id== null)) _source_reference_id = value ? this.source_reference_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesource_reference_id() { return source_reference_idSpecified; }
+    private void Resetsource_reference_id() { source_reference_idSpecified = false; }
+    
 
-    private int _parent_stack_index = default(int);
+    private int? _parent_stack_index;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"parent_stack_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int parent_stack_index
     {
-      get { return _parent_stack_index; }
+      get { return _parent_stack_index?? default(int); }
       set { _parent_stack_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parent_stack_indexSpecified
+    {
+      get { return _parent_stack_index != null; }
+      set { if (value == (_parent_stack_index== null)) _parent_stack_index = value ? this.parent_stack_index : (int?)null; }
+    }
+    private bool ShouldSerializeparent_stack_index() { return parent_stack_indexSpecified; }
+    private void Resetparent_stack_index() { parent_stack_indexSpecified = false; }
+    
 
-    private bool _default_price = default(bool);
+    private bool? _default_price;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"default_price", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool default_price
     {
-      get { return _default_price; }
+      get { return _default_price?? default(bool); }
       set { _default_price = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool default_priceSpecified
+    {
+      get { return _default_price != null; }
+      set { if (value == (_default_price== null)) _default_price = value ? this.default_price : (bool?)null; }
+    }
+    private bool ShouldSerializedefault_price() { return default_priceSpecified; }
+    private void Resetdefault_price() { default_priceSpecified = false; }
+    
 
-    private bool _is_user_facing = default(bool);
+    private bool? _is_user_facing;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_user_facing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_user_facing
     {
-      get { return _is_user_facing; }
+      get { return _is_user_facing?? default(bool); }
       set { _is_user_facing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_user_facingSpecified
+    {
+      get { return _is_user_facing != null; }
+      set { if (value == (_is_user_facing== null)) _is_user_facing = value ? this.is_user_facing : (bool?)null; }
+    }
+    private bool ShouldSerializeis_user_facing() { return is_user_facingSpecified; }
+    private void Resetis_user_facing() { is_user_facingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3548,14 +5557,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _order = value; }
     }
 
-    private uint _reason_code = default(uint);
+    private uint? _reason_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reason_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reason_code
     {
-      get { return _reason_code; }
+      get { return _reason_code?? default(uint); }
       set { _reason_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reason_codeSpecified
+    {
+      get { return _reason_code != null; }
+      set { if (value == (_reason_code== null)) _reason_code = value ? this.reason_code : (uint?)null; }
+    }
+    private bool ShouldSerializereason_code() { return reason_codeSpecified; }
+    private void Resetreason_code() { reason_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3567,14 +5585,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCStoreProcessCDKeyTransactionResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3595,14 +5622,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _order = value; }
     }
 
-    private uint _partner = default(uint);
+    private uint? _partner;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"partner", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint partner
     {
-      get { return _partner; }
+      get { return _partner?? default(uint); }
       set { _partner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool partnerSpecified
+    {
+      get { return _partner != null; }
+      set { if (value == (_partner== null)) _partner = value ? this.partner : (uint?)null; }
+    }
+    private bool ShouldSerializepartner() { return partnerSpecified; }
+    private void Resetpartner() { partnerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3614,14 +5650,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCStoreProcessSettlementResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3633,41 +5678,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCBroadcastConsoleCommand() {}
     
 
-    private string _con_command = "";
+    private string _con_command;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"con_command", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string con_command
     {
-      get { return _con_command; }
+      get { return _con_command?? ""; }
       set { _con_command = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool con_commandSpecified
+    {
+      get { return _con_command != null; }
+      set { if (value == (_con_command== null)) _con_command = value ? this.con_command : (string)null; }
+    }
+    private bool ShouldSerializecon_command() { return con_commandSpecified; }
+    private void Resetcon_command() { con_commandSpecified = false; }
+    
 
-    private bool _report_output = default(bool);
+    private bool? _report_output;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"report_output", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool report_output
     {
-      get { return _report_output; }
+      get { return _report_output?? default(bool); }
       set { _report_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool report_outputSpecified
+    {
+      get { return _report_output != null; }
+      set { if (value == (_report_output== null)) _report_output = value ? this.report_output : (bool?)null; }
+    }
+    private bool ShouldSerializereport_output() { return report_outputSpecified; }
+    private void Resetreport_output() { report_outputSpecified = false; }
+    
 
-    private uint _sending_gc = default(uint);
+    private uint? _sending_gc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sending_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sending_gc
     {
-      get { return _sending_gc; }
+      get { return _sending_gc?? default(uint); }
       set { _sending_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sending_gcSpecified
+    {
+      get { return _sending_gc != null; }
+      set { if (value == (_sending_gc== null)) _sending_gc = value ? this.sending_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesending_gc() { return sending_gcSpecified; }
+    private void Resetsending_gc() { sending_gcSpecified = false; }
+    
 
-    private string _output_initiator = "";
+    private string _output_initiator;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"output_initiator", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string output_initiator
     {
-      get { return _output_initiator; }
+      get { return _output_initiator?? ""; }
       set { _output_initiator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool output_initiatorSpecified
+    {
+      get { return _output_initiator != null; }
+      set { if (value == (_output_initiator== null)) _output_initiator = value ? this.output_initiator : (string)null; }
+    }
+    private bool ShouldSerializeoutput_initiator() { return output_initiatorSpecified; }
+    private void Resetoutput_initiator() { output_initiatorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3679,23 +5760,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCConsoleOutput() {}
     
 
-    private string _initiator = "";
+    private string _initiator;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"initiator", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string initiator
     {
-      get { return _initiator; }
+      get { return _initiator?? ""; }
       set { _initiator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiatorSpecified
+    {
+      get { return _initiator != null; }
+      set { if (value == (_initiator== null)) _initiator = value ? this.initiator : (string)null; }
+    }
+    private bool ShouldSerializeinitiator() { return initiatorSpecified; }
+    private void Resetinitiator() { initiatorSpecified = false; }
+    
 
-    private uint _sending_gc = default(uint);
+    private uint? _sending_gc;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sending_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sending_gc
     {
-      get { return _sending_gc; }
+      get { return _sending_gc?? default(uint); }
       set { _sending_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sending_gcSpecified
+    {
+      get { return _sending_gc != null; }
+      set { if (value == (_sending_gc== null)) _sending_gc = value ? this.sending_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesending_gc() { return sending_gcSpecified; }
+    private void Resetsending_gc() { sending_gcSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToGCConsoleOutput.OutputLine> _msgs = new global::System.Collections.Generic.List<CMsgGCToGCConsoleOutput.OutputLine>();
     [global::ProtoBuf.ProtoMember(3, Name=@"msgs", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToGCConsoleOutput.OutputLine> msgs
@@ -3709,23 +5808,41 @@ namespace SteamKit2.GC.Dota.Internal
     public OutputLine() {}
     
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
 
-    private uint _spew_level = default(uint);
+    private uint? _spew_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"spew_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spew_level
     {
-      get { return _spew_level; }
+      get { return _spew_level?? default(uint); }
       set { _spew_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spew_levelSpecified
+    {
+      get { return _spew_level != null; }
+      set { if (value == (_spew_level== null)) _spew_level = value ? this.spew_level : (uint?)null; }
+    }
+    private bool ShouldSerializespew_level() { return spew_levelSpecified; }
+    private void Resetspew_level() { spew_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3754,23 +5871,41 @@ namespace SteamKit2.GC.Dota.Internal
     public MaxItemIDTimestamp() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private ulong _max_item_id = default(ulong);
+    private ulong? _max_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong max_item_id
     {
-      get { return _max_item_id; }
+      get { return _max_item_id?? default(ulong); }
       set { _max_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_item_idSpecified
+    {
+      get { return _max_item_id != null; }
+      set { if (value == (_max_item_id== null)) _max_item_id = value ? this.max_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemax_item_id() { return max_item_idSpecified; }
+    private void Resetmax_item_id() { max_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3787,68 +5922,131 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCInternalTestMsg() {}
     
 
-    private uint _sending_gc = default(uint);
+    private uint? _sending_gc;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sending_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sending_gc
     {
-      get { return _sending_gc; }
+      get { return _sending_gc?? default(uint); }
       set { _sending_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sending_gcSpecified
+    {
+      get { return _sending_gc != null; }
+      set { if (value == (_sending_gc== null)) _sending_gc = value ? this.sending_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesending_gc() { return sending_gcSpecified; }
+    private void Resetsending_gc() { sending_gcSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private uint _context = default(uint);
+    private uint? _context;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"context", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint context
     {
-      get { return _context; }
+      get { return _context?? default(uint); }
       set { _context = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contextSpecified
+    {
+      get { return _context != null; }
+      set { if (value == (_context== null)) _context = value ? this.context : (uint?)null; }
+    }
+    private bool ShouldSerializecontext() { return contextSpecified; }
+    private void Resetcontext() { contextSpecified = false; }
+    
 
-    private uint _message_id = default(uint);
+    private uint? _message_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"message_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint message_id
     {
-      get { return _message_id; }
+      get { return _message_id?? default(uint); }
       set { _message_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_idSpecified
+    {
+      get { return _message_id != null; }
+      set { if (value == (_message_id== null)) _message_id = value ? this.message_id : (uint?)null; }
+    }
+    private bool ShouldSerializemessage_id() { return message_idSpecified; }
+    private void Resetmessage_id() { message_idSpecified = false; }
+    
 
-    private byte[] _message_body = null;
+    private byte[] _message_body;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"message_body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] message_body
     {
-      get { return _message_body; }
+      get { return _message_body?? null; }
       set { _message_body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_bodySpecified
+    {
+      get { return _message_body != null; }
+      set { if (value == (_message_body== null)) _message_body = value ? this.message_body : (byte[])null; }
+    }
+    private bool ShouldSerializemessage_body() { return message_bodySpecified; }
+    private void Resetmessage_body() { message_bodySpecified = false; }
+    
 
-    private ulong _job_id_source = default(ulong);
+    private ulong? _job_id_source;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"job_id_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong job_id_source
     {
-      get { return _job_id_source; }
+      get { return _job_id_source?? default(ulong); }
       set { _job_id_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_sourceSpecified
+    {
+      get { return _job_id_source != null; }
+      set { if (value == (_job_id_source== null)) _job_id_source = value ? this.job_id_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_source() { return job_id_sourceSpecified; }
+    private void Resetjob_id_source() { job_id_sourceSpecified = false; }
+    
 
-    private ulong _job_id_target = default(ulong);
+    private ulong? _job_id_target;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"job_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong job_id_target
     {
-      get { return _job_id_target; }
+      get { return _job_id_target?? default(ulong); }
       set { _job_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_targetSpecified
+    {
+      get { return _job_id_target != null; }
+      set { if (value == (_job_id_target== null)) _job_id_target = value ? this.job_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_target() { return job_id_targetSpecified; }
+    private void Resetjob_id_target() { job_id_targetSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3860,41 +6058,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCClientServerVersionsUpdated() {}
     
 
-    private uint _client_min_allowed_version = default(uint);
+    private uint? _client_min_allowed_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_min_allowed_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_min_allowed_version
     {
-      get { return _client_min_allowed_version; }
+      get { return _client_min_allowed_version?? default(uint); }
       set { _client_min_allowed_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_min_allowed_versionSpecified
+    {
+      get { return _client_min_allowed_version != null; }
+      set { if (value == (_client_min_allowed_version== null)) _client_min_allowed_version = value ? this.client_min_allowed_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_min_allowed_version() { return client_min_allowed_versionSpecified; }
+    private void Resetclient_min_allowed_version() { client_min_allowed_versionSpecified = false; }
+    
 
-    private uint _client_active_version = default(uint);
+    private uint? _client_active_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_active_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_active_version
     {
-      get { return _client_active_version; }
+      get { return _client_active_version?? default(uint); }
       set { _client_active_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_active_versionSpecified
+    {
+      get { return _client_active_version != null; }
+      set { if (value == (_client_active_version== null)) _client_active_version = value ? this.client_active_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_active_version() { return client_active_versionSpecified; }
+    private void Resetclient_active_version() { client_active_versionSpecified = false; }
+    
 
-    private uint _server_active_version = default(uint);
+    private uint? _server_active_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_active_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_active_version
     {
-      get { return _server_active_version; }
+      get { return _server_active_version?? default(uint); }
       set { _server_active_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_active_versionSpecified
+    {
+      get { return _server_active_version != null; }
+      set { if (value == (_server_active_version== null)) _server_active_version = value ? this.server_active_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_active_version() { return server_active_versionSpecified; }
+    private void Resetserver_active_version() { server_active_versionSpecified = false; }
+    
 
-    private uint _server_deployed_version = default(uint);
+    private uint? _server_deployed_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_deployed_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_deployed_version
     {
-      get { return _server_deployed_version; }
+      get { return _server_deployed_version?? default(uint); }
       set { _server_deployed_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_deployed_versionSpecified
+    {
+      get { return _server_deployed_version != null; }
+      set { if (value == (_server_deployed_version== null)) _server_deployed_version = value ? this.server_deployed_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_deployed_version() { return server_deployed_versionSpecified; }
+    private void Resetserver_deployed_version() { server_deployed_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCEconSharedEnums.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCEconSharedEnums.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: econ_shared_enums.proto
 namespace SteamKit2.GC.Dota.Internal
 {
@@ -17,23 +19,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGenericResult() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _debug_message = "";
+    private string _debug_message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"debug_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string debug_message
     {
-      get { return _debug_message; }
+      get { return _debug_message?? ""; }
       set { _debug_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool debug_messageSpecified
+    {
+      get { return _debug_message != null; }
+      set { if (value == (_debug_message== null)) _debug_message = value ? this.debug_message : (string)null; }
+    }
+    private bool ShouldSerializedebug_message() { return debug_messageSpecified; }
+    private void Resetdebug_message() { debug_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCSDK.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCSDK.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsdk_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.Dota.Internal
@@ -49,23 +51,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSOIDOwner() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -77,32 +97,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSOSingleObject() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -113,14 +160,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -139,14 +195,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> _objects_added = new global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject>();
     [global::ProtoBuf.ProtoMember(4, Name=@"objects_added", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> objects_added
@@ -171,37 +236,64 @@ namespace SteamKit2.GC.Dota.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"SingleObject")]
   public partial class SingleObject : global::ProtoBuf.IExtensible
   {
     public SingleObject() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -225,14 +317,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -243,14 +344,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -259,28 +369,46 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"SubscribedType")]
   public partial class SubscribedType : global::ProtoBuf.IExtensible
   {
     public SubscribedType() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _object_data = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> object_data
@@ -304,14 +432,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSOCacheSubscribedUpToDate() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -322,14 +459,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -338,14 +484,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -376,14 +531,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSOCacheSubscriptionCheck() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -394,14 +558,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -410,14 +583,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -448,14 +630,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSOCacheVersion() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -467,23 +658,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCMultiplexMessage() {}
     
 
-    private uint _msgtype = default(uint);
+    private uint? _msgtype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msgtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgtype
     {
-      get { return _msgtype; }
+      get { return _msgtype?? default(uint); }
       set { _msgtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgtypeSpecified
+    {
+      get { return _msgtype != null; }
+      set { if (value == (_msgtype== null)) _msgtype = value ? this.msgtype : (uint?)null; }
+    }
+    private bool ShouldSerializemsgtype() { return msgtypeSpecified; }
+    private void Resetmsgtype() { msgtypeSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamids
@@ -502,32 +711,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCToGCMsgMasterAck() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
 
-    private string _process_name = "";
+    private string _process_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"process_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string process_name
     {
-      get { return _process_name; }
+      get { return _process_name?? ""; }
       set { _process_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool process_nameSpecified
+    {
+      get { return _process_name != null; }
+      set { if (value == (_process_name== null)) _process_name = value ? this.process_name : (string)null; }
+    }
+    private bool ShouldSerializeprocess_name() { return process_nameSpecified; }
+    private void Resetprocess_name() { process_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGCToGCMsgMasterAck.Process> _directory = new global::System.Collections.Generic.List<CGCToGCMsgMasterAck.Process>();
     [global::ProtoBuf.ProtoMember(6, Name=@"directory", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGCToGCMsgMasterAck.Process> directory
@@ -541,14 +777,23 @@ namespace SteamKit2.GC.Dota.Internal
     public Process() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _type_instances = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"type_instances", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> type_instances
@@ -572,14 +817,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCToGCMsgMasterAck_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -591,14 +845,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCUniverseStartup() {}
     
 
-    private bool _is_initial_startup = default(bool);
+    private bool? _is_initial_startup;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_initial_startup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_initial_startup
     {
-      get { return _is_initial_startup; }
+      get { return _is_initial_startup?? default(bool); }
       set { _is_initial_startup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_initial_startupSpecified
+    {
+      get { return _is_initial_startup != null; }
+      set { if (value == (_is_initial_startup== null)) _is_initial_startup = value ? this.is_initial_startup : (bool?)null; }
+    }
+    private bool ShouldSerializeis_initial_startup() { return is_initial_startupSpecified; }
+    private void Resetis_initial_startup() { is_initial_startupSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -610,14 +873,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCUniverseStartupResponse() {}
     
 
-    private int _eresult = default(int);
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(int); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -641,23 +913,41 @@ namespace SteamKit2.GC.Dota.Internal
     public GCInfo() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -674,32 +964,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCToGCMsgRouted() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -711,23 +1028,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CGCToGCMsgRoutedReply() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -751,32 +1086,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgUpdate() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private bool _trusted = default(bool);
+    private bool? _trusted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trusted
     {
-      get { return _trusted; }
+      get { return _trusted?? default(bool); }
       set { _trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trustedSpecified
+    {
+      get { return _trusted != null; }
+      set { if (value == (_trusted== null)) _trusted = value ? this.trusted : (bool?)null; }
+    }
+    private bool ShouldSerializetrusted() { return trustedSpecified; }
+    private void Resettrusted() { trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -793,14 +1155,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCRequestSubGCSessionInfo() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -812,41 +1183,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCRequestSubGCSessionInfoResponse() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private bool _trusted = default(bool);
+    private bool? _trusted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trusted
     {
-      get { return _trusted; }
+      get { return _trusted?? default(bool); }
       set { _trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trustedSpecified
+    {
+      get { return _trusted != null; }
+      set { if (value == (_trusted== null)) _trusted = value ? this.trusted : (bool?)null; }
+    }
+    private bool ShouldSerializetrusted() { return trustedSpecified; }
+    private void Resettrusted() { trustedSpecified = false; }
+    
 
-    private uint _port = default(uint);
+    private uint? _port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint port
     {
-      get { return _port; }
+      get { return _port?? default(uint); }
       set { _port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool portSpecified
+    {
+      get { return _port != null; }
+      set { if (value == (_port== null)) _port = value ? this.port : (uint?)null; }
+    }
+    private bool ShouldSerializeport() { return portSpecified; }
+    private void Resetport() { portSpecified = false; }
+    
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -867,32 +1274,59 @@ namespace SteamKit2.GC.Dota.Internal
       set { _soid = value; }
     }
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
 
-    private uint _cached_file_version = default(uint);
+    private uint? _cached_file_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cached_file_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cached_file_version
     {
-      get { return _cached_file_version; }
+      get { return _cached_file_version?? default(uint); }
       set { _cached_file_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cached_file_versionSpecified
+    {
+      get { return _cached_file_version != null; }
+      set { if (value == (_cached_file_version== null)) _cached_file_version = value ? this.cached_file_version : (uint?)null; }
+    }
+    private bool ShouldSerializecached_file_version() { return cached_file_versionSpecified; }
+    private void Resetcached_file_version() { cached_file_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -904,14 +1338,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientHello() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> _socache_have_versions = new global::System.Collections.Generic.List<CMsgSOCacheHaveVersion>();
     [global::ProtoBuf.ProtoMember(2, Name=@"socache_have_versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheHaveVersion> socache_have_versions
@@ -920,50 +1363,95 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _client_session_need = default(uint);
+    private uint? _client_session_need;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_session_need
     {
-      get { return _client_session_need; }
+      get { return _client_session_need?? default(uint); }
       set { _client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_needSpecified
+    {
+      get { return _client_session_need != null; }
+      set { if (value == (_client_session_need== null)) _client_session_need = value ? this.client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_session_need() { return client_session_needSpecified; }
+    private void Resetclient_session_need() { client_session_needSpecified = false; }
+    
 
-    private PartnerAccountType _client_launcher = PartnerAccountType.PARTNER_NONE;
+    private PartnerAccountType? _client_launcher;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_launcher", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PartnerAccountType.PARTNER_NONE)]
     public PartnerAccountType client_launcher
     {
-      get { return _client_launcher; }
+      get { return _client_launcher?? PartnerAccountType.PARTNER_NONE; }
       set { _client_launcher = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_launcherSpecified
+    {
+      get { return _client_launcher != null; }
+      set { if (value == (_client_launcher== null)) _client_launcher = value ? this.client_launcher : (PartnerAccountType?)null; }
+    }
+    private bool ShouldSerializeclient_launcher() { return client_launcherSpecified; }
+    private void Resetclient_launcher() { client_launcherSpecified = false; }
+    
 
-    private string _secret_key = "";
+    private string _secret_key;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"secret_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string secret_key
     {
-      get { return _secret_key; }
+      get { return _secret_key?? ""; }
       set { _secret_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secret_keySpecified
+    {
+      get { return _secret_key != null; }
+      set { if (value == (_secret_key== null)) _secret_key = value ? this.secret_key : (string)null; }
+    }
+    private bool ShouldSerializesecret_key() { return secret_keySpecified; }
+    private void Resetsecret_key() { secret_keySpecified = false; }
+    
 
-    private uint _client_language = default(uint);
+    private uint? _client_language;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"client_language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_language
     {
-      get { return _client_language; }
+      get { return _client_language?? default(uint); }
       set { _client_language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_languageSpecified
+    {
+      get { return _client_language != null; }
+      set { if (value == (_client_language== null)) _client_language = value ? this.client_language : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_language() { return client_languageSpecified; }
+    private void Resetclient_language() { client_languageSpecified = false; }
+    
 
-    private ESourceEngine _engine = ESourceEngine.k_ESE_Source1;
+    private ESourceEngine? _engine;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"engine", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ESourceEngine.k_ESE_Source1)]
     public ESourceEngine engine
     {
-      get { return _engine; }
+      get { return _engine?? ESourceEngine.k_ESE_Source1; }
       set { _engine = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool engineSpecified
+    {
+      get { return _engine != null; }
+      set { if (value == (_engine== null)) _engine = value ? this.engine : (ESourceEngine?)null; }
+    }
+    private bool ShouldSerializeengine() { return engineSpecified; }
+    private void Resetengine() { engineSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -975,23 +1463,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgClientWelcome() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private byte[] _game_data = null;
+    private byte[] _game_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data
     {
-      get { return _game_data; }
+      get { return _game_data?? null; }
       set { _game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_dataSpecified
+    {
+      get { return _game_data != null; }
+      set { if (value == (_game_data== null)) _game_data = value ? this.game_data : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data() { return game_dataSpecified; }
+    private void Resetgame_data() { game_dataSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheSubscribed> _outofdate_subscribed_caches = new global::System.Collections.Generic.List<CMsgSOCacheSubscribed>();
     [global::ProtoBuf.ProtoMember(3, Name=@"outofdate_subscribed_caches", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheSubscribed> outofdate_subscribed_caches
@@ -1016,73 +1522,136 @@ namespace SteamKit2.GC.Dota.Internal
       set { _location = value; }
     }
 
-    private byte[] _save_game_key = null;
+    private byte[] _save_game_key;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"save_game_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] save_game_key
     {
-      get { return _save_game_key; }
+      get { return _save_game_key?? null; }
       set { _save_game_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool save_game_keySpecified
+    {
+      get { return _save_game_key != null; }
+      set { if (value == (_save_game_key== null)) _save_game_key = value ? this.save_game_key : (byte[])null; }
+    }
+    private bool ShouldSerializesave_game_key() { return save_game_keySpecified; }
+    private void Resetsave_game_key() { save_game_keySpecified = false; }
+    
 
-    private uint _item_schema_crc = default(uint);
+    private uint? _item_schema_crc;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"item_schema_crc", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_schema_crc
     {
-      get { return _item_schema_crc; }
+      get { return _item_schema_crc?? default(uint); }
       set { _item_schema_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_schema_crcSpecified
+    {
+      get { return _item_schema_crc != null; }
+      set { if (value == (_item_schema_crc== null)) _item_schema_crc = value ? this.item_schema_crc : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_schema_crc() { return item_schema_crcSpecified; }
+    private void Resetitem_schema_crc() { item_schema_crcSpecified = false; }
+    
 
-    private string _items_game_url = "";
+    private string _items_game_url;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"items_game_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string items_game_url
     {
-      get { return _items_game_url; }
+      get { return _items_game_url?? ""; }
       set { _items_game_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_game_urlSpecified
+    {
+      get { return _items_game_url != null; }
+      set { if (value == (_items_game_url== null)) _items_game_url = value ? this.items_game_url : (string)null; }
+    }
+    private bool ShouldSerializeitems_game_url() { return items_game_urlSpecified; }
+    private void Resetitems_game_url() { items_game_urlSpecified = false; }
+    
 
-    private uint _gc_socache_file_version = default(uint);
+    private uint? _gc_socache_file_version;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"gc_socache_file_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_socache_file_version
     {
-      get { return _gc_socache_file_version; }
+      get { return _gc_socache_file_version?? default(uint); }
       set { _gc_socache_file_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_socache_file_versionSpecified
+    {
+      get { return _gc_socache_file_version != null; }
+      set { if (value == (_gc_socache_file_version== null)) _gc_socache_file_version = value ? this.gc_socache_file_version : (uint?)null; }
+    }
+    private bool ShouldSerializegc_socache_file_version() { return gc_socache_file_versionSpecified; }
+    private void Resetgc_socache_file_version() { gc_socache_file_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Location")]
   public partial class Location : global::ProtoBuf.IExtensible
   {
     public Location() {}
     
 
-    private float _latitude = default(float);
+    private float? _latitude;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float latitude
     {
-      get { return _latitude; }
+      get { return _latitude?? default(float); }
       set { _latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latitudeSpecified
+    {
+      get { return _latitude != null; }
+      set { if (value == (_latitude== null)) _latitude = value ? this.latitude : (float?)null; }
+    }
+    private bool ShouldSerializelatitude() { return latitudeSpecified; }
+    private void Resetlatitude() { latitudeSpecified = false; }
+    
 
-    private float _longitude = default(float);
+    private float? _longitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float longitude
     {
-      get { return _longitude; }
+      get { return _longitude?? default(float); }
       set { _longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool longitudeSpecified
+    {
+      get { return _longitude != null; }
+      set { if (value == (_longitude== null)) _longitude = value ? this.longitude : (float?)null; }
+    }
+    private bool ShouldSerializelongitude() { return longitudeSpecified; }
+    private void Resetlongitude() { longitudeSpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1099,59 +1668,113 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgConnectionStatus() {}
     
 
-    private GCConnectionStatus _status = GCConnectionStatus.GCConnectionStatus_HAVE_SESSION;
+    private GCConnectionStatus? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCConnectionStatus.GCConnectionStatus_HAVE_SESSION)]
     public GCConnectionStatus status
     {
-      get { return _status; }
+      get { return _status?? GCConnectionStatus.GCConnectionStatus_HAVE_SESSION; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (GCConnectionStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _client_session_need = default(uint);
+    private uint? _client_session_need;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_session_need
     {
-      get { return _client_session_need; }
+      get { return _client_session_need?? default(uint); }
       set { _client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_needSpecified
+    {
+      get { return _client_session_need != null; }
+      set { if (value == (_client_session_need== null)) _client_session_need = value ? this.client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_session_need() { return client_session_needSpecified; }
+    private void Resetclient_session_need() { client_session_needSpecified = false; }
+    
 
-    private int _queue_position = default(int);
+    private int? _queue_position;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"queue_position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_position
     {
-      get { return _queue_position; }
+      get { return _queue_position?? default(int); }
       set { _queue_position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_positionSpecified
+    {
+      get { return _queue_position != null; }
+      set { if (value == (_queue_position== null)) _queue_position = value ? this.queue_position : (int?)null; }
+    }
+    private bool ShouldSerializequeue_position() { return queue_positionSpecified; }
+    private void Resetqueue_position() { queue_positionSpecified = false; }
+    
 
-    private int _queue_size = default(int);
+    private int? _queue_size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"queue_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_size
     {
-      get { return _queue_size; }
+      get { return _queue_size?? default(int); }
       set { _queue_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_sizeSpecified
+    {
+      get { return _queue_size != null; }
+      set { if (value == (_queue_size== null)) _queue_size = value ? this.queue_size : (int?)null; }
+    }
+    private bool ShouldSerializequeue_size() { return queue_sizeSpecified; }
+    private void Resetqueue_size() { queue_sizeSpecified = false; }
+    
 
-    private int _wait_seconds = default(int);
+    private int? _wait_seconds;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"wait_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int wait_seconds
     {
-      get { return _wait_seconds; }
+      get { return _wait_seconds?? default(int); }
       set { _wait_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wait_secondsSpecified
+    {
+      get { return _wait_seconds != null; }
+      set { if (value == (_wait_seconds== null)) _wait_seconds = value ? this.wait_seconds : (int?)null; }
+    }
+    private bool ShouldSerializewait_seconds() { return wait_secondsSpecified; }
+    private void Resetwait_seconds() { wait_secondsSpecified = false; }
+    
 
-    private int _estimated_wait_seconds_remaining = default(int);
+    private int? _estimated_wait_seconds_remaining;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"estimated_wait_seconds_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int estimated_wait_seconds_remaining
     {
-      get { return _estimated_wait_seconds_remaining; }
+      get { return _estimated_wait_seconds_remaining?? default(int); }
       set { _estimated_wait_seconds_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estimated_wait_seconds_remainingSpecified
+    {
+      get { return _estimated_wait_seconds_remaining != null; }
+      set { if (value == (_estimated_wait_seconds_remaining== null)) _estimated_wait_seconds_remaining = value ? this.estimated_wait_seconds_remaining : (int?)null; }
+    }
+    private bool ShouldSerializeestimated_wait_seconds_remaining() { return estimated_wait_seconds_remainingSpecified; }
+    private void Resetestimated_wait_seconds_remaining() { estimated_wait_seconds_remainingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1163,32 +1786,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCSOCacheSubscribe() {}
     
 
-    private ulong _subscriber = default(ulong);
+    private ulong? _subscriber;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subscriber", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscriber
     {
-      get { return _subscriber; }
+      get { return _subscriber?? default(ulong); }
       set { _subscriber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscriberSpecified
+    {
+      get { return _subscriber != null; }
+      set { if (value == (_subscriber== null)) _subscriber = value ? this.subscriber : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscriber() { return subscriberSpecified; }
+    private void Resetsubscriber() { subscriberSpecified = false; }
+    
 
-    private ulong _subscribe_to_id = default(ulong);
+    private ulong? _subscribe_to_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subscribe_to_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscribe_to_id
     {
-      get { return _subscribe_to_id; }
+      get { return _subscribe_to_id?? default(ulong); }
       set { _subscribe_to_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscribe_to_idSpecified
+    {
+      get { return _subscribe_to_id != null; }
+      set { if (value == (_subscribe_to_id== null)) _subscribe_to_id = value ? this.subscribe_to_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscribe_to_id() { return subscribe_to_idSpecified; }
+    private void Resetsubscribe_to_id() { subscribe_to_idSpecified = false; }
+    
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions> _have_versions = new global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions>();
     [global::ProtoBuf.ProtoMember(4, Name=@"have_versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions> have_versions
@@ -1197,37 +1847,64 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _subscribe_to_type = default(uint);
+    private uint? _subscribe_to_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"subscribe_to_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint subscribe_to_type
     {
-      get { return _subscribe_to_type; }
+      get { return _subscribe_to_type?? default(uint); }
       set { _subscribe_to_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscribe_to_typeSpecified
+    {
+      get { return _subscribe_to_type != null; }
+      set { if (value == (_subscribe_to_type== null)) _subscribe_to_type = value ? this.subscribe_to_type : (uint?)null; }
+    }
+    private bool ShouldSerializesubscribe_to_type() { return subscribe_to_typeSpecified; }
+    private void Resetsubscribe_to_type() { subscribe_to_typeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CMsgHaveVersions")]
   public partial class CMsgHaveVersions : global::ProtoBuf.IExtensible
   {
     public CMsgHaveVersions() {}
     
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1244,32 +1921,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCSOCacheUnsubscribe() {}
     
 
-    private ulong _subscriber = default(ulong);
+    private ulong? _subscriber;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subscriber", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscriber
     {
-      get { return _subscriber; }
+      get { return _subscriber?? default(ulong); }
       set { _subscriber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscriberSpecified
+    {
+      get { return _subscriber != null; }
+      set { if (value == (_subscriber== null)) _subscriber = value ? this.subscriber : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscriber() { return subscriberSpecified; }
+    private void Resetsubscriber() { subscriberSpecified = false; }
+    
 
-    private ulong _unsubscribe_from_id = default(ulong);
+    private ulong? _unsubscribe_from_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"unsubscribe_from_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong unsubscribe_from_id
     {
-      get { return _unsubscribe_from_id; }
+      get { return _unsubscribe_from_id?? default(ulong); }
       set { _unsubscribe_from_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unsubscribe_from_idSpecified
+    {
+      get { return _unsubscribe_from_id != null; }
+      set { if (value == (_unsubscribe_from_id== null)) _unsubscribe_from_id = value ? this.unsubscribe_from_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeunsubscribe_from_id() { return unsubscribe_from_idSpecified; }
+    private void Resetunsubscribe_from_id() { unsubscribe_from_idSpecified = false; }
+    
 
-    private uint _unsubscribe_from_type = default(uint);
+    private uint? _unsubscribe_from_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"unsubscribe_from_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unsubscribe_from_type
     {
-      get { return _unsubscribe_from_type; }
+      get { return _unsubscribe_from_type?? default(uint); }
       set { _unsubscribe_from_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unsubscribe_from_typeSpecified
+    {
+      get { return _unsubscribe_from_type != null; }
+      set { if (value == (_unsubscribe_from_type== null)) _unsubscribe_from_type = value ? this.unsubscribe_from_type : (uint?)null; }
+    }
+    private bool ShouldSerializeunsubscribe_from_type() { return unsubscribe_from_typeSpecified; }
+    private void Resetunsubscribe_from_type() { unsubscribe_from_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1291,14 +1995,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCForwardAccountDetails() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
     private CGCSystemMsg_GetAccountDetails_Response _account_details = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1309,14 +2022,23 @@ namespace SteamKit2.GC.Dota.Internal
       set { _account_details = value; }
     }
 
-    private uint _age_seconds = default(uint);
+    private uint? _age_seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"age_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint age_seconds
     {
-      get { return _age_seconds; }
+      get { return _age_seconds?? default(uint); }
       set { _age_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool age_secondsSpecified
+    {
+      get { return _age_seconds != null; }
+      set { if (value == (_age_seconds== null)) _age_seconds = value ? this.age_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializeage_seconds() { return age_secondsSpecified; }
+    private void Resetage_seconds() { age_secondsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1328,14 +2050,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCLoadSessionSOCache() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
     private CMsgGCToGCForwardAccountDetails _forward_account_details = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"forward_account_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1366,32 +2097,59 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToGCUpdateSessionStats() {}
     
 
-    private uint _user_sessions = default(uint);
+    private uint? _user_sessions;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_sessions
     {
-      get { return _user_sessions; }
+      get { return _user_sessions?? default(uint); }
       set { _user_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_sessionsSpecified
+    {
+      get { return _user_sessions != null; }
+      set { if (value == (_user_sessions== null)) _user_sessions = value ? this.user_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_sessions() { return user_sessionsSpecified; }
+    private void Resetuser_sessions() { user_sessionsSpecified = false; }
+    
 
-    private uint _server_sessions = default(uint);
+    private uint? _server_sessions;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_sessions
     {
-      get { return _server_sessions; }
+      get { return _server_sessions?? default(uint); }
       set { _server_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_sessionsSpecified
+    {
+      get { return _server_sessions != null; }
+      set { if (value == (_server_sessions== null)) _server_sessions = value ? this.server_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_sessions() { return server_sessionsSpecified; }
+    private void Resetserver_sessions() { server_sessionsSpecified = false; }
+    
 
-    private bool _in_logon_surge = default(bool);
+    private bool? _in_logon_surge;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"in_logon_surge", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_logon_surge
     {
-      get { return _in_logon_surge; }
+      get { return _in_logon_surge?? default(bool); }
       set { _in_logon_surge = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_logon_surgeSpecified
+    {
+      get { return _in_logon_surge != null; }
+      set { if (value == (_in_logon_surge== null)) _in_logon_surge = value ? this.in_logon_surge : (bool?)null; }
+    }
+    private bool ShouldSerializein_logon_surge() { return in_logon_surgeSpecified; }
+    private void Resetin_logon_surge() { in_logon_surgeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1403,14 +2161,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CWorkshop_PopulateItemDescriptions_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> _languages = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock>();
     [global::ProtoBuf.ProtoMember(2, Name=@"languages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> languages
@@ -1424,23 +2191,41 @@ namespace SteamKit2.GC.Dota.Internal
     public SingleItemDescription() {}
     
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
 
-    private string _item_description = "";
+    private string _item_description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_description
     {
-      get { return _item_description; }
+      get { return _item_description?? ""; }
       set { _item_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_descriptionSpecified
+    {
+      get { return _item_description != null; }
+      set { if (value == (_item_description== null)) _item_description = value ? this.item_description : (string)null; }
+    }
+    private bool ShouldSerializeitem_description() { return item_descriptionSpecified; }
+    private void Resetitem_description() { item_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1452,14 +2237,23 @@ namespace SteamKit2.GC.Dota.Internal
     public ItemDescriptionsLanguageBlock() {}
     
 
-    private string _language = "";
+    private string _language;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language
     {
-      get { return _language; }
+      get { return _language?? ""; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (string)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> _descriptions = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription>();
     [global::ProtoBuf.ProtoMember(2, Name=@"descriptions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> descriptions
@@ -1483,23 +2277,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CWorkshop_GetContributors_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1528,23 +2340,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CWorkshop_SetItemPaymentRules_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> _associated_workshop_files = new global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule>();
     [global::ProtoBuf.ProtoMember(3, Name=@"associated_workshop_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> associated_workshop_files
@@ -1565,32 +2395,59 @@ namespace SteamKit2.GC.Dota.Internal
     public WorkshopItemPaymentRule() {}
     
 
-    private ulong _workshop_file_id = default(ulong);
+    private ulong? _workshop_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"workshop_file_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong workshop_file_id
     {
-      get { return _workshop_file_id; }
+      get { return _workshop_file_id?? default(ulong); }
       set { _workshop_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_file_idSpecified
+    {
+      get { return _workshop_file_id != null; }
+      set { if (value == (_workshop_file_id== null)) _workshop_file_id = value ? this.workshop_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeworkshop_file_id() { return workshop_file_idSpecified; }
+    private void Resetworkshop_file_id() { workshop_file_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1602,32 +2459,59 @@ namespace SteamKit2.GC.Dota.Internal
     public PartnerItemPaymentRule() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1654,41 +2538,77 @@ namespace SteamKit2.GC.Dota.Internal
     public CBroadcast_PostGameDataFrame_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private byte[] _frame_data = null;
+    private byte[] _frame_data;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"frame_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] frame_data
     {
-      get { return _frame_data; }
+      get { return _frame_data?? null; }
       set { _frame_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool frame_dataSpecified
+    {
+      get { return _frame_data != null; }
+      set { if (value == (_frame_data== null)) _frame_data = value ? this.frame_data : (byte[])null; }
+    }
+    private bool ShouldSerializeframe_data() { return frame_dataSpecified; }
+    private void Resetframe_data() { frame_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1700,14 +2620,23 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgSerializedSOCache() {}
     
 
-    private uint _file_version = default(uint);
+    private uint? _file_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_version
     {
-      get { return _file_version; }
+      get { return _file_version?? default(uint); }
       set { _file_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_versionSpecified
+    {
+      get { return _file_version != null; }
+      set { if (value == (_file_version== null)) _file_version = value ? this.file_version : (uint?)null; }
+    }
+    private bool ShouldSerializefile_version() { return file_versionSpecified; }
+    private void Resetfile_version() { file_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache> _caches = new global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache>();
     [global::ProtoBuf.ProtoMember(2, Name=@"caches", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache> caches
@@ -1716,28 +2645,46 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _gc_socache_file_version = default(uint);
+    private uint? _gc_socache_file_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gc_socache_file_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_socache_file_version
     {
-      get { return _gc_socache_file_version; }
+      get { return _gc_socache_file_version?? default(uint); }
       set { _gc_socache_file_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_socache_file_versionSpecified
+    {
+      get { return _gc_socache_file_version != null; }
+      set { if (value == (_gc_socache_file_version== null)) _gc_socache_file_version = value ? this.gc_socache_file_version : (uint?)null; }
+    }
+    private bool ShouldSerializegc_socache_file_version() { return gc_socache_file_versionSpecified; }
+    private void Resetgc_socache_file_version() { gc_socache_file_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"TypeCache")]
   public partial class TypeCache : global::ProtoBuf.IExtensible
   {
     public TypeCache() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _objects = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"objects", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> objects
@@ -1746,14 +2693,23 @@ namespace SteamKit2.GC.Dota.Internal
     }
   
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1765,23 +2721,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Cache() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache.Version> _versions = new global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache.Version>();
     [global::ProtoBuf.ProtoMember(3, Name=@"versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSerializedSOCache.Cache.Version> versions
@@ -1802,23 +2776,41 @@ namespace SteamKit2.GC.Dota.Internal
     public Version() {}
     
 
-    private uint _service = default(uint);
+    private uint? _service;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"service", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service
     {
-      get { return _service; }
+      get { return _service?? default(uint); }
       set { _service = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serviceSpecified
+    {
+      get { return _service != null; }
+      set { if (value == (_service== null)) _service = value ? this.service : (uint?)null; }
+    }
+    private bool ShouldSerializeservice() { return serviceSpecified; }
+    private void Resetservice() { serviceSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1840,23 +2832,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPollConvarRequest() {}
     
 
-    private string _convar_name = "";
+    private string _convar_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"convar_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string convar_name
     {
-      get { return _convar_name; }
+      get { return _convar_name?? ""; }
       set { _convar_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool convar_nameSpecified
+    {
+      get { return _convar_name != null; }
+      set { if (value == (_convar_name== null)) _convar_name = value ? this.convar_name : (string)null; }
+    }
+    private bool ShouldSerializeconvar_name() { return convar_nameSpecified; }
+    private void Resetconvar_name() { convar_nameSpecified = false; }
+    
 
-    private uint _poll_id = default(uint);
+    private uint? _poll_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"poll_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint poll_id
     {
-      get { return _poll_id; }
+      get { return _poll_id?? default(uint); }
       set { _poll_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool poll_idSpecified
+    {
+      get { return _poll_id != null; }
+      set { if (value == (_poll_id== null)) _poll_id = value ? this.poll_id : (uint?)null; }
+    }
+    private bool ShouldSerializepoll_id() { return poll_idSpecified; }
+    private void Resetpoll_id() { poll_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1868,23 +2878,41 @@ namespace SteamKit2.GC.Dota.Internal
     public CMsgGCToClientPollConvarResponse() {}
     
 
-    private uint _poll_id = default(uint);
+    private uint? _poll_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"poll_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint poll_id
     {
-      get { return _poll_id; }
+      get { return _poll_id?? default(uint); }
       set { _poll_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool poll_idSpecified
+    {
+      get { return _poll_id != null; }
+      set { if (value == (_poll_id== null)) _poll_id = value ? this.poll_id : (uint?)null; }
+    }
+    private bool ShouldSerializepoll_id() { return poll_idSpecified; }
+    private void Resetpoll_id() { poll_idSpecified = false; }
+    
 
-    private string _convar_value = "";
+    private string _convar_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"convar_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string convar_value
     {
-      get { return _convar_value; }
+      get { return _convar_value?? ""; }
       set { _convar_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool convar_valueSpecified
+    {
+      get { return _convar_value != null; }
+      set { if (value == (_convar_value== null)) _convar_value = value ? this.convar_value : (string)null; }
+    }
+    private bool ShouldSerializeconvar_value() { return convar_valueSpecified; }
+    private void Resetconvar_value() { convar_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCSystem.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/Dota/SteamMsgGCSystem.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsystemmsgs.proto
 namespace SteamKit2.GC.Dota.Internal
 {

--- a/SteamKit2/SteamKit2/Base/Generated/GC/MsgBaseGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/MsgBaseGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gc.proto
 namespace SteamKit2.GC.Internal
 {
@@ -17,95 +19,185 @@ namespace SteamKit2.GC.Internal
     public CMsgProtoBufHeader() {}
     
 
-    private ulong _client_steam_id = default(ulong);
+    private ulong? _client_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_steam_id
     {
-      get { return _client_steam_id; }
+      get { return _client_steam_id?? default(ulong); }
       set { _client_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_steam_idSpecified
+    {
+      get { return _client_steam_id != null; }
+      set { if (value == (_client_steam_id== null)) _client_steam_id = value ? this.client_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_steam_id() { return client_steam_idSpecified; }
+    private void Resetclient_steam_id() { client_steam_idSpecified = false; }
+    
 
-    private int _client_session_id = default(int);
+    private int? _client_session_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int client_session_id
     {
-      get { return _client_session_id; }
+      get { return _client_session_id?? default(int); }
       set { _client_session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_idSpecified
+    {
+      get { return _client_session_id != null; }
+      set { if (value == (_client_session_id== null)) _client_session_id = value ? this.client_session_id : (int?)null; }
+    }
+    private bool ShouldSerializeclient_session_id() { return client_session_idSpecified; }
+    private void Resetclient_session_id() { client_session_idSpecified = false; }
+    
 
-    private uint _source_app_id = default(uint);
+    private uint? _source_app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_app_id
     {
-      get { return _source_app_id; }
+      get { return _source_app_id?? default(uint); }
       set { _source_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_app_idSpecified
+    {
+      get { return _source_app_id != null; }
+      set { if (value == (_source_app_id== null)) _source_app_id = value ? this.source_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializesource_app_id() { return source_app_idSpecified; }
+    private void Resetsource_app_id() { source_app_idSpecified = false; }
+    
 
-    private ulong _job_id_source = (ulong)18446744073709551615;
+    private ulong? _job_id_source;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"job_id_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_source
     {
-      get { return _job_id_source; }
+      get { return _job_id_source?? (ulong)18446744073709551615; }
       set { _job_id_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_sourceSpecified
+    {
+      get { return _job_id_source != null; }
+      set { if (value == (_job_id_source== null)) _job_id_source = value ? this.job_id_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_source() { return job_id_sourceSpecified; }
+    private void Resetjob_id_source() { job_id_sourceSpecified = false; }
+    
 
-    private ulong _job_id_target = (ulong)18446744073709551615;
+    private ulong? _job_id_target;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"job_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_target
     {
-      get { return _job_id_target; }
+      get { return _job_id_target?? (ulong)18446744073709551615; }
       set { _job_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_targetSpecified
+    {
+      get { return _job_id_target != null; }
+      set { if (value == (_job_id_target== null)) _job_id_target = value ? this.job_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_target() { return job_id_targetSpecified; }
+    private void Resetjob_id_target() { job_id_targetSpecified = false; }
+    
 
-    private string _target_job_name = "";
+    private string _target_job_name;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"target_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string target_job_name
     {
-      get { return _target_job_name; }
+      get { return _target_job_name?? ""; }
       set { _target_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_job_nameSpecified
+    {
+      get { return _target_job_name != null; }
+      set { if (value == (_target_job_name== null)) _target_job_name = value ? this.target_job_name : (string)null; }
+    }
+    private bool ShouldSerializetarget_job_name() { return target_job_nameSpecified; }
+    private void Resettarget_job_name() { target_job_nameSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
 
-    private GCProtoBufMsgSrc _gc_msg_src = GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified;
+    private GCProtoBufMsgSrc? _gc_msg_src;
     [global::ProtoBuf.ProtoMember(200, IsRequired = false, Name=@"gc_msg_src", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified)]
     public GCProtoBufMsgSrc gc_msg_src
     {
-      get { return _gc_msg_src; }
+      get { return _gc_msg_src?? GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified; }
       set { _gc_msg_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_msg_srcSpecified
+    {
+      get { return _gc_msg_src != null; }
+      set { if (value == (_gc_msg_src== null)) _gc_msg_src = value ? this.gc_msg_src : (GCProtoBufMsgSrc?)null; }
+    }
+    private bool ShouldSerializegc_msg_src() { return gc_msg_srcSpecified; }
+    private void Resetgc_msg_src() { gc_msg_srcSpecified = false; }
+    
 
-    private uint _gc_dir_index_source = default(uint);
+    private uint? _gc_dir_index_source;
     [global::ProtoBuf.ProtoMember(201, IsRequired = false, Name=@"gc_dir_index_source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_dir_index_source
     {
-      get { return _gc_dir_index_source; }
+      get { return _gc_dir_index_source?? default(uint); }
       set { _gc_dir_index_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_dir_index_sourceSpecified
+    {
+      get { return _gc_dir_index_source != null; }
+      set { if (value == (_gc_dir_index_source== null)) _gc_dir_index_source = value ? this.gc_dir_index_source : (uint?)null; }
+    }
+    private bool ShouldSerializegc_dir_index_source() { return gc_dir_index_sourceSpecified; }
+    private void Resetgc_dir_index_source() { gc_dir_index_sourceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/MsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/MsgGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: tf_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 // Note: requires additional types generated from: base_gcmessages.proto
@@ -19,32 +21,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFGoldenWrenchBroadcast() {}
     
 
-    private int _wrench_number = default(int);
+    private int? _wrench_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"wrench_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int wrench_number
     {
-      get { return _wrench_number; }
+      get { return _wrench_number?? default(int); }
       set { _wrench_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wrench_numberSpecified
+    {
+      get { return _wrench_number != null; }
+      set { if (value == (_wrench_number== null)) _wrench_number = value ? this.wrench_number : (int?)null; }
+    }
+    private bool ShouldSerializewrench_number() { return wrench_numberSpecified; }
+    private void Resetwrench_number() { wrench_numberSpecified = false; }
+    
 
-    private bool _deleted = default(bool);
+    private bool? _deleted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"deleted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool deleted
     {
-      get { return _deleted; }
+      get { return _deleted?? default(bool); }
       set { _deleted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deletedSpecified
+    {
+      get { return _deleted != null; }
+      set { if (value == (_deleted== null)) _deleted = value ? this.deleted : (bool?)null; }
+    }
+    private bool ShouldSerializedeleted() { return deletedSpecified; }
+    private void Resetdeleted() { deletedSpecified = false; }
+    
 
-    private string _user_name = "";
+    private string _user_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"user_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string user_name
     {
-      get { return _user_name; }
+      get { return _user_name?? ""; }
       set { _user_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_nameSpecified
+    {
+      get { return _user_name != null; }
+      set { if (value == (_user_name== null)) _user_name = value ? this.user_name : (string)null; }
+    }
+    private bool ShouldSerializeuser_name() { return user_nameSpecified; }
+    private void Resetuser_name() { user_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -56,23 +85,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFSaxxyBroadcast() {}
     
 
-    private int _category_number = default(int);
+    private int? _category_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"category_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int category_number
     {
-      get { return _category_number; }
+      get { return _category_number?? default(int); }
       set { _category_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool category_numberSpecified
+    {
+      get { return _category_number != null; }
+      set { if (value == (_category_number== null)) _category_number = value ? this.category_number : (int?)null; }
+    }
+    private bool ShouldSerializecategory_number() { return category_numberSpecified; }
+    private void Resetcategory_number() { category_numberSpecified = false; }
+    
 
-    private string _user_name = "";
+    private string _user_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"user_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string user_name
     {
-      get { return _user_name; }
+      get { return _user_name?? ""; }
       set { _user_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_nameSpecified
+    {
+      get { return _user_name != null; }
+      set { if (value == (_user_name== null)) _user_name = value ? this.user_name : (string)null; }
+    }
+    private bool ShouldSerializeuser_name() { return user_nameSpecified; }
+    private void Resetuser_name() { user_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -84,32 +131,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCTFSpecificItemBroadcast() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private bool _was_destruction = default(bool);
+    private bool? _was_destruction;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"was_destruction", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_destruction
     {
-      get { return _was_destruction; }
+      get { return _was_destruction?? default(bool); }
       set { _was_destruction = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_destructionSpecified
+    {
+      get { return _was_destruction != null; }
+      set { if (value == (_was_destruction== null)) _was_destruction = value ? this.was_destruction : (bool?)null; }
+    }
+    private bool ShouldSerializewas_destruction() { return was_destructionSpecified; }
+    private void Resetwas_destruction() { was_destructionSpecified = false; }
+    
 
-    private string _user_name = "";
+    private string _user_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"user_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string user_name
     {
-      get { return _user_name; }
+      get { return _user_name?? ""; }
       set { _user_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_nameSpecified
+    {
+      get { return _user_name != null; }
+      set { if (value == (_user_name== null)) _user_name = value ? this.user_name : (string)null; }
+    }
+    private bool ShouldSerializeuser_name() { return user_nameSpecified; }
+    private void Resetuser_name() { user_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -121,14 +195,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFWorldStatus() {}
     
 
-    private bool _beta_stress_test_event_active = (bool)false;
+    private bool? _beta_stress_test_event_active;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"beta_stress_test_event_active", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool beta_stress_test_event_active
     {
-      get { return _beta_stress_test_event_active; }
+      get { return _beta_stress_test_event_active?? (bool)false; }
       set { _beta_stress_test_event_active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool beta_stress_test_event_activeSpecified
+    {
+      get { return _beta_stress_test_event_active != null; }
+      set { if (value == (_beta_stress_test_event_active== null)) _beta_stress_test_event_active = value ? this.beta_stress_test_event_active : (bool?)null; }
+    }
+    private bool ShouldSerializebeta_stress_test_event_active() { return beta_stress_test_event_activeSpecified; }
+    private void Resetbeta_stress_test_event_active() { beta_stress_test_event_activeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -140,59 +223,113 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFDuelSummary() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _duel_wins = default(uint);
+    private uint? _duel_wins;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"duel_wins", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel_wins
     {
-      get { return _duel_wins; }
+      get { return _duel_wins?? default(uint); }
       set { _duel_wins = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel_winsSpecified
+    {
+      get { return _duel_wins != null; }
+      set { if (value == (_duel_wins== null)) _duel_wins = value ? this.duel_wins : (uint?)null; }
+    }
+    private bool ShouldSerializeduel_wins() { return duel_winsSpecified; }
+    private void Resetduel_wins() { duel_winsSpecified = false; }
+    
 
-    private uint _duel_losses = default(uint);
+    private uint? _duel_losses;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"duel_losses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel_losses
     {
-      get { return _duel_losses; }
+      get { return _duel_losses?? default(uint); }
       set { _duel_losses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel_lossesSpecified
+    {
+      get { return _duel_losses != null; }
+      set { if (value == (_duel_losses== null)) _duel_losses = value ? this.duel_losses : (uint?)null; }
+    }
+    private bool ShouldSerializeduel_losses() { return duel_lossesSpecified; }
+    private void Resetduel_losses() { duel_lossesSpecified = false; }
+    
 
-    private uint _last_duel_account_id = default(uint);
+    private uint? _last_duel_account_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"last_duel_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_duel_account_id
     {
-      get { return _last_duel_account_id; }
+      get { return _last_duel_account_id?? default(uint); }
       set { _last_duel_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_duel_account_idSpecified
+    {
+      get { return _last_duel_account_id != null; }
+      set { if (value == (_last_duel_account_id== null)) _last_duel_account_id = value ? this.last_duel_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializelast_duel_account_id() { return last_duel_account_idSpecified; }
+    private void Resetlast_duel_account_id() { last_duel_account_idSpecified = false; }
+    
 
-    private uint _last_duel_timestamp = default(uint);
+    private uint? _last_duel_timestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"last_duel_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_duel_timestamp
     {
-      get { return _last_duel_timestamp; }
+      get { return _last_duel_timestamp?? default(uint); }
       set { _last_duel_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_duel_timestampSpecified
+    {
+      get { return _last_duel_timestamp != null; }
+      set { if (value == (_last_duel_timestamp== null)) _last_duel_timestamp = value ? this.last_duel_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializelast_duel_timestamp() { return last_duel_timestampSpecified; }
+    private void Resetlast_duel_timestamp() { last_duel_timestampSpecified = false; }
+    
 
-    private uint _last_duel_status = default(uint);
+    private uint? _last_duel_status;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"last_duel_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_duel_status
     {
-      get { return _last_duel_status; }
+      get { return _last_duel_status?? default(uint); }
       set { _last_duel_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_duel_statusSpecified
+    {
+      get { return _last_duel_status != null; }
+      set { if (value == (_last_duel_status== null)) _last_duel_status = value ? this.last_duel_status : (uint?)null; }
+    }
+    private bool ShouldSerializelast_duel_status() { return last_duel_statusSpecified; }
+    private void Resetlast_duel_status() { last_duel_statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -204,32 +341,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFMapContribution() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _contribution_level = default(uint);
+    private uint? _contribution_level;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"contribution_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint contribution_level
     {
-      get { return _contribution_level; }
+      get { return _contribution_level?? default(uint); }
       set { _contribution_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contribution_levelSpecified
+    {
+      get { return _contribution_level != null; }
+      set { if (value == (_contribution_level== null)) _contribution_level = value ? this.contribution_level : (uint?)null; }
+    }
+    private bool ShouldSerializecontribution_level() { return contribution_levelSpecified; }
+    private void Resetcontribution_level() { contribution_levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -241,23 +405,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFVoteKickBanPlayer() {}
     
 
-    private uint _account_id_subject = default(uint);
+    private uint? _account_id_subject;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_subject", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_subject
     {
-      get { return _account_id_subject; }
+      get { return _account_id_subject?? default(uint); }
       set { _account_id_subject = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_subjectSpecified
+    {
+      get { return _account_id_subject != null; }
+      set { if (value == (_account_id_subject== null)) _account_id_subject = value ? this.account_id_subject : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_subject() { return account_id_subjectSpecified; }
+    private void Resetaccount_id_subject() { account_id_subjectSpecified = false; }
+    
 
-    private uint _kick_reason = default(uint);
+    private uint? _kick_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"kick_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kick_reason
     {
-      get { return _kick_reason; }
+      get { return _kick_reason?? default(uint); }
       set { _kick_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kick_reasonSpecified
+    {
+      get { return _kick_reason != null; }
+      set { if (value == (_kick_reason== null)) _kick_reason = value ? this.kick_reason : (uint?)null; }
+    }
+    private bool ShouldSerializekick_reason() { return kick_reasonSpecified; }
+    private void Resetkick_reason() { kick_reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -269,68 +451,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFVoteKickBanPlayerResult() {}
     
 
-    private uint _account_id_initiator = default(uint);
+    private uint? _account_id_initiator;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_initiator", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_initiator
     {
-      get { return _account_id_initiator; }
+      get { return _account_id_initiator?? default(uint); }
       set { _account_id_initiator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_initiatorSpecified
+    {
+      get { return _account_id_initiator != null; }
+      set { if (value == (_account_id_initiator== null)) _account_id_initiator = value ? this.account_id_initiator : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_initiator() { return account_id_initiatorSpecified; }
+    private void Resetaccount_id_initiator() { account_id_initiatorSpecified = false; }
+    
 
-    private uint _account_id_subject = default(uint);
+    private uint? _account_id_subject;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id_subject", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_subject
     {
-      get { return _account_id_subject; }
+      get { return _account_id_subject?? default(uint); }
       set { _account_id_subject = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_subjectSpecified
+    {
+      get { return _account_id_subject != null; }
+      set { if (value == (_account_id_subject== null)) _account_id_subject = value ? this.account_id_subject : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_subject() { return account_id_subjectSpecified; }
+    private void Resetaccount_id_subject() { account_id_subjectSpecified = false; }
+    
 
-    private uint _kick_reason = default(uint);
+    private uint? _kick_reason;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"kick_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kick_reason
     {
-      get { return _kick_reason; }
+      get { return _kick_reason?? default(uint); }
       set { _kick_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kick_reasonSpecified
+    {
+      get { return _kick_reason != null; }
+      set { if (value == (_kick_reason== null)) _kick_reason = value ? this.kick_reason : (uint?)null; }
+    }
+    private bool ShouldSerializekick_reason() { return kick_reasonSpecified; }
+    private void Resetkick_reason() { kick_reasonSpecified = false; }
+    
 
-    private bool _kick_successful = default(bool);
+    private bool? _kick_successful;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"kick_successful", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool kick_successful
     {
-      get { return _kick_successful; }
+      get { return _kick_successful?? default(bool); }
       set { _kick_successful = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kick_successfulSpecified
+    {
+      get { return _kick_successful != null; }
+      set { if (value == (_kick_successful== null)) _kick_successful = value ? this.kick_successful : (bool?)null; }
+    }
+    private bool ShouldSerializekick_successful() { return kick_successfulSpecified; }
+    private void Resetkick_successful() { kick_successfulSpecified = false; }
+    
 
-    private uint _num_yes_votes = default(uint);
+    private uint? _num_yes_votes;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"num_yes_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_yes_votes
     {
-      get { return _num_yes_votes; }
+      get { return _num_yes_votes?? default(uint); }
       set { _num_yes_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_yes_votesSpecified
+    {
+      get { return _num_yes_votes != null; }
+      set { if (value == (_num_yes_votes== null)) _num_yes_votes = value ? this.num_yes_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenum_yes_votes() { return num_yes_votesSpecified; }
+    private void Resetnum_yes_votes() { num_yes_votesSpecified = false; }
+    
 
-    private uint _num_no_votes = default(uint);
+    private uint? _num_no_votes;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_no_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_no_votes
     {
-      get { return _num_no_votes; }
+      get { return _num_no_votes?? default(uint); }
       set { _num_no_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_no_votesSpecified
+    {
+      get { return _num_no_votes != null; }
+      set { if (value == (_num_no_votes== null)) _num_no_votes = value ? this.num_no_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenum_no_votes() { return num_no_votesSpecified; }
+    private void Resetnum_no_votes() { num_no_votesSpecified = false; }
+    
 
-    private uint _num_possible_votes = default(uint);
+    private uint? _num_possible_votes;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"num_possible_votes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_possible_votes
     {
-      get { return _num_possible_votes; }
+      get { return _num_possible_votes?? default(uint); }
       set { _num_possible_votes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_possible_votesSpecified
+    {
+      get { return _num_possible_votes != null; }
+      set { if (value == (_num_possible_votes== null)) _num_possible_votes = value ? this.num_possible_votes : (uint?)null; }
+    }
+    private bool ShouldSerializenum_possible_votes() { return num_possible_votesSpecified; }
+    private void Resetnum_possible_votes() { num_possible_votesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -342,14 +587,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFFreeTrialChooseMostHelpfulFriend() {}
     
 
-    private uint _account_id_friend = default(uint);
+    private uint? _account_id_friend;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_friend", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_friend
     {
-      get { return _account_id_friend; }
+      get { return _account_id_friend?? default(uint); }
       set { _account_id_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_friendSpecified
+    {
+      get { return _account_id_friend != null; }
+      set { if (value == (_account_id_friend== null)) _account_id_friend = value ? this.account_id_friend : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_friend() { return account_id_friendSpecified; }
+    private void Resetaccount_id_friend() { account_id_friendSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -395,14 +649,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFPlayerInfo() {}
     
 
-    private uint _num_new_users_helped = default(uint);
+    private uint? _num_new_users_helped;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"num_new_users_helped", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_new_users_helped
     {
-      get { return _num_new_users_helped; }
+      get { return _num_new_users_helped?? default(uint); }
       set { _num_new_users_helped = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_new_users_helpedSpecified
+    {
+      get { return _num_new_users_helped != null; }
+      set { if (value == (_num_new_users_helped== null)) _num_new_users_helped = value ? this.num_new_users_helped : (uint?)null; }
+    }
+    private bool ShouldSerializenum_new_users_helped() { return num_new_users_helpedSpecified; }
+    private void Resetnum_new_users_helped() { num_new_users_helpedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -414,14 +677,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFThankedBySomeone() {}
     
 
-    private ulong _thanker_steam_id = default(ulong);
+    private ulong? _thanker_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"thanker_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong thanker_steam_id
     {
-      get { return _thanker_steam_id; }
+      get { return _thanker_steam_id?? default(ulong); }
       set { _thanker_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool thanker_steam_idSpecified
+    {
+      get { return _thanker_steam_id != null; }
+      set { if (value == (_thanker_steam_id== null)) _thanker_steam_id = value ? this.thanker_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializethanker_steam_id() { return thanker_steam_idSpecified; }
+    private void Resetthanker_steam_id() { thanker_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -453,14 +725,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSaxxyAwarded() {}
     
 
-    private uint _category = default(uint);
+    private uint? _category;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint category
     {
-      get { return _category; }
+      get { return _category?? default(uint); }
       set { _category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool categorySpecified
+    {
+      get { return _category != null; }
+      set { if (value == (_category== null)) _category = value ? this.category : (uint?)null; }
+    }
+    private bool ShouldSerializecategory() { return categorySpecified; }
+    private void Resetcategory() { categorySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _winner_names = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(2, Name=@"winner_names", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> winner_names
@@ -479,23 +760,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgReplaySubmitContestEntry() {}
     
 
-    private string _youtube_url = "";
+    private string _youtube_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"youtube_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_url
     {
-      get { return _youtube_url; }
+      get { return _youtube_url?? ""; }
       set { _youtube_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_urlSpecified
+    {
+      get { return _youtube_url != null; }
+      set { if (value == (_youtube_url== null)) _youtube_url = value ? this.youtube_url : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_url() { return youtube_urlSpecified; }
+    private void Resetyoutube_url() { youtube_urlSpecified = false; }
+    
 
-    private uint _category = default(uint);
+    private uint? _category;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint category
     {
-      get { return _category; }
+      get { return _category?? default(uint); }
       set { _category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool categorySpecified
+    {
+      get { return _category != null; }
+      set { if (value == (_category== null)) _category = value ? this.category : (uint?)null; }
+    }
+    private bool ShouldSerializecategory() { return categorySpecified; }
+    private void Resetcategory() { categorySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -507,14 +806,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgReplaySubmitContestEntryResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -526,23 +834,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CReplayCachedContestData() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _num_votes_last_day = default(uint);
+    private uint? _num_votes_last_day;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_votes_last_day", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_votes_last_day
     {
-      get { return _num_votes_last_day; }
+      get { return _num_votes_last_day?? default(uint); }
       set { _num_votes_last_day = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_votes_last_daySpecified
+    {
+      get { return _num_votes_last_day != null; }
+      set { if (value == (_num_votes_last_day== null)) _num_votes_last_day = value ? this.num_votes_last_day : (uint?)null; }
+    }
+    private bool ShouldSerializenum_votes_last_day() { return num_votes_last_daySpecified; }
+    private void Resetnum_votes_last_day() { num_votes_last_daySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _video_entry_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"video_entry_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> video_entry_ids
@@ -551,14 +877,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _num_flags_last_day = default(uint);
+    private uint? _num_flags_last_day;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_flags_last_day", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_flags_last_day
     {
-      get { return _num_flags_last_day; }
+      get { return _num_flags_last_day?? default(uint); }
       set { _num_flags_last_day = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_flags_last_daySpecified
+    {
+      get { return _num_flags_last_day != null; }
+      set { if (value == (_num_flags_last_day== null)) _num_flags_last_day = value ? this.num_flags_last_day : (uint?)null; }
+    }
+    private bool ShouldSerializenum_flags_last_day() { return num_flags_last_daySpecified; }
+    private void Resetnum_flags_last_day() { num_flags_last_daySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -590,14 +925,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_FindCoach() {}
     
 
-    private uint _account_id_friend_as_coach = default(uint);
+    private uint? _account_id_friend_as_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_friend_as_coach", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_friend_as_coach
     {
-      get { return _account_id_friend_as_coach; }
+      get { return _account_id_friend_as_coach?? default(uint); }
       set { _account_id_friend_as_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_friend_as_coachSpecified
+    {
+      get { return _account_id_friend_as_coach != null; }
+      set { if (value == (_account_id_friend_as_coach== null)) _account_id_friend_as_coach = value ? this.account_id_friend_as_coach : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_friend_as_coach() { return account_id_friend_as_coachSpecified; }
+    private void Resetaccount_id_friend_as_coach() { account_id_friend_as_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -609,32 +953,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_FindCoachResponse() {}
     
 
-    private bool _found_coach = default(bool);
+    private bool? _found_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"found_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found_coach
     {
-      get { return _found_coach; }
+      get { return _found_coach?? default(bool); }
       set { _found_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool found_coachSpecified
+    {
+      get { return _found_coach != null; }
+      set { if (value == (_found_coach== null)) _found_coach = value ? this.found_coach : (bool?)null; }
+    }
+    private bool ShouldSerializefound_coach() { return found_coachSpecified; }
+    private void Resetfound_coach() { found_coachSpecified = false; }
+    
 
-    private uint _num_likes = default(uint);
+    private uint? _num_likes;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_likes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_likes
     {
-      get { return _num_likes; }
+      get { return _num_likes?? default(uint); }
       set { _num_likes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_likesSpecified
+    {
+      get { return _num_likes != null; }
+      set { if (value == (_num_likes== null)) _num_likes = value ? this.num_likes : (uint?)null; }
+    }
+    private bool ShouldSerializenum_likes() { return num_likesSpecified; }
+    private void Resetnum_likes() { num_likesSpecified = false; }
+    
 
-    private string _coach_name = "";
+    private string _coach_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"coach_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string coach_name
     {
-      get { return _coach_name; }
+      get { return _coach_name?? ""; }
       set { _coach_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool coach_nameSpecified
+    {
+      get { return _coach_name != null; }
+      set { if (value == (_coach_name== null)) _coach_name = value ? this.coach_name : (string)null; }
+    }
+    private bool ShouldSerializecoach_name() { return coach_nameSpecified; }
+    private void Resetcoach_name() { coach_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -646,23 +1017,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_AskCoach() {}
     
 
-    private uint _account_id_student = default(uint);
+    private uint? _account_id_student;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_student", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_student
     {
-      get { return _account_id_student; }
+      get { return _account_id_student?? default(uint); }
       set { _account_id_student = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_studentSpecified
+    {
+      get { return _account_id_student != null; }
+      set { if (value == (_account_id_student== null)) _account_id_student = value ? this.account_id_student : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_student() { return account_id_studentSpecified; }
+    private void Resetaccount_id_student() { account_id_studentSpecified = false; }
+    
 
-    private bool _student_is_friend = default(bool);
+    private bool? _student_is_friend;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"student_is_friend", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool student_is_friend
     {
-      get { return _student_is_friend; }
+      get { return _student_is_friend?? default(bool); }
       set { _student_is_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool student_is_friendSpecified
+    {
+      get { return _student_is_friend != null; }
+      set { if (value == (_student_is_friend== null)) _student_is_friend = value ? this.student_is_friend : (bool?)null; }
+    }
+    private bool ShouldSerializestudent_is_friend() { return student_is_friendSpecified; }
+    private void Resetstudent_is_friend() { student_is_friendSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -674,14 +1063,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_AskCoachResponse() {}
     
 
-    private bool _accept_coaching_assignment = default(bool);
+    private bool? _accept_coaching_assignment;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accept_coaching_assignment", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept_coaching_assignment
     {
-      get { return _accept_coaching_assignment; }
+      get { return _accept_coaching_assignment?? default(bool); }
       set { _accept_coaching_assignment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accept_coaching_assignmentSpecified
+    {
+      get { return _accept_coaching_assignment != null; }
+      set { if (value == (_accept_coaching_assignment== null)) _accept_coaching_assignment = value ? this.accept_coaching_assignment : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept_coaching_assignment() { return accept_coaching_assignmentSpecified; }
+    private void Resetaccept_coaching_assignment() { accept_coaching_assignmentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -693,41 +1091,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_CoachJoinGame() {}
     
 
-    private bool _join_game = default(bool);
+    private bool? _join_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"join_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool join_game
     {
-      get { return _join_game; }
+      get { return _join_game?? default(bool); }
       set { _join_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool join_gameSpecified
+    {
+      get { return _join_game != null; }
+      set { if (value == (_join_game== null)) _join_game = value ? this.join_game : (bool?)null; }
+    }
+    private bool ShouldSerializejoin_game() { return join_gameSpecified; }
+    private void Resetjoin_game() { join_gameSpecified = false; }
+    
 
-    private uint _server_address = default(uint);
+    private uint? _server_address;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_address
     {
-      get { return _server_address; }
+      get { return _server_address?? default(uint); }
       set { _server_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addressSpecified
+    {
+      get { return _server_address != null; }
+      set { if (value == (_server_address== null)) _server_address = value ? this.server_address : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_address() { return server_addressSpecified; }
+    private void Resetserver_address() { server_addressSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _account_id_student = default(uint);
+    private uint? _account_id_student;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"account_id_student", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_student
     {
-      get { return _account_id_student; }
+      get { return _account_id_student?? default(uint); }
       set { _account_id_student = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_studentSpecified
+    {
+      get { return _account_id_student != null; }
+      set { if (value == (_account_id_student== null)) _account_id_student = value ? this.account_id_student : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_student() { return account_id_studentSpecified; }
+    private void Resetaccount_id_student() { account_id_studentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -739,23 +1173,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_CoachJoining() {}
     
 
-    private uint _account_id_coach = default(uint);
+    private uint? _account_id_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_coach", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_coach
     {
-      get { return _account_id_coach; }
+      get { return _account_id_coach?? default(uint); }
       set { _account_id_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_coachSpecified
+    {
+      get { return _account_id_coach != null; }
+      set { if (value == (_account_id_coach== null)) _account_id_coach = value ? this.account_id_coach : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_coach() { return account_id_coachSpecified; }
+    private void Resetaccount_id_coach() { account_id_coachSpecified = false; }
+    
 
-    private uint _account_id_student = default(uint);
+    private uint? _account_id_student;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id_student", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_student
     {
-      get { return _account_id_student; }
+      get { return _account_id_student?? default(uint); }
       set { _account_id_student = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_studentSpecified
+    {
+      get { return _account_id_student != null; }
+      set { if (value == (_account_id_student== null)) _account_id_student = value ? this.account_id_student : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_student() { return account_id_studentSpecified; }
+    private void Resetaccount_id_student() { account_id_studentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -767,14 +1219,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_CoachJoined() {}
     
 
-    private uint _account_id_coach = default(uint);
+    private uint? _account_id_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_coach", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_coach
     {
-      get { return _account_id_coach; }
+      get { return _account_id_coach?? default(uint); }
       set { _account_id_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_coachSpecified
+    {
+      get { return _account_id_coach != null; }
+      set { if (value == (_account_id_coach== null)) _account_id_coach = value ? this.account_id_coach : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_coach() { return account_id_coachSpecified; }
+    private void Resetaccount_id_coach() { account_id_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -786,14 +1247,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_LikeCurrentCoach() {}
     
 
-    private bool _like_coach = default(bool);
+    private bool? _like_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"like_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool like_coach
     {
-      get { return _like_coach; }
+      get { return _like_coach?? default(bool); }
       set { _like_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool like_coachSpecified
+    {
+      get { return _like_coach != null; }
+      set { if (value == (_like_coach== null)) _like_coach = value ? this.like_coach : (bool?)null; }
+    }
+    private bool ShouldSerializelike_coach() { return like_coachSpecified; }
+    private void Resetlike_coach() { like_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -805,14 +1275,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFCoaching_RemoveCurrentCoach() {}
     
 
-    private uint _account_id_coach = default(uint);
+    private uint? _account_id_coach;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_coach", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_coach
     {
-      get { return _account_id_coach; }
+      get { return _account_id_coach?? default(uint); }
       set { _account_id_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_coachSpecified
+    {
+      get { return _account_id_coach != null; }
+      set { if (value == (_account_id_coach== null)) _account_id_coach = value ? this.account_id_coach : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_coach() { return account_id_coachSpecified; }
+    private void Resetaccount_id_coach() { account_id_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -836,59 +1315,113 @@ namespace SteamKit2.GC.TF2.Internal
     public ServerInfo() {}
     
 
-    private uint _server_address = default(uint);
+    private uint? _server_address;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_address
     {
-      get { return _server_address; }
+      get { return _server_address?? default(uint); }
       set { _server_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addressSpecified
+    {
+      get { return _server_address != null; }
+      set { if (value == (_server_address== null)) _server_address = value ? this.server_address : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_address() { return server_addressSpecified; }
+    private void Resetserver_address() { server_addressSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _num_users = default(uint);
+    private uint? _num_users;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_users", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_users
     {
-      get { return _num_users; }
+      get { return _num_users?? default(uint); }
       set { _num_users = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_usersSpecified
+    {
+      get { return _num_users != null; }
+      set { if (value == (_num_users== null)) _num_users = value ? this.num_users : (uint?)null; }
+    }
+    private bool ShouldSerializenum_users() { return num_usersSpecified; }
+    private void Resetnum_users() { num_usersSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _max_users = default(uint);
+    private uint? _max_users;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"max_users", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_users
     {
-      get { return _max_users; }
+      get { return _max_users?? default(uint); }
       set { _max_users = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_usersSpecified
+    {
+      get { return _max_users != null; }
+      set { if (value == (_max_users== null)) _max_users = value ? this.max_users : (uint?)null; }
+    }
+    private bool ShouldSerializemax_users() { return max_usersSpecified; }
+    private void Resetmax_users() { max_usersSpecified = false; }
+    
 
-    private float _user_score = default(float);
+    private float? _user_score;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"user_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float user_score
     {
-      get { return _user_score; }
+      get { return _user_score?? default(float); }
       set { _user_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_scoreSpecified
+    {
+      get { return _user_score != null; }
+      set { if (value == (_user_score== null)) _user_score = value ? this.user_score : (float?)null; }
+    }
+    private bool ShouldSerializeuser_score() { return user_scoreSpecified; }
+    private void Resetuser_score() { user_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -917,50 +1450,95 @@ namespace SteamKit2.GC.TF2.Internal
     public ServerInfo() {}
     
 
-    private uint _server_address = default(uint);
+    private uint? _server_address;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_address
     {
-      get { return _server_address; }
+      get { return _server_address?? default(uint); }
       set { _server_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addressSpecified
+    {
+      get { return _server_address != null; }
+      set { if (value == (_server_address== null)) _server_address = value ? this.server_address : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_address() { return server_addressSpecified; }
+    private void Resetserver_address() { server_addressSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private float _total_score = default(float);
+    private float? _total_score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float total_score
     {
-      get { return _total_score; }
+      get { return _total_score?? default(float); }
       set { _total_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_scoreSpecified
+    {
+      get { return _total_score != null; }
+      set { if (value == (_total_score== null)) _total_score = value ? this.total_score : (float?)null; }
+    }
+    private bool ShouldSerializetotal_score() { return total_scoreSpecified; }
+    private void Resettotal_score() { total_scoreSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _options_score = default(uint);
+    private uint? _options_score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"options_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint options_score
     {
-      get { return _options_score; }
+      get { return _options_score?? default(uint); }
       set { _options_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool options_scoreSpecified
+    {
+      get { return _options_score != null; }
+      set { if (value == (_options_score== null)) _options_score = value ? this.options_score : (uint?)null; }
+    }
+    private bool ShouldSerializeoptions_score() { return options_scoreSpecified; }
+    private void Resetoptions_score() { options_scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -977,14 +1555,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFQuickplay_PlayerJoining() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -996,23 +1583,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_LevelInfo() {}
     
 
-    private bool _level_loaded = default(bool);
+    private bool? _level_loaded;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"level_loaded", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool level_loaded
     {
-      get { return _level_loaded; }
+      get { return _level_loaded?? default(bool); }
       set { _level_loaded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_loadedSpecified
+    {
+      get { return _level_loaded != null; }
+      set { if (value == (_level_loaded== null)) _level_loaded = value ? this.level_loaded : (bool?)null; }
+    }
+    private bool ShouldSerializelevel_loaded() { return level_loadedSpecified; }
+    private void Resetlevel_loaded() { level_loadedSpecified = false; }
+    
 
-    private string _level_name = "";
+    private string _level_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"level_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string level_name
     {
-      get { return _level_name; }
+      get { return _level_name?? ""; }
       set { _level_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_nameSpecified
+    {
+      get { return _level_name != null; }
+      set { if (value == (_level_name== null)) _level_name = value ? this.level_name : (string)null; }
+    }
+    private bool ShouldSerializelevel_name() { return level_nameSpecified; }
+    private void Resetlevel_name() { level_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1024,14 +1629,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_AuthChallenge() {}
     
 
-    private string _challenge_string = "";
+    private string _challenge_string;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"challenge_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string challenge_string
     {
-      get { return _challenge_string; }
+      get { return _challenge_string?? ""; }
       set { _challenge_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool challenge_stringSpecified
+    {
+      get { return _challenge_string != null; }
+      set { if (value == (_challenge_string== null)) _challenge_string = value ? this.challenge_string : (string)null; }
+    }
+    private bool ShouldSerializechallenge_string() { return challenge_stringSpecified; }
+    private void Resetchallenge_string() { challenge_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1043,50 +1657,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_AuthResult() {}
     
 
-    private bool _authenticated = default(bool);
+    private bool? _authenticated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"authenticated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool authenticated
     {
-      get { return _authenticated; }
+      get { return _authenticated?? default(bool); }
       set { _authenticated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticatedSpecified
+    {
+      get { return _authenticated != null; }
+      set { if (value == (_authenticated== null)) _authenticated = value ? this.authenticated : (bool?)null; }
+    }
+    private bool ShouldSerializeauthenticated() { return authenticatedSpecified; }
+    private void Resetauthenticated() { authenticatedSpecified = false; }
+    
 
-    private int _game_server_standing = default(int);
+    private int? _game_server_standing;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_server_standing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_server_standing
     {
-      get { return _game_server_standing; }
+      get { return _game_server_standing?? default(int); }
       set { _game_server_standing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_standingSpecified
+    {
+      get { return _game_server_standing != null; }
+      set { if (value == (_game_server_standing== null)) _game_server_standing = value ? this.game_server_standing : (int?)null; }
+    }
+    private bool ShouldSerializegame_server_standing() { return game_server_standingSpecified; }
+    private void Resetgame_server_standing() { game_server_standingSpecified = false; }
+    
 
-    private int _game_server_standing_trend = default(int);
+    private int? _game_server_standing_trend;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_standing_trend", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_server_standing_trend
     {
-      get { return _game_server_standing_trend; }
+      get { return _game_server_standing_trend?? default(int); }
       set { _game_server_standing_trend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_standing_trendSpecified
+    {
+      get { return _game_server_standing_trend != null; }
+      set { if (value == (_game_server_standing_trend== null)) _game_server_standing_trend = value ? this.game_server_standing_trend : (int?)null; }
+    }
+    private bool ShouldSerializegame_server_standing_trend() { return game_server_standing_trendSpecified; }
+    private void Resetgame_server_standing_trend() { game_server_standing_trendSpecified = false; }
+    
 
-    private bool _is_valve_server = default(bool);
+    private bool? _is_valve_server;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_valve_server", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_valve_server
     {
-      get { return _is_valve_server; }
+      get { return _is_valve_server?? default(bool); }
       set { _is_valve_server = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_valve_serverSpecified
+    {
+      get { return _is_valve_server != null; }
+      set { if (value == (_is_valve_server== null)) _is_valve_server = value ? this.is_valve_server : (bool?)null; }
+    }
+    private bool ShouldSerializeis_valve_server() { return is_valve_serverSpecified; }
+    private void Resetis_valve_server() { is_valve_serverSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1098,23 +1757,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_AuthChallengeResponse() {}
     
 
-    private uint _game_server_account_id = default(uint);
+    private uint? _game_server_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_server_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_account_id
     {
-      get { return _game_server_account_id; }
+      get { return _game_server_account_id?? default(uint); }
       set { _game_server_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_account_idSpecified
+    {
+      get { return _game_server_account_id != null; }
+      set { if (value == (_game_server_account_id== null)) _game_server_account_id = value ? this.game_server_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_account_id() { return game_server_account_idSpecified; }
+    private void Resetgame_server_account_id() { game_server_account_idSpecified = false; }
+    
 
-    private byte[] _hashed_challenge_string = null;
+    private byte[] _hashed_challenge_string;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hashed_challenge_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] hashed_challenge_string
     {
-      get { return _hashed_challenge_string; }
+      get { return _hashed_challenge_string?? null; }
       set { _hashed_challenge_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hashed_challenge_stringSpecified
+    {
+      get { return _hashed_challenge_string != null; }
+      set { if (value == (_hashed_challenge_string== null)) _hashed_challenge_string = value ? this.hashed_challenge_string : (byte[])null; }
+    }
+    private bool ShouldSerializehashed_challenge_string() { return hashed_challenge_stringSpecified; }
+    private void Resethashed_challenge_string() { hashed_challenge_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1126,14 +1803,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_CreateIdentity() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1145,41 +1831,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_CreateIdentityResponse() {}
     
 
-    private bool _account_created = default(bool);
+    private bool? _account_created;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_created", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool account_created
     {
-      get { return _account_created; }
+      get { return _account_created?? default(bool); }
       set { _account_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_createdSpecified
+    {
+      get { return _account_created != null; }
+      set { if (value == (_account_created== null)) _account_created = value ? this.account_created : (bool?)null; }
+    }
+    private bool ShouldSerializeaccount_created() { return account_createdSpecified; }
+    private void Resetaccount_created() { account_createdSpecified = false; }
+    
 
-    private uint _game_server_account_id = default(uint);
+    private uint? _game_server_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_server_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_account_id
     {
-      get { return _game_server_account_id; }
+      get { return _game_server_account_id?? default(uint); }
       set { _game_server_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_account_idSpecified
+    {
+      get { return _game_server_account_id != null; }
+      set { if (value == (_game_server_account_id== null)) _game_server_account_id = value ? this.game_server_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_account_id() { return game_server_account_idSpecified; }
+    private void Resetgame_server_account_id() { game_server_account_idSpecified = false; }
+    
 
-    private string _game_server_identity_token = "";
+    private string _game_server_identity_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_identity_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_server_identity_token
     {
-      get { return _game_server_identity_token; }
+      get { return _game_server_identity_token?? ""; }
       set { _game_server_identity_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_identity_tokenSpecified
+    {
+      get { return _game_server_identity_token != null; }
+      set { if (value == (_game_server_identity_token== null)) _game_server_identity_token = value ? this.game_server_identity_token : (string)null; }
+    }
+    private bool ShouldSerializegame_server_identity_token() { return game_server_identity_tokenSpecified; }
+    private void Resetgame_server_identity_token() { game_server_identity_tokenSpecified = false; }
+    
 
-    private CMsgGC_GameServer_CreateIdentityResponse.EStatus _status = CMsgGC_GameServer_CreateIdentityResponse.EStatus.kStatus_GenericFailure;
+    private CMsgGC_GameServer_CreateIdentityResponse.EStatus? _status;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGC_GameServer_CreateIdentityResponse.EStatus.kStatus_GenericFailure)]
     public CMsgGC_GameServer_CreateIdentityResponse.EStatus status
     {
-      get { return _status; }
+      get { return _status?? CMsgGC_GameServer_CreateIdentityResponse.EStatus.kStatus_GenericFailure; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (CMsgGC_GameServer_CreateIdentityResponse.EStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EStatus", EnumPassthru=true)]
     public enum EStatus
     {
@@ -1208,14 +1930,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_List() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1239,41 +1970,77 @@ namespace SteamKit2.GC.TF2.Internal
     public GameServerIdentity() {}
     
 
-    private uint _game_server_account_id = default(uint);
+    private uint? _game_server_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_server_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_account_id
     {
-      get { return _game_server_account_id; }
+      get { return _game_server_account_id?? default(uint); }
       set { _game_server_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_account_idSpecified
+    {
+      get { return _game_server_account_id != null; }
+      set { if (value == (_game_server_account_id== null)) _game_server_account_id = value ? this.game_server_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_account_id() { return game_server_account_idSpecified; }
+    private void Resetgame_server_account_id() { game_server_account_idSpecified = false; }
+    
 
-    private string _game_server_identity_token = "";
+    private string _game_server_identity_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_server_identity_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_server_identity_token
     {
-      get { return _game_server_identity_token; }
+      get { return _game_server_identity_token?? ""; }
       set { _game_server_identity_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_identity_tokenSpecified
+    {
+      get { return _game_server_identity_token != null; }
+      set { if (value == (_game_server_identity_token== null)) _game_server_identity_token = value ? this.game_server_identity_token : (string)null; }
+    }
+    private bool ShouldSerializegame_server_identity_token() { return game_server_identity_tokenSpecified; }
+    private void Resetgame_server_identity_token() { game_server_identity_tokenSpecified = false; }
+    
 
-    private int _game_server_standing = default(int);
+    private int? _game_server_standing;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_standing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_server_standing
     {
-      get { return _game_server_standing; }
+      get { return _game_server_standing?? default(int); }
       set { _game_server_standing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_standingSpecified
+    {
+      get { return _game_server_standing != null; }
+      set { if (value == (_game_server_standing== null)) _game_server_standing = value ? this.game_server_standing : (int?)null; }
+    }
+    private bool ShouldSerializegame_server_standing() { return game_server_standingSpecified; }
+    private void Resetgame_server_standing() { game_server_standingSpecified = false; }
+    
 
-    private int _game_server_standing_trend = default(int);
+    private int? _game_server_standing_trend;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_server_standing_trend", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_server_standing_trend
     {
-      get { return _game_server_standing_trend; }
+      get { return _game_server_standing_trend?? default(int); }
       set { _game_server_standing_trend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_standing_trendSpecified
+    {
+      get { return _game_server_standing_trend != null; }
+      set { if (value == (_game_server_standing_trend== null)) _game_server_standing_trend = value ? this.game_server_standing_trend : (int?)null; }
+    }
+    private bool ShouldSerializegame_server_standing_trend() { return game_server_standing_trendSpecified; }
+    private void Resetgame_server_standing_trend() { game_server_standing_trendSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1290,14 +2057,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_ResetIdentity() {}
     
 
-    private uint _game_server_account_id = default(uint);
+    private uint? _game_server_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_server_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_account_id
     {
-      get { return _game_server_account_id; }
+      get { return _game_server_account_id?? default(uint); }
       set { _game_server_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_account_idSpecified
+    {
+      get { return _game_server_account_id != null; }
+      set { if (value == (_game_server_account_id== null)) _game_server_account_id = value ? this.game_server_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_account_id() { return game_server_account_idSpecified; }
+    private void Resetgame_server_account_id() { game_server_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1309,32 +2085,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_ResetIdentityResponse() {}
     
 
-    private bool _game_server_identity_token_reset = default(bool);
+    private bool? _game_server_identity_token_reset;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_server_identity_token_reset", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool game_server_identity_token_reset
     {
-      get { return _game_server_identity_token_reset; }
+      get { return _game_server_identity_token_reset?? default(bool); }
       set { _game_server_identity_token_reset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_identity_token_resetSpecified
+    {
+      get { return _game_server_identity_token_reset != null; }
+      set { if (value == (_game_server_identity_token_reset== null)) _game_server_identity_token_reset = value ? this.game_server_identity_token_reset : (bool?)null; }
+    }
+    private bool ShouldSerializegame_server_identity_token_reset() { return game_server_identity_token_resetSpecified; }
+    private void Resetgame_server_identity_token_reset() { game_server_identity_token_resetSpecified = false; }
+    
 
-    private uint _game_server_account_id = default(uint);
+    private uint? _game_server_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_server_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_account_id
     {
-      get { return _game_server_account_id; }
+      get { return _game_server_account_id?? default(uint); }
       set { _game_server_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_account_idSpecified
+    {
+      get { return _game_server_account_id != null; }
+      set { if (value == (_game_server_account_id== null)) _game_server_account_id = value ? this.game_server_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_account_id() { return game_server_account_idSpecified; }
+    private void Resetgame_server_account_id() { game_server_account_idSpecified = false; }
+    
 
-    private string _game_server_identity_token = "";
+    private string _game_server_identity_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_identity_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_server_identity_token
     {
-      get { return _game_server_identity_token; }
+      get { return _game_server_identity_token?? ""; }
       set { _game_server_identity_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_identity_tokenSpecified
+    {
+      get { return _game_server_identity_token != null; }
+      set { if (value == (_game_server_identity_token== null)) _game_server_identity_token = value ? this.game_server_identity_token : (string)null; }
+    }
+    private bool ShouldSerializegame_server_identity_token() { return game_server_identity_tokenSpecified; }
+    private void Resetgame_server_identity_token() { game_server_identity_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1356,23 +2159,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_AckPolicyResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1384,14 +2205,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Client_UseServerModificationItem() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1403,14 +2233,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Client_UseServerModificationItem_Response() {}
     
 
-    private CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse _response_code = CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse.kServerModificationItemResponse_AlreadyInUse;
+    private CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse? _response_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse.kServerModificationItemResponse_AlreadyInUse)]
     public CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse response_code
     {
-      get { return _response_code; }
+      get { return _response_code?? CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse.kServerModificationItemResponse_AlreadyInUse; }
       set { _response_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool response_codeSpecified
+    {
+      get { return _response_code != null; }
+      set { if (value == (_response_code== null)) _response_code = value ? this.response_code : (CMsgGC_Client_UseServerModificationItem_Response.EServerModificationItemResponse?)null; }
+    }
+    private bool ShouldSerializeresponse_code() { return response_codeSpecified; }
+    private void Resetresponse_code() { response_codeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EServerModificationItemResponse", EnumPassthru=true)]
     public enum EServerModificationItemResponse
     {
@@ -1442,14 +2281,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_UseServerModificationItem() {}
     
 
-    private EServerModificationItemType _modification_type = EServerModificationItemType.kGameServerModificationItem_Halloween;
+    private EServerModificationItemType? _modification_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"modification_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EServerModificationItemType.kGameServerModificationItem_Halloween)]
     public EServerModificationItemType modification_type
     {
-      get { return _modification_type; }
+      get { return _modification_type?? EServerModificationItemType.kGameServerModificationItem_Halloween; }
       set { _modification_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modification_typeSpecified
+    {
+      get { return _modification_type != null; }
+      set { if (value == (_modification_type== null)) _modification_type = value ? this.modification_type : (EServerModificationItemType?)null; }
+    }
+    private bool ShouldSerializemodification_type() { return modification_typeSpecified; }
+    private void Resetmodification_type() { modification_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1461,23 +2309,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_UseServerModificationItem_Response() {}
     
 
-    private EServerModificationItemType _modification_type = EServerModificationItemType.kGameServerModificationItem_Halloween;
+    private EServerModificationItemType? _modification_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"modification_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EServerModificationItemType.kGameServerModificationItem_Halloween)]
     public EServerModificationItemType modification_type
     {
-      get { return _modification_type; }
+      get { return _modification_type?? EServerModificationItemType.kGameServerModificationItem_Halloween; }
       set { _modification_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modification_typeSpecified
+    {
+      get { return _modification_type != null; }
+      set { if (value == (_modification_type== null)) _modification_type = value ? this.modification_type : (EServerModificationItemType?)null; }
+    }
+    private bool ShouldSerializemodification_type() { return modification_typeSpecified; }
+    private void Resetmodification_type() { modification_typeSpecified = false; }
+    
 
-    private CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse _server_response_code = CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse.kServerModificationItemServerResponse_Accepted;
+    private CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse? _server_response_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_response_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse.kServerModificationItemServerResponse_Accepted)]
     public CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse server_response_code
     {
-      get { return _server_response_code; }
+      get { return _server_response_code?? CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse.kServerModificationItemServerResponse_Accepted; }
       set { _server_response_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_response_codeSpecified
+    {
+      get { return _server_response_code != null; }
+      set { if (value == (_server_response_code== null)) _server_response_code = value ? this.server_response_code : (CMsgGC_GameServer_UseServerModificationItem_Response.EServerModificationItemServerResponse?)null; }
+    }
+    private bool ShouldSerializeserver_response_code() { return server_response_codeSpecified; }
+    private void Resetserver_response_code() { server_response_codeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EServerModificationItemServerResponse", EnumPassthru=true)]
     public enum EServerModificationItemServerResponse
     {
@@ -1503,14 +2369,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_ServerModificationItemExpired() {}
     
 
-    private EServerModificationItemType _modification_type = EServerModificationItemType.kGameServerModificationItem_Halloween;
+    private EServerModificationItemType? _modification_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"modification_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EServerModificationItemType.kGameServerModificationItem_Halloween)]
     public EServerModificationItemType modification_type
     {
-      get { return _modification_type; }
+      get { return _modification_type?? EServerModificationItemType.kGameServerModificationItem_Halloween; }
       set { _modification_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modification_typeSpecified
+    {
+      get { return _modification_type != null; }
+      set { if (value == (_modification_type== null)) _modification_type = value ? this.modification_type : (EServerModificationItemType?)null; }
+    }
+    private bool ShouldSerializemodification_type() { return modification_typeSpecified; }
+    private void Resetmodification_type() { modification_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1522,23 +2397,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_GameServer_ServerModificationItem() {}
     
 
-    private EServerModificationItemType _modification_type = EServerModificationItemType.kGameServerModificationItem_Halloween;
+    private EServerModificationItemType? _modification_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"modification_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EServerModificationItemType.kGameServerModificationItem_Halloween)]
     public EServerModificationItemType modification_type
     {
-      get { return _modification_type; }
+      get { return _modification_type?? EServerModificationItemType.kGameServerModificationItem_Halloween; }
       set { _modification_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modification_typeSpecified
+    {
+      get { return _modification_type != null; }
+      set { if (value == (_modification_type== null)) _modification_type = value ? this.modification_type : (EServerModificationItemType?)null; }
+    }
+    private bool ShouldSerializemodification_type() { return modification_typeSpecified; }
+    private void Resetmodification_type() { modification_typeSpecified = false; }
+    
 
-    private bool _active = default(bool);
+    private bool? _active;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"active", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool active
     {
-      get { return _active; }
+      get { return _active?? default(bool); }
       set { _active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activeSpecified
+    {
+      get { return _active != null; }
+      set { if (value == (_active== null)) _active = value ? this.active : (bool?)null; }
+    }
+    private bool ShouldSerializeactive() { return activeSpecified; }
+    private void Resetactive() { activeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1571,14 +2464,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _spawn_meta_info = default(uint);
+    private uint? _spawn_meta_info;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"spawn_meta_info", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spawn_meta_info
     {
-      get { return _spawn_meta_info; }
+      get { return _spawn_meta_info?? default(uint); }
       set { _spawn_meta_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spawn_meta_infoSpecified
+    {
+      get { return _spawn_meta_info != null; }
+      set { if (value == (_spawn_meta_info== null)) _spawn_meta_info = value ? this.spawn_meta_info : (uint?)null; }
+    }
+    private bool ShouldSerializespawn_meta_info() { return spawn_meta_infoSpecified; }
+    private void Resetspawn_meta_info() { spawn_meta_infoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1590,32 +2492,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Halloween_GrantItem() {}
     
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
 
-    private uint _level_id = default(uint);
+    private uint? _level_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"level_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level_id
     {
-      get { return _level_id; }
+      get { return _level_id?? default(uint); }
       set { _level_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_idSpecified
+    {
+      get { return _level_id != null; }
+      set { if (value == (_level_id== null)) _level_id = value ? this.level_id : (uint?)null; }
+    }
+    private bool ShouldSerializelevel_id() { return level_idSpecified; }
+    private void Resetlevel_id() { level_idSpecified = false; }
+    
 
-    private bool _flagged = default(bool);
+    private bool? _flagged;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"flagged", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool flagged
     {
-      get { return _flagged; }
+      get { return _flagged?? default(bool); }
       set { _flagged = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flaggedSpecified
+    {
+      get { return _flagged != null; }
+      set { if (value == (_flagged== null)) _flagged = value ? this.flagged : (bool?)null; }
+    }
+    private bool ShouldSerializeflagged() { return flaggedSpecified; }
+    private void Resetflagged() { flaggedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1627,14 +2556,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Halloween_GrantItemResponse() {}
     
 
-    private uint _recipient_account_id = default(uint);
+    private uint? _recipient_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"recipient_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recipient_account_id
     {
-      get { return _recipient_account_id; }
+      get { return _recipient_account_id?? default(uint); }
       set { _recipient_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recipient_account_idSpecified
+    {
+      get { return _recipient_account_id != null; }
+      set { if (value == (_recipient_account_id== null)) _recipient_account_id = value ? this.recipient_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializerecipient_account_id() { return recipient_account_idSpecified; }
+    private void Resetrecipient_account_id() { recipient_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1656,23 +2594,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_PickupItemEligibility_Query() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _seconds_ago = default(uint);
+    private uint? _seconds_ago;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"seconds_ago", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds_ago
     {
-      get { return _seconds_ago; }
+      get { return _seconds_ago?? default(uint); }
       set { _seconds_ago = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_agoSpecified
+    {
+      get { return _seconds_ago != null; }
+      set { if (value == (_seconds_ago== null)) _seconds_ago = value ? this.seconds_ago : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds_ago() { return seconds_agoSpecified; }
+    private void Resetseconds_ago() { seconds_agoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1684,32 +2640,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_PickupItemEligibility_QueryResponse() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private bool _was_eligible = default(bool);
+    private bool? _was_eligible;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"was_eligible", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_eligible
     {
-      get { return _was_eligible; }
+      get { return _was_eligible?? default(bool); }
       set { _was_eligible = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_eligibleSpecified
+    {
+      get { return _was_eligible != null; }
+      set { if (value == (_was_eligible== null)) _was_eligible = value ? this.was_eligible : (bool?)null; }
+    }
+    private bool ShouldSerializewas_eligible() { return was_eligibleSpecified; }
+    private void Resetwas_eligible() { was_eligibleSpecified = false; }
+    
 
-    private uint _level_id = default(uint);
+    private uint? _level_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"level_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level_id
     {
-      get { return _level_id; }
+      get { return _level_id?? default(uint); }
       set { _level_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_idSpecified
+    {
+      get { return _level_id != null; }
+      set { if (value == (_level_id== null)) _level_id = value ? this.level_id : (uint?)null; }
+    }
+    private bool ShouldSerializelevel_id() { return level_idSpecified; }
+    private void Resetlevel_id() { level_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1721,95 +2704,185 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFPartyMember() {}
     
 
-    private bool _owns_ticket = default(bool);
+    private bool? _owns_ticket;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owns_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool owns_ticket
     {
-      get { return _owns_ticket; }
+      get { return _owns_ticket?? default(bool); }
       set { _owns_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owns_ticketSpecified
+    {
+      get { return _owns_ticket != null; }
+      set { if (value == (_owns_ticket== null)) _owns_ticket = value ? this.owns_ticket : (bool?)null; }
+    }
+    private bool ShouldSerializeowns_ticket() { return owns_ticketSpecified; }
+    private void Resetowns_ticket() { owns_ticketSpecified = false; }
+    
 
-    private uint _completed_missions = default(uint);
+    private uint? _completed_missions;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"completed_missions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint completed_missions
     {
-      get { return _completed_missions; }
+      get { return _completed_missions?? default(uint); }
       set { _completed_missions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool completed_missionsSpecified
+    {
+      get { return _completed_missions != null; }
+      set { if (value == (_completed_missions== null)) _completed_missions = value ? this.completed_missions : (uint?)null; }
+    }
+    private bool ShouldSerializecompleted_missions() { return completed_missionsSpecified; }
+    private void Resetcompleted_missions() { completed_missionsSpecified = false; }
+    
 
-    private uint _badge_level = default(uint);
+    private uint? _badge_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"badge_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_level
     {
-      get { return _badge_level; }
+      get { return _badge_level?? default(uint); }
       set { _badge_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_levelSpecified
+    {
+      get { return _badge_level != null; }
+      set { if (value == (_badge_level== null)) _badge_level = value ? this.badge_level : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_level() { return badge_levelSpecified; }
+    private void Resetbadge_level() { badge_levelSpecified = false; }
+    
 
-    private bool _squad_surplus = default(bool);
+    private bool? _squad_surplus;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"squad_surplus", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool squad_surplus
     {
-      get { return _squad_surplus; }
+      get { return _squad_surplus?? default(bool); }
       set { _squad_surplus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool squad_surplusSpecified
+    {
+      get { return _squad_surplus != null; }
+      set { if (value == (_squad_surplus== null)) _squad_surplus = value ? this.squad_surplus : (bool?)null; }
+    }
+    private bool ShouldSerializesquad_surplus() { return squad_surplusSpecified; }
+    private void Resetsquad_surplus() { squad_surplusSpecified = false; }
+    
 
-    private bool _is_banned = (bool)false;
+    private bool? _is_banned;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool is_banned
     {
-      get { return _is_banned; }
+      get { return _is_banned?? (bool)false; }
       set { _is_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_bannedSpecified
+    {
+      get { return _is_banned != null; }
+      set { if (value == (_is_banned== null)) _is_banned = value ? this.is_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned() { return is_bannedSpecified; }
+    private void Resetis_banned() { is_bannedSpecified = false; }
+    
 
-    private bool _competitive_access = default(bool);
+    private bool? _competitive_access;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"competitive_access", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool competitive_access
     {
-      get { return _competitive_access; }
+      get { return _competitive_access?? default(bool); }
       set { _competitive_access = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool competitive_accessSpecified
+    {
+      get { return _competitive_access != null; }
+      set { if (value == (_competitive_access== null)) _competitive_access = value ? this.competitive_access : (bool?)null; }
+    }
+    private bool ShouldSerializecompetitive_access() { return competitive_accessSpecified; }
+    private void Resetcompetitive_access() { competitive_accessSpecified = false; }
+    
 
-    private uint _ladder_rank = default(uint);
+    private uint? _ladder_rank;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"ladder_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ladder_rank
     {
-      get { return _ladder_rank; }
+      get { return _ladder_rank?? default(uint); }
       set { _ladder_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ladder_rankSpecified
+    {
+      get { return _ladder_rank != null; }
+      set { if (value == (_ladder_rank== null)) _ladder_rank = value ? this.ladder_rank : (uint?)null; }
+    }
+    private bool ShouldSerializeladder_rank() { return ladder_rankSpecified; }
+    private void Resetladder_rank() { ladder_rankSpecified = false; }
+    
 
-    private bool _is_low_priority = (bool)false;
+    private bool? _is_low_priority;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"is_low_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool is_low_priority
     {
-      get { return _is_low_priority; }
+      get { return _is_low_priority?? (bool)false; }
       set { _is_low_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_low_prioritySpecified
+    {
+      get { return _is_low_priority != null; }
+      set { if (value == (_is_low_priority== null)) _is_low_priority = value ? this.is_low_priority : (bool?)null; }
+    }
+    private bool ShouldSerializeis_low_priority() { return is_low_prioritySpecified; }
+    private void Resetis_low_priority() { is_low_prioritySpecified = false; }
+    
 
-    private uint _experience = default(uint);
+    private uint? _experience;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"experience", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint experience
     {
-      get { return _experience; }
+      get { return _experience?? default(uint); }
       set { _experience = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experienceSpecified
+    {
+      get { return _experience != null; }
+      set { if (value == (_experience== null)) _experience = value ? this.experience : (uint?)null; }
+    }
+    private bool ShouldSerializeexperience() { return experienceSpecified; }
+    private void Resetexperience() { experienceSpecified = false; }
+    
 
-    private uint _skillrating = (uint)10000;
+    private uint? _skillrating;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)10000)]
     public uint skillrating
     {
-      get { return _skillrating; }
+      get { return _skillrating?? (uint)10000; }
       set { _skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillratingSpecified
+    {
+      get { return _skillrating != null; }
+      set { if (value == (_skillrating== null)) _skillrating = value ? this.skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializeskillrating() { return skillratingSpecified; }
+    private void Resetskillrating() { skillratingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1821,41 +2894,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgMatchSearchCriteria() {}
     
 
-    private TF_MatchmakingMode _matchmaking_mode = TF_MatchmakingMode.TF_Matchmaking_INVALID;
+    private TF_MatchmakingMode? _matchmaking_mode;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"matchmaking_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_MatchmakingMode.TF_Matchmaking_INVALID)]
     public TF_MatchmakingMode matchmaking_mode
     {
-      get { return _matchmaking_mode; }
+      get { return _matchmaking_mode?? TF_MatchmakingMode.TF_Matchmaking_INVALID; }
       set { _matchmaking_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_modeSpecified
+    {
+      get { return _matchmaking_mode != null; }
+      set { if (value == (_matchmaking_mode== null)) _matchmaking_mode = value ? this.matchmaking_mode : (TF_MatchmakingMode?)null; }
+    }
+    private bool ShouldSerializematchmaking_mode() { return matchmaking_modeSpecified; }
+    private void Resetmatchmaking_mode() { matchmaking_modeSpecified = false; }
+    
 
-    private bool _late_join_ok = default(bool);
+    private bool? _late_join_ok;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"late_join_ok", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool late_join_ok
     {
-      get { return _late_join_ok; }
+      get { return _late_join_ok?? default(bool); }
       set { _late_join_ok = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool late_join_okSpecified
+    {
+      get { return _late_join_ok != null; }
+      set { if (value == (_late_join_ok== null)) _late_join_ok = value ? this.late_join_ok : (bool?)null; }
+    }
+    private bool ShouldSerializelate_join_ok() { return late_join_okSpecified; }
+    private void Resetlate_join_ok() { late_join_okSpecified = false; }
+    
 
-    private uint _custom_ping_tolerance = (uint)0;
+    private uint? _custom_ping_tolerance;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"custom_ping_tolerance", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint custom_ping_tolerance
     {
-      get { return _custom_ping_tolerance; }
+      get { return _custom_ping_tolerance?? (uint)0; }
       set { _custom_ping_tolerance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_ping_toleranceSpecified
+    {
+      get { return _custom_ping_tolerance != null; }
+      set { if (value == (_custom_ping_tolerance== null)) _custom_ping_tolerance = value ? this.custom_ping_tolerance : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_ping_tolerance() { return custom_ping_toleranceSpecified; }
+    private void Resetcustom_ping_tolerance() { custom_ping_toleranceSpecified = false; }
+    
 
-    private string _mvm_mannup_tour = "";
+    private string _mvm_mannup_tour;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"mvm_mannup_tour", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mvm_mannup_tour
     {
-      get { return _mvm_mannup_tour; }
+      get { return _mvm_mannup_tour?? ""; }
       set { _mvm_mannup_tour = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mvm_mannup_tourSpecified
+    {
+      get { return _mvm_mannup_tour != null; }
+      set { if (value == (_mvm_mannup_tour== null)) _mvm_mannup_tour = value ? this.mvm_mannup_tour : (string)null; }
+    }
+    private bool ShouldSerializemvm_mannup_tour() { return mvm_mannup_tourSpecified; }
+    private void Resetmvm_mannup_tour() { mvm_mannup_tourSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _mvm_missions = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(9, Name=@"mvm_missions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> mvm_missions
@@ -1864,32 +2973,59 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _play_for_bragging_rights = default(bool);
+    private bool? _play_for_bragging_rights;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"play_for_bragging_rights", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool play_for_bragging_rights
     {
-      get { return _play_for_bragging_rights; }
+      get { return _play_for_bragging_rights?? default(bool); }
       set { _play_for_bragging_rights = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool play_for_bragging_rightsSpecified
+    {
+      get { return _play_for_bragging_rights != null; }
+      set { if (value == (_play_for_bragging_rights== null)) _play_for_bragging_rights = value ? this.play_for_bragging_rights : (bool?)null; }
+    }
+    private bool ShouldSerializeplay_for_bragging_rights() { return play_for_bragging_rightsSpecified; }
+    private void Resetplay_for_bragging_rights() { play_for_bragging_rightsSpecified = false; }
+    
 
-    private uint _quickplay_game_type = default(uint);
+    private uint? _quickplay_game_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"quickplay_game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quickplay_game_type
     {
-      get { return _quickplay_game_type; }
+      get { return _quickplay_game_type?? default(uint); }
       set { _quickplay_game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quickplay_game_typeSpecified
+    {
+      get { return _quickplay_game_type != null; }
+      set { if (value == (_quickplay_game_type== null)) _quickplay_game_type = value ? this.quickplay_game_type : (uint?)null; }
+    }
+    private bool ShouldSerializequickplay_game_type() { return quickplay_game_typeSpecified; }
+    private void Resetquickplay_game_type() { quickplay_game_typeSpecified = false; }
+    
 
-    private uint _ladder_game_type = default(uint);
+    private uint? _ladder_game_type;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"ladder_game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ladder_game_type
     {
-      get { return _ladder_game_type; }
+      get { return _ladder_game_type?? default(uint); }
       set { _ladder_game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ladder_game_typeSpecified
+    {
+      get { return _ladder_game_type != null; }
+      set { if (value == (_ladder_game_type== null)) _ladder_game_type = value ? this.ladder_game_type : (uint?)null; }
+    }
+    private bool ShouldSerializeladder_game_type() { return ladder_game_typeSpecified; }
+    private void Resetladder_game_type() { ladder_game_typeSpecified = false; }
+    
 
     private CMsgCasualMatchmakingSearchCriteria _casual_criteria = null;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"casual_criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1936,41 +3072,77 @@ namespace SteamKit2.GC.TF2.Internal
       set { _search_criteria = value; }
     }
 
-    private ulong _steam_lobby_id = default(ulong);
+    private ulong? _steam_lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_lobby_id
     {
-      get { return _steam_lobby_id; }
+      get { return _steam_lobby_id?? default(ulong); }
       set { _steam_lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_lobby_idSpecified
+    {
+      get { return _steam_lobby_id != null; }
+      set { if (value == (_steam_lobby_id== null)) _steam_lobby_id = value ? this.steam_lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_lobby_id() { return steam_lobby_idSpecified; }
+    private void Resetsteam_lobby_id() { steam_lobby_idSpecified = false; }
+    
 
-    private bool _squad_surplus = default(bool);
+    private bool? _squad_surplus;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"squad_surplus", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool squad_surplus
     {
-      get { return _squad_surplus; }
+      get { return _squad_surplus?? default(bool); }
       set { _squad_surplus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool squad_surplusSpecified
+    {
+      get { return _squad_surplus != null; }
+      set { if (value == (_squad_surplus== null)) _squad_surplus = value ? this.squad_surplus : (bool?)null; }
+    }
+    private bool ShouldSerializesquad_surplus() { return squad_surplusSpecified; }
+    private void Resetsquad_surplus() { squad_surplusSpecified = false; }
+    
 
-    private TF_Matchmaking_WizardStep _wizard_step = TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID;
+    private TF_Matchmaking_WizardStep? _wizard_step;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"wizard_step", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID)]
     public TF_Matchmaking_WizardStep wizard_step
     {
-      get { return _wizard_step; }
+      get { return _wizard_step?? TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID; }
       set { _wizard_step = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wizard_stepSpecified
+    {
+      get { return _wizard_step != null; }
+      set { if (value == (_wizard_step== null)) _wizard_step = value ? this.wizard_step : (TF_Matchmaking_WizardStep?)null; }
+    }
+    private bool ShouldSerializewizard_step() { return wizard_stepSpecified; }
+    private void Resetwizard_step() { wizard_stepSpecified = false; }
+    
 
-    private uint _client_version = (uint)1225;
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1225)]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? (uint)1225; }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1982,32 +3154,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgCreateOrUpdatePartyReply() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private TF_Matchmaking_WizardStep _wizard_step = TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID;
+    private TF_Matchmaking_WizardStep? _wizard_step;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"wizard_step", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID)]
     public TF_Matchmaking_WizardStep wizard_step
     {
-      get { return _wizard_step; }
+      get { return _wizard_step?? TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID; }
       set { _wizard_step = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wizard_stepSpecified
+    {
+      get { return _wizard_step != null; }
+      set { if (value == (_wizard_step== null)) _wizard_step = value ? this.wizard_step : (TF_Matchmaking_WizardStep?)null; }
+    }
+    private bool ShouldSerializewizard_step() { return wizard_stepSpecified; }
+    private void Resetwizard_step() { wizard_stepSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2019,23 +3218,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFParty() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private ulong _leader_id = default(ulong);
+    private ulong? _leader_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leader_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong leader_id
     {
-      get { return _leader_id; }
+      get { return _leader_id?? default(ulong); }
       set { _leader_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_idSpecified
+    {
+      get { return _leader_id != null; }
+      set { if (value == (_leader_id== null)) _leader_id = value ? this.leader_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeleader_id() { return leader_idSpecified; }
+    private void Resetleader_id() { leader_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _member_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"member_ids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> member_ids
@@ -2058,41 +3275,77 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _associated_lobby_id = default(ulong);
+    private ulong? _associated_lobby_id;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"associated_lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong associated_lobby_id
     {
-      get { return _associated_lobby_id; }
+      get { return _associated_lobby_id?? default(ulong); }
       set { _associated_lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool associated_lobby_idSpecified
+    {
+      get { return _associated_lobby_id != null; }
+      set { if (value == (_associated_lobby_id== null)) _associated_lobby_id = value ? this.associated_lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeassociated_lobby_id() { return associated_lobby_idSpecified; }
+    private void Resetassociated_lobby_id() { associated_lobby_idSpecified = false; }
+    
 
-    private CSOTFParty.State _state = CSOTFParty.State.UI;
+    private CSOTFParty.State? _state;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSOTFParty.State.UI)]
     public CSOTFParty.State state
     {
-      get { return _state; }
+      get { return _state?? CSOTFParty.State.UI; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (CSOTFParty.State?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private TF_Matchmaking_WizardStep _wizard_step = TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID;
+    private TF_Matchmaking_WizardStep? _wizard_step;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"wizard_step", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID)]
     public TF_Matchmaking_WizardStep wizard_step
     {
-      get { return _wizard_step; }
+      get { return _wizard_step?? TF_Matchmaking_WizardStep.TF_Matchmaking_WizardStep_INVALID; }
       set { _wizard_step = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wizard_stepSpecified
+    {
+      get { return _wizard_step != null; }
+      set { if (value == (_wizard_step== null)) _wizard_step = value ? this.wizard_step : (TF_Matchmaking_WizardStep?)null; }
+    }
+    private bool ShouldSerializewizard_step() { return wizard_stepSpecified; }
+    private void Resetwizard_step() { wizard_stepSpecified = false; }
+    
 
-    private uint _started_matchmaking_time = default(uint);
+    private uint? _started_matchmaking_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"started_matchmaking_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint started_matchmaking_time
     {
-      get { return _started_matchmaking_time; }
+      get { return _started_matchmaking_time?? default(uint); }
       set { _started_matchmaking_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool started_matchmaking_timeSpecified
+    {
+      get { return _started_matchmaking_time != null; }
+      set { if (value == (_started_matchmaking_time== null)) _started_matchmaking_time = value ? this.started_matchmaking_time : (uint?)null; }
+    }
+    private bool ShouldSerializestarted_matchmaking_time() { return started_matchmaking_timeSpecified; }
+    private void Resetstarted_matchmaking_time() { started_matchmaking_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _searching_players_by_group = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(10, Name=@"searching_players_by_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> searching_players_by_group
@@ -2101,41 +3354,77 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _steam_lobby_id = default(ulong);
+    private ulong? _steam_lobby_id;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"steam_lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_lobby_id
     {
-      get { return _steam_lobby_id; }
+      get { return _steam_lobby_id?? default(ulong); }
       set { _steam_lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_lobby_idSpecified
+    {
+      get { return _steam_lobby_id != null; }
+      set { if (value == (_steam_lobby_id== null)) _steam_lobby_id = value ? this.steam_lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_lobby_id() { return steam_lobby_idSpecified; }
+    private void Resetsteam_lobby_id() { steam_lobby_idSpecified = false; }
+    
 
-    private TF_MatchmakingMode _matchmaking_mode = TF_MatchmakingMode.TF_Matchmaking_INVALID;
+    private TF_MatchmakingMode? _matchmaking_mode;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"matchmaking_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_MatchmakingMode.TF_Matchmaking_INVALID)]
     public TF_MatchmakingMode matchmaking_mode
     {
-      get { return _matchmaking_mode; }
+      get { return _matchmaking_mode?? TF_MatchmakingMode.TF_Matchmaking_INVALID; }
       set { _matchmaking_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_modeSpecified
+    {
+      get { return _matchmaking_mode != null; }
+      set { if (value == (_matchmaking_mode== null)) _matchmaking_mode = value ? this.matchmaking_mode : (TF_MatchmakingMode?)null; }
+    }
+    private bool ShouldSerializematchmaking_mode() { return matchmaking_modeSpecified; }
+    private void Resetmatchmaking_mode() { matchmaking_modeSpecified = false; }
+    
 
-    private bool _search_late_join_ok = default(bool);
+    private bool? _search_late_join_ok;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"search_late_join_ok", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool search_late_join_ok
     {
-      get { return _search_late_join_ok; }
+      get { return _search_late_join_ok?? default(bool); }
       set { _search_late_join_ok = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_late_join_okSpecified
+    {
+      get { return _search_late_join_ok != null; }
+      set { if (value == (_search_late_join_ok== null)) _search_late_join_ok = value ? this.search_late_join_ok : (bool?)null; }
+    }
+    private bool ShouldSerializesearch_late_join_ok() { return search_late_join_okSpecified; }
+    private void Resetsearch_late_join_ok() { search_late_join_okSpecified = false; }
+    
 
-    private string _search_mvm_mannup_tour = "";
+    private string _search_mvm_mannup_tour;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"search_mvm_mannup_tour", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_mvm_mannup_tour
     {
-      get { return _search_mvm_mannup_tour; }
+      get { return _search_mvm_mannup_tour?? ""; }
       set { _search_mvm_mannup_tour = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_mvm_mannup_tourSpecified
+    {
+      get { return _search_mvm_mannup_tour != null; }
+      set { if (value == (_search_mvm_mannup_tour== null)) _search_mvm_mannup_tour = value ? this.search_mvm_mannup_tour : (string)null; }
+    }
+    private bool ShouldSerializesearch_mvm_mannup_tour() { return search_mvm_mannup_tourSpecified; }
+    private void Resetsearch_mvm_mannup_tour() { search_mvm_mannup_tourSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _search_mvm_missions = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(31, Name=@"search_mvm_missions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> search_mvm_missions
@@ -2144,32 +3433,59 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _search_play_for_bragging_rights = default(bool);
+    private bool? _search_play_for_bragging_rights;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"search_play_for_bragging_rights", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool search_play_for_bragging_rights
     {
-      get { return _search_play_for_bragging_rights; }
+      get { return _search_play_for_bragging_rights?? default(bool); }
       set { _search_play_for_bragging_rights = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_play_for_bragging_rightsSpecified
+    {
+      get { return _search_play_for_bragging_rights != null; }
+      set { if (value == (_search_play_for_bragging_rights== null)) _search_play_for_bragging_rights = value ? this.search_play_for_bragging_rights : (bool?)null; }
+    }
+    private bool ShouldSerializesearch_play_for_bragging_rights() { return search_play_for_bragging_rightsSpecified; }
+    private void Resetsearch_play_for_bragging_rights() { search_play_for_bragging_rightsSpecified = false; }
+    
 
-    private uint _search_quickplay_game_type = default(uint);
+    private uint? _search_quickplay_game_type;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"search_quickplay_game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_quickplay_game_type
     {
-      get { return _search_quickplay_game_type; }
+      get { return _search_quickplay_game_type?? default(uint); }
       set { _search_quickplay_game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_quickplay_game_typeSpecified
+    {
+      get { return _search_quickplay_game_type != null; }
+      set { if (value == (_search_quickplay_game_type== null)) _search_quickplay_game_type = value ? this.search_quickplay_game_type : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_quickplay_game_type() { return search_quickplay_game_typeSpecified; }
+    private void Resetsearch_quickplay_game_type() { search_quickplay_game_typeSpecified = false; }
+    
 
-    private uint _search_ladder_game_type = default(uint);
+    private uint? _search_ladder_game_type;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"search_ladder_game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_ladder_game_type
     {
-      get { return _search_ladder_game_type; }
+      get { return _search_ladder_game_type?? default(uint); }
       set { _search_ladder_game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_ladder_game_typeSpecified
+    {
+      get { return _search_ladder_game_type != null; }
+      set { if (value == (_search_ladder_game_type== null)) _search_ladder_game_type = value ? this.search_ladder_game_type : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_ladder_game_type() { return search_ladder_game_typeSpecified; }
+    private void Resetsearch_ladder_game_type() { search_ladder_game_typeSpecified = false; }
+    
 
     private CMsgCasualMatchmakingSearchCriteria _search_casual = null;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"search_casual", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2180,41 +3496,77 @@ namespace SteamKit2.GC.TF2.Internal
       set { _search_casual = value; }
     }
 
-    private uint _custom_ping_tolerance = default(uint);
+    private uint? _custom_ping_tolerance;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"custom_ping_tolerance", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint custom_ping_tolerance
     {
-      get { return _custom_ping_tolerance; }
+      get { return _custom_ping_tolerance?? default(uint); }
       set { _custom_ping_tolerance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_ping_toleranceSpecified
+    {
+      get { return _custom_ping_tolerance != null; }
+      set { if (value == (_custom_ping_tolerance== null)) _custom_ping_tolerance = value ? this.custom_ping_tolerance : (uint?)null; }
+    }
+    private bool ShouldSerializecustom_ping_tolerance() { return custom_ping_toleranceSpecified; }
+    private void Resetcustom_ping_tolerance() { custom_ping_toleranceSpecified = false; }
+    
 
-    private uint _matchmaking_ban_time = default(uint);
+    private uint? _matchmaking_ban_time;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"matchmaking_ban_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ban_time
     {
-      get { return _matchmaking_ban_time; }
+      get { return _matchmaking_ban_time?? default(uint); }
       set { _matchmaking_ban_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ban_timeSpecified
+    {
+      get { return _matchmaking_ban_time != null; }
+      set { if (value == (_matchmaking_ban_time== null)) _matchmaking_ban_time = value ? this.matchmaking_ban_time : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ban_time() { return matchmaking_ban_timeSpecified; }
+    private void Resetmatchmaking_ban_time() { matchmaking_ban_timeSpecified = false; }
+    
 
-    private uint _matchmaking_ban_account_id = default(uint);
+    private uint? _matchmaking_ban_account_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"matchmaking_ban_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ban_account_id
     {
-      get { return _matchmaking_ban_account_id; }
+      get { return _matchmaking_ban_account_id?? default(uint); }
       set { _matchmaking_ban_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ban_account_idSpecified
+    {
+      get { return _matchmaking_ban_account_id != null; }
+      set { if (value == (_matchmaking_ban_account_id== null)) _matchmaking_ban_account_id = value ? this.matchmaking_ban_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ban_account_id() { return matchmaking_ban_account_idSpecified; }
+    private void Resetmatchmaking_ban_account_id() { matchmaking_ban_account_idSpecified = false; }
+    
 
-    private uint _matchmaking_low_priority_time = default(uint);
+    private uint? _matchmaking_low_priority_time;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"matchmaking_low_priority_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_low_priority_time
     {
-      get { return _matchmaking_low_priority_time; }
+      get { return _matchmaking_low_priority_time?? default(uint); }
       set { _matchmaking_low_priority_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_low_priority_timeSpecified
+    {
+      get { return _matchmaking_low_priority_time != null; }
+      set { if (value == (_matchmaking_low_priority_time== null)) _matchmaking_low_priority_time = value ? this.matchmaking_low_priority_time : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_low_priority_time() { return matchmaking_low_priority_timeSpecified; }
+    private void Resetmatchmaking_low_priority_time() { matchmaking_low_priority_timeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"State", EnumPassthru=true)]
     public enum State
     {
@@ -2243,32 +3595,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFPartyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOTFPartyInvite.PartyMember> _members = new global::System.Collections.Generic.List<CSOTFPartyInvite.PartyMember>();
     [global::ProtoBuf.ProtoMember(4, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOTFPartyInvite.PartyMember> members
@@ -2282,32 +3661,59 @@ namespace SteamKit2.GC.TF2.Internal
     public PartyMember() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _avatar = default(uint);
+    private uint? _avatar;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"avatar", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avatar
     {
-      get { return _avatar; }
+      get { return _avatar?? default(uint); }
       set { _avatar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avatarSpecified
+    {
+      get { return _avatar != null; }
+      set { if (value == (_avatar== null)) _avatar = value ? this.avatar : (uint?)null; }
+    }
+    private bool ShouldSerializeavatar() { return avatarSpecified; }
+    private void Resetavatar() { avatarSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2324,95 +3730,185 @@ namespace SteamKit2.GC.TF2.Internal
     public CTFLobbyMember() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private TF_GC_TEAM _team = TF_GC_TEAM.TF_GC_TEAM_DEFENDERS;
+    private TF_GC_TEAM? _team;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_GC_TEAM.TF_GC_TEAM_DEFENDERS)]
     public TF_GC_TEAM team
     {
-      get { return _team; }
+      get { return _team?? TF_GC_TEAM.TF_GC_TEAM_DEFENDERS; }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (TF_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private CTFLobbyMember.ConnectState _connect_state = CTFLobbyMember.ConnectState.INVALID;
+    private CTFLobbyMember.ConnectState? _connect_state;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"connect_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CTFLobbyMember.ConnectState.INVALID)]
     public CTFLobbyMember.ConnectState connect_state
     {
-      get { return _connect_state; }
+      get { return _connect_state?? CTFLobbyMember.ConnectState.INVALID; }
       set { _connect_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_stateSpecified
+    {
+      get { return _connect_state != null; }
+      set { if (value == (_connect_state== null)) _connect_state = value ? this.connect_state : (CTFLobbyMember.ConnectState?)null; }
+    }
+    private bool ShouldSerializeconnect_state() { return connect_stateSpecified; }
+    private void Resetconnect_state() { connect_stateSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private TFLobbyReadyState _ready_state = TFLobbyReadyState.TFLobbyReadyState_UNDECLARED;
+    private TFLobbyReadyState? _ready_state;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"ready_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TFLobbyReadyState.TFLobbyReadyState_UNDECLARED)]
     public TFLobbyReadyState ready_state
     {
-      get { return _ready_state; }
+      get { return _ready_state?? TFLobbyReadyState.TFLobbyReadyState_UNDECLARED; }
       set { _ready_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ready_stateSpecified
+    {
+      get { return _ready_state != null; }
+      set { if (value == (_ready_state== null)) _ready_state = value ? this.ready_state : (TFLobbyReadyState?)null; }
+    }
+    private bool ShouldSerializeready_state() { return ready_stateSpecified; }
+    private void Resetready_state() { ready_stateSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private bool _squad_surplus = default(bool);
+    private bool? _squad_surplus;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"squad_surplus", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool squad_surplus
     {
-      get { return _squad_surplus; }
+      get { return _squad_surplus?? default(bool); }
       set { _squad_surplus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool squad_surplusSpecified
+    {
+      get { return _squad_surplus != null; }
+      set { if (value == (_squad_surplus== null)) _squad_surplus = value ? this.squad_surplus : (bool?)null; }
+    }
+    private bool ShouldSerializesquad_surplus() { return squad_surplusSpecified; }
+    private void Resetsquad_surplus() { squad_surplusSpecified = false; }
+    
 
-    private uint _badge_level = default(uint);
+    private uint? _badge_level;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"badge_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_level
     {
-      get { return _badge_level; }
+      get { return _badge_level?? default(uint); }
       set { _badge_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_levelSpecified
+    {
+      get { return _badge_level != null; }
+      set { if (value == (_badge_level== null)) _badge_level = value ? this.badge_level : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_level() { return badge_levelSpecified; }
+    private void Resetbadge_level() { badge_levelSpecified = false; }
+    
 
-    private uint _skillrating = (uint)10000;
+    private uint? _skillrating;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)10000)]
     public uint skillrating
     {
-      get { return _skillrating; }
+      get { return _skillrating?? (uint)10000; }
       set { _skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillratingSpecified
+    {
+      get { return _skillrating != null; }
+      set { if (value == (_skillrating== null)) _skillrating = value ? this.skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializeskillrating() { return skillratingSpecified; }
+    private void Resetskillrating() { skillratingSpecified = false; }
+    
 
-    private uint _last_connect_time = default(uint);
+    private uint? _last_connect_time;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"last_connect_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_connect_time
     {
-      get { return _last_connect_time; }
+      get { return _last_connect_time?? default(uint); }
       set { _last_connect_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_connect_timeSpecified
+    {
+      get { return _last_connect_time != null; }
+      set { if (value == (_last_connect_time== null)) _last_connect_time = value ? this.last_connect_time : (uint?)null; }
+    }
+    private bool ShouldSerializelast_connect_time() { return last_connect_timeSpecified; }
+    private void Resetlast_connect_time() { last_connect_timeSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"ConnectState", EnumPassthru=true)]
     public enum ConnectState
     {
@@ -2444,23 +3940,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CLobbyPendingPlayerReport() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _date = default(uint);
+    private uint? _date;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"date", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint date
     {
-      get { return _date; }
+      get { return _date?? default(uint); }
       set { _date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dateSpecified
+    {
+      get { return _date != null; }
+      set { if (value == (_date== null)) _date = value ? this.date : (uint?)null; }
+    }
+    private bool ShouldSerializedate() { return dateSpecified; }
+    private void Resetdate() { dateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2472,14 +3986,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFGameServerLobby() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CTFLobbyMember> _members = new global::System.Collections.Generic.List<CTFLobbyMember>();
     [global::ProtoBuf.ProtoMember(2, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CTFLobbyMember> members
@@ -2495,23 +4018,41 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _leader_id = default(ulong);
+    private ulong? _leader_id;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"leader_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong leader_id
     {
-      get { return _leader_id; }
+      get { return _leader_id?? default(ulong); }
       set { _leader_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leader_idSpecified
+    {
+      get { return _leader_id != null; }
+      set { if (value == (_leader_id== null)) _leader_id = value ? this.leader_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeleader_id() { return leader_idSpecified; }
+    private void Resetleader_id() { leader_idSpecified = false; }
+    
 
-    private ulong _server_id = (ulong)0;
+    private ulong? _server_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong server_id
     {
-      get { return _server_id; }
+      get { return _server_id?? (ulong)0; }
       set { _server_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_idSpecified
+    {
+      get { return _server_id != null; }
+      set { if (value == (_server_id== null)) _server_id = value ? this.server_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_id() { return server_idSpecified; }
+    private void Resetserver_id() { server_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _pending_invites = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(10, Name=@"pending_invites", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> pending_invites
@@ -2520,221 +4061,437 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private CSOTFGameServerLobby.State _state = CSOTFGameServerLobby.State.SERVERSETUP;
+    private CSOTFGameServerLobby.State? _state;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSOTFGameServerLobby.State.SERVERSETUP)]
     public CSOTFGameServerLobby.State state
     {
-      get { return _state; }
+      get { return _state?? CSOTFGameServerLobby.State.SERVERSETUP; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (CSOTFGameServerLobby.State?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _connect = "";
+    private string _connect;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"connect", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string connect
     {
-      get { return _connect; }
+      get { return _connect?? ""; }
       set { _connect = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connectSpecified
+    {
+      get { return _connect != null; }
+      set { if (value == (_connect== null)) _connect = value ? this.connect : (string)null; }
+    }
+    private bool ShouldSerializeconnect() { return connectSpecified; }
+    private void Resetconnect() { connectSpecified = false; }
+    
 
-    private CSOTFGameServerLobby.LobbyType _lobby_type = CSOTFGameServerLobby.LobbyType.INVALID;
+    private CSOTFGameServerLobby.LobbyType? _lobby_type;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSOTFGameServerLobby.LobbyType.INVALID)]
     public CSOTFGameServerLobby.LobbyType lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? CSOTFGameServerLobby.LobbyType.INVALID; }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (CSOTFGameServerLobby.LobbyType?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private bool _allow_cheats = default(bool);
+    private bool? _allow_cheats;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"allow_cheats", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_cheats
     {
-      get { return _allow_cheats; }
+      get { return _allow_cheats?? default(bool); }
       set { _allow_cheats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_cheatsSpecified
+    {
+      get { return _allow_cheats != null; }
+      set { if (value == (_allow_cheats== null)) _allow_cheats = value ? this.allow_cheats : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_cheats() { return allow_cheatsSpecified; }
+    private void Resetallow_cheats() { allow_cheatsSpecified = false; }
+    
 
-    private string _game_name = "";
+    private string _game_name;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"game_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_name
     {
-      get { return _game_name; }
+      get { return _game_name?? ""; }
       set { _game_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_nameSpecified
+    {
+      get { return _game_name != null; }
+      set { if (value == (_game_name== null)) _game_name = value ? this.game_name : (string)null; }
+    }
+    private bool ShouldSerializegame_name() { return game_nameSpecified; }
+    private void Resetgame_name() { game_nameSpecified = false; }
+    
 
-    private uint _server_region = (uint)0;
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? (uint)0; }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private TF_GC_GameState _game_state = TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT;
+    private TF_GC_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT)]
     public TF_GC_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (TF_GC_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private uint _num_spectators = default(uint);
+    private uint? _num_spectators;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"num_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_spectators
     {
-      get { return _num_spectators; }
+      get { return _num_spectators?? default(uint); }
       set { _num_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_spectatorsSpecified
+    {
+      get { return _num_spectators != null; }
+      set { if (value == (_num_spectators== null)) _num_spectators = value ? this.num_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializenum_spectators() { return num_spectatorsSpecified; }
+    private void Resetnum_spectators() { num_spectatorsSpecified = false; }
+    
 
-    private float _readyup_remaining_time = default(float);
+    private float? _readyup_remaining_time;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"readyup_remaining_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float readyup_remaining_time
     {
-      get { return _readyup_remaining_time; }
+      get { return _readyup_remaining_time?? default(float); }
       set { _readyup_remaining_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool readyup_remaining_timeSpecified
+    {
+      get { return _readyup_remaining_time != null; }
+      set { if (value == (_readyup_remaining_time== null)) _readyup_remaining_time = value ? this.readyup_remaining_time : (float?)null; }
+    }
+    private bool ShouldSerializereadyup_remaining_time() { return readyup_remaining_timeSpecified; }
+    private void Resetreadyup_remaining_time() { readyup_remaining_timeSpecified = false; }
+    
 
-    private bool _allow_spectating = (bool)true;
+    private bool? _allow_spectating;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"allow_spectating", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool allow_spectating
     {
-      get { return _allow_spectating; }
+      get { return _allow_spectating?? (bool)true; }
       set { _allow_spectating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_spectatingSpecified
+    {
+      get { return _allow_spectating != null; }
+      set { if (value == (_allow_spectating== null)) _allow_spectating = value ? this.allow_spectating : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_spectating() { return allow_spectatingSpecified; }
+    private void Resetallow_spectating() { allow_spectatingSpecified = false; }
+    
 
-    private uint _average_rank = default(uint);
+    private uint? _average_rank;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"average_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint average_rank
     {
-      get { return _average_rank; }
+      get { return _average_rank?? default(uint); }
       set { _average_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool average_rankSpecified
+    {
+      get { return _average_rank != null; }
+      set { if (value == (_average_rank== null)) _average_rank = value ? this.average_rank : (uint?)null; }
+    }
+    private bool ShouldSerializeaverage_rank() { return average_rankSpecified; }
+    private void Resetaverage_rank() { average_rankSpecified = false; }
+    
 
-    private ulong _load_game_lobby_id = default(ulong);
+    private ulong? _load_game_lobby_id;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"load_game_lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong load_game_lobby_id
     {
-      get { return _load_game_lobby_id; }
+      get { return _load_game_lobby_id?? default(ulong); }
       set { _load_game_lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool load_game_lobby_idSpecified
+    {
+      get { return _load_game_lobby_id != null; }
+      set { if (value == (_load_game_lobby_id== null)) _load_game_lobby_id = value ? this.load_game_lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeload_game_lobby_id() { return load_game_lobby_idSpecified; }
+    private void Resetload_game_lobby_id() { load_game_lobby_idSpecified = false; }
+    
 
-    private uint _load_game_save_number = default(uint);
+    private uint? _load_game_save_number;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"load_game_save_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint load_game_save_number
     {
-      get { return _load_game_save_number; }
+      get { return _load_game_save_number?? default(uint); }
       set { _load_game_save_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool load_game_save_numberSpecified
+    {
+      get { return _load_game_save_number != null; }
+      set { if (value == (_load_game_save_number== null)) _load_game_save_number = value ? this.load_game_save_number : (uint?)null; }
+    }
+    private bool ShouldSerializeload_game_save_number() { return load_game_save_numberSpecified; }
+    private void Resetload_game_save_number() { load_game_save_numberSpecified = false; }
+    
 
-    private string _mannup_tour_name = "";
+    private string _mannup_tour_name;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"mannup_tour_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mannup_tour_name
     {
-      get { return _mannup_tour_name; }
+      get { return _mannup_tour_name?? ""; }
       set { _mannup_tour_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mannup_tour_nameSpecified
+    {
+      get { return _mannup_tour_name != null; }
+      set { if (value == (_mannup_tour_name== null)) _mannup_tour_name = value ? this.mannup_tour_name : (string)null; }
+    }
+    private bool ShouldSerializemannup_tour_name() { return mannup_tour_nameSpecified; }
+    private void Resetmannup_tour_name() { mannup_tour_nameSpecified = false; }
+    
 
-    private string _map_name = "";
+    private string _map_name;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"map_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map_name
     {
-      get { return _map_name; }
+      get { return _map_name?? ""; }
       set { _map_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_nameSpecified
+    {
+      get { return _map_name != null; }
+      set { if (value == (_map_name== null)) _map_name = value ? this.map_name : (string)null; }
+    }
+    private bool ShouldSerializemap_name() { return map_nameSpecified; }
+    private void Resetmap_name() { map_nameSpecified = false; }
+    
 
-    private string _mission_name = "";
+    private string _mission_name;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"mission_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mission_name
     {
-      get { return _mission_name; }
+      get { return _mission_name?? ""; }
       set { _mission_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mission_nameSpecified
+    {
+      get { return _mission_name != null; }
+      set { if (value == (_mission_name== null)) _mission_name = value ? this.mission_name : (string)null; }
+    }
+    private bool ShouldSerializemission_name() { return mission_nameSpecified; }
+    private void Resetmission_name() { mission_nameSpecified = false; }
+    
 
-    private uint _match_group = default(uint);
+    private uint? _match_group;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(uint); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (uint?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private ulong _match_id = (ulong)0;
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? (ulong)0; }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _replay_salt = default(uint);
+    private uint? _replay_salt;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"replay_salt", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint replay_salt
     {
-      get { return _replay_salt; }
+      get { return _replay_salt?? default(uint); }
       set { _replay_salt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool replay_saltSpecified
+    {
+      get { return _replay_salt != null; }
+      set { if (value == (_replay_salt== null)) _replay_salt = value ? this.replay_salt : (uint?)null; }
+    }
+    private bool ShouldSerializereplay_salt() { return replay_saltSpecified; }
+    private void Resetreplay_salt() { replay_saltSpecified = false; }
+    
 
-    private uint _formed_time = default(uint);
+    private uint? _formed_time;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"formed_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint formed_time
     {
-      get { return _formed_time; }
+      get { return _formed_time?? default(uint); }
       set { _formed_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool formed_timeSpecified
+    {
+      get { return _formed_time != null; }
+      set { if (value == (_formed_time== null)) _formed_time = value ? this.formed_time : (uint?)null; }
+    }
+    private bool ShouldSerializeformed_time() { return formed_timeSpecified; }
+    private void Resetformed_time() { formed_timeSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private bool _late_join_eligible = default(bool);
+    private bool? _late_join_eligible;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"late_join_eligible", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool late_join_eligible
     {
-      get { return _late_join_eligible; }
+      get { return _late_join_eligible?? default(bool); }
       set { _late_join_eligible = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool late_join_eligibleSpecified
+    {
+      get { return _late_join_eligible != null; }
+      set { if (value == (_late_join_eligible== null)) _late_join_eligible = value ? this.late_join_eligible : (bool?)null; }
+    }
+    private bool ShouldSerializelate_join_eligible() { return late_join_eligibleSpecified; }
+    private void Resetlate_join_eligible() { late_join_eligibleSpecified = false; }
+    
 
-    private uint _fixed_match_size = default(uint);
+    private uint? _fixed_match_size;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"fixed_match_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint fixed_match_size
     {
-      get { return _fixed_match_size; }
+      get { return _fixed_match_size?? default(uint); }
       set { _fixed_match_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fixed_match_sizeSpecified
+    {
+      get { return _fixed_match_size != null; }
+      set { if (value == (_fixed_match_size== null)) _fixed_match_size = value ? this.fixed_match_size : (uint?)null; }
+    }
+    private bool ShouldSerializefixed_match_size() { return fixed_match_sizeSpecified; }
+    private void Resetfixed_match_size() { fixed_match_sizeSpecified = false; }
+    
 
-    private CSOTFGameServerLobby.WarMatch _is_war_match = CSOTFGameServerLobby.WarMatch.NOPE;
+    private CSOTFGameServerLobby.WarMatch? _is_war_match;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"is_war_match", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CSOTFGameServerLobby.WarMatch.NOPE)]
     public CSOTFGameServerLobby.WarMatch is_war_match
     {
-      get { return _is_war_match; }
+      get { return _is_war_match?? CSOTFGameServerLobby.WarMatch.NOPE; }
       set { _is_war_match = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_war_matchSpecified
+    {
+      get { return _is_war_match != null; }
+      set { if (value == (_is_war_match== null)) _is_war_match = value ? this.is_war_match : (CSOTFGameServerLobby.WarMatch?)null; }
+    }
+    private bool ShouldSerializeis_war_match() { return is_war_matchSpecified; }
+    private void Resetis_war_match() { is_war_matchSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _next_maps_for_vote = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(47, Name=@"next_maps_for_vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> next_maps_for_vote
@@ -2801,32 +4558,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgExitMatchmaking() {}
     
 
-    private bool _explicit_abandon = default(bool);
+    private bool? _explicit_abandon;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"explicit_abandon", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool explicit_abandon
     {
-      get { return _explicit_abandon; }
+      get { return _explicit_abandon?? default(bool); }
       set { _explicit_abandon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool explicit_abandonSpecified
+    {
+      get { return _explicit_abandon != null; }
+      set { if (value == (_explicit_abandon== null)) _explicit_abandon = value ? this.explicit_abandon : (bool?)null; }
+    }
+    private bool ShouldSerializeexplicit_abandon() { return explicit_abandonSpecified; }
+    private void Resetexplicit_abandon() { explicit_abandonSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2838,32 +4622,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAcceptInvite() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private ulong _steamid_lobby = default(ulong);
+    private ulong? _steamid_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_lobby
     {
-      get { return _steamid_lobby; }
+      get { return _steamid_lobby?? default(ulong); }
       set { _steamid_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_lobbySpecified
+    {
+      get { return _steamid_lobby != null; }
+      set { if (value == (_steamid_lobby== null)) _steamid_lobby = value ? this.steamid_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_lobby() { return steamid_lobbySpecified; }
+    private void Resetsteamid_lobby() { steamid_lobbySpecified = false; }
+    
 
-    private uint _client_version = (uint)1225;
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1225)]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? (uint)1225; }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2875,14 +4686,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAcceptInviteResponse() {}
     
 
-    private int _result_code = default(int);
+    private int? _result_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result_code
     {
-      get { return _result_code; }
+      get { return _result_code?? default(int); }
       set { _result_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool result_codeSpecified
+    {
+      get { return _result_code != null; }
+      set { if (value == (_result_code== null)) _result_code = value ? this.result_code : (int?)null; }
+    }
+    private bool ShouldSerializeresult_code() { return result_codeSpecified; }
+    private void Resetresult_code() { result_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2894,14 +4714,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgReadyUp() {}
     
 
-    private TFLobbyReadyState _state = TFLobbyReadyState.TFLobbyReadyState_UNDECLARED;
+    private TFLobbyReadyState? _state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TFLobbyReadyState.TFLobbyReadyState_UNDECLARED)]
     public TFLobbyReadyState state
     {
-      get { return _state; }
+      get { return _state?? TFLobbyReadyState.TFLobbyReadyState_UNDECLARED; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (TFLobbyReadyState?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2950,41 +4779,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFJoinChatChannel() {}
     
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private ChatChannelType_t _channel_type = ChatChannelType_t.ChatChannelType_Regional;
+    private ChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ChatChannelType_t.ChatChannelType_Regional)]
     public ChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? ChatChannelType_t.ChatChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (ChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2996,14 +4861,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFLeaveChatChannel() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3015,41 +4889,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFJoinChatChannelResponse() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private uint _max_members = default(uint);
+    private uint? _max_members;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(uint); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (uint?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgTFJoinChatChannelResponse.ChatMember> _members = new global::System.Collections.Generic.List<CMsgTFJoinChatChannelResponse.ChatMember>();
     [global::ProtoBuf.ProtoMember(5, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgTFJoinChatChannelResponse.ChatMember> members
@@ -3063,23 +4973,41 @@ namespace SteamKit2.GC.TF2.Internal
     public ChatMember() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3096,32 +5024,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFOtherJoinedChatChannel() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3133,23 +5088,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFOtherLeftChatChannel() {}
     
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3171,23 +5144,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFRequestDefaultChatChannelResponse() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private ulong _channel_id = default(ulong);
+    private ulong? _channel_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"channel_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong channel_id
     {
-      get { return _channel_id; }
+      get { return _channel_id?? default(ulong); }
       set { _channel_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_idSpecified
+    {
+      get { return _channel_id != null; }
+      set { if (value == (_channel_id== null)) _channel_id = value ? this.channel_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechannel_id() { return channel_idSpecified; }
+    private void Resetchannel_id() { channel_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3221,32 +5212,59 @@ namespace SteamKit2.GC.TF2.Internal
     public ChatChannel() {}
     
 
-    private string _channel_name = "";
+    private string _channel_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"channel_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string channel_name
     {
-      get { return _channel_name; }
+      get { return _channel_name?? ""; }
       set { _channel_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_nameSpecified
+    {
+      get { return _channel_name != null; }
+      set { if (value == (_channel_name== null)) _channel_name = value ? this.channel_name : (string)null; }
+    }
+    private bool ShouldSerializechannel_name() { return channel_nameSpecified; }
+    private void Resetchannel_name() { channel_nameSpecified = false; }
+    
 
-    private uint _num_members = default(uint);
+    private uint? _num_members;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_members
     {
-      get { return _num_members; }
+      get { return _num_members?? default(uint); }
       set { _num_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_membersSpecified
+    {
+      get { return _num_members != null; }
+      set { if (value == (_num_members== null)) _num_members = value ? this.num_members : (uint?)null; }
+    }
+    private bool ShouldSerializenum_members() { return num_membersSpecified; }
+    private void Resetnum_members() { num_membersSpecified = false; }
+    
 
-    private ChatChannelType_t _channel_type = ChatChannelType_t.ChatChannelType_Regional;
+    private ChatChannelType_t? _channel_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"channel_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ChatChannelType_t.ChatChannelType_Regional)]
     public ChatChannelType_t channel_type
     {
-      get { return _channel_type; }
+      get { return _channel_type?? ChatChannelType_t.ChatChannelType_Regional; }
       set { _channel_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool channel_typeSpecified
+    {
+      get { return _channel_type != null; }
+      set { if (value == (_channel_type== null)) _channel_type = value ? this.channel_type : (ChatChannelType_t?)null; }
+    }
+    private bool ShouldSerializechannel_type() { return channel_typeSpecified; }
+    private void Resetchannel_type() { channel_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3263,131 +5281,257 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGameServerMatchmakingStatus() {}
     
 
-    private uint _server_version = (uint)1225;
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1225)]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? (uint)1225; }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
-    private ServerMatchmakingState _matchmaking_state = ServerMatchmakingState.ServerMatchmakingState_INVALID;
+    private ServerMatchmakingState? _matchmaking_state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"matchmaking_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(ServerMatchmakingState.ServerMatchmakingState_INVALID)]
     public ServerMatchmakingState matchmaking_state
     {
-      get { return _matchmaking_state; }
+      get { return _matchmaking_state?? ServerMatchmakingState.ServerMatchmakingState_INVALID; }
       set { _matchmaking_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_stateSpecified
+    {
+      get { return _matchmaking_state != null; }
+      set { if (value == (_matchmaking_state== null)) _matchmaking_state = value ? this.matchmaking_state : (ServerMatchmakingState?)null; }
+    }
+    private bool ShouldSerializematchmaking_state() { return matchmaking_stateSpecified; }
+    private void Resetmatchmaking_state() { matchmaking_stateSpecified = false; }
+    
 
-    private TF_MatchmakingMode _matchmaking_mode = TF_MatchmakingMode.TF_Matchmaking_INVALID;
+    private TF_MatchmakingMode? _matchmaking_mode;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matchmaking_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_MatchmakingMode.TF_Matchmaking_INVALID)]
     public TF_MatchmakingMode matchmaking_mode
     {
-      get { return _matchmaking_mode; }
+      get { return _matchmaking_mode?? TF_MatchmakingMode.TF_Matchmaking_INVALID; }
       set { _matchmaking_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_modeSpecified
+    {
+      get { return _matchmaking_mode != null; }
+      set { if (value == (_matchmaking_mode== null)) _matchmaking_mode = value ? this.matchmaking_mode : (TF_MatchmakingMode?)null; }
+    }
+    private bool ShouldSerializematchmaking_mode() { return matchmaking_modeSpecified; }
+    private void Resetmatchmaking_mode() { matchmaking_modeSpecified = false; }
+    
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private string _tags = "";
+    private string _tags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tags
     {
-      get { return _tags; }
+      get { return _tags?? ""; }
       set { _tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagsSpecified
+    {
+      get { return _tags != null; }
+      set { if (value == (_tags== null)) _tags = value ? this.tags : (string)null; }
+    }
+    private bool ShouldSerializetags() { return tagsSpecified; }
+    private void Resettags() { tagsSpecified = false; }
+    
 
-    private uint _bot_count = default(uint);
+    private uint? _bot_count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"bot_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bot_count
     {
-      get { return _bot_count; }
+      get { return _bot_count?? default(uint); }
       set { _bot_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_countSpecified
+    {
+      get { return _bot_count != null; }
+      set { if (value == (_bot_count== null)) _bot_count = value ? this.bot_count : (uint?)null; }
+    }
+    private bool ShouldSerializebot_count() { return bot_countSpecified; }
+    private void Resetbot_count() { bot_countSpecified = false; }
+    
 
-    private uint _num_spectators = default(uint);
+    private uint? _num_spectators;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_spectators
     {
-      get { return _num_spectators; }
+      get { return _num_spectators?? default(uint); }
       set { _num_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_spectatorsSpecified
+    {
+      get { return _num_spectators != null; }
+      set { if (value == (_num_spectators== null)) _num_spectators = value ? this.num_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializenum_spectators() { return num_spectatorsSpecified; }
+    private void Resetnum_spectators() { num_spectatorsSpecified = false; }
+    
 
-    private uint _max_players = default(uint);
+    private uint? _max_players;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"max_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_players
     {
-      get { return _max_players; }
+      get { return _max_players?? default(uint); }
       set { _max_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_playersSpecified
+    {
+      get { return _max_players != null; }
+      set { if (value == (_max_players== null)) _max_players = value ? this.max_players : (uint?)null; }
+    }
+    private bool ShouldSerializemax_players() { return max_playersSpecified; }
+    private void Resetmax_players() { max_playersSpecified = false; }
+    
 
-    private uint _slots_free = default(uint);
+    private uint? _slots_free;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"slots_free", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slots_free
     {
-      get { return _slots_free; }
+      get { return _slots_free?? default(uint); }
       set { _slots_free = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slots_freeSpecified
+    {
+      get { return _slots_free != null; }
+      set { if (value == (_slots_free== null)) _slots_free = value ? this.slots_free : (uint?)null; }
+    }
+    private bool ShouldSerializeslots_free() { return slots_freeSpecified; }
+    private void Resetslots_free() { slots_freeSpecified = false; }
+    
 
-    private uint _server_region = default(uint);
+    private uint? _server_region;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"server_region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_region
     {
-      get { return _server_region; }
+      get { return _server_region?? default(uint); }
       set { _server_region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_regionSpecified
+    {
+      get { return _server_region != null; }
+      set { if (value == (_server_region== null)) _server_region = value ? this.server_region : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_region() { return server_regionSpecified; }
+    private void Resetserver_region() { server_regionSpecified = false; }
+    
 
-    private float _server_loadavg = default(float);
+    private float? _server_loadavg;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"server_loadavg", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float server_loadavg
     {
-      get { return _server_loadavg; }
+      get { return _server_loadavg?? default(float); }
       set { _server_loadavg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_loadavgSpecified
+    {
+      get { return _server_loadavg != null; }
+      set { if (value == (_server_loadavg== null)) _server_loadavg = value ? this.server_loadavg : (float?)null; }
+    }
+    private bool ShouldSerializeserver_loadavg() { return server_loadavgSpecified; }
+    private void Resetserver_loadavg() { server_loadavgSpecified = false; }
+    
 
-    private bool _server_trusted = default(bool);
+    private bool? _server_trusted;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"server_trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool server_trusted
     {
-      get { return _server_trusted; }
+      get { return _server_trusted?? default(bool); }
       set { _server_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_trustedSpecified
+    {
+      get { return _server_trusted != null; }
+      set { if (value == (_server_trusted== null)) _server_trusted = value ? this.server_trusted : (bool?)null; }
+    }
+    private bool ShouldSerializeserver_trusted() { return server_trustedSpecified; }
+    private void Resetserver_trusted() { server_trustedSpecified = false; }
+    
 
-    private bool _server_dedicated = default(bool);
+    private bool? _server_dedicated;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"server_dedicated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool server_dedicated
     {
-      get { return _server_dedicated; }
+      get { return _server_dedicated?? default(bool); }
       set { _server_dedicated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_dedicatedSpecified
+    {
+      get { return _server_dedicated != null; }
+      set { if (value == (_server_dedicated== null)) _server_dedicated = value ? this.server_dedicated : (bool?)null; }
+    }
+    private bool ShouldSerializeserver_dedicated() { return server_dedicatedSpecified; }
+    private void Resetserver_dedicated() { server_dedicatedSpecified = false; }
+    
 
-    private uint _strict = default(uint);
+    private uint? _strict;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"strict", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strict
     {
-      get { return _strict; }
+      get { return _strict?? default(uint); }
       set { _strict = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strictSpecified
+    {
+      get { return _strict != null; }
+      set { if (value == (_strict== null)) _strict = value ? this.strict : (uint?)null; }
+    }
+    private bool ShouldSerializestrict() { return strictSpecified; }
+    private void Resetstrict() { strictSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGameServerMatchmakingStatus.Player> _players = new global::System.Collections.Generic.List<CMsgGameServerMatchmakingStatus.Player>();
     [global::ProtoBuf.ProtoMember(13, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGameServerMatchmakingStatus.Player> players
@@ -3396,82 +5540,154 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private TF_GC_GameState _game_state = TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT;
+    private TF_GC_GameState? _game_state;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"game_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT)]
     public TF_GC_GameState game_state
     {
-      get { return _game_state; }
+      get { return _game_state?? TF_GC_GameState.TF_GC_GAMESTATE_STATE_INIT; }
       set { _game_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_stateSpecified
+    {
+      get { return _game_state != null; }
+      set { if (value == (_game_state== null)) _game_state = value ? this.game_state : (TF_GC_GameState?)null; }
+    }
+    private bool ShouldSerializegame_state() { return game_stateSpecified; }
+    private void Resetgame_state() { game_stateSpecified = false; }
+    
 
-    private CMsgGameServerMatchmakingStatus.Event _event = CMsgGameServerMatchmakingStatus.Event.None;
+    private CMsgGameServerMatchmakingStatus.Event? _event;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"event", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerMatchmakingStatus.Event.None)]
     public CMsgGameServerMatchmakingStatus.Event @event
     {
-      get { return _event; }
+      get { return _event?? CMsgGameServerMatchmakingStatus.Event.None; }
       set { _event = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eventSpecified
+    {
+      get { return _event != null; }
+      set { if (value == (_event== null)) _event = value ? this.@event : (CMsgGameServerMatchmakingStatus.Event?)null; }
+    }
+    private bool ShouldSerializeevent() { return eventSpecified; }
+    private void Resetevent() { eventSpecified = false; }
+    
 
-    private uint _mvm_wave = default(uint);
+    private uint? _mvm_wave;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"mvm_wave", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mvm_wave
     {
-      get { return _mvm_wave; }
+      get { return _mvm_wave?? default(uint); }
       set { _mvm_wave = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mvm_waveSpecified
+    {
+      get { return _mvm_wave != null; }
+      set { if (value == (_mvm_wave== null)) _mvm_wave = value ? this.mvm_wave : (uint?)null; }
+    }
+    private bool ShouldSerializemvm_wave() { return mvm_waveSpecified; }
+    private void Resetmvm_wave() { mvm_waveSpecified = false; }
+    
 
-    private uint _mvm_credits_acquired = default(uint);
+    private uint? _mvm_credits_acquired;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"mvm_credits_acquired", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mvm_credits_acquired
     {
-      get { return _mvm_credits_acquired; }
+      get { return _mvm_credits_acquired?? default(uint); }
       set { _mvm_credits_acquired = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mvm_credits_acquiredSpecified
+    {
+      get { return _mvm_credits_acquired != null; }
+      set { if (value == (_mvm_credits_acquired== null)) _mvm_credits_acquired = value ? this.mvm_credits_acquired : (uint?)null; }
+    }
+    private bool ShouldSerializemvm_credits_acquired() { return mvm_credits_acquiredSpecified; }
+    private void Resetmvm_credits_acquired() { mvm_credits_acquiredSpecified = false; }
+    
 
-    private uint _mvm_credits_dropped = default(uint);
+    private uint? _mvm_credits_dropped;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"mvm_credits_dropped", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mvm_credits_dropped
     {
-      get { return _mvm_credits_dropped; }
+      get { return _mvm_credits_dropped?? default(uint); }
       set { _mvm_credits_dropped = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mvm_credits_droppedSpecified
+    {
+      get { return _mvm_credits_dropped != null; }
+      set { if (value == (_mvm_credits_dropped== null)) _mvm_credits_dropped = value ? this.mvm_credits_dropped : (uint?)null; }
+    }
+    private bool ShouldSerializemvm_credits_dropped() { return mvm_credits_droppedSpecified; }
+    private void Resetmvm_credits_dropped() { mvm_credits_droppedSpecified = false; }
+    
 
-    private int _match_group = (int)-1;
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.ZigZag)]
-    [global::System.ComponentModel.DefaultValue((int)-1)]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? (int)-1; }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private CMsgGameServerMatchmakingStatus.PlayerConnectState _connect_state = CMsgGameServerMatchmakingStatus.PlayerConnectState.INVALID;
+    private CMsgGameServerMatchmakingStatus.PlayerConnectState? _connect_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"connect_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGameServerMatchmakingStatus.PlayerConnectState.INVALID)]
     public CMsgGameServerMatchmakingStatus.PlayerConnectState connect_state
     {
-      get { return _connect_state; }
+      get { return _connect_state?? CMsgGameServerMatchmakingStatus.PlayerConnectState.INVALID; }
       set { _connect_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_stateSpecified
+    {
+      get { return _connect_state != null; }
+      set { if (value == (_connect_state== null)) _connect_state = value ? this.connect_state : (CMsgGameServerMatchmakingStatus.PlayerConnectState?)null; }
+    }
+    private bool ShouldSerializeconnect_state() { return connect_stateSpecified; }
+    private void Resetconnect_state() { connect_stateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3519,149 +5735,293 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgMatchmakingProgress() {}
     
 
-    private uint _avg_wait_time_new = default(uint);
+    private uint? _avg_wait_time_new;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"avg_wait_time_new", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_wait_time_new
     {
-      get { return _avg_wait_time_new; }
+      get { return _avg_wait_time_new?? default(uint); }
       set { _avg_wait_time_new = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_wait_time_newSpecified
+    {
+      get { return _avg_wait_time_new != null; }
+      set { if (value == (_avg_wait_time_new== null)) _avg_wait_time_new = value ? this.avg_wait_time_new : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_wait_time_new() { return avg_wait_time_newSpecified; }
+    private void Resetavg_wait_time_new() { avg_wait_time_newSpecified = false; }
+    
 
-    private uint _avg_wait_time_join_late = default(uint);
+    private uint? _avg_wait_time_join_late;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"avg_wait_time_join_late", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_wait_time_join_late
     {
-      get { return _avg_wait_time_join_late; }
+      get { return _avg_wait_time_join_late?? default(uint); }
       set { _avg_wait_time_join_late = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_wait_time_join_lateSpecified
+    {
+      get { return _avg_wait_time_join_late != null; }
+      set { if (value == (_avg_wait_time_join_late== null)) _avg_wait_time_join_late = value ? this.avg_wait_time_join_late : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_wait_time_join_late() { return avg_wait_time_join_lateSpecified; }
+    private void Resetavg_wait_time_join_late() { avg_wait_time_join_lateSpecified = false; }
+    
 
-    private uint _your_wait_time = default(uint);
+    private uint? _your_wait_time;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"your_wait_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint your_wait_time
     {
-      get { return _your_wait_time; }
+      get { return _your_wait_time?? default(uint); }
       set { _your_wait_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool your_wait_timeSpecified
+    {
+      get { return _your_wait_time != null; }
+      set { if (value == (_your_wait_time== null)) _your_wait_time = value ? this.your_wait_time : (uint?)null; }
+    }
+    private bool ShouldSerializeyour_wait_time() { return your_wait_timeSpecified; }
+    private void Resetyour_wait_time() { your_wait_timeSpecified = false; }
+    
 
-    private uint _matching_worldwide_searching_players = default(uint);
+    private uint? _matching_worldwide_searching_players;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"matching_worldwide_searching_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_worldwide_searching_players
     {
-      get { return _matching_worldwide_searching_players; }
+      get { return _matching_worldwide_searching_players?? default(uint); }
       set { _matching_worldwide_searching_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_worldwide_searching_playersSpecified
+    {
+      get { return _matching_worldwide_searching_players != null; }
+      set { if (value == (_matching_worldwide_searching_players== null)) _matching_worldwide_searching_players = value ? this.matching_worldwide_searching_players : (uint?)null; }
+    }
+    private bool ShouldSerializematching_worldwide_searching_players() { return matching_worldwide_searching_playersSpecified; }
+    private void Resetmatching_worldwide_searching_players() { matching_worldwide_searching_playersSpecified = false; }
+    
 
-    private uint _matching_near_you_searching_players = default(uint);
+    private uint? _matching_near_you_searching_players;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"matching_near_you_searching_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_near_you_searching_players
     {
-      get { return _matching_near_you_searching_players; }
+      get { return _matching_near_you_searching_players?? default(uint); }
       set { _matching_near_you_searching_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_near_you_searching_playersSpecified
+    {
+      get { return _matching_near_you_searching_players != null; }
+      set { if (value == (_matching_near_you_searching_players== null)) _matching_near_you_searching_players = value ? this.matching_near_you_searching_players : (uint?)null; }
+    }
+    private bool ShouldSerializematching_near_you_searching_players() { return matching_near_you_searching_playersSpecified; }
+    private void Resetmatching_near_you_searching_players() { matching_near_you_searching_playersSpecified = false; }
+    
 
-    private uint _total_worldwide_searching_players = default(uint);
+    private uint? _total_worldwide_searching_players;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"total_worldwide_searching_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_worldwide_searching_players
     {
-      get { return _total_worldwide_searching_players; }
+      get { return _total_worldwide_searching_players?? default(uint); }
       set { _total_worldwide_searching_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_worldwide_searching_playersSpecified
+    {
+      get { return _total_worldwide_searching_players != null; }
+      set { if (value == (_total_worldwide_searching_players== null)) _total_worldwide_searching_players = value ? this.total_worldwide_searching_players : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_worldwide_searching_players() { return total_worldwide_searching_playersSpecified; }
+    private void Resettotal_worldwide_searching_players() { total_worldwide_searching_playersSpecified = false; }
+    
 
-    private uint _total_near_you_searching_players = default(uint);
+    private uint? _total_near_you_searching_players;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"total_near_you_searching_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_near_you_searching_players
     {
-      get { return _total_near_you_searching_players; }
+      get { return _total_near_you_searching_players?? default(uint); }
       set { _total_near_you_searching_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_near_you_searching_playersSpecified
+    {
+      get { return _total_near_you_searching_players != null; }
+      set { if (value == (_total_near_you_searching_players== null)) _total_near_you_searching_players = value ? this.total_near_you_searching_players : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_near_you_searching_players() { return total_near_you_searching_playersSpecified; }
+    private void Resettotal_near_you_searching_players() { total_near_you_searching_playersSpecified = false; }
+    
 
-    private uint _matching_worldwide_active_players = default(uint);
+    private uint? _matching_worldwide_active_players;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"matching_worldwide_active_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_worldwide_active_players
     {
-      get { return _matching_worldwide_active_players; }
+      get { return _matching_worldwide_active_players?? default(uint); }
       set { _matching_worldwide_active_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_worldwide_active_playersSpecified
+    {
+      get { return _matching_worldwide_active_players != null; }
+      set { if (value == (_matching_worldwide_active_players== null)) _matching_worldwide_active_players = value ? this.matching_worldwide_active_players : (uint?)null; }
+    }
+    private bool ShouldSerializematching_worldwide_active_players() { return matching_worldwide_active_playersSpecified; }
+    private void Resetmatching_worldwide_active_players() { matching_worldwide_active_playersSpecified = false; }
+    
 
-    private uint _matching_near_you_active_players = default(uint);
+    private uint? _matching_near_you_active_players;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"matching_near_you_active_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_near_you_active_players
     {
-      get { return _matching_near_you_active_players; }
+      get { return _matching_near_you_active_players?? default(uint); }
       set { _matching_near_you_active_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_near_you_active_playersSpecified
+    {
+      get { return _matching_near_you_active_players != null; }
+      set { if (value == (_matching_near_you_active_players== null)) _matching_near_you_active_players = value ? this.matching_near_you_active_players : (uint?)null; }
+    }
+    private bool ShouldSerializematching_near_you_active_players() { return matching_near_you_active_playersSpecified; }
+    private void Resetmatching_near_you_active_players() { matching_near_you_active_playersSpecified = false; }
+    
 
-    private uint _total_worldwide_active_players = default(uint);
+    private uint? _total_worldwide_active_players;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"total_worldwide_active_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_worldwide_active_players
     {
-      get { return _total_worldwide_active_players; }
+      get { return _total_worldwide_active_players?? default(uint); }
       set { _total_worldwide_active_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_worldwide_active_playersSpecified
+    {
+      get { return _total_worldwide_active_players != null; }
+      set { if (value == (_total_worldwide_active_players== null)) _total_worldwide_active_players = value ? this.total_worldwide_active_players : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_worldwide_active_players() { return total_worldwide_active_playersSpecified; }
+    private void Resettotal_worldwide_active_players() { total_worldwide_active_playersSpecified = false; }
+    
 
-    private uint _total_near_you_active_players = default(uint);
+    private uint? _total_near_you_active_players;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"total_near_you_active_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_near_you_active_players
     {
-      get { return _total_near_you_active_players; }
+      get { return _total_near_you_active_players?? default(uint); }
       set { _total_near_you_active_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_near_you_active_playersSpecified
+    {
+      get { return _total_near_you_active_players != null; }
+      set { if (value == (_total_near_you_active_players== null)) _total_near_you_active_players = value ? this.total_near_you_active_players : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_near_you_active_players() { return total_near_you_active_playersSpecified; }
+    private void Resettotal_near_you_active_players() { total_near_you_active_playersSpecified = false; }
+    
 
-    private uint _matching_worldwide_empty_gameservers = default(uint);
+    private uint? _matching_worldwide_empty_gameservers;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"matching_worldwide_empty_gameservers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_worldwide_empty_gameservers
     {
-      get { return _matching_worldwide_empty_gameservers; }
+      get { return _matching_worldwide_empty_gameservers?? default(uint); }
       set { _matching_worldwide_empty_gameservers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_worldwide_empty_gameserversSpecified
+    {
+      get { return _matching_worldwide_empty_gameservers != null; }
+      set { if (value == (_matching_worldwide_empty_gameservers== null)) _matching_worldwide_empty_gameservers = value ? this.matching_worldwide_empty_gameservers : (uint?)null; }
+    }
+    private bool ShouldSerializematching_worldwide_empty_gameservers() { return matching_worldwide_empty_gameserversSpecified; }
+    private void Resetmatching_worldwide_empty_gameservers() { matching_worldwide_empty_gameserversSpecified = false; }
+    
 
-    private uint _matching_near_you_empty_gameservers = default(uint);
+    private uint? _matching_near_you_empty_gameservers;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"matching_near_you_empty_gameservers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_near_you_empty_gameservers
     {
-      get { return _matching_near_you_empty_gameservers; }
+      get { return _matching_near_you_empty_gameservers?? default(uint); }
       set { _matching_near_you_empty_gameservers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_near_you_empty_gameserversSpecified
+    {
+      get { return _matching_near_you_empty_gameservers != null; }
+      set { if (value == (_matching_near_you_empty_gameservers== null)) _matching_near_you_empty_gameservers = value ? this.matching_near_you_empty_gameservers : (uint?)null; }
+    }
+    private bool ShouldSerializematching_near_you_empty_gameservers() { return matching_near_you_empty_gameserversSpecified; }
+    private void Resetmatching_near_you_empty_gameservers() { matching_near_you_empty_gameserversSpecified = false; }
+    
 
-    private uint _total_worldwide_empty_gameservers = default(uint);
+    private uint? _total_worldwide_empty_gameservers;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"total_worldwide_empty_gameservers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_worldwide_empty_gameservers
     {
-      get { return _total_worldwide_empty_gameservers; }
+      get { return _total_worldwide_empty_gameservers?? default(uint); }
       set { _total_worldwide_empty_gameservers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_worldwide_empty_gameserversSpecified
+    {
+      get { return _total_worldwide_empty_gameservers != null; }
+      set { if (value == (_total_worldwide_empty_gameservers== null)) _total_worldwide_empty_gameservers = value ? this.total_worldwide_empty_gameservers : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_worldwide_empty_gameservers() { return total_worldwide_empty_gameserversSpecified; }
+    private void Resettotal_worldwide_empty_gameservers() { total_worldwide_empty_gameserversSpecified = false; }
+    
 
-    private uint _total_near_you_empty_gameservers = default(uint);
+    private uint? _total_near_you_empty_gameservers;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"total_near_you_empty_gameservers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_near_you_empty_gameservers
     {
-      get { return _total_near_you_empty_gameservers; }
+      get { return _total_near_you_empty_gameservers?? default(uint); }
       set { _total_near_you_empty_gameservers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_near_you_empty_gameserversSpecified
+    {
+      get { return _total_near_you_empty_gameservers != null; }
+      set { if (value == (_total_near_you_empty_gameservers== null)) _total_near_you_empty_gameservers = value ? this.total_near_you_empty_gameservers : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_near_you_empty_gameservers() { return total_near_you_empty_gameserversSpecified; }
+    private void Resettotal_near_you_empty_gameservers() { total_near_you_empty_gameserversSpecified = false; }
+    
 
-    private uint _urgency_pct = default(uint);
+    private uint? _urgency_pct;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"urgency_pct", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint urgency_pct
     {
-      get { return _urgency_pct; }
+      get { return _urgency_pct?? default(uint); }
       set { _urgency_pct = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urgency_pctSpecified
+    {
+      get { return _urgency_pct != null; }
+      set { if (value == (_urgency_pct== null)) _urgency_pct = value ? this.urgency_pct : (uint?)null; }
+    }
+    private bool ShouldSerializeurgency_pct() { return urgency_pctSpecified; }
+    private void Reseturgency_pct() { urgency_pctSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3680,55 +6040,100 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private string _tour_name = "";
+    private string _tour_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tour_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tour_name
     {
-      get { return _tour_name; }
+      get { return _tour_name?? ""; }
       set { _tour_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tour_nameSpecified
+    {
+      get { return _tour_name != null; }
+      set { if (value == (_tour_name== null)) _tour_name = value ? this.tour_name : (string)null; }
+    }
+    private bool ShouldSerializetour_name() { return tour_nameSpecified; }
+    private void Resettour_name() { tour_nameSpecified = false; }
+    
 
-    private string _mission_name = "";
+    private string _mission_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"mission_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mission_name
     {
-      get { return _mission_name; }
+      get { return _mission_name?? ""; }
       set { _mission_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mission_nameSpecified
+    {
+      get { return _mission_name != null; }
+      set { if (value == (_mission_name== null)) _mission_name = value ? this.mission_name : (string)null; }
+    }
+    private bool ShouldSerializemission_name() { return mission_nameSpecified; }
+    private void Resetmission_name() { mission_nameSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Item")]
   public partial class Item : global::ProtoBuf.IExtensible
   {
     public Item() {}
     
 
-    private CMsgMvMVictoryInfo.GrantReason _grant_reason = CMsgMvMVictoryInfo.GrantReason.INVALID;
+    private CMsgMvMVictoryInfo.GrantReason? _grant_reason;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"grant_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgMvMVictoryInfo.GrantReason.INVALID)]
     public CMsgMvMVictoryInfo.GrantReason grant_reason
     {
-      get { return _grant_reason; }
+      get { return _grant_reason?? CMsgMvMVictoryInfo.GrantReason.INVALID; }
       set { _grant_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool grant_reasonSpecified
+    {
+      get { return _grant_reason != null; }
+      set { if (value == (_grant_reason== null)) _grant_reason = value ? this.grant_reason : (CMsgMvMVictoryInfo.GrantReason?)null; }
+    }
+    private bool ShouldSerializegrant_reason() { return grant_reasonSpecified; }
+    private void Resetgrant_reason() { grant_reasonSpecified = false; }
+    
 
-    private byte[] _item_data = null;
+    private byte[] _item_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] item_data
     {
-      get { return _item_data; }
+      get { return _item_data?? null; }
       set { _item_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_dataSpecified
+    {
+      get { return _item_data != null; }
+      set { if (value == (_item_data== null)) _item_data = value ? this.item_data : (byte[])null; }
+    }
+    private bool ShouldSerializeitem_data() { return item_dataSpecified; }
+    private void Resetitem_data() { item_dataSpecified = false; }
+    
 
-    private ulong _squad_surplus_claimer_steam_id = default(ulong);
+    private ulong? _squad_surplus_claimer_steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"squad_surplus_claimer_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong squad_surplus_claimer_steam_id
     {
-      get { return _squad_surplus_claimer_steam_id; }
+      get { return _squad_surplus_claimer_steam_id?? default(ulong); }
       set { _squad_surplus_claimer_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool squad_surplus_claimer_steam_idSpecified
+    {
+      get { return _squad_surplus_claimer_steam_id != null; }
+      set { if (value == (_squad_surplus_claimer_steam_id== null)) _squad_surplus_claimer_steam_id = value ? this.squad_surplus_claimer_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesquad_surplus_claimer_steam_id() { return squad_surplus_claimer_steam_idSpecified; }
+    private void Resetsquad_surplus_claimer_steam_id() { squad_surplus_claimer_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3740,59 +6145,113 @@ namespace SteamKit2.GC.TF2.Internal
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private bool _badge_granted = default(bool);
+    private bool? _badge_granted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"badge_granted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool badge_granted
     {
-      get { return _badge_granted; }
+      get { return _badge_granted?? default(bool); }
       set { _badge_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_grantedSpecified
+    {
+      get { return _badge_granted != null; }
+      set { if (value == (_badge_granted== null)) _badge_granted = value ? this.badge_granted : (bool?)null; }
+    }
+    private bool ShouldSerializebadge_granted() { return badge_grantedSpecified; }
+    private void Resetbadge_granted() { badge_grantedSpecified = false; }
+    
 
-    private bool _badge_progress_updated = default(bool);
+    private bool? _badge_progress_updated;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"badge_progress_updated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool badge_progress_updated
     {
-      get { return _badge_progress_updated; }
+      get { return _badge_progress_updated?? default(bool); }
       set { _badge_progress_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_progress_updatedSpecified
+    {
+      get { return _badge_progress_updated != null; }
+      set { if (value == (_badge_progress_updated== null)) _badge_progress_updated = value ? this.badge_progress_updated : (bool?)null; }
+    }
+    private bool ShouldSerializebadge_progress_updated() { return badge_progress_updatedSpecified; }
+    private void Resetbadge_progress_updated() { badge_progress_updatedSpecified = false; }
+    
 
-    private bool _badge_leveled = default(bool);
+    private bool? _badge_leveled;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"badge_leveled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool badge_leveled
     {
-      get { return _badge_leveled; }
+      get { return _badge_leveled?? default(bool); }
       set { _badge_leveled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_leveledSpecified
+    {
+      get { return _badge_leveled != null; }
+      set { if (value == (_badge_leveled== null)) _badge_leveled = value ? this.badge_leveled : (bool?)null; }
+    }
+    private bool ShouldSerializebadge_leveled() { return badge_leveledSpecified; }
+    private void Resetbadge_leveled() { badge_leveledSpecified = false; }
+    
 
-    private uint _badge_level = default(uint);
+    private uint? _badge_level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"badge_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_level
     {
-      get { return _badge_level; }
+      get { return _badge_level?? default(uint); }
       set { _badge_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_levelSpecified
+    {
+      get { return _badge_level != null; }
+      set { if (value == (_badge_level== null)) _badge_level = value ? this.badge_level : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_level() { return badge_levelSpecified; }
+    private void Resetbadge_level() { badge_levelSpecified = false; }
+    
 
-    private uint _badge_progress_bits = default(uint);
+    private uint? _badge_progress_bits;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"badge_progress_bits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_progress_bits
     {
-      get { return _badge_progress_bits; }
+      get { return _badge_progress_bits?? default(uint); }
       set { _badge_progress_bits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_progress_bitsSpecified
+    {
+      get { return _badge_progress_bits != null; }
+      set { if (value == (_badge_progress_bits== null)) _badge_progress_bits = value ? this.badge_progress_bits : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_progress_bits() { return badge_progress_bitsSpecified; }
+    private void Resetbadge_progress_bits() { badge_progress_bitsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgMvMVictoryInfo.Item> _items = new global::System.Collections.Generic.List<CMsgMvMVictoryInfo.Item>();
     [global::ProtoBuf.ProtoMember(8, Name=@"items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgMvMVictoryInfo.Item> items
@@ -3801,23 +6260,41 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _voucher_missing = default(bool);
+    private bool? _voucher_missing;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"voucher_missing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool voucher_missing
     {
-      get { return _voucher_missing; }
+      get { return _voucher_missing?? default(bool); }
       set { _voucher_missing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voucher_missingSpecified
+    {
+      get { return _voucher_missing != null; }
+      set { if (value == (_voucher_missing== null)) _voucher_missing = value ? this.voucher_missing : (bool?)null; }
+    }
+    private bool ShouldSerializevoucher_missing() { return voucher_missingSpecified; }
+    private void Resetvoucher_missing() { voucher_missingSpecified = false; }
+    
 
-    private uint _badge_points = default(uint);
+    private uint? _badge_points;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"badge_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint badge_points
     {
-      get { return _badge_points; }
+      get { return _badge_points?? default(uint); }
       set { _badge_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool badge_pointsSpecified
+    {
+      get { return _badge_points != null; }
+      set { if (value == (_badge_points== null)) _badge_points = value ? this.badge_points : (uint?)null; }
+    }
+    private bool ShouldSerializebadge_points() { return badge_pointsSpecified; }
+    private void Resetbadge_points() { badge_pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3854,14 +6331,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgTFHelloResponse() {}
     
 
-    private uint _version_check = default(uint);
+    private uint? _version_check;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version_check", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_check
     {
-      get { return _version_check; }
+      get { return _version_check?? default(uint); }
       set { _version_check = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checkSpecified
+    {
+      get { return _version_check != null; }
+      set { if (value == (_version_check== null)) _version_check = value ? this.version_check : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_check() { return version_checkSpecified; }
+    private void Resetversion_check() { version_checkSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _version_checksum = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"version_checksum", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> version_checksum
@@ -3870,14 +6356,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _version_verbose = default(uint);
+    private uint? _version_verbose;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version_verbose", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_verbose
     {
-      get { return _version_verbose; }
+      get { return _version_verbose?? default(uint); }
       set { _version_verbose = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_verboseSpecified
+    {
+      get { return _version_verbose != null; }
+      set { if (value == (_version_verbose== null)) _version_verbose = value ? this.version_verbose : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_verbose() { return version_verboseSpecified; }
+    private void Resetversion_verbose() { version_verboseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3889,50 +6384,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgTFSync() {}
     
 
-    private byte[] _version_checksum = null;
+    private byte[] _version_checksum;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version_checksum", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] version_checksum
     {
-      get { return _version_checksum; }
+      get { return _version_checksum?? null; }
       set { _version_checksum = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checksumSpecified
+    {
+      get { return _version_checksum != null; }
+      set { if (value == (_version_checksum== null)) _version_checksum = value ? this.version_checksum : (byte[])null; }
+    }
+    private bool ShouldSerializeversion_checksum() { return version_checksumSpecified; }
+    private void Resetversion_checksum() { version_checksumSpecified = false; }
+    
 
-    private uint _version_check = default(uint);
+    private uint? _version_check;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version_check", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_check
     {
-      get { return _version_check; }
+      get { return _version_check?? default(uint); }
       set { _version_check = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checkSpecified
+    {
+      get { return _version_check != null; }
+      set { if (value == (_version_check== null)) _version_check = value ? this.version_check : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_check() { return version_checkSpecified; }
+    private void Resetversion_check() { version_checkSpecified = false; }
+    
 
-    private uint _version_check_ex = default(uint);
+    private uint? _version_check_ex;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version_check_ex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_check_ex
     {
-      get { return _version_check_ex; }
+      get { return _version_check_ex?? default(uint); }
       set { _version_check_ex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_check_exSpecified
+    {
+      get { return _version_check_ex != null; }
+      set { if (value == (_version_check_ex== null)) _version_check_ex = value ? this.version_check_ex : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_check_ex() { return version_check_exSpecified; }
+    private void Resetversion_check_ex() { version_check_exSpecified = false; }
+    
 
-    private uint _version_check_ex2 = default(uint);
+    private uint? _version_check_ex2;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version_check_ex2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_check_ex2
     {
-      get { return _version_check_ex2; }
+      get { return _version_check_ex2?? default(uint); }
       set { _version_check_ex2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_check_ex2Specified
+    {
+      get { return _version_check_ex2 != null; }
+      set { if (value == (_version_check_ex2== null)) _version_check_ex2 = value ? this.version_check_ex2 : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_check_ex2() { return version_check_ex2Specified; }
+    private void Resetversion_check_ex2() { version_check_ex2Specified = false; }
+    
 
-    private byte[] _version_checksum_ex = null;
+    private byte[] _version_checksum_ex;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"version_checksum_ex", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] version_checksum_ex
     {
-      get { return _version_checksum_ex; }
+      get { return _version_checksum_ex?? null; }
       set { _version_checksum_ex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checksum_exSpecified
+    {
+      get { return _version_checksum_ex != null; }
+      set { if (value == (_version_checksum_ex== null)) _version_checksum_ex = value ? this.version_checksum_ex : (byte[])null; }
+    }
+    private bool ShouldSerializeversion_checksum_ex() { return version_checksum_exSpecified; }
+    private void Resetversion_checksum_ex() { version_checksum_exSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3944,32 +6484,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgTFSyncEx() {}
     
 
-    private string _version_checksum = "";
+    private string _version_checksum;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version_checksum", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string version_checksum
     {
-      get { return _version_checksum; }
+      get { return _version_checksum?? ""; }
       set { _version_checksum = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checksumSpecified
+    {
+      get { return _version_checksum != null; }
+      set { if (value == (_version_checksum== null)) _version_checksum = value ? this.version_checksum : (string)null; }
+    }
+    private bool ShouldSerializeversion_checksum() { return version_checksumSpecified; }
+    private void Resetversion_checksum() { version_checksumSpecified = false; }
+    
 
-    private byte[] _version_checksum_ex = null;
+    private byte[] _version_checksum_ex;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version_checksum_ex", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] version_checksum_ex
     {
-      get { return _version_checksum_ex; }
+      get { return _version_checksum_ex?? null; }
       set { _version_checksum_ex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checksum_exSpecified
+    {
+      get { return _version_checksum_ex != null; }
+      set { if (value == (_version_checksum_ex== null)) _version_checksum_ex = value ? this.version_checksum_ex : (byte[])null; }
+    }
+    private bool ShouldSerializeversion_checksum_ex() { return version_checksum_exSpecified; }
+    private void Resetversion_checksum_ex() { version_checksum_exSpecified = false; }
+    
 
-    private uint _version_check = default(uint);
+    private uint? _version_check;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version_check", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version_check
     {
-      get { return _version_check; }
+      get { return _version_check?? default(uint); }
       set { _version_check = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool version_checkSpecified
+    {
+      get { return _version_check != null; }
+      set { if (value == (_version_check== null)) _version_check = value ? this.version_check : (uint?)null; }
+    }
+    private bool ShouldSerializeversion_check() { return version_checkSpecified; }
+    private void Resetversion_check() { version_checkSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3981,32 +6548,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgMvMVictory() {}
     
 
-    private uint _legacy_mission_index = default(uint);
+    private uint? _legacy_mission_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"legacy_mission_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint legacy_mission_index
     {
-      get { return _legacy_mission_index; }
+      get { return _legacy_mission_index?? default(uint); }
       set { _legacy_mission_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool legacy_mission_indexSpecified
+    {
+      get { return _legacy_mission_index != null; }
+      set { if (value == (_legacy_mission_index== null)) _legacy_mission_index = value ? this.legacy_mission_index : (uint?)null; }
+    }
+    private bool ShouldSerializelegacy_mission_index() { return legacy_mission_indexSpecified; }
+    private void Resetlegacy_mission_index() { legacy_mission_indexSpecified = false; }
+    
 
-    private string _tour_name_mannup = "";
+    private string _tour_name_mannup;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tour_name_mannup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tour_name_mannup
     {
-      get { return _tour_name_mannup; }
+      get { return _tour_name_mannup?? ""; }
       set { _tour_name_mannup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tour_name_mannupSpecified
+    {
+      get { return _tour_name_mannup != null; }
+      set { if (value == (_tour_name_mannup== null)) _tour_name_mannup = value ? this.tour_name_mannup : (string)null; }
+    }
+    private bool ShouldSerializetour_name_mannup() { return tour_name_mannupSpecified; }
+    private void Resettour_name_mannup() { tour_name_mannupSpecified = false; }
+    
 
-    private string _mission_name = "";
+    private string _mission_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"mission_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mission_name
     {
-      get { return _mission_name; }
+      get { return _mission_name?? ""; }
       set { _mission_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mission_nameSpecified
+    {
+      get { return _mission_name != null; }
+      set { if (value == (_mission_name== null)) _mission_name = value ? this.mission_name : (string)null; }
+    }
+    private bool ShouldSerializemission_name() { return mission_nameSpecified; }
+    private void Resetmission_name() { mission_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgMvMVictory.Player> _players = new global::System.Collections.Generic.List<CMsgMvMVictory.Player>();
     [global::ProtoBuf.ProtoMember(2, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgMvMVictory.Player> players
@@ -4015,46 +6609,82 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private uint _event_time = default(uint);
+    private uint? _event_time;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_time
     {
-      get { return _event_time; }
+      get { return _event_time?? default(uint); }
       set { _event_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_timeSpecified
+    {
+      get { return _event_time != null; }
+      set { if (value == (_event_time== null)) _event_time = value ? this.event_time : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_time() { return event_timeSpecified; }
+    private void Resetevent_time() { event_timeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private bool _squad_surplus = default(bool);
+    private bool? _squad_surplus;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"squad_surplus", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool squad_surplus
     {
-      get { return _squad_surplus; }
+      get { return _squad_surplus?? default(bool); }
       set { _squad_surplus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool squad_surplusSpecified
+    {
+      get { return _squad_surplus != null; }
+      set { if (value == (_squad_surplus== null)) _squad_surplus = value ? this.squad_surplus : (bool?)null; }
+    }
+    private bool ShouldSerializesquad_surplus() { return squad_surplusSpecified; }
+    private void Resetsquad_surplus() { squad_surplusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4088,32 +6718,59 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _create_party = (bool)true;
+    private bool? _create_party;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"create_party", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool create_party
     {
-      get { return _create_party; }
+      get { return _create_party?? (bool)true; }
       set { _create_party = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool create_partySpecified
+    {
+      get { return _create_party != null; }
+      set { if (value == (_create_party== null)) _create_party = value ? this.create_party : (bool?)null; }
+    }
+    private bool ShouldSerializecreate_party() { return create_partySpecified; }
+    private void Resetcreate_party() { create_partySpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4135,14 +6792,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgLeaveGameAndPrepareToJoinParty() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4154,50 +6820,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgPlayerLeftMatch() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private TFMatchLeaveReason _leave_reason = TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED;
+    private TFMatchLeaveReason? _leave_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leave_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED)]
     public TFMatchLeaveReason leave_reason
     {
-      get { return _leave_reason; }
+      get { return _leave_reason?? TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED; }
       set { _leave_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leave_reasonSpecified
+    {
+      get { return _leave_reason != null; }
+      set { if (value == (_leave_reason== null)) _leave_reason = value ? this.leave_reason : (TFMatchLeaveReason?)null; }
+    }
+    private bool ShouldSerializeleave_reason() { return leave_reasonSpecified; }
+    private void Resetleave_reason() { leave_reasonSpecified = false; }
+    
 
-    private bool _was_abandon = default(bool);
+    private bool? _was_abandon;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"was_abandon", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_abandon
     {
-      get { return _was_abandon; }
+      get { return _was_abandon?? default(bool); }
       set { _was_abandon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_abandonSpecified
+    {
+      get { return _was_abandon != null; }
+      set { if (value == (_was_abandon== null)) _was_abandon = value ? this.was_abandon : (bool?)null; }
+    }
+    private bool ShouldSerializewas_abandon() { return was_abandonSpecified; }
+    private void Resetwas_abandon() { was_abandonSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgTFXPSource> _xp_breakdown = new global::System.Collections.Generic.List<CMsgTFXPSource>();
     [global::ProtoBuf.ProtoMember(6, Name=@"xp_breakdown", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgTFXPSource> xp_breakdown
@@ -4226,68 +6937,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgHalloween_ServerBossEvent() {}
     
 
-    private uint _event_counter = default(uint);
+    private uint? _event_counter;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_counter", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_counter
     {
-      get { return _event_counter; }
+      get { return _event_counter?? default(uint); }
       set { _event_counter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_counterSpecified
+    {
+      get { return _event_counter != null; }
+      set { if (value == (_event_counter== null)) _event_counter = value ? this.event_counter : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_counter() { return event_counterSpecified; }
+    private void Resetevent_counter() { event_counterSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _boss_type = default(uint);
+    private uint? _boss_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"boss_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint boss_type
     {
-      get { return _boss_type; }
+      get { return _boss_type?? default(uint); }
       set { _boss_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boss_typeSpecified
+    {
+      get { return _boss_type != null; }
+      set { if (value == (_boss_type== null)) _boss_type = value ? this.boss_type : (uint?)null; }
+    }
+    private bool ShouldSerializeboss_type() { return boss_typeSpecified; }
+    private void Resetboss_type() { boss_typeSpecified = false; }
+    
 
-    private uint _boss_level = default(uint);
+    private uint? _boss_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"boss_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint boss_level
     {
-      get { return _boss_level; }
+      get { return _boss_level?? default(uint); }
       set { _boss_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boss_levelSpecified
+    {
+      get { return _boss_level != null; }
+      set { if (value == (_boss_level== null)) _boss_level = value ? this.boss_level : (uint?)null; }
+    }
+    private bool ShouldSerializeboss_level() { return boss_levelSpecified; }
+    private void Resetboss_level() { boss_levelSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private uint _players_involved = default(uint);
+    private uint? _players_involved;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"players_involved", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint players_involved
     {
-      get { return _players_involved; }
+      get { return _players_involved?? default(uint); }
       set { _players_involved = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool players_involvedSpecified
+    {
+      get { return _players_involved != null; }
+      set { if (value == (_players_involved== null)) _players_involved = value ? this.players_involved : (uint?)null; }
+    }
+    private bool ShouldSerializeplayers_involved() { return players_involvedSpecified; }
+    private void Resetplayers_involved() { players_involvedSpecified = false; }
+    
 
-    private float _elapsed_time = default(float);
+    private float? _elapsed_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"elapsed_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float elapsed_time
     {
-      get { return _elapsed_time; }
+      get { return _elapsed_time?? default(float); }
       set { _elapsed_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool elapsed_timeSpecified
+    {
+      get { return _elapsed_time != null; }
+      set { if (value == (_elapsed_time== null)) _elapsed_time = value ? this.elapsed_time : (float?)null; }
+    }
+    private bool ShouldSerializeelapsed_time() { return elapsed_timeSpecified; }
+    private void Resetelapsed_time() { elapsed_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4299,275 +7073,545 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgHalloween_Merasmus2012() {}
     
 
-    private uint _event_counter = default(uint);
+    private uint? _event_counter;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_counter", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_counter
     {
-      get { return _event_counter; }
+      get { return _event_counter?? default(uint); }
       set { _event_counter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_counterSpecified
+    {
+      get { return _event_counter != null; }
+      set { if (value == (_event_counter== null)) _event_counter = value ? this.event_counter : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_counter() { return event_counterSpecified; }
+    private void Resetevent_counter() { event_counterSpecified = false; }
+    
 
-    private uint _time_submitted = default(uint);
+    private uint? _time_submitted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_submitted", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_submitted
     {
-      get { return _time_submitted; }
+      get { return _time_submitted?? default(uint); }
       set { _time_submitted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_submittedSpecified
+    {
+      get { return _time_submitted != null; }
+      set { if (value == (_time_submitted== null)) _time_submitted = value ? this.time_submitted : (uint?)null; }
+    }
+    private bool ShouldSerializetime_submitted() { return time_submittedSpecified; }
+    private void Resettime_submitted() { time_submittedSpecified = false; }
+    
 
-    private bool _is_valve_server = default(bool);
+    private bool? _is_valve_server;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_valve_server", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_valve_server
     {
-      get { return _is_valve_server; }
+      get { return _is_valve_server?? default(bool); }
       set { _is_valve_server = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_valve_serverSpecified
+    {
+      get { return _is_valve_server != null; }
+      set { if (value == (_is_valve_server== null)) _is_valve_server = value ? this.is_valve_server : (bool?)null; }
+    }
+    private bool ShouldSerializeis_valve_server() { return is_valve_serverSpecified; }
+    private void Resetis_valve_server() { is_valve_serverSpecified = false; }
+    
 
-    private uint _boss_level = default(uint);
+    private uint? _boss_level;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"boss_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint boss_level
     {
-      get { return _boss_level; }
+      get { return _boss_level?? default(uint); }
       set { _boss_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boss_levelSpecified
+    {
+      get { return _boss_level != null; }
+      set { if (value == (_boss_level== null)) _boss_level = value ? this.boss_level : (uint?)null; }
+    }
+    private bool ShouldSerializeboss_level() { return boss_levelSpecified; }
+    private void Resetboss_level() { boss_levelSpecified = false; }
+    
 
-    private uint _spawned_health = default(uint);
+    private uint? _spawned_health;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"spawned_health", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spawned_health
     {
-      get { return _spawned_health; }
+      get { return _spawned_health?? default(uint); }
       set { _spawned_health = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spawned_healthSpecified
+    {
+      get { return _spawned_health != null; }
+      set { if (value == (_spawned_health== null)) _spawned_health = value ? this.spawned_health : (uint?)null; }
+    }
+    private bool ShouldSerializespawned_health() { return spawned_healthSpecified; }
+    private void Resetspawned_health() { spawned_healthSpecified = false; }
+    
 
-    private uint _remaining_health = default(uint);
+    private uint? _remaining_health;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"remaining_health", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint remaining_health
     {
-      get { return _remaining_health; }
+      get { return _remaining_health?? default(uint); }
       set { _remaining_health = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool remaining_healthSpecified
+    {
+      get { return _remaining_health != null; }
+      set { if (value == (_remaining_health== null)) _remaining_health = value ? this.remaining_health : (uint?)null; }
+    }
+    private bool ShouldSerializeremaining_health() { return remaining_healthSpecified; }
+    private void Resetremaining_health() { remaining_healthSpecified = false; }
+    
 
-    private uint _life_time = default(uint);
+    private uint? _life_time;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"life_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint life_time
     {
-      get { return _life_time; }
+      get { return _life_time?? default(uint); }
       set { _life_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool life_timeSpecified
+    {
+      get { return _life_time != null; }
+      set { if (value == (_life_time== null)) _life_time = value ? this.life_time : (uint?)null; }
+    }
+    private bool ShouldSerializelife_time() { return life_timeSpecified; }
+    private void Resetlife_time() { life_timeSpecified = false; }
+    
 
-    private uint _bomb_kills = default(uint);
+    private uint? _bomb_kills;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"bomb_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bomb_kills
     {
-      get { return _bomb_kills; }
+      get { return _bomb_kills?? default(uint); }
       set { _bomb_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bomb_killsSpecified
+    {
+      get { return _bomb_kills != null; }
+      set { if (value == (_bomb_kills== null)) _bomb_kills = value ? this.bomb_kills : (uint?)null; }
+    }
+    private bool ShouldSerializebomb_kills() { return bomb_killsSpecified; }
+    private void Resetbomb_kills() { bomb_killsSpecified = false; }
+    
 
-    private uint _staff_kills = default(uint);
+    private uint? _staff_kills;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"staff_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint staff_kills
     {
-      get { return _staff_kills; }
+      get { return _staff_kills?? default(uint); }
       set { _staff_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool staff_killsSpecified
+    {
+      get { return _staff_kills != null; }
+      set { if (value == (_staff_kills== null)) _staff_kills = value ? this.staff_kills : (uint?)null; }
+    }
+    private bool ShouldSerializestaff_kills() { return staff_killsSpecified; }
+    private void Resetstaff_kills() { staff_killsSpecified = false; }
+    
 
-    private uint _pvp_kills = default(uint);
+    private uint? _pvp_kills;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"pvp_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pvp_kills
     {
-      get { return _pvp_kills; }
+      get { return _pvp_kills?? default(uint); }
       set { _pvp_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pvp_killsSpecified
+    {
+      get { return _pvp_kills != null; }
+      set { if (value == (_pvp_kills== null)) _pvp_kills = value ? this.pvp_kills : (uint?)null; }
+    }
+    private bool ShouldSerializepvp_kills() { return pvp_killsSpecified; }
+    private void Resetpvp_kills() { pvp_killsSpecified = false; }
+    
 
-    private uint _prophunt_time1 = default(uint);
+    private uint? _prophunt_time1;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"prophunt_time1", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prophunt_time1
     {
-      get { return _prophunt_time1; }
+      get { return _prophunt_time1?? default(uint); }
       set { _prophunt_time1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prophunt_time1Specified
+    {
+      get { return _prophunt_time1 != null; }
+      set { if (value == (_prophunt_time1== null)) _prophunt_time1 = value ? this.prophunt_time1 : (uint?)null; }
+    }
+    private bool ShouldSerializeprophunt_time1() { return prophunt_time1Specified; }
+    private void Resetprophunt_time1() { prophunt_time1Specified = false; }
+    
 
-    private uint _prophunt_time2 = default(uint);
+    private uint? _prophunt_time2;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"prophunt_time2", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prophunt_time2
     {
-      get { return _prophunt_time2; }
+      get { return _prophunt_time2?? default(uint); }
       set { _prophunt_time2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prophunt_time2Specified
+    {
+      get { return _prophunt_time2 != null; }
+      set { if (value == (_prophunt_time2== null)) _prophunt_time2 = value ? this.prophunt_time2 : (uint?)null; }
+    }
+    private bool ShouldSerializeprophunt_time2() { return prophunt_time2Specified; }
+    private void Resetprophunt_time2() { prophunt_time2Specified = false; }
+    
 
-    private uint _dmg_scout = default(uint);
+    private uint? _dmg_scout;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"dmg_scout", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_scout
     {
-      get { return _dmg_scout; }
+      get { return _dmg_scout?? default(uint); }
       set { _dmg_scout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_scoutSpecified
+    {
+      get { return _dmg_scout != null; }
+      set { if (value == (_dmg_scout== null)) _dmg_scout = value ? this.dmg_scout : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_scout() { return dmg_scoutSpecified; }
+    private void Resetdmg_scout() { dmg_scoutSpecified = false; }
+    
 
-    private uint _dmg_sniper = default(uint);
+    private uint? _dmg_sniper;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"dmg_sniper", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_sniper
     {
-      get { return _dmg_sniper; }
+      get { return _dmg_sniper?? default(uint); }
       set { _dmg_sniper = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_sniperSpecified
+    {
+      get { return _dmg_sniper != null; }
+      set { if (value == (_dmg_sniper== null)) _dmg_sniper = value ? this.dmg_sniper : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_sniper() { return dmg_sniperSpecified; }
+    private void Resetdmg_sniper() { dmg_sniperSpecified = false; }
+    
 
-    private uint _dmg_soldier = default(uint);
+    private uint? _dmg_soldier;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"dmg_soldier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_soldier
     {
-      get { return _dmg_soldier; }
+      get { return _dmg_soldier?? default(uint); }
       set { _dmg_soldier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_soldierSpecified
+    {
+      get { return _dmg_soldier != null; }
+      set { if (value == (_dmg_soldier== null)) _dmg_soldier = value ? this.dmg_soldier : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_soldier() { return dmg_soldierSpecified; }
+    private void Resetdmg_soldier() { dmg_soldierSpecified = false; }
+    
 
-    private uint _dmg_demo = default(uint);
+    private uint? _dmg_demo;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"dmg_demo", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_demo
     {
-      get { return _dmg_demo; }
+      get { return _dmg_demo?? default(uint); }
       set { _dmg_demo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_demoSpecified
+    {
+      get { return _dmg_demo != null; }
+      set { if (value == (_dmg_demo== null)) _dmg_demo = value ? this.dmg_demo : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_demo() { return dmg_demoSpecified; }
+    private void Resetdmg_demo() { dmg_demoSpecified = false; }
+    
 
-    private uint _dmg_medic = default(uint);
+    private uint? _dmg_medic;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"dmg_medic", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_medic
     {
-      get { return _dmg_medic; }
+      get { return _dmg_medic?? default(uint); }
       set { _dmg_medic = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_medicSpecified
+    {
+      get { return _dmg_medic != null; }
+      set { if (value == (_dmg_medic== null)) _dmg_medic = value ? this.dmg_medic : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_medic() { return dmg_medicSpecified; }
+    private void Resetdmg_medic() { dmg_medicSpecified = false; }
+    
 
-    private uint _dmg_heavy = default(uint);
+    private uint? _dmg_heavy;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"dmg_heavy", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_heavy
     {
-      get { return _dmg_heavy; }
+      get { return _dmg_heavy?? default(uint); }
       set { _dmg_heavy = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_heavySpecified
+    {
+      get { return _dmg_heavy != null; }
+      set { if (value == (_dmg_heavy== null)) _dmg_heavy = value ? this.dmg_heavy : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_heavy() { return dmg_heavySpecified; }
+    private void Resetdmg_heavy() { dmg_heavySpecified = false; }
+    
 
-    private uint _dmg_pyro = default(uint);
+    private uint? _dmg_pyro;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"dmg_pyro", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_pyro
     {
-      get { return _dmg_pyro; }
+      get { return _dmg_pyro?? default(uint); }
       set { _dmg_pyro = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_pyroSpecified
+    {
+      get { return _dmg_pyro != null; }
+      set { if (value == (_dmg_pyro== null)) _dmg_pyro = value ? this.dmg_pyro : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_pyro() { return dmg_pyroSpecified; }
+    private void Resetdmg_pyro() { dmg_pyroSpecified = false; }
+    
 
-    private uint _dmg_spy = default(uint);
+    private uint? _dmg_spy;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"dmg_spy", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_spy
     {
-      get { return _dmg_spy; }
+      get { return _dmg_spy?? default(uint); }
       set { _dmg_spy = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_spySpecified
+    {
+      get { return _dmg_spy != null; }
+      set { if (value == (_dmg_spy== null)) _dmg_spy = value ? this.dmg_spy : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_spy() { return dmg_spySpecified; }
+    private void Resetdmg_spy() { dmg_spySpecified = false; }
+    
 
-    private uint _dmg_engineer = default(uint);
+    private uint? _dmg_engineer;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"dmg_engineer", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dmg_engineer
     {
-      get { return _dmg_engineer; }
+      get { return _dmg_engineer?? default(uint); }
       set { _dmg_engineer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dmg_engineerSpecified
+    {
+      get { return _dmg_engineer != null; }
+      set { if (value == (_dmg_engineer== null)) _dmg_engineer = value ? this.dmg_engineer : (uint?)null; }
+    }
+    private bool ShouldSerializedmg_engineer() { return dmg_engineerSpecified; }
+    private void Resetdmg_engineer() { dmg_engineerSpecified = false; }
+    
 
-    private uint _scout_count = default(uint);
+    private uint? _scout_count;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"scout_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint scout_count
     {
-      get { return _scout_count; }
+      get { return _scout_count?? default(uint); }
       set { _scout_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scout_countSpecified
+    {
+      get { return _scout_count != null; }
+      set { if (value == (_scout_count== null)) _scout_count = value ? this.scout_count : (uint?)null; }
+    }
+    private bool ShouldSerializescout_count() { return scout_countSpecified; }
+    private void Resetscout_count() { scout_countSpecified = false; }
+    
 
-    private uint _sniper_count = default(uint);
+    private uint? _sniper_count;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"sniper_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sniper_count
     {
-      get { return _sniper_count; }
+      get { return _sniper_count?? default(uint); }
       set { _sniper_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sniper_countSpecified
+    {
+      get { return _sniper_count != null; }
+      set { if (value == (_sniper_count== null)) _sniper_count = value ? this.sniper_count : (uint?)null; }
+    }
+    private bool ShouldSerializesniper_count() { return sniper_countSpecified; }
+    private void Resetsniper_count() { sniper_countSpecified = false; }
+    
 
-    private uint _solider_count = default(uint);
+    private uint? _solider_count;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"solider_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint solider_count
     {
-      get { return _solider_count; }
+      get { return _solider_count?? default(uint); }
       set { _solider_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool solider_countSpecified
+    {
+      get { return _solider_count != null; }
+      set { if (value == (_solider_count== null)) _solider_count = value ? this.solider_count : (uint?)null; }
+    }
+    private bool ShouldSerializesolider_count() { return solider_countSpecified; }
+    private void Resetsolider_count() { solider_countSpecified = false; }
+    
 
-    private uint _demo_count = default(uint);
+    private uint? _demo_count;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"demo_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint demo_count
     {
-      get { return _demo_count; }
+      get { return _demo_count?? default(uint); }
       set { _demo_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool demo_countSpecified
+    {
+      get { return _demo_count != null; }
+      set { if (value == (_demo_count== null)) _demo_count = value ? this.demo_count : (uint?)null; }
+    }
+    private bool ShouldSerializedemo_count() { return demo_countSpecified; }
+    private void Resetdemo_count() { demo_countSpecified = false; }
+    
 
-    private uint _medic_count = default(uint);
+    private uint? _medic_count;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"medic_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint medic_count
     {
-      get { return _medic_count; }
+      get { return _medic_count?? default(uint); }
       set { _medic_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool medic_countSpecified
+    {
+      get { return _medic_count != null; }
+      set { if (value == (_medic_count== null)) _medic_count = value ? this.medic_count : (uint?)null; }
+    }
+    private bool ShouldSerializemedic_count() { return medic_countSpecified; }
+    private void Resetmedic_count() { medic_countSpecified = false; }
+    
 
-    private uint _heavy_count = default(uint);
+    private uint? _heavy_count;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"heavy_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint heavy_count
     {
-      get { return _heavy_count; }
+      get { return _heavy_count?? default(uint); }
       set { _heavy_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heavy_countSpecified
+    {
+      get { return _heavy_count != null; }
+      set { if (value == (_heavy_count== null)) _heavy_count = value ? this.heavy_count : (uint?)null; }
+    }
+    private bool ShouldSerializeheavy_count() { return heavy_countSpecified; }
+    private void Resetheavy_count() { heavy_countSpecified = false; }
+    
 
-    private uint _pyro_count = default(uint);
+    private uint? _pyro_count;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"pyro_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pyro_count
     {
-      get { return _pyro_count; }
+      get { return _pyro_count?? default(uint); }
       set { _pyro_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pyro_countSpecified
+    {
+      get { return _pyro_count != null; }
+      set { if (value == (_pyro_count== null)) _pyro_count = value ? this.pyro_count : (uint?)null; }
+    }
+    private bool ShouldSerializepyro_count() { return pyro_countSpecified; }
+    private void Resetpyro_count() { pyro_countSpecified = false; }
+    
 
-    private uint _spy_count = default(uint);
+    private uint? _spy_count;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"spy_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint spy_count
     {
-      get { return _spy_count; }
+      get { return _spy_count?? default(uint); }
       set { _spy_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spy_countSpecified
+    {
+      get { return _spy_count != null; }
+      set { if (value == (_spy_count== null)) _spy_count = value ? this.spy_count : (uint?)null; }
+    }
+    private bool ShouldSerializespy_count() { return spy_countSpecified; }
+    private void Resetspy_count() { spy_countSpecified = false; }
+    
 
-    private uint _engineer_count = default(uint);
+    private uint? _engineer_count;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"engineer_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint engineer_count
     {
-      get { return _engineer_count; }
+      get { return _engineer_count?? default(uint); }
       set { _engineer_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool engineer_countSpecified
+    {
+      get { return _engineer_count != null; }
+      set { if (value == (_engineer_count== null)) _engineer_count = value ? this.engineer_count : (uint?)null; }
+    }
+    private bool ShouldSerializeengineer_count() { return engineer_countSpecified; }
+    private void Resetengineer_count() { engineer_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4586,28 +7630,46 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _merasmus_level = default(uint);
+    private uint? _merasmus_level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"merasmus_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint merasmus_level
     {
-      get { return _merasmus_level; }
+      get { return _merasmus_level?? default(uint); }
       set { _merasmus_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool merasmus_levelSpecified
+    {
+      get { return _merasmus_level != null; }
+      set { if (value == (_merasmus_level== null)) _merasmus_level = value ? this.merasmus_level : (uint?)null; }
+    }
+    private bool ShouldSerializemerasmus_level() { return merasmus_levelSpecified; }
+    private void Resetmerasmus_level() { merasmus_levelSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4624,14 +7686,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CAttribute_String() {}
     
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4643,59 +7714,113 @@ namespace SteamKit2.GC.TF2.Internal
     public CAttribute_DynamicRecipeComponent() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _item_quality = default(uint);
+    private uint? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(uint); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private uint _component_flags = default(uint);
+    private uint? _component_flags;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"component_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint component_flags
     {
-      get { return _component_flags; }
+      get { return _component_flags?? default(uint); }
       set { _component_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool component_flagsSpecified
+    {
+      get { return _component_flags != null; }
+      set { if (value == (_component_flags== null)) _component_flags = value ? this.component_flags : (uint?)null; }
+    }
+    private bool ShouldSerializecomponent_flags() { return component_flagsSpecified; }
+    private void Resetcomponent_flags() { component_flagsSpecified = false; }
+    
 
-    private string _attributes_string = "";
+    private string _attributes_string;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"attributes_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string attributes_string
     {
-      get { return _attributes_string; }
+      get { return _attributes_string?? ""; }
       set { _attributes_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attributes_stringSpecified
+    {
+      get { return _attributes_string != null; }
+      set { if (value == (_attributes_string== null)) _attributes_string = value ? this.attributes_string : (string)null; }
+    }
+    private bool ShouldSerializeattributes_string() { return attributes_stringSpecified; }
+    private void Resetattributes_string() { attributes_stringSpecified = false; }
+    
 
-    private uint _num_required = default(uint);
+    private uint? _num_required;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"num_required", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_required
     {
-      get { return _num_required; }
+      get { return _num_required?? default(uint); }
       set { _num_required = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_requiredSpecified
+    {
+      get { return _num_required != null; }
+      set { if (value == (_num_required== null)) _num_required = value ? this.num_required : (uint?)null; }
+    }
+    private bool ShouldSerializenum_required() { return num_requiredSpecified; }
+    private void Resetnum_required() { num_requiredSpecified = false; }
+    
 
-    private uint _num_fulfilled = default(uint);
+    private uint? _num_fulfilled;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_fulfilled", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_fulfilled
     {
-      get { return _num_fulfilled; }
+      get { return _num_fulfilled?? default(uint); }
       set { _num_fulfilled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_fulfilledSpecified
+    {
+      get { return _num_fulfilled != null; }
+      set { if (value == (_num_fulfilled== null)) _num_fulfilled = value ? this.num_fulfilled : (uint?)null; }
+    }
+    private bool ShouldSerializenum_fulfilled() { return num_fulfilledSpecified; }
+    private void Resetnum_fulfilled() { num_fulfilledSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4707,95 +7832,185 @@ namespace SteamKit2.GC.TF2.Internal
     public CAttribute_DynamicRecipeComponent_COMPAT_NEVER_SERIALIZE_THIS_OUT() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _item_quality = default(uint);
+    private uint? _item_quality;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(uint); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private uint _component_flags = default(uint);
+    private uint? _component_flags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"component_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint component_flags
     {
-      get { return _component_flags; }
+      get { return _component_flags?? default(uint); }
       set { _component_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool component_flagsSpecified
+    {
+      get { return _component_flags != null; }
+      set { if (value == (_component_flags== null)) _component_flags = value ? this.component_flags : (uint?)null; }
+    }
+    private bool ShouldSerializecomponent_flags() { return component_flagsSpecified; }
+    private void Resetcomponent_flags() { component_flagsSpecified = false; }
+    
 
-    private uint _item_flags = default(uint);
+    private uint? _item_flags;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_flags
     {
-      get { return _item_flags; }
+      get { return _item_flags?? default(uint); }
       set { _item_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_flagsSpecified
+    {
+      get { return _item_flags != null; }
+      set { if (value == (_item_flags== null)) _item_flags = value ? this.item_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_flags() { return item_flagsSpecified; }
+    private void Resetitem_flags() { item_flagsSpecified = false; }
+    
 
-    private string _attributes_string = "";
+    private string _attributes_string;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"attributes_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string attributes_string
     {
-      get { return _attributes_string; }
+      get { return _attributes_string?? ""; }
       set { _attributes_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attributes_stringSpecified
+    {
+      get { return _attributes_string != null; }
+      set { if (value == (_attributes_string== null)) _attributes_string = value ? this.attributes_string : (string)null; }
+    }
+    private bool ShouldSerializeattributes_string() { return attributes_stringSpecified; }
+    private void Resetattributes_string() { attributes_stringSpecified = false; }
+    
 
-    private uint _num_required = default(uint);
+    private uint? _num_required;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"num_required", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_required
     {
-      get { return _num_required; }
+      get { return _num_required?? default(uint); }
       set { _num_required = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_requiredSpecified
+    {
+      get { return _num_required != null; }
+      set { if (value == (_num_required== null)) _num_required = value ? this.num_required : (uint?)null; }
+    }
+    private bool ShouldSerializenum_required() { return num_requiredSpecified; }
+    private void Resetnum_required() { num_requiredSpecified = false; }
+    
 
-    private uint _item_count = default(uint);
+    private uint? _item_count;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"item_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_count
     {
-      get { return _item_count; }
+      get { return _item_count?? default(uint); }
       set { _item_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_countSpecified
+    {
+      get { return _item_count != null; }
+      set { if (value == (_item_count== null)) _item_count = value ? this.item_count : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_count() { return item_countSpecified; }
+    private void Resetitem_count() { item_countSpecified = false; }
+    
 
-    private uint _num_fulfilled = default(uint);
+    private uint? _num_fulfilled;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"num_fulfilled", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_fulfilled
     {
-      get { return _num_fulfilled; }
+      get { return _num_fulfilled?? default(uint); }
       set { _num_fulfilled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_fulfilledSpecified
+    {
+      get { return _num_fulfilled != null; }
+      set { if (value == (_num_fulfilled== null)) _num_fulfilled = value ? this.num_fulfilled : (uint?)null; }
+    }
+    private bool ShouldSerializenum_fulfilled() { return num_fulfilledSpecified; }
+    private void Resetnum_fulfilled() { num_fulfilledSpecified = false; }
+    
 
-    private uint _items_fulfilled = default(uint);
+    private uint? _items_fulfilled;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"items_fulfilled", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint items_fulfilled
     {
-      get { return _items_fulfilled; }
+      get { return _items_fulfilled?? default(uint); }
       set { _items_fulfilled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_fulfilledSpecified
+    {
+      get { return _items_fulfilled != null; }
+      set { if (value == (_items_fulfilled== null)) _items_fulfilled = value ? this.items_fulfilled : (uint?)null; }
+    }
+    private bool ShouldSerializeitems_fulfilled() { return items_fulfilledSpecified; }
+    private void Resetitems_fulfilled() { items_fulfilledSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4807,14 +8022,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CAttribute_ItemSlotCriteria() {}
     
 
-    private string _tags = "";
+    private string _tags;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tags
     {
-      get { return _tags; }
+      get { return _tags?? ""; }
       set { _tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagsSpecified
+    {
+      get { return _tags != null; }
+      set { if (value == (_tags== null)) _tags = value ? this.tags : (string)null; }
+    }
+    private bool ShouldSerializetags() { return tagsSpecified; }
+    private void Resettags() { tagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4826,32 +8050,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSetItemSlotAttribute() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private ulong _slot_item_original_id = default(ulong);
+    private ulong? _slot_item_original_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"slot_item_original_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong slot_item_original_id
     {
-      get { return _slot_item_original_id; }
+      get { return _slot_item_original_id?? default(ulong); }
       set { _slot_item_original_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_item_original_idSpecified
+    {
+      get { return _slot_item_original_id != null; }
+      set { if (value == (_slot_item_original_id== null)) _slot_item_original_id = value ? this.slot_item_original_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeslot_item_original_id() { return slot_item_original_idSpecified; }
+    private void Resetslot_item_original_id() { slot_item_original_idSpecified = false; }
+    
 
-    private uint _slot_index = default(uint);
+    private uint? _slot_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_index
     {
-      get { return _slot_index; }
+      get { return _slot_index?? default(uint); }
       set { _slot_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_indexSpecified
+    {
+      get { return _slot_index != null; }
+      set { if (value == (_slot_index== null)) _slot_index = value ? this.slot_index : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_index() { return slot_indexSpecified; }
+    private void Resetslot_index() { slot_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4863,41 +8114,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOWarData() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _war_id = default(uint);
+    private uint? _war_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"war_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint war_id
     {
-      get { return _war_id; }
+      get { return _war_id?? default(uint); }
       set { _war_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool war_idSpecified
+    {
+      get { return _war_id != null; }
+      set { if (value == (_war_id== null)) _war_id = value ? this.war_id : (uint?)null; }
+    }
+    private bool ShouldSerializewar_id() { return war_idSpecified; }
+    private void Resetwar_id() { war_idSpecified = false; }
+    
 
-    private uint _affiliation = default(uint);
+    private uint? _affiliation;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"affiliation", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint affiliation
     {
-      get { return _affiliation; }
+      get { return _affiliation?? default(uint); }
       set { _affiliation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool affiliationSpecified
+    {
+      get { return _affiliation != null; }
+      set { if (value == (_affiliation== null)) _affiliation = value ? this.affiliation : (uint?)null; }
+    }
+    private bool ShouldSerializeaffiliation() { return affiliationSpecified; }
+    private void Resetaffiliation() { affiliationSpecified = false; }
+    
 
-    private uint _points_scored = default(uint);
+    private uint? _points_scored;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"points_scored", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint points_scored
     {
-      get { return _points_scored; }
+      get { return _points_scored?? default(uint); }
       set { _points_scored = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool points_scoredSpecified
+    {
+      get { return _points_scored != null; }
+      set { if (value == (_points_scored== null)) _points_scored = value ? this.points_scored : (uint?)null; }
+    }
+    private bool ShouldSerializepoints_scored() { return points_scoredSpecified; }
+    private void Resetpoints_scored() { points_scoredSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4909,32 +8196,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgGC_War_IndividualUpdate() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _war_id = default(uint);
+    private uint? _war_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"war_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint war_id
     {
-      get { return _war_id; }
+      get { return _war_id?? default(uint); }
       set { _war_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool war_idSpecified
+    {
+      get { return _war_id != null; }
+      set { if (value == (_war_id== null)) _war_id = value ? this.war_id : (uint?)null; }
+    }
+    private bool ShouldSerializewar_id() { return war_idSpecified; }
+    private void Resetwar_id() { war_idSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4946,23 +8260,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgGC_War_JoinWar() {}
     
 
-    private uint _affiliation = default(uint);
+    private uint? _affiliation;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"affiliation", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint affiliation
     {
-      get { return _affiliation; }
+      get { return _affiliation?? default(uint); }
       set { _affiliation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool affiliationSpecified
+    {
+      get { return _affiliation != null; }
+      set { if (value == (_affiliation== null)) _affiliation = value ? this.affiliation : (uint?)null; }
+    }
+    private bool ShouldSerializeaffiliation() { return affiliationSpecified; }
+    private void Resetaffiliation() { affiliationSpecified = false; }
+    
 
-    private uint _war_id = default(uint);
+    private uint? _war_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"war_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint war_id
     {
-      get { return _war_id; }
+      get { return _war_id?? default(uint); }
       set { _war_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool war_idSpecified
+    {
+      get { return _war_id != null; }
+      set { if (value == (_war_id== null)) _war_id = value ? this.war_id : (uint?)null; }
+    }
+    private bool ShouldSerializewar_id() { return war_idSpecified; }
+    private void Resetwar_id() { war_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4974,14 +8306,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgGC_War_RequestGlobalStats() {}
     
 
-    private uint _war_id = default(uint);
+    private uint? _war_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"war_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint war_id
     {
-      get { return _war_id; }
+      get { return _war_id?? default(uint); }
       set { _war_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool war_idSpecified
+    {
+      get { return _war_id != null; }
+      set { if (value == (_war_id== null)) _war_id = value ? this.war_id : (uint?)null; }
+    }
+    private bool ShouldSerializewar_id() { return war_idSpecified; }
+    private void Resetwar_id() { war_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5000,37 +8341,64 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _war_id = default(uint);
+    private uint? _war_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"war_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint war_id
     {
-      get { return _war_id; }
+      get { return _war_id?? default(uint); }
       set { _war_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool war_idSpecified
+    {
+      get { return _war_id != null; }
+      set { if (value == (_war_id== null)) _war_id = value ? this.war_id : (uint?)null; }
+    }
+    private bool ShouldSerializewar_id() { return war_idSpecified; }
+    private void Resetwar_id() { war_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"SideScore")]
   public partial class SideScore : global::ProtoBuf.IExtensible
   {
     public SideScore() {}
     
 
-    private uint _side = default(uint);
+    private uint? _side;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"side", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint side
     {
-      get { return _side; }
+      get { return _side?? default(uint); }
       set { _side = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sideSpecified
+    {
+      get { return _side != null; }
+      set { if (value == (_side== null)) _side = value ? this.side : (uint?)null; }
+    }
+    private bool ShouldSerializeside() { return sideSpecified; }
+    private void Resetside() { sideSpecified = false; }
+    
 
-    private ulong _score = default(ulong);
+    private ulong? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong score
     {
-      get { return _score; }
+      get { return _score?? default(ulong); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (ulong?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5047,41 +8415,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgGC_PlayerDuckLeaderboard_IndividualUpdate() {}
     
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private byte[] _score_id = null;
+    private byte[] _score_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"score_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] score_id
     {
-      get { return _score_id; }
+      get { return _score_id?? null; }
       set { _score_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_idSpecified
+    {
+      get { return _score_id != null; }
+      set { if (value == (_score_id== null)) _score_id = value ? this.score_id : (byte[])null; }
+    }
+    private bool ShouldSerializescore_id() { return score_idSpecified; }
+    private void Resetscore_id() { score_idSpecified = false; }
+    
 
-    private uint _score_check = default(uint);
+    private uint? _score_check;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score_check", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_check
     {
-      get { return _score_check; }
+      get { return _score_check?? default(uint); }
       set { _score_check = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_checkSpecified
+    {
+      get { return _score_check != null; }
+      set { if (value == (_score_check== null)) _score_check = value ? this.score_check : (uint?)null; }
+    }
+    private bool ShouldSerializescore_check() { return score_checkSpecified; }
+    private void Resetscore_check() { score_checkSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5093,68 +8497,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CAttribute_WorldItemPlacement() {}
     
 
-    private ulong _original_item_id = default(ulong);
+    private ulong? _original_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"original_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong original_item_id
     {
-      get { return _original_item_id; }
+      get { return _original_item_id?? default(ulong); }
       set { _original_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_item_idSpecified
+    {
+      get { return _original_item_id != null; }
+      set { if (value == (_original_item_id== null)) _original_item_id = value ? this.original_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeoriginal_item_id() { return original_item_idSpecified; }
+    private void Resetoriginal_item_id() { original_item_idSpecified = false; }
+    
 
-    private float _pos_x = default(float);
+    private float? _pos_x;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pos_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_x
     {
-      get { return _pos_x; }
+      get { return _pos_x?? default(float); }
       set { _pos_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_xSpecified
+    {
+      get { return _pos_x != null; }
+      set { if (value == (_pos_x== null)) _pos_x = value ? this.pos_x : (float?)null; }
+    }
+    private bool ShouldSerializepos_x() { return pos_xSpecified; }
+    private void Resetpos_x() { pos_xSpecified = false; }
+    
 
-    private float _pos_y = default(float);
+    private float? _pos_y;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pos_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_y
     {
-      get { return _pos_y; }
+      get { return _pos_y?? default(float); }
       set { _pos_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_ySpecified
+    {
+      get { return _pos_y != null; }
+      set { if (value == (_pos_y== null)) _pos_y = value ? this.pos_y : (float?)null; }
+    }
+    private bool ShouldSerializepos_y() { return pos_ySpecified; }
+    private void Resetpos_y() { pos_ySpecified = false; }
+    
 
-    private float _pos_z = default(float);
+    private float? _pos_z;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"pos_z", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_z
     {
-      get { return _pos_z; }
+      get { return _pos_z?? default(float); }
       set { _pos_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_zSpecified
+    {
+      get { return _pos_z != null; }
+      set { if (value == (_pos_z== null)) _pos_z = value ? this.pos_z : (float?)null; }
+    }
+    private bool ShouldSerializepos_z() { return pos_zSpecified; }
+    private void Resetpos_z() { pos_zSpecified = false; }
+    
 
-    private float _ang_x = default(float);
+    private float? _ang_x;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ang_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_x
     {
-      get { return _ang_x; }
+      get { return _ang_x?? default(float); }
       set { _ang_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_xSpecified
+    {
+      get { return _ang_x != null; }
+      set { if (value == (_ang_x== null)) _ang_x = value ? this.ang_x : (float?)null; }
+    }
+    private bool ShouldSerializeang_x() { return ang_xSpecified; }
+    private void Resetang_x() { ang_xSpecified = false; }
+    
 
-    private float _ang_y = default(float);
+    private float? _ang_y;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ang_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_y
     {
-      get { return _ang_y; }
+      get { return _ang_y?? default(float); }
       set { _ang_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_ySpecified
+    {
+      get { return _ang_y != null; }
+      set { if (value == (_ang_y== null)) _ang_y = value ? this.ang_y : (float?)null; }
+    }
+    private bool ShouldSerializeang_y() { return ang_ySpecified; }
+    private void Resetang_y() { ang_ySpecified = false; }
+    
 
-    private float _ang_z = default(float);
+    private float? _ang_z;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"ang_z", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_z
     {
-      get { return _ang_z; }
+      get { return _ang_z?? default(float); }
       set { _ang_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_zSpecified
+    {
+      get { return _ang_z != null; }
+      set { if (value == (_ang_z== null)) _ang_z = value ? this.ang_z : (float?)null; }
+    }
+    private bool ShouldSerializeang_z() { return ang_zSpecified; }
+    private void Resetang_z() { ang_zSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5166,86 +8633,167 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsg_WorldItemPlacement_Update() {}
     
 
-    private ulong _original_item_id = default(ulong);
+    private ulong? _original_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"original_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong original_item_id
     {
-      get { return _original_item_id; }
+      get { return _original_item_id?? default(ulong); }
       set { _original_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_item_idSpecified
+    {
+      get { return _original_item_id != null; }
+      set { if (value == (_original_item_id== null)) _original_item_id = value ? this.original_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeoriginal_item_id() { return original_item_idSpecified; }
+    private void Resetoriginal_item_id() { original_item_idSpecified = false; }
+    
 
-    private float _pos_x = default(float);
+    private float? _pos_x;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pos_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_x
     {
-      get { return _pos_x; }
+      get { return _pos_x?? default(float); }
       set { _pos_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_xSpecified
+    {
+      get { return _pos_x != null; }
+      set { if (value == (_pos_x== null)) _pos_x = value ? this.pos_x : (float?)null; }
+    }
+    private bool ShouldSerializepos_x() { return pos_xSpecified; }
+    private void Resetpos_x() { pos_xSpecified = false; }
+    
 
-    private float _pos_y = default(float);
+    private float? _pos_y;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pos_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_y
     {
-      get { return _pos_y; }
+      get { return _pos_y?? default(float); }
       set { _pos_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_ySpecified
+    {
+      get { return _pos_y != null; }
+      set { if (value == (_pos_y== null)) _pos_y = value ? this.pos_y : (float?)null; }
+    }
+    private bool ShouldSerializepos_y() { return pos_ySpecified; }
+    private void Resetpos_y() { pos_ySpecified = false; }
+    
 
-    private float _pos_z = default(float);
+    private float? _pos_z;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"pos_z", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float pos_z
     {
-      get { return _pos_z; }
+      get { return _pos_z?? default(float); }
       set { _pos_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pos_zSpecified
+    {
+      get { return _pos_z != null; }
+      set { if (value == (_pos_z== null)) _pos_z = value ? this.pos_z : (float?)null; }
+    }
+    private bool ShouldSerializepos_z() { return pos_zSpecified; }
+    private void Resetpos_z() { pos_zSpecified = false; }
+    
 
-    private float _ang_x = default(float);
+    private float? _ang_x;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ang_x", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_x
     {
-      get { return _ang_x; }
+      get { return _ang_x?? default(float); }
       set { _ang_x = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_xSpecified
+    {
+      get { return _ang_x != null; }
+      set { if (value == (_ang_x== null)) _ang_x = value ? this.ang_x : (float?)null; }
+    }
+    private bool ShouldSerializeang_x() { return ang_xSpecified; }
+    private void Resetang_x() { ang_xSpecified = false; }
+    
 
-    private float _ang_y = default(float);
+    private float? _ang_y;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ang_y", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_y
     {
-      get { return _ang_y; }
+      get { return _ang_y?? default(float); }
       set { _ang_y = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_ySpecified
+    {
+      get { return _ang_y != null; }
+      set { if (value == (_ang_y== null)) _ang_y = value ? this.ang_y : (float?)null; }
+    }
+    private bool ShouldSerializeang_y() { return ang_ySpecified; }
+    private void Resetang_y() { ang_ySpecified = false; }
+    
 
-    private float _ang_z = default(float);
+    private float? _ang_z;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"ang_z", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float ang_z
     {
-      get { return _ang_z; }
+      get { return _ang_z?? default(float); }
       set { _ang_z = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ang_zSpecified
+    {
+      get { return _ang_z != null; }
+      set { if (value == (_ang_z== null)) _ang_z = value ? this.ang_z : (float?)null; }
+    }
+    private bool ShouldSerializeang_z() { return ang_zSpecified; }
+    private void Resetang_z() { ang_zSpecified = false; }
+    
 
-    private bool _force_remove_all = default(bool);
+    private bool? _force_remove_all;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"force_remove_all", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool force_remove_all
     {
-      get { return _force_remove_all; }
+      get { return _force_remove_all?? default(bool); }
       set { _force_remove_all = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool force_remove_allSpecified
+    {
+      get { return _force_remove_all != null; }
+      set { if (value == (_force_remove_all== null)) _force_remove_all = value ? this.force_remove_all : (bool?)null; }
+    }
+    private bool ShouldSerializeforce_remove_all() { return force_remove_allSpecified; }
+    private void Resetforce_remove_all() { force_remove_allSpecified = false; }
+    
 
-    private string _attrib_name = "";
+    private string _attrib_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"attrib_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string attrib_name
     {
-      get { return _attrib_name; }
+      get { return _attrib_name?? ""; }
       set { _attrib_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attrib_nameSpecified
+    {
+      get { return _attrib_name != null; }
+      set { if (value == (_attrib_name== null)) _attrib_name = value ? this.attrib_name : (string)null; }
+    }
+    private bool ShouldSerializeattrib_name() { return attrib_nameSpecified; }
+    private void Resetattrib_name() { attrib_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5257,23 +8805,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAcknowledgeXP() {}
     
 
-    private int _match_group = default(int);
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(int); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private uint _predicted_experience = default(uint);
+    private uint? _predicted_experience;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"predicted_experience", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint predicted_experience
     {
-      get { return _predicted_experience; }
+      get { return _predicted_experience?? default(uint); }
       set { _predicted_experience = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool predicted_experienceSpecified
+    {
+      get { return _predicted_experience != null; }
+      set { if (value == (_predicted_experience== null)) _predicted_experience = value ? this.predicted_experience : (uint?)null; }
+    }
+    private bool ShouldSerializepredicted_experience() { return predicted_experienceSpecified; }
+    private void Resetpredicted_experience() { predicted_experienceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5285,50 +8851,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFXPSource() {}
     
 
-    private CMsgTFXPSource.XPSourceType _type = CMsgTFXPSource.XPSourceType.SOURCE_SCORE;
+    private CMsgTFXPSource.XPSourceType? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgTFXPSource.XPSourceType.SOURCE_SCORE)]
     public CMsgTFXPSource.XPSourceType type
     {
-      get { return _type; }
+      get { return _type?? CMsgTFXPSource.XPSourceType.SOURCE_SCORE; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (CMsgTFXPSource.XPSourceType?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private int _amount = default(int);
+    private int? _amount;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int amount
     {
-      get { return _amount; }
+      get { return _amount?? default(int); }
       set { _amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool amountSpecified
+    {
+      get { return _amount != null; }
+      set { if (value == (_amount== null)) _amount = value ? this.amount : (int?)null; }
+    }
+    private bool ShouldSerializeamount() { return amountSpecified; }
+    private void Resetamount() { amountSpecified = false; }
+    
 
-    private int _match_group = default(int);
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(int); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"XPSourceType", EnumPassthru=true)]
     public enum XPSourceType
     {
@@ -5386,23 +8997,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTFClientInit() {}
     
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5414,50 +9043,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCNotification() {}
     
 
-    private ulong _notification_id = default(ulong);
+    private ulong? _notification_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"notification_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong notification_id
     {
-      get { return _notification_id; }
+      get { return _notification_id?? default(ulong); }
       set { _notification_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_idSpecified
+    {
+      get { return _notification_id != null; }
+      set { if (value == (_notification_id== null)) _notification_id = value ? this.notification_id : (ulong?)null; }
+    }
+    private bool ShouldSerializenotification_id() { return notification_idSpecified; }
+    private void Resetnotification_id() { notification_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
 
-    private CMsgGCNotification.NotificationType _type = CMsgGCNotification.NotificationType.NOTIFICATION_CUSTOM_STRING;
+    private CMsgGCNotification.NotificationType? _type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCNotification.NotificationType.NOTIFICATION_CUSTOM_STRING)]
     public CMsgGCNotification.NotificationType type
     {
-      get { return _type; }
+      get { return _type?? CMsgGCNotification.NotificationType.NOTIFICATION_CUSTOM_STRING; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (CMsgGCNotification.NotificationType?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private string _notification_string = "";
+    private string _notification_string;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"notification_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_string
     {
-      get { return _notification_string; }
+      get { return _notification_string?? ""; }
       set { _notification_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_stringSpecified
+    {
+      get { return _notification_string != null; }
+      set { if (value == (_notification_string== null)) _notification_string = value ? this.notification_string : (string)null; }
+    }
+    private bool ShouldSerializenotification_string() { return notification_stringSpecified; }
+    private void Resetnotification_string() { notification_stringSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"NotificationType", EnumPassthru=true)]
     public enum NotificationType
     {
@@ -5509,23 +9183,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgNotificationAcknowledge() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _notification_id = default(ulong);
+    private ulong? _notification_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"notification_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong notification_id
     {
-      get { return _notification_id; }
+      get { return _notification_id?? default(ulong); }
       set { _notification_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_idSpecified
+    {
+      get { return _notification_id != null; }
+      set { if (value == (_notification_id== null)) _notification_id = value ? this.notification_id : (ulong?)null; }
+    }
+    private bool ShouldSerializenotification_id() { return notification_idSpecified; }
+    private void Resetnotification_id() { notification_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5547,86 +9239,167 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Match_Result() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private int _match_group = default(int);
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(int); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private CMsgGC_Match_Result.Status _status = CMsgGC_Match_Result.Status.MATCH_SUCCEEDED;
+    private CMsgGC_Match_Result.Status? _status;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGC_Match_Result.Status.MATCH_SUCCEEDED)]
     public CMsgGC_Match_Result.Status status
     {
-      get { return _status; }
+      get { return _status?? CMsgGC_Match_Result.Status.MATCH_SUCCEEDED; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (CMsgGC_Match_Result.Status?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
 
-    private uint _red_score = default(uint);
+    private uint? _red_score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"red_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint red_score
     {
-      get { return _red_score; }
+      get { return _red_score?? default(uint); }
       set { _red_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool red_scoreSpecified
+    {
+      get { return _red_score != null; }
+      set { if (value == (_red_score== null)) _red_score = value ? this.red_score : (uint?)null; }
+    }
+    private bool ShouldSerializered_score() { return red_scoreSpecified; }
+    private void Resetred_score() { red_scoreSpecified = false; }
+    
 
-    private uint _blue_score = default(uint);
+    private uint? _blue_score;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"blue_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint blue_score
     {
-      get { return _blue_score; }
+      get { return _blue_score?? default(uint); }
       set { _blue_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool blue_scoreSpecified
+    {
+      get { return _blue_score != null; }
+      set { if (value == (_blue_score== null)) _blue_score = value ? this.blue_score : (uint?)null; }
+    }
+    private bool ShouldSerializeblue_score() { return blue_scoreSpecified; }
+    private void Resetblue_score() { blue_scoreSpecified = false; }
+    
 
-    private uint _winning_team = default(uint);
+    private uint? _winning_team;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"winning_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint winning_team
     {
-      get { return _winning_team; }
+      get { return _winning_team?? default(uint); }
       set { _winning_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool winning_teamSpecified
+    {
+      get { return _winning_team != null; }
+      set { if (value == (_winning_team== null)) _winning_team = value ? this.winning_team : (uint?)null; }
+    }
+    private bool ShouldSerializewinning_team() { return winning_teamSpecified; }
+    private void Resetwinning_team() { winning_teamSpecified = false; }
+    
 
-    private uint _map_index = default(uint);
+    private uint? _map_index;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"map_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint map_index
     {
-      get { return _map_index; }
+      get { return _map_index?? default(uint); }
       set { _map_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_indexSpecified
+    {
+      get { return _map_index != null; }
+      set { if (value == (_map_index== null)) _map_index = value ? this.map_index : (uint?)null; }
+    }
+    private bool ShouldSerializemap_index() { return map_indexSpecified; }
+    private void Resetmap_index() { map_indexSpecified = false; }
+    
 
-    private uint _game_type = (uint)0;
+    private uint? _game_type;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? (uint)0; }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (uint?)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGC_Match_Result.Player> _players = new global::System.Collections.Generic.List<CMsgGC_Match_Result.Player>();
     [global::ProtoBuf.ProtoMember(10, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGC_Match_Result.Player> players
@@ -5635,253 +9408,496 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _red_skillrating = default(uint);
+    private uint? _red_skillrating;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"red_skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint red_skillrating
     {
-      get { return _red_skillrating; }
+      get { return _red_skillrating?? default(uint); }
       set { _red_skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool red_skillratingSpecified
+    {
+      get { return _red_skillrating != null; }
+      set { if (value == (_red_skillrating== null)) _red_skillrating = value ? this.red_skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializered_skillrating() { return red_skillratingSpecified; }
+    private void Resetred_skillrating() { red_skillratingSpecified = false; }
+    
 
-    private uint _blue_skillrating = default(uint);
+    private uint? _blue_skillrating;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"blue_skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint blue_skillrating
     {
-      get { return _blue_skillrating; }
+      get { return _blue_skillrating?? default(uint); }
       set { _blue_skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool blue_skillratingSpecified
+    {
+      get { return _blue_skillrating != null; }
+      set { if (value == (_blue_skillrating== null)) _blue_skillrating = value ? this.blue_skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializeblue_skillrating() { return blue_skillratingSpecified; }
+    private void Resetblue_skillrating() { blue_skillratingSpecified = false; }
+    
 
-    private uint _win_reason = default(uint);
+    private uint? _win_reason;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"win_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint win_reason
     {
-      get { return _win_reason; }
+      get { return _win_reason?? default(uint); }
       set { _win_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool win_reasonSpecified
+    {
+      get { return _win_reason != null; }
+      set { if (value == (_win_reason== null)) _win_reason = value ? this.win_reason : (uint?)null; }
+    }
+    private bool ShouldSerializewin_reason() { return win_reasonSpecified; }
+    private void Resetwin_reason() { win_reasonSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _server_version = default(uint);
+    private uint? _server_version;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"server_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_version
     {
-      get { return _server_version; }
+      get { return _server_version?? default(uint); }
       set { _server_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_versionSpecified
+    {
+      get { return _server_version != null; }
+      set { if (value == (_server_version== null)) _server_version = value ? this.server_version : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_version() { return server_versionSpecified; }
+    private void Resetserver_version() { server_versionSpecified = false; }
+    
 
-    private uint _bots = default(uint);
+    private uint? _bots;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"bots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bots
     {
-      get { return _bots; }
+      get { return _bots?? default(uint); }
       set { _bots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool botsSpecified
+    {
+      get { return _bots != null; }
+      set { if (value == (_bots== null)) _bots = value ? this.bots : (uint?)null; }
+    }
+    private bool ShouldSerializebots() { return botsSpecified; }
+    private void Resetbots() { botsSpecified = false; }
+    
 
-    private bool _server_created = (bool)false;
+    private bool? _server_created;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"server_created", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool server_created
     {
-      get { return _server_created; }
+      get { return _server_created?? (bool)false; }
       set { _server_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_createdSpecified
+    {
+      get { return _server_created != null; }
+      set { if (value == (_server_created== null)) _server_created = value ? this.server_created : (bool?)null; }
+    }
+    private bool ShouldSerializeserver_created() { return server_createdSpecified; }
+    private void Resetserver_created() { server_createdSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _ping = default(uint);
+    private uint? _ping;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ping", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ping
     {
-      get { return _ping; }
+      get { return _ping?? default(uint); }
       set { _ping = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingSpecified
+    {
+      get { return _ping != null; }
+      set { if (value == (_ping== null)) _ping = value ? this.ping : (uint?)null; }
+    }
+    private bool ShouldSerializeping() { return pingSpecified; }
+    private void Resetping() { pingSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _skillrating = default(uint);
+    private uint? _skillrating;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skillrating
     {
-      get { return _skillrating; }
+      get { return _skillrating?? default(uint); }
       set { _skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillratingSpecified
+    {
+      get { return _skillrating != null; }
+      set { if (value == (_skillrating== null)) _skillrating = value ? this.skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializeskillrating() { return skillratingSpecified; }
+    private void Resetskillrating() { skillratingSpecified = false; }
+    
 
-    private int _skillrating_change = default(int);
+    private int? _skillrating_change;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"skillrating_change", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int skillrating_change
     {
-      get { return _skillrating_change; }
+      get { return _skillrating_change?? default(int); }
       set { _skillrating_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillrating_changeSpecified
+    {
+      get { return _skillrating_change != null; }
+      set { if (value == (_skillrating_change== null)) _skillrating_change = value ? this.skillrating_change : (int?)null; }
+    }
+    private bool ShouldSerializeskillrating_change() { return skillrating_changeSpecified; }
+    private void Resetskillrating_change() { skillrating_changeSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _classes_played = default(uint);
+    private uint? _classes_played;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"classes_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint classes_played
     {
-      get { return _classes_played; }
+      get { return _classes_played?? default(uint); }
       set { _classes_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool classes_playedSpecified
+    {
+      get { return _classes_played != null; }
+      set { if (value == (_classes_played== null)) _classes_played = value ? this.classes_played : (uint?)null; }
+    }
+    private bool ShouldSerializeclasses_played() { return classes_playedSpecified; }
+    private void Resetclasses_played() { classes_playedSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _damage = default(uint);
+    private uint? _damage;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage
     {
-      get { return _damage; }
+      get { return _damage?? default(uint); }
       set { _damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damageSpecified
+    {
+      get { return _damage != null; }
+      set { if (value == (_damage== null)) _damage = value ? this.damage : (uint?)null; }
+    }
+    private bool ShouldSerializedamage() { return damageSpecified; }
+    private void Resetdamage() { damageSpecified = false; }
+    
 
-    private uint _healing = default(uint);
+    private uint? _healing;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing
     {
-      get { return _healing; }
+      get { return _healing?? default(uint); }
       set { _healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healingSpecified
+    {
+      get { return _healing != null; }
+      set { if (value == (_healing== null)) _healing = value ? this.healing : (uint?)null; }
+    }
+    private bool ShouldSerializehealing() { return healingSpecified; }
+    private void Resethealing() { healingSpecified = false; }
+    
 
-    private uint _support = default(uint);
+    private uint? _support;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"support", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support
     {
-      get { return _support; }
+      get { return _support?? default(uint); }
       set { _support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supportSpecified
+    {
+      get { return _support != null; }
+      set { if (value == (_support== null)) _support = value ? this.support : (uint?)null; }
+    }
+    private bool ShouldSerializesupport() { return supportSpecified; }
+    private void Resetsupport() { supportSpecified = false; }
+    
 
-    private uint _score_medal = default(uint);
+    private uint? _score_medal;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"score_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_medal
     {
-      get { return _score_medal; }
+      get { return _score_medal?? default(uint); }
       set { _score_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_medalSpecified
+    {
+      get { return _score_medal != null; }
+      set { if (value == (_score_medal== null)) _score_medal = value ? this.score_medal : (uint?)null; }
+    }
+    private bool ShouldSerializescore_medal() { return score_medalSpecified; }
+    private void Resetscore_medal() { score_medalSpecified = false; }
+    
 
-    private uint _kills_medal = default(uint);
+    private uint? _kills_medal;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"kills_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills_medal
     {
-      get { return _kills_medal; }
+      get { return _kills_medal?? default(uint); }
       set { _kills_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kills_medalSpecified
+    {
+      get { return _kills_medal != null; }
+      set { if (value == (_kills_medal== null)) _kills_medal = value ? this.kills_medal : (uint?)null; }
+    }
+    private bool ShouldSerializekills_medal() { return kills_medalSpecified; }
+    private void Resetkills_medal() { kills_medalSpecified = false; }
+    
 
-    private uint _damage_medal = default(uint);
+    private uint? _damage_medal;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"damage_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_medal
     {
-      get { return _damage_medal; }
+      get { return _damage_medal?? default(uint); }
       set { _damage_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_medalSpecified
+    {
+      get { return _damage_medal != null; }
+      set { if (value == (_damage_medal== null)) _damage_medal = value ? this.damage_medal : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_medal() { return damage_medalSpecified; }
+    private void Resetdamage_medal() { damage_medalSpecified = false; }
+    
 
-    private uint _healing_medal = default(uint);
+    private uint? _healing_medal;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"healing_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing_medal
     {
-      get { return _healing_medal; }
+      get { return _healing_medal?? default(uint); }
       set { _healing_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healing_medalSpecified
+    {
+      get { return _healing_medal != null; }
+      set { if (value == (_healing_medal== null)) _healing_medal = value ? this.healing_medal : (uint?)null; }
+    }
+    private bool ShouldSerializehealing_medal() { return healing_medalSpecified; }
+    private void Resethealing_medal() { healing_medalSpecified = false; }
+    
 
-    private uint _support_medal = default(uint);
+    private uint? _support_medal;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"support_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_medal
     {
-      get { return _support_medal; }
+      get { return _support_medal?? default(uint); }
       set { _support_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_medalSpecified
+    {
+      get { return _support_medal != null; }
+      set { if (value == (_support_medal== null)) _support_medal = value ? this.support_medal : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_medal() { return support_medalSpecified; }
+    private void Resetsupport_medal() { support_medalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgTFXPSource> _xp_breakdown = new global::System.Collections.Generic.List<CMsgTFXPSource>();
     [global::ProtoBuf.ProtoMember(21, Name=@"xp_breakdown", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgTFXPSource> xp_breakdown
@@ -5890,32 +9906,59 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _leave_time = default(uint);
+    private uint? _leave_time;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"leave_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint leave_time
     {
-      get { return _leave_time; }
+      get { return _leave_time?? default(uint); }
       set { _leave_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leave_timeSpecified
+    {
+      get { return _leave_time != null; }
+      set { if (value == (_leave_time== null)) _leave_time = value ? this.leave_time : (uint?)null; }
+    }
+    private bool ShouldSerializeleave_time() { return leave_timeSpecified; }
+    private void Resetleave_time() { leave_timeSpecified = false; }
+    
 
-    private TFMatchLeaveReason _leave_reason = TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED;
+    private TFMatchLeaveReason? _leave_reason;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"leave_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED)]
     public TFMatchLeaveReason leave_reason
     {
-      get { return _leave_reason; }
+      get { return _leave_reason?? TFMatchLeaveReason.TFMatchLeaveReason_UNSPECIFIED; }
       set { _leave_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leave_reasonSpecified
+    {
+      get { return _leave_reason != null; }
+      set { if (value == (_leave_reason== null)) _leave_reason = value ? this.leave_reason : (TFMatchLeaveReason?)null; }
+    }
+    private bool ShouldSerializeleave_reason() { return leave_reasonSpecified; }
+    private void Resetleave_reason() { leave_reasonSpecified = false; }
+    
 
-    private uint _connect_time = default(uint);
+    private uint? _connect_time;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"connect_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint connect_time
     {
-      get { return _connect_time; }
+      get { return _connect_time?? default(uint); }
       set { _connect_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_timeSpecified
+    {
+      get { return _connect_time != null; }
+      set { if (value == (_connect_time== null)) _connect_time = value ? this.connect_time : (uint?)null; }
+    }
+    private bool ShouldSerializeconnect_time() { return connect_timeSpecified; }
+    private void Resetconnect_time() { connect_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5987,41 +10030,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_Client2GCEconPreviewDataBlockRequest() {}
     
 
-    private ulong _param_s = default(ulong);
+    private ulong? _param_s;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"param_s", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_s
     {
-      get { return _param_s; }
+      get { return _param_s?? default(ulong); }
       set { _param_s = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_sSpecified
+    {
+      get { return _param_s != null; }
+      set { if (value == (_param_s== null)) _param_s = value ? this.param_s : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_s() { return param_sSpecified; }
+    private void Resetparam_s() { param_sSpecified = false; }
+    
 
-    private ulong _param_a = default(ulong);
+    private ulong? _param_a;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"param_a", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_a
     {
-      get { return _param_a; }
+      get { return _param_a?? default(ulong); }
       set { _param_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_aSpecified
+    {
+      get { return _param_a != null; }
+      set { if (value == (_param_a== null)) _param_a = value ? this.param_a : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_a() { return param_aSpecified; }
+    private void Resetparam_a() { param_aSpecified = false; }
+    
 
-    private ulong _param_d = default(ulong);
+    private ulong? _param_d;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"param_d", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_d
     {
-      get { return _param_d; }
+      get { return _param_d?? default(ulong); }
       set { _param_d = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_dSpecified
+    {
+      get { return _param_d != null; }
+      set { if (value == (_param_d== null)) _param_d = value ? this.param_d : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_d() { return param_dSpecified; }
+    private void Resetparam_d() { param_dSpecified = false; }
+    
 
-    private ulong _param_m = default(ulong);
+    private ulong? _param_m;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"param_m", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong param_m
     {
-      get { return _param_m; }
+      get { return _param_m?? default(ulong); }
       set { _param_m = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_mSpecified
+    {
+      get { return _param_m != null; }
+      set { if (value == (_param_m== null)) _param_m = value ? this.param_m : (ulong?)null; }
+    }
+    private bool ShouldSerializeparam_m() { return param_mSpecified; }
+    private void Resetparam_m() { param_mSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6052,293 +10131,581 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFLadderPlayerStats() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private int _match_group = default(int);
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(int); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private uint _season_id = default(uint);
+    private uint? _season_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"season_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_id
     {
-      get { return _season_id; }
+      get { return _season_id?? default(uint); }
       set { _season_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_idSpecified
+    {
+      get { return _season_id != null; }
+      set { if (value == (_season_id== null)) _season_id = value ? this.season_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_id() { return season_idSpecified; }
+    private void Resetseason_id() { season_idSpecified = false; }
+    
 
-    private uint _rating = default(uint);
+    private uint? _rating;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rating
     {
-      get { return _rating; }
+      get { return _rating?? default(uint); }
       set { _rating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ratingSpecified
+    {
+      get { return _rating != null; }
+      set { if (value == (_rating== null)) _rating = value ? this.rating : (uint?)null; }
+    }
+    private bool ShouldSerializerating() { return ratingSpecified; }
+    private void Resetrating() { ratingSpecified = false; }
+    
 
-    private uint _last_ackd_rating = default(uint);
+    private uint? _last_ackd_rating;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"last_ackd_rating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_ackd_rating
     {
-      get { return _last_ackd_rating; }
+      get { return _last_ackd_rating?? default(uint); }
       set { _last_ackd_rating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_ackd_ratingSpecified
+    {
+      get { return _last_ackd_rating != null; }
+      set { if (value == (_last_ackd_rating== null)) _last_ackd_rating = value ? this.last_ackd_rating : (uint?)null; }
+    }
+    private bool ShouldSerializelast_ackd_rating() { return last_ackd_ratingSpecified; }
+    private void Resetlast_ackd_rating() { last_ackd_ratingSpecified = false; }
+    
 
-    private int _last_rating_change = default(int);
+    private int? _last_rating_change;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"last_rating_change", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int last_rating_change
     {
-      get { return _last_rating_change; }
+      get { return _last_rating_change?? default(int); }
       set { _last_rating_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_rating_changeSpecified
+    {
+      get { return _last_rating_change != null; }
+      set { if (value == (_last_rating_change== null)) _last_rating_change = value ? this.last_rating_change : (int?)null; }
+    }
+    private bool ShouldSerializelast_rating_change() { return last_rating_changeSpecified; }
+    private void Resetlast_rating_change() { last_rating_changeSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _highest_rank = default(uint);
+    private uint? _highest_rank;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"highest_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint highest_rank
     {
-      get { return _highest_rank; }
+      get { return _highest_rank?? default(uint); }
       set { _highest_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool highest_rankSpecified
+    {
+      get { return _highest_rank != null; }
+      set { if (value == (_highest_rank== null)) _highest_rank = value ? this.highest_rank : (uint?)null; }
+    }
+    private bool ShouldSerializehighest_rank() { return highest_rankSpecified; }
+    private void Resethighest_rank() { highest_rankSpecified = false; }
+    
 
-    private uint _experience = default(uint);
+    private uint? _experience;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"experience", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint experience
     {
-      get { return _experience; }
+      get { return _experience?? default(uint); }
       set { _experience = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experienceSpecified
+    {
+      get { return _experience != null; }
+      set { if (value == (_experience== null)) _experience = value ? this.experience : (uint?)null; }
+    }
+    private bool ShouldSerializeexperience() { return experienceSpecified; }
+    private void Resetexperience() { experienceSpecified = false; }
+    
 
-    private uint _last_ackd_experience = default(uint);
+    private uint? _last_ackd_experience;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"last_ackd_experience", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_ackd_experience
     {
-      get { return _last_ackd_experience; }
+      get { return _last_ackd_experience?? default(uint); }
       set { _last_ackd_experience = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_ackd_experienceSpecified
+    {
+      get { return _last_ackd_experience != null; }
+      set { if (value == (_last_ackd_experience== null)) _last_ackd_experience = value ? this.last_ackd_experience : (uint?)null; }
+    }
+    private bool ShouldSerializelast_ackd_experience() { return last_ackd_experienceSpecified; }
+    private void Resetlast_ackd_experience() { last_ackd_experienceSpecified = false; }
+    
 
-    private uint _games = default(uint);
+    private uint? _games;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint games
     {
-      get { return _games; }
+      get { return _games?? default(uint); }
       set { _games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamesSpecified
+    {
+      get { return _games != null; }
+      set { if (value == (_games== null)) _games = value ? this.games : (uint?)null; }
+    }
+    private bool ShouldSerializegames() { return gamesSpecified; }
+    private void Resetgames() { gamesSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _damage = default(uint);
+    private uint? _damage;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage
     {
-      get { return _damage; }
+      get { return _damage?? default(uint); }
       set { _damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damageSpecified
+    {
+      get { return _damage != null; }
+      set { if (value == (_damage== null)) _damage = value ? this.damage : (uint?)null; }
+    }
+    private bool ShouldSerializedamage() { return damageSpecified; }
+    private void Resetdamage() { damageSpecified = false; }
+    
 
-    private uint _healing = default(uint);
+    private uint? _healing;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing
     {
-      get { return _healing; }
+      get { return _healing?? default(uint); }
       set { _healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healingSpecified
+    {
+      get { return _healing != null; }
+      set { if (value == (_healing== null)) _healing = value ? this.healing : (uint?)null; }
+    }
+    private bool ShouldSerializehealing() { return healingSpecified; }
+    private void Resethealing() { healingSpecified = false; }
+    
 
-    private uint _support = default(uint);
+    private uint? _support;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"support", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support
     {
-      get { return _support; }
+      get { return _support?? default(uint); }
       set { _support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supportSpecified
+    {
+      get { return _support != null; }
+      set { if (value == (_support== null)) _support = value ? this.support : (uint?)null; }
+    }
+    private bool ShouldSerializesupport() { return supportSpecified; }
+    private void Resetsupport() { supportSpecified = false; }
+    
 
-    private uint _score_bronze = default(uint);
+    private uint? _score_bronze;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"score_bronze", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_bronze
     {
-      get { return _score_bronze; }
+      get { return _score_bronze?? default(uint); }
       set { _score_bronze = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_bronzeSpecified
+    {
+      get { return _score_bronze != null; }
+      set { if (value == (_score_bronze== null)) _score_bronze = value ? this.score_bronze : (uint?)null; }
+    }
+    private bool ShouldSerializescore_bronze() { return score_bronzeSpecified; }
+    private void Resetscore_bronze() { score_bronzeSpecified = false; }
+    
 
-    private uint _score_silver = default(uint);
+    private uint? _score_silver;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"score_silver", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_silver
     {
-      get { return _score_silver; }
+      get { return _score_silver?? default(uint); }
       set { _score_silver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_silverSpecified
+    {
+      get { return _score_silver != null; }
+      set { if (value == (_score_silver== null)) _score_silver = value ? this.score_silver : (uint?)null; }
+    }
+    private bool ShouldSerializescore_silver() { return score_silverSpecified; }
+    private void Resetscore_silver() { score_silverSpecified = false; }
+    
 
-    private uint _score_gold = default(uint);
+    private uint? _score_gold;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"score_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_gold
     {
-      get { return _score_gold; }
+      get { return _score_gold?? default(uint); }
       set { _score_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_goldSpecified
+    {
+      get { return _score_gold != null; }
+      set { if (value == (_score_gold== null)) _score_gold = value ? this.score_gold : (uint?)null; }
+    }
+    private bool ShouldSerializescore_gold() { return score_goldSpecified; }
+    private void Resetscore_gold() { score_goldSpecified = false; }
+    
 
-    private uint _kills_bronze = default(uint);
+    private uint? _kills_bronze;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"kills_bronze", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills_bronze
     {
-      get { return _kills_bronze; }
+      get { return _kills_bronze?? default(uint); }
       set { _kills_bronze = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kills_bronzeSpecified
+    {
+      get { return _kills_bronze != null; }
+      set { if (value == (_kills_bronze== null)) _kills_bronze = value ? this.kills_bronze : (uint?)null; }
+    }
+    private bool ShouldSerializekills_bronze() { return kills_bronzeSpecified; }
+    private void Resetkills_bronze() { kills_bronzeSpecified = false; }
+    
 
-    private uint _kills_silver = default(uint);
+    private uint? _kills_silver;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"kills_silver", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills_silver
     {
-      get { return _kills_silver; }
+      get { return _kills_silver?? default(uint); }
       set { _kills_silver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kills_silverSpecified
+    {
+      get { return _kills_silver != null; }
+      set { if (value == (_kills_silver== null)) _kills_silver = value ? this.kills_silver : (uint?)null; }
+    }
+    private bool ShouldSerializekills_silver() { return kills_silverSpecified; }
+    private void Resetkills_silver() { kills_silverSpecified = false; }
+    
 
-    private uint _kills_gold = default(uint);
+    private uint? _kills_gold;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"kills_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills_gold
     {
-      get { return _kills_gold; }
+      get { return _kills_gold?? default(uint); }
       set { _kills_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kills_goldSpecified
+    {
+      get { return _kills_gold != null; }
+      set { if (value == (_kills_gold== null)) _kills_gold = value ? this.kills_gold : (uint?)null; }
+    }
+    private bool ShouldSerializekills_gold() { return kills_goldSpecified; }
+    private void Resetkills_gold() { kills_goldSpecified = false; }
+    
 
-    private uint _damage_bronze = default(uint);
+    private uint? _damage_bronze;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"damage_bronze", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_bronze
     {
-      get { return _damage_bronze; }
+      get { return _damage_bronze?? default(uint); }
       set { _damage_bronze = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_bronzeSpecified
+    {
+      get { return _damage_bronze != null; }
+      set { if (value == (_damage_bronze== null)) _damage_bronze = value ? this.damage_bronze : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_bronze() { return damage_bronzeSpecified; }
+    private void Resetdamage_bronze() { damage_bronzeSpecified = false; }
+    
 
-    private uint _damage_silver = default(uint);
+    private uint? _damage_silver;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"damage_silver", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_silver
     {
-      get { return _damage_silver; }
+      get { return _damage_silver?? default(uint); }
       set { _damage_silver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_silverSpecified
+    {
+      get { return _damage_silver != null; }
+      set { if (value == (_damage_silver== null)) _damage_silver = value ? this.damage_silver : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_silver() { return damage_silverSpecified; }
+    private void Resetdamage_silver() { damage_silverSpecified = false; }
+    
 
-    private uint _damage_gold = default(uint);
+    private uint? _damage_gold;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"damage_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_gold
     {
-      get { return _damage_gold; }
+      get { return _damage_gold?? default(uint); }
       set { _damage_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_goldSpecified
+    {
+      get { return _damage_gold != null; }
+      set { if (value == (_damage_gold== null)) _damage_gold = value ? this.damage_gold : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_gold() { return damage_goldSpecified; }
+    private void Resetdamage_gold() { damage_goldSpecified = false; }
+    
 
-    private uint _healing_bronze = default(uint);
+    private uint? _healing_bronze;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"healing_bronze", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing_bronze
     {
-      get { return _healing_bronze; }
+      get { return _healing_bronze?? default(uint); }
       set { _healing_bronze = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healing_bronzeSpecified
+    {
+      get { return _healing_bronze != null; }
+      set { if (value == (_healing_bronze== null)) _healing_bronze = value ? this.healing_bronze : (uint?)null; }
+    }
+    private bool ShouldSerializehealing_bronze() { return healing_bronzeSpecified; }
+    private void Resethealing_bronze() { healing_bronzeSpecified = false; }
+    
 
-    private uint _healing_silver = default(uint);
+    private uint? _healing_silver;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"healing_silver", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing_silver
     {
-      get { return _healing_silver; }
+      get { return _healing_silver?? default(uint); }
       set { _healing_silver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healing_silverSpecified
+    {
+      get { return _healing_silver != null; }
+      set { if (value == (_healing_silver== null)) _healing_silver = value ? this.healing_silver : (uint?)null; }
+    }
+    private bool ShouldSerializehealing_silver() { return healing_silverSpecified; }
+    private void Resethealing_silver() { healing_silverSpecified = false; }
+    
 
-    private uint _healing_gold = default(uint);
+    private uint? _healing_gold;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"healing_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing_gold
     {
-      get { return _healing_gold; }
+      get { return _healing_gold?? default(uint); }
       set { _healing_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healing_goldSpecified
+    {
+      get { return _healing_gold != null; }
+      set { if (value == (_healing_gold== null)) _healing_gold = value ? this.healing_gold : (uint?)null; }
+    }
+    private bool ShouldSerializehealing_gold() { return healing_goldSpecified; }
+    private void Resethealing_gold() { healing_goldSpecified = false; }
+    
 
-    private uint _support_bronze = default(uint);
+    private uint? _support_bronze;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"support_bronze", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_bronze
     {
-      get { return _support_bronze; }
+      get { return _support_bronze?? default(uint); }
       set { _support_bronze = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_bronzeSpecified
+    {
+      get { return _support_bronze != null; }
+      set { if (value == (_support_bronze== null)) _support_bronze = value ? this.support_bronze : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_bronze() { return support_bronzeSpecified; }
+    private void Resetsupport_bronze() { support_bronzeSpecified = false; }
+    
 
-    private uint _support_silver = default(uint);
+    private uint? _support_silver;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"support_silver", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_silver
     {
-      get { return _support_silver; }
+      get { return _support_silver?? default(uint); }
       set { _support_silver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_silverSpecified
+    {
+      get { return _support_silver != null; }
+      set { if (value == (_support_silver== null)) _support_silver = value ? this.support_silver : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_silver() { return support_silverSpecified; }
+    private void Resetsupport_silver() { support_silverSpecified = false; }
+    
 
-    private uint _support_gold = default(uint);
+    private uint? _support_gold;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"support_gold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_gold
     {
-      get { return _support_gold; }
+      get { return _support_gold?? default(uint); }
       set { _support_gold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_goldSpecified
+    {
+      get { return _support_gold != null; }
+      set { if (value == (_support_gold== null)) _support_gold = value ? this.support_gold : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_gold() { return support_goldSpecified; }
+    private void Resetsupport_gold() { support_goldSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6350,23 +10717,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_TFVoteKickPlayerRequest() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private ulong _target_id = default(ulong);
+    private ulong? _target_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_id
     {
-      get { return _target_id; }
+      get { return _target_id?? default(ulong); }
       set { _target_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_idSpecified
+    {
+      get { return _target_id != null; }
+      set { if (value == (_target_id== null)) _target_id = value ? this.target_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_id() { return target_idSpecified; }
+    private void Resettarget_id() { target_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6378,14 +10763,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_VoteKickPlayerRequestResponse() {}
     
 
-    private bool _allowed = default(bool);
+    private bool? _allowed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"allowed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allowed
     {
-      get { return _allowed; }
+      get { return _allowed?? default(bool); }
       set { _allowed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allowedSpecified
+    {
+      get { return _allowed != null; }
+      set { if (value == (_allowed== null)) _allowed = value ? this.allowed : (bool?)null; }
+    }
+    private bool ShouldSerializeallowed() { return allowedSpecified; }
+    private void Resetallowed() { allowedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6419,113 +10813,221 @@ namespace SteamKit2.GC.TF2.Internal
     public RankBucketEntry() {}
     
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _records = default(uint);
+    private uint? _records;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"records", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint records
     {
-      get { return _records; }
+      get { return _records?? default(uint); }
       set { _records = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recordsSpecified
+    {
+      get { return _records != null; }
+      set { if (value == (_records== null)) _records = value ? this.records : (uint?)null; }
+    }
+    private bool ShouldSerializerecords() { return recordsSpecified; }
+    private void Resetrecords() { recordsSpecified = false; }
+    
 
-    private uint _avg_score = default(uint);
+    private uint? _avg_score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"avg_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_score
     {
-      get { return _avg_score; }
+      get { return _avg_score?? default(uint); }
       set { _avg_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_scoreSpecified
+    {
+      get { return _avg_score != null; }
+      set { if (value == (_avg_score== null)) _avg_score = value ? this.avg_score : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_score() { return avg_scoreSpecified; }
+    private void Resetavg_score() { avg_scoreSpecified = false; }
+    
 
-    private uint _stdev_score = default(uint);
+    private uint? _stdev_score;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"stdev_score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stdev_score
     {
-      get { return _stdev_score; }
+      get { return _stdev_score?? default(uint); }
       set { _stdev_score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stdev_scoreSpecified
+    {
+      get { return _stdev_score != null; }
+      set { if (value == (_stdev_score== null)) _stdev_score = value ? this.stdev_score : (uint?)null; }
+    }
+    private bool ShouldSerializestdev_score() { return stdev_scoreSpecified; }
+    private void Resetstdev_score() { stdev_scoreSpecified = false; }
+    
 
-    private uint _avg_kills = default(uint);
+    private uint? _avg_kills;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"avg_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_kills
     {
-      get { return _avg_kills; }
+      get { return _avg_kills?? default(uint); }
       set { _avg_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_killsSpecified
+    {
+      get { return _avg_kills != null; }
+      set { if (value == (_avg_kills== null)) _avg_kills = value ? this.avg_kills : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_kills() { return avg_killsSpecified; }
+    private void Resetavg_kills() { avg_killsSpecified = false; }
+    
 
-    private uint _stdev_kills = default(uint);
+    private uint? _stdev_kills;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"stdev_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stdev_kills
     {
-      get { return _stdev_kills; }
+      get { return _stdev_kills?? default(uint); }
       set { _stdev_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stdev_killsSpecified
+    {
+      get { return _stdev_kills != null; }
+      set { if (value == (_stdev_kills== null)) _stdev_kills = value ? this.stdev_kills : (uint?)null; }
+    }
+    private bool ShouldSerializestdev_kills() { return stdev_killsSpecified; }
+    private void Resetstdev_kills() { stdev_killsSpecified = false; }
+    
 
-    private uint _avg_damage = default(uint);
+    private uint? _avg_damage;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"avg_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_damage
     {
-      get { return _avg_damage; }
+      get { return _avg_damage?? default(uint); }
       set { _avg_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_damageSpecified
+    {
+      get { return _avg_damage != null; }
+      set { if (value == (_avg_damage== null)) _avg_damage = value ? this.avg_damage : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_damage() { return avg_damageSpecified; }
+    private void Resetavg_damage() { avg_damageSpecified = false; }
+    
 
-    private uint _stdev_damage = default(uint);
+    private uint? _stdev_damage;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"stdev_damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stdev_damage
     {
-      get { return _stdev_damage; }
+      get { return _stdev_damage?? default(uint); }
       set { _stdev_damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stdev_damageSpecified
+    {
+      get { return _stdev_damage != null; }
+      set { if (value == (_stdev_damage== null)) _stdev_damage = value ? this.stdev_damage : (uint?)null; }
+    }
+    private bool ShouldSerializestdev_damage() { return stdev_damageSpecified; }
+    private void Resetstdev_damage() { stdev_damageSpecified = false; }
+    
 
-    private uint _avg_healing = default(uint);
+    private uint? _avg_healing;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"avg_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_healing
     {
-      get { return _avg_healing; }
+      get { return _avg_healing?? default(uint); }
       set { _avg_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_healingSpecified
+    {
+      get { return _avg_healing != null; }
+      set { if (value == (_avg_healing== null)) _avg_healing = value ? this.avg_healing : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_healing() { return avg_healingSpecified; }
+    private void Resetavg_healing() { avg_healingSpecified = false; }
+    
 
-    private uint _stdev_healing = default(uint);
+    private uint? _stdev_healing;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"stdev_healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stdev_healing
     {
-      get { return _stdev_healing; }
+      get { return _stdev_healing?? default(uint); }
       set { _stdev_healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stdev_healingSpecified
+    {
+      get { return _stdev_healing != null; }
+      set { if (value == (_stdev_healing== null)) _stdev_healing = value ? this.stdev_healing : (uint?)null; }
+    }
+    private bool ShouldSerializestdev_healing() { return stdev_healingSpecified; }
+    private void Resetstdev_healing() { stdev_healingSpecified = false; }
+    
 
-    private uint _avg_support = default(uint);
+    private uint? _avg_support;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"avg_support", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_support
     {
-      get { return _avg_support; }
+      get { return _avg_support?? default(uint); }
       set { _avg_support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_supportSpecified
+    {
+      get { return _avg_support != null; }
+      set { if (value == (_avg_support== null)) _avg_support = value ? this.avg_support : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_support() { return avg_supportSpecified; }
+    private void Resetavg_support() { avg_supportSpecified = false; }
+    
 
-    private uint _stdev_support = default(uint);
+    private uint? _stdev_support;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"stdev_support", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stdev_support
     {
-      get { return _stdev_support; }
+      get { return _stdev_support?? default(uint); }
       set { _stdev_support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stdev_supportSpecified
+    {
+      get { return _stdev_support != null; }
+      set { if (value == (_stdev_support== null)) _stdev_support = value ? this.stdev_support : (uint?)null; }
+    }
+    private bool ShouldSerializestdev_support() { return stdev_supportSpecified; }
+    private void Resetstdev_support() { stdev_supportSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6542,23 +11044,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_ReportPlayer() {}
     
 
-    private uint _account_id_target = default(uint);
+    private uint? _account_id_target;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id_target", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id_target
     {
-      get { return _account_id_target; }
+      get { return _account_id_target?? default(uint); }
       set { _account_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_id_targetSpecified
+    {
+      get { return _account_id_target != null; }
+      set { if (value == (_account_id_target== null)) _account_id_target = value ? this.account_id_target : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id_target() { return account_id_targetSpecified; }
+    private void Resetaccount_id_target() { account_id_targetSpecified = false; }
+    
 
-    private CMsgGC_ReportPlayer.EReason _reason = CMsgGC_ReportPlayer.EReason.kReason_INVALID;
+    private CMsgGC_ReportPlayer.EReason? _reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGC_ReportPlayer.EReason.kReason_INVALID)]
     public CMsgGC_ReportPlayer.EReason reason
     {
-      get { return _reason; }
+      get { return _reason?? CMsgGC_ReportPlayer.EReason.kReason_INVALID; }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (CMsgGC_ReportPlayer.EReason?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EReason", EnumPassthru=true)]
     public enum EReason
     {
@@ -6593,239 +11113,473 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOTFMatchResultPlayerStats() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private int _match_group = default(int);
+    private int? _match_group;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"match_group", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int match_group
     {
-      get { return _match_group; }
+      get { return _match_group?? default(int); }
       set { _match_group = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_groupSpecified
+    {
+      get { return _match_group != null; }
+      set { if (value == (_match_group== null)) _match_group = value ? this.match_group : (int?)null; }
+    }
+    private bool ShouldSerializematch_group() { return match_groupSpecified; }
+    private void Resetmatch_group() { match_groupSpecified = false; }
+    
 
-    private uint _endtime = default(uint);
+    private uint? _endtime;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"endtime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint endtime
     {
-      get { return _endtime; }
+      get { return _endtime?? default(uint); }
       set { _endtime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool endtimeSpecified
+    {
+      get { return _endtime != null; }
+      set { if (value == (_endtime== null)) _endtime = value ? this.endtime : (uint?)null; }
+    }
+    private bool ShouldSerializeendtime() { return endtimeSpecified; }
+    private void Resetendtime() { endtimeSpecified = false; }
+    
 
-    private uint _season_id = default(uint);
+    private uint? _season_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"season_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint season_id
     {
-      get { return _season_id; }
+      get { return _season_id?? default(uint); }
       set { _season_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool season_idSpecified
+    {
+      get { return _season_id != null; }
+      set { if (value == (_season_id== null)) _season_id = value ? this.season_id : (uint?)null; }
+    }
+    private bool ShouldSerializeseason_id() { return season_idSpecified; }
+    private void Resetseason_id() { season_idSpecified = false; }
+    
 
-    private uint _status = default(uint);
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? default(uint); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _party_id = default(uint);
+    private uint? _party_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(uint); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (uint?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private uint _team = default(uint);
+    private uint? _team;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team
     {
-      get { return _team; }
+      get { return _team?? default(uint); }
       set { _team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool teamSpecified
+    {
+      get { return _team != null; }
+      set { if (value == (_team== null)) _team = value ? this.team : (uint?)null; }
+    }
+    private bool ShouldSerializeteam() { return teamSpecified; }
+    private void Resetteam() { teamSpecified = false; }
+    
 
-    private uint _score = default(uint);
+    private uint? _score;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score
     {
-      get { return _score; }
+      get { return _score?? default(uint); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (uint?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _ping = default(uint);
+    private uint? _ping;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"ping", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ping
     {
-      get { return _ping; }
+      get { return _ping?? default(uint); }
       set { _ping = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingSpecified
+    {
+      get { return _ping != null; }
+      set { if (value == (_ping== null)) _ping = value ? this.ping : (uint?)null; }
+    }
+    private bool ShouldSerializeping() { return pingSpecified; }
+    private void Resetping() { pingSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _skillrating = default(uint);
+    private uint? _skillrating;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"skillrating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skillrating
     {
-      get { return _skillrating; }
+      get { return _skillrating?? default(uint); }
       set { _skillrating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillratingSpecified
+    {
+      get { return _skillrating != null; }
+      set { if (value == (_skillrating== null)) _skillrating = value ? this.skillrating : (uint?)null; }
+    }
+    private bool ShouldSerializeskillrating() { return skillratingSpecified; }
+    private void Resetskillrating() { skillratingSpecified = false; }
+    
 
-    private int _skillrating_change = default(int);
+    private int? _skillrating_change;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"skillrating_change", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int skillrating_change
     {
-      get { return _skillrating_change; }
+      get { return _skillrating_change?? default(int); }
       set { _skillrating_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skillrating_changeSpecified
+    {
+      get { return _skillrating_change != null; }
+      set { if (value == (_skillrating_change== null)) _skillrating_change = value ? this.skillrating_change : (int?)null; }
+    }
+    private bool ShouldSerializeskillrating_change() { return skillrating_changeSpecified; }
+    private void Resetskillrating_change() { skillrating_changeSpecified = false; }
+    
 
-    private uint _rank = default(uint);
+    private uint? _rank;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rank
     {
-      get { return _rank; }
+      get { return _rank?? default(uint); }
       set { _rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rankSpecified
+    {
+      get { return _rank != null; }
+      set { if (value == (_rank== null)) _rank = value ? this.rank : (uint?)null; }
+    }
+    private bool ShouldSerializerank() { return rankSpecified; }
+    private void Resetrank() { rankSpecified = false; }
+    
 
-    private uint _classes_played = default(uint);
+    private uint? _classes_played;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"classes_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint classes_played
     {
-      get { return _classes_played; }
+      get { return _classes_played?? default(uint); }
       set { _classes_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool classes_playedSpecified
+    {
+      get { return _classes_played != null; }
+      set { if (value == (_classes_played== null)) _classes_played = value ? this.classes_played : (uint?)null; }
+    }
+    private bool ShouldSerializeclasses_played() { return classes_playedSpecified; }
+    private void Resetclasses_played() { classes_playedSpecified = false; }
+    
 
-    private uint _kills = default(uint);
+    private uint? _kills;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills
     {
-      get { return _kills; }
+      get { return _kills?? default(uint); }
       set { _kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killsSpecified
+    {
+      get { return _kills != null; }
+      set { if (value == (_kills== null)) _kills = value ? this.kills : (uint?)null; }
+    }
+    private bool ShouldSerializekills() { return killsSpecified; }
+    private void Resetkills() { killsSpecified = false; }
+    
 
-    private uint _deaths = default(uint);
+    private uint? _deaths;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"deaths", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deaths
     {
-      get { return _deaths; }
+      get { return _deaths?? default(uint); }
       set { _deaths = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deathsSpecified
+    {
+      get { return _deaths != null; }
+      set { if (value == (_deaths== null)) _deaths = value ? this.deaths : (uint?)null; }
+    }
+    private bool ShouldSerializedeaths() { return deathsSpecified; }
+    private void Resetdeaths() { deathsSpecified = false; }
+    
 
-    private uint _damage = default(uint);
+    private uint? _damage;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"damage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage
     {
-      get { return _damage; }
+      get { return _damage?? default(uint); }
       set { _damage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damageSpecified
+    {
+      get { return _damage != null; }
+      set { if (value == (_damage== null)) _damage = value ? this.damage : (uint?)null; }
+    }
+    private bool ShouldSerializedamage() { return damageSpecified; }
+    private void Resetdamage() { damageSpecified = false; }
+    
 
-    private uint _healing = default(uint);
+    private uint? _healing;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"healing", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing
     {
-      get { return _healing; }
+      get { return _healing?? default(uint); }
       set { _healing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healingSpecified
+    {
+      get { return _healing != null; }
+      set { if (value == (_healing== null)) _healing = value ? this.healing : (uint?)null; }
+    }
+    private bool ShouldSerializehealing() { return healingSpecified; }
+    private void Resethealing() { healingSpecified = false; }
+    
 
-    private uint _support = default(uint);
+    private uint? _support;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"support", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support
     {
-      get { return _support; }
+      get { return _support?? default(uint); }
       set { _support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supportSpecified
+    {
+      get { return _support != null; }
+      set { if (value == (_support== null)) _support = value ? this.support : (uint?)null; }
+    }
+    private bool ShouldSerializesupport() { return supportSpecified; }
+    private void Resetsupport() { supportSpecified = false; }
+    
 
-    private uint _score_medal = default(uint);
+    private uint? _score_medal;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"score_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint score_medal
     {
-      get { return _score_medal; }
+      get { return _score_medal?? default(uint); }
       set { _score_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_medalSpecified
+    {
+      get { return _score_medal != null; }
+      set { if (value == (_score_medal== null)) _score_medal = value ? this.score_medal : (uint?)null; }
+    }
+    private bool ShouldSerializescore_medal() { return score_medalSpecified; }
+    private void Resetscore_medal() { score_medalSpecified = false; }
+    
 
-    private uint _kills_medal = default(uint);
+    private uint? _kills_medal;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"kills_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint kills_medal
     {
-      get { return _kills_medal; }
+      get { return _kills_medal?? default(uint); }
       set { _kills_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kills_medalSpecified
+    {
+      get { return _kills_medal != null; }
+      set { if (value == (_kills_medal== null)) _kills_medal = value ? this.kills_medal : (uint?)null; }
+    }
+    private bool ShouldSerializekills_medal() { return kills_medalSpecified; }
+    private void Resetkills_medal() { kills_medalSpecified = false; }
+    
 
-    private uint _damage_medal = default(uint);
+    private uint? _damage_medal;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"damage_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint damage_medal
     {
-      get { return _damage_medal; }
+      get { return _damage_medal?? default(uint); }
       set { _damage_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool damage_medalSpecified
+    {
+      get { return _damage_medal != null; }
+      set { if (value == (_damage_medal== null)) _damage_medal = value ? this.damage_medal : (uint?)null; }
+    }
+    private bool ShouldSerializedamage_medal() { return damage_medalSpecified; }
+    private void Resetdamage_medal() { damage_medalSpecified = false; }
+    
 
-    private uint _healing_medal = default(uint);
+    private uint? _healing_medal;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"healing_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint healing_medal
     {
-      get { return _healing_medal; }
+      get { return _healing_medal?? default(uint); }
       set { _healing_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool healing_medalSpecified
+    {
+      get { return _healing_medal != null; }
+      set { if (value == (_healing_medal== null)) _healing_medal = value ? this.healing_medal : (uint?)null; }
+    }
+    private bool ShouldSerializehealing_medal() { return healing_medalSpecified; }
+    private void Resethealing_medal() { healing_medalSpecified = false; }
+    
 
-    private uint _support_medal = default(uint);
+    private uint? _support_medal;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"support_medal", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint support_medal
     {
-      get { return _support_medal; }
+      get { return _support_medal?? default(uint); }
       set { _support_medal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool support_medalSpecified
+    {
+      get { return _support_medal != null; }
+      set { if (value == (_support_medal== null)) _support_medal = value ? this.support_medal : (uint?)null; }
+    }
+    private bool ShouldSerializesupport_medal() { return support_medalSpecified; }
+    private void Resetsupport_medal() { support_medalSpecified = false; }
+    
 
-    private uint _map_index = default(uint);
+    private uint? _map_index;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"map_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint map_index
     {
-      get { return _map_index; }
+      get { return _map_index?? default(uint); }
       set { _map_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool map_indexSpecified
+    {
+      get { return _map_index != null; }
+      set { if (value == (_map_index== null)) _map_index = value ? this.map_index : (uint?)null; }
+    }
+    private bool ShouldSerializemap_index() { return map_indexSpecified; }
+    private void Resetmap_index() { map_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6847,23 +11601,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCDataCenterPopulation() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private float _health_ratio = default(float);
+    private float? _health_ratio;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"health_ratio", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float health_ratio
     {
-      get { return _health_ratio; }
+      get { return _health_ratio?? default(float); }
       set { _health_ratio = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool health_ratioSpecified
+    {
+      get { return _health_ratio != null; }
+      set { if (value == (_health_ratio== null)) _health_ratio = value ? this.health_ratio : (float?)null; }
+    }
+    private bool ShouldSerializehealth_ratio() { return health_ratioSpecified; }
+    private void Resethealth_ratio() { health_ratioSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6938,32 +11710,59 @@ namespace SteamKit2.GC.TF2.Internal
     public PingEntry() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _ping = default(uint);
+    private uint? _ping;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ping", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ping
     {
-      get { return _ping; }
+      get { return _ping?? default(uint); }
       set { _ping = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pingSpecified
+    {
+      get { return _ping != null; }
+      set { if (value == (_ping== null)) _ping = value ? this.ping : (uint?)null; }
+    }
+    private bool ShouldSerializeping() { return pingSpecified; }
+    private void Resetping() { pingSpecified = false; }
+    
 
-    private CMsgGCDataCenterPing_Update.Status _ping_status = CMsgGCDataCenterPing_Update.Status.Normal;
+    private CMsgGCDataCenterPing_Update.Status? _ping_status;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ping_status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCDataCenterPing_Update.Status.Normal)]
     public CMsgGCDataCenterPing_Update.Status ping_status
     {
-      get { return _ping_status; }
+      get { return _ping_status?? CMsgGCDataCenterPing_Update.Status.Normal; }
       set { _ping_status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ping_statusSpecified
+    {
+      get { return _ping_status != null; }
+      set { if (value == (_ping_status== null)) _ping_status = value ? this.ping_status : (CMsgGCDataCenterPing_Update.Status?)null; }
+    }
+    private bool ShouldSerializeping_status() { return ping_statusSpecified; }
+    private void Resetping_status() { ping_statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6997,14 +11796,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGC_KickPlayerFromLobby() {}
     
 
-    private ulong _targetID = default(ulong);
+    private ulong? _targetID;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"targetID", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong targetID
     {
-      get { return _targetID; }
+      get { return _targetID?? default(ulong); }
       set { _targetID = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool targetIDSpecified
+    {
+      get { return _targetID != null; }
+      set { if (value == (_targetID== null)) _targetID = value ? this.targetID : (ulong?)null; }
+    }
+    private bool ShouldSerializetargetID() { return targetIDSpecified; }
+    private void ResettargetID() { targetIDSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7016,23 +11824,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCSurveyRequest() {}
     
 
-    private SurveyQuestionType _question_type = SurveyQuestionType.QUESTION_MATCH_QUALITY;
+    private SurveyQuestionType? _question_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"question_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SurveyQuestionType.QUESTION_MATCH_QUALITY)]
     public SurveyQuestionType question_type
     {
-      get { return _question_type; }
+      get { return _question_type?? SurveyQuestionType.QUESTION_MATCH_QUALITY; }
       set { _question_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool question_typeSpecified
+    {
+      get { return _question_type != null; }
+      set { if (value == (_question_type== null)) _question_type = value ? this.question_type : (SurveyQuestionType?)null; }
+    }
+    private bool ShouldSerializequestion_type() { return question_typeSpecified; }
+    private void Resetquestion_type() { question_typeSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7044,32 +11870,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCSurveyResponse() {}
     
 
-    private SurveyQuestionType _question_type = SurveyQuestionType.QUESTION_MATCH_QUALITY;
+    private SurveyQuestionType? _question_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"question_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(SurveyQuestionType.QUESTION_MATCH_QUALITY)]
     public SurveyQuestionType question_type
     {
-      get { return _question_type; }
+      get { return _question_type?? SurveyQuestionType.QUESTION_MATCH_QUALITY; }
       set { _question_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool question_typeSpecified
+    {
+      get { return _question_type != null; }
+      set { if (value == (_question_type== null)) _question_type = value ? this.question_type : (SurveyQuestionType?)null; }
+    }
+    private bool ShouldSerializequestion_type() { return question_typeSpecified; }
+    private void Resetquestion_type() { question_typeSpecified = false; }
+    
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private int _response = default(int);
+    private int? _response;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int response
     {
-      get { return _response; }
+      get { return _response?? default(int); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (int?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7081,32 +11934,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCNewMatchForLobbyRequest() {}
     
 
-    private ulong _current_match_id = default(ulong);
+    private ulong? _current_match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"current_match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong current_match_id
     {
-      get { return _current_match_id; }
+      get { return _current_match_id?? default(ulong); }
       set { _current_match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_match_idSpecified
+    {
+      get { return _current_match_id != null; }
+      set { if (value == (_current_match_id== null)) _current_match_id = value ? this.current_match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecurrent_match_id() { return current_match_idSpecified; }
+    private void Resetcurrent_match_id() { current_match_idSpecified = false; }
+    
 
-    private uint _next_map_id = default(uint);
+    private uint? _next_map_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"next_map_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint next_map_id
     {
-      get { return _next_map_id; }
+      get { return _next_map_id?? default(uint); }
       set { _next_map_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool next_map_idSpecified
+    {
+      get { return _next_map_id != null; }
+      set { if (value == (_next_map_id== null)) _next_map_id = value ? this.next_map_id : (uint?)null; }
+    }
+    private bool ShouldSerializenext_map_id() { return next_map_idSpecified; }
+    private void Resetnext_map_id() { next_map_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7118,14 +11998,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCNewMatchForLobbyResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7137,23 +12026,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCChangeMatchPlayerTeamsRequest() {}
     
 
-    private ulong _match_id = default(ulong);
+    private ulong? _match_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"match_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong match_id
     {
-      get { return _match_id; }
+      get { return _match_id?? default(ulong); }
       set { _match_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_idSpecified
+    {
+      get { return _match_id != null; }
+      set { if (value == (_match_id== null)) _match_id = value ? this.match_id : (ulong?)null; }
+    }
+    private bool ShouldSerializematch_id() { return match_idSpecified; }
+    private void Resetmatch_id() { match_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCChangeMatchPlayerTeamsRequest.Member> _member = new global::System.Collections.Generic.List<CMsgGCChangeMatchPlayerTeamsRequest.Member>();
     [global::ProtoBuf.ProtoMember(3, Name=@"member", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCChangeMatchPlayerTeamsRequest.Member> member
@@ -7167,23 +12074,41 @@ namespace SteamKit2.GC.TF2.Internal
     public Member() {}
     
 
-    private ulong _member_id = default(ulong);
+    private ulong? _member_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"member_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong member_id
     {
-      get { return _member_id; }
+      get { return _member_id?? default(ulong); }
       set { _member_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool member_idSpecified
+    {
+      get { return _member_id != null; }
+      set { if (value == (_member_id== null)) _member_id = value ? this.member_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemember_id() { return member_idSpecified; }
+    private void Resetmember_id() { member_idSpecified = false; }
+    
 
-    private TF_GC_TEAM _new_team = TF_GC_TEAM.TF_GC_TEAM_NOTEAM;
+    private TF_GC_TEAM? _new_team;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_team", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(TF_GC_TEAM.TF_GC_TEAM_NOTEAM)]
     public TF_GC_TEAM new_team
     {
-      get { return _new_team; }
+      get { return _new_team?? TF_GC_TEAM.TF_GC_TEAM_NOTEAM; }
       set { _new_team = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_teamSpecified
+    {
+      get { return _new_team != null; }
+      set { if (value == (_new_team== null)) _new_team = value ? this.new_team : (TF_GC_TEAM?)null; }
+    }
+    private bool ShouldSerializenew_team() { return new_teamSpecified; }
+    private void Resetnew_team() { new_teamSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7200,14 +12125,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCChangeMatchPlayerTeamsResponse() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgBase.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.GC.TF2.Internal
@@ -18,95 +20,185 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgProtoBufHeader() {}
     
 
-    private ulong _client_steam_id = default(ulong);
+    private ulong? _client_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_steam_id
     {
-      get { return _client_steam_id; }
+      get { return _client_steam_id?? default(ulong); }
       set { _client_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_steam_idSpecified
+    {
+      get { return _client_steam_id != null; }
+      set { if (value == (_client_steam_id== null)) _client_steam_id = value ? this.client_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_steam_id() { return client_steam_idSpecified; }
+    private void Resetclient_steam_id() { client_steam_idSpecified = false; }
+    
 
-    private int _client_session_id = default(int);
+    private int? _client_session_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int client_session_id
     {
-      get { return _client_session_id; }
+      get { return _client_session_id?? default(int); }
       set { _client_session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_idSpecified
+    {
+      get { return _client_session_id != null; }
+      set { if (value == (_client_session_id== null)) _client_session_id = value ? this.client_session_id : (int?)null; }
+    }
+    private bool ShouldSerializeclient_session_id() { return client_session_idSpecified; }
+    private void Resetclient_session_id() { client_session_idSpecified = false; }
+    
 
-    private uint _source_app_id = default(uint);
+    private uint? _source_app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"source_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_app_id
     {
-      get { return _source_app_id; }
+      get { return _source_app_id?? default(uint); }
       set { _source_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_app_idSpecified
+    {
+      get { return _source_app_id != null; }
+      set { if (value == (_source_app_id== null)) _source_app_id = value ? this.source_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializesource_app_id() { return source_app_idSpecified; }
+    private void Resetsource_app_id() { source_app_idSpecified = false; }
+    
 
-    private ulong _job_id_source = (ulong)18446744073709551615;
+    private ulong? _job_id_source;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"job_id_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_source
     {
-      get { return _job_id_source; }
+      get { return _job_id_source?? (ulong)18446744073709551615; }
       set { _job_id_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_sourceSpecified
+    {
+      get { return _job_id_source != null; }
+      set { if (value == (_job_id_source== null)) _job_id_source = value ? this.job_id_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_source() { return job_id_sourceSpecified; }
+    private void Resetjob_id_source() { job_id_sourceSpecified = false; }
+    
 
-    private ulong _job_id_target = (ulong)18446744073709551615;
+    private ulong? _job_id_target;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"job_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong job_id_target
     {
-      get { return _job_id_target; }
+      get { return _job_id_target?? (ulong)18446744073709551615; }
       set { _job_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_id_targetSpecified
+    {
+      get { return _job_id_target != null; }
+      set { if (value == (_job_id_target== null)) _job_id_target = value ? this.job_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_id_target() { return job_id_targetSpecified; }
+    private void Resetjob_id_target() { job_id_targetSpecified = false; }
+    
 
-    private string _target_job_name = "";
+    private string _target_job_name;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"target_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string target_job_name
     {
-      get { return _target_job_name; }
+      get { return _target_job_name?? ""; }
       set { _target_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_job_nameSpecified
+    {
+      get { return _target_job_name != null; }
+      set { if (value == (_target_job_name== null)) _target_job_name = value ? this.target_job_name : (string)null; }
+    }
+    private bool ShouldSerializetarget_job_name() { return target_job_nameSpecified; }
+    private void Resettarget_job_name() { target_job_nameSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
 
-    private GCProtoBufMsgSrc _gc_msg_src = GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified;
+    private GCProtoBufMsgSrc? _gc_msg_src;
     [global::ProtoBuf.ProtoMember(200, IsRequired = false, Name=@"gc_msg_src", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified)]
     public GCProtoBufMsgSrc gc_msg_src
     {
-      get { return _gc_msg_src; }
+      get { return _gc_msg_src?? GCProtoBufMsgSrc.GCProtoBufMsgSrc_Unspecified; }
       set { _gc_msg_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_msg_srcSpecified
+    {
+      get { return _gc_msg_src != null; }
+      set { if (value == (_gc_msg_src== null)) _gc_msg_src = value ? this.gc_msg_src : (GCProtoBufMsgSrc?)null; }
+    }
+    private bool ShouldSerializegc_msg_src() { return gc_msg_srcSpecified; }
+    private void Resetgc_msg_src() { gc_msg_srcSpecified = false; }
+    
 
-    private uint _gc_dir_index_source = default(uint);
+    private uint? _gc_dir_index_source;
     [global::ProtoBuf.ProtoMember(201, IsRequired = false, Name=@"gc_dir_index_source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_dir_index_source
     {
-      get { return _gc_dir_index_source; }
+      get { return _gc_dir_index_source?? default(uint); }
       set { _gc_dir_index_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_dir_index_sourceSpecified
+    {
+      get { return _gc_dir_index_source != null; }
+      set { if (value == (_gc_dir_index_source== null)) _gc_dir_index_source = value ? this.gc_dir_index_source : (uint?)null; }
+    }
+    private bool ShouldSerializegc_dir_index_source() { return gc_dir_index_sourceSpecified; }
+    private void Resetgc_dir_index_source() { gc_dir_index_sourceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -118,50 +210,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgWebAPIKey() {}
     
 
-    private uint _status = (uint)255;
+    private uint? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)255)]
     public uint status
     {
-      get { return _status; }
+      get { return _status?? (uint)255; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (uint?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _account_id = (uint)0;
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? (uint)0; }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _publisher_group_id = (uint)0;
+    private uint? _publisher_group_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"publisher_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint publisher_group_id
     {
-      get { return _publisher_group_id; }
+      get { return _publisher_group_id?? (uint)0; }
       set { _publisher_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publisher_group_idSpecified
+    {
+      get { return _publisher_group_id != null; }
+      set { if (value == (_publisher_group_id== null)) _publisher_group_id = value ? this.publisher_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializepublisher_group_id() { return publisher_group_idSpecified; }
+    private void Resetpublisher_group_id() { publisher_group_idSpecified = false; }
+    
 
-    private uint _key_id = default(uint);
+    private uint? _key_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"key_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint key_id
     {
-      get { return _key_id; }
+      get { return _key_id?? default(uint); }
       set { _key_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool key_idSpecified
+    {
+      get { return _key_id != null; }
+      set { if (value == (_key_id== null)) _key_id = value ? this.key_id : (uint?)null; }
+    }
+    private bool ShouldSerializekey_id() { return key_idSpecified; }
+    private void Resetkey_id() { key_idSpecified = false; }
+    
 
-    private string _domain = "";
+    private string _domain;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"domain", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string domain
     {
-      get { return _domain; }
+      get { return _domain?? ""; }
       set { _domain = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool domainSpecified
+    {
+      get { return _domain != null; }
+      set { if (value == (_domain== null)) _domain = value ? this.domain : (string)null; }
+    }
+    private bool ShouldSerializedomain() { return domainSpecified; }
+    private void Resetdomain() { domainSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,32 +310,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgHttpRequest() {}
     
 
-    private uint _request_method = default(uint);
+    private uint? _request_method;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"request_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint request_method
     {
-      get { return _request_method; }
+      get { return _request_method?? default(uint); }
       set { _request_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool request_methodSpecified
+    {
+      get { return _request_method != null; }
+      set { if (value == (_request_method== null)) _request_method = value ? this.request_method : (uint?)null; }
+    }
+    private bool ShouldSerializerequest_method() { return request_methodSpecified; }
+    private void Resetrequest_method() { request_methodSpecified = false; }
+    
 
-    private string _hostname = "";
+    private string _hostname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hostname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string hostname
     {
-      get { return _hostname; }
+      get { return _hostname?? ""; }
       set { _hostname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hostnameSpecified
+    {
+      get { return _hostname != null; }
+      set { if (value == (_hostname== null)) _hostname = value ? this.hostname : (string)null; }
+    }
+    private bool ShouldSerializehostname() { return hostnameSpecified; }
+    private void Resethostname() { hostnameSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader>();
     [global::ProtoBuf.ProtoMember(4, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpRequest.RequestHeader> headers
@@ -221,46 +385,82 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
 
-    private uint _absolute_timeout = default(uint);
+    private uint? _absolute_timeout;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"absolute_timeout", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint absolute_timeout
     {
-      get { return _absolute_timeout; }
+      get { return _absolute_timeout?? default(uint); }
       set { _absolute_timeout = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool absolute_timeoutSpecified
+    {
+      get { return _absolute_timeout != null; }
+      set { if (value == (_absolute_timeout== null)) _absolute_timeout = value ? this.absolute_timeout : (uint?)null; }
+    }
+    private bool ShouldSerializeabsolute_timeout() { return absolute_timeoutSpecified; }
+    private void Resetabsolute_timeout() { absolute_timeoutSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"RequestHeader")]
   public partial class RequestHeader : global::ProtoBuf.IExtensible
   {
     public RequestHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -272,23 +472,41 @@ namespace SteamKit2.GC.TF2.Internal
     public QueryParam() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -305,41 +523,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgWebAPIRequest() {}
     
 
-    private string _UNUSED_job_name = "";
+    private string _UNUSED_job_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"UNUSED_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string UNUSED_job_name
     {
-      get { return _UNUSED_job_name; }
+      get { return _UNUSED_job_name?? ""; }
       set { _UNUSED_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool UNUSED_job_nameSpecified
+    {
+      get { return _UNUSED_job_name != null; }
+      set { if (value == (_UNUSED_job_name== null)) _UNUSED_job_name = value ? this.UNUSED_job_name : (string)null; }
+    }
+    private bool ShouldSerializeUNUSED_job_name() { return UNUSED_job_nameSpecified; }
+    private void ResetUNUSED_job_name() { UNUSED_job_nameSpecified = false; }
+    
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgWebAPIKey _api_key = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"api_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -359,14 +613,23 @@ namespace SteamKit2.GC.TF2.Internal
       set { _request = value; }
     }
 
-    private uint _routing_app_id = default(uint);
+    private uint? _routing_app_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"routing_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint routing_app_id
     {
-      get { return _routing_app_id; }
+      get { return _routing_app_id?? default(uint); }
       set { _routing_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_app_idSpecified
+    {
+      get { return _routing_app_id != null; }
+      set { if (value == (_routing_app_id== null)) _routing_app_id = value ? this.routing_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializerouting_app_id() { return routing_app_idSpecified; }
+    private void Resetrouting_app_id() { routing_app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -378,14 +641,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgHttpResponse() {}
     
 
-    private uint _status_code = default(uint);
+    private uint? _status_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_code
     {
-      get { return _status_code; }
+      get { return _status_code?? default(uint); }
       set { _status_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_codeSpecified
+    {
+      get { return _status_code != null; }
+      set { if (value == (_status_code== null)) _status_code = value ? this.status_code : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_code() { return status_codeSpecified; }
+    private void Resetstatus_code() { status_codeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> _headers = new global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader>();
     [global::ProtoBuf.ProtoMember(2, Name=@"headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgHttpResponse.ResponseHeader> headers
@@ -394,37 +666,64 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private byte[] _body = null;
+    private byte[] _body;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] body
     {
-      get { return _body; }
+      get { return _body?? null; }
       set { _body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bodySpecified
+    {
+      get { return _body != null; }
+      set { if (value == (_body== null)) _body = value ? this.body : (byte[])null; }
+    }
+    private bool ShouldSerializebody() { return bodySpecified; }
+    private void Resetbody() { bodySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ResponseHeader")]
   public partial class ResponseHeader : global::ProtoBuf.IExtensible
   {
     public ResponseHeader() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -441,23 +740,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMFindAccounts() {}
     
 
-    private uint _search_type = default(uint);
+    private uint? _search_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"search_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint search_type
     {
-      get { return _search_type; }
+      get { return _search_type?? default(uint); }
       set { _search_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_typeSpecified
+    {
+      get { return _search_type != null; }
+      set { if (value == (_search_type== null)) _search_type = value ? this.search_type : (uint?)null; }
+    }
+    private bool ShouldSerializesearch_type() { return search_typeSpecified; }
+    private void Resetsearch_type() { search_typeSpecified = false; }
+    
 
-    private string _search_string = "";
+    private string _search_string;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"search_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_string
     {
-      get { return _search_string; }
+      get { return _search_string?? ""; }
       set { _search_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_stringSpecified
+    {
+      get { return _search_string != null; }
+      set { if (value == (_search_string== null)) _search_string = value ? this.search_string : (string)null; }
+    }
+    private bool ShouldSerializesearch_string() { return search_stringSpecified; }
+    private void Resetsearch_string() { search_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -486,68 +803,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgNotifyWatchdog() {}
     
 
-    private uint _source = default(uint);
+    private uint? _source;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source
     {
-      get { return _source; }
+      get { return _source?? default(uint); }
       set { _source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sourceSpecified
+    {
+      get { return _source != null; }
+      set { if (value == (_source== null)) _source = value ? this.source : (uint?)null; }
+    }
+    private bool ShouldSerializesource() { return sourceSpecified; }
+    private void Resetsource() { sourceSpecified = false; }
+    
 
-    private uint _alert_type = default(uint);
+    private uint? _alert_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"alert_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint alert_type
     {
-      get { return _alert_type; }
+      get { return _alert_type?? default(uint); }
       set { _alert_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool alert_typeSpecified
+    {
+      get { return _alert_type != null; }
+      set { if (value == (_alert_type== null)) _alert_type = value ? this.alert_type : (uint?)null; }
+    }
+    private bool ShouldSerializealert_type() { return alert_typeSpecified; }
+    private void Resetalert_type() { alert_typeSpecified = false; }
+    
 
-    private uint _alert_destination = default(uint);
+    private uint? _alert_destination;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"alert_destination", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint alert_destination
     {
-      get { return _alert_destination; }
+      get { return _alert_destination?? default(uint); }
       set { _alert_destination = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool alert_destinationSpecified
+    {
+      get { return _alert_destination != null; }
+      set { if (value == (_alert_destination== null)) _alert_destination = value ? this.alert_destination : (uint?)null; }
+    }
+    private bool ShouldSerializealert_destination() { return alert_destinationSpecified; }
+    private void Resetalert_destination() { alert_destinationSpecified = false; }
+    
 
-    private bool _critical = default(bool);
+    private bool? _critical;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"critical", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool critical
     {
-      get { return _critical; }
+      get { return _critical?? default(bool); }
       set { _critical = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool criticalSpecified
+    {
+      get { return _critical != null; }
+      set { if (value == (_critical== null)) _critical = value ? this.critical : (bool?)null; }
+    }
+    private bool ShouldSerializecritical() { return criticalSpecified; }
+    private void Resetcritical() { criticalSpecified = false; }
+    
 
-    private uint _time = default(uint);
+    private uint? _time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time
     {
-      get { return _time; }
+      get { return _time?? default(uint); }
       set { _time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timeSpecified
+    {
+      get { return _time != null; }
+      set { if (value == (_time== null)) _time = value ? this.time : (uint?)null; }
+    }
+    private bool ShouldSerializetime() { return timeSpecified; }
+    private void Resettime() { timeSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _text = "";
+    private string _text;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string text
     {
-      get { return _text; }
+      get { return _text?? ""; }
       set { _text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool textSpecified
+    {
+      get { return _text != null; }
+      set { if (value == (_text== null)) _text = value ? this.text : (string)null; }
+    }
+    private bool ShouldSerializetext() { return textSpecified; }
+    private void Resettext() { textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -559,14 +939,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMGetLicenses() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -578,32 +967,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgPackageLicense() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -622,14 +1038,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -641,23 +1066,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMGetUserGameStats() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _stats = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> stats
@@ -676,32 +1119,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMGetUserGameStatsResponse() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> _stats = new global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats>();
     [global::ProtoBuf.ProtoMember(4, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMGetUserGameStatsResponse.Stats> stats
@@ -722,23 +1192,41 @@ namespace SteamKit2.GC.TF2.Internal
     public Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -750,32 +1238,59 @@ namespace SteamKit2.GC.TF2.Internal
     public Achievement_Blocks() {}
     
 
-    private uint _achievement_id = default(uint);
+    private uint? _achievement_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"achievement_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_id
     {
-      get { return _achievement_id; }
+      get { return _achievement_id?? default(uint); }
       set { _achievement_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_idSpecified
+    {
+      get { return _achievement_id != null; }
+      set { if (value == (_achievement_id== null)) _achievement_id = value ? this.achievement_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_id() { return achievement_idSpecified; }
+    private void Resetachievement_id() { achievement_idSpecified = false; }
+    
 
-    private uint _achievement_bit_id = default(uint);
+    private uint? _achievement_bit_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"achievement_bit_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_bit_id
     {
-      get { return _achievement_bit_id; }
+      get { return _achievement_bit_id?? default(uint); }
       set { _achievement_bit_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_bit_idSpecified
+    {
+      get { return _achievement_bit_id != null; }
+      set { if (value == (_achievement_bit_id== null)) _achievement_bit_id = value ? this.achievement_bit_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_bit_id() { return achievement_bit_idSpecified; }
+    private void Resetachievement_bit_id() { achievement_bit_idSpecified = false; }
+    
 
-    private uint _unlock_time = default(uint);
+    private uint? _unlock_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"unlock_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unlock_time
     {
-      get { return _unlock_time; }
+      get { return _unlock_time?? default(uint); }
       set { _unlock_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unlock_timeSpecified
+    {
+      get { return _unlock_time != null; }
+      set { if (value == (_unlock_time== null)) _unlock_time = value ? this.unlock_time : (uint?)null; }
+    }
+    private bool ShouldSerializeunlock_time() { return unlock_timeSpecified; }
+    private void Resetunlock_time() { unlock_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -792,23 +1307,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGetCommandList() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _command_prefix = "";
+    private string _command_prefix;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"command_prefix", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_prefix
     {
-      get { return _command_prefix; }
+      get { return _command_prefix?? ""; }
       set { _command_prefix = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_prefixSpecified
+    {
+      get { return _command_prefix != null; }
+      set { if (value == (_command_prefix== null)) _command_prefix = value ? this.command_prefix : (string)null; }
+    }
+    private bool ShouldSerializecommand_prefix() { return command_prefixSpecified; }
+    private void Resetcommand_prefix() { command_prefixSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -866,23 +1399,41 @@ namespace SteamKit2.GC.TF2.Internal
     public ValueTag() {}
     
 
-    private bool _found = default(bool);
+    private bool? _found;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"found", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found
     {
-      get { return _found; }
+      get { return _found?? default(bool); }
       set { _found = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool foundSpecified
+    {
+      get { return _found != null; }
+      set { if (value == (_found== null)) _found = value ? this.found : (bool?)null; }
+    }
+    private bool ShouldSerializefound() { return foundSpecified; }
+    private void Resetfound() { foundSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -911,23 +1462,41 @@ namespace SteamKit2.GC.TF2.Internal
     public KeyPair() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private byte[] _value = null;
+    private byte[] _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value
     {
-      get { return _value; }
+      get { return _value?? null; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (byte[])null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -971,131 +1540,257 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgMemCachedStatsResponse() {}
     
 
-    private ulong _curr_connections = default(ulong);
+    private ulong? _curr_connections;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"curr_connections", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_connections
     {
-      get { return _curr_connections; }
+      get { return _curr_connections?? default(ulong); }
       set { _curr_connections = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_connectionsSpecified
+    {
+      get { return _curr_connections != null; }
+      set { if (value == (_curr_connections== null)) _curr_connections = value ? this.curr_connections : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_connections() { return curr_connectionsSpecified; }
+    private void Resetcurr_connections() { curr_connectionsSpecified = false; }
+    
 
-    private ulong _cmd_get = default(ulong);
+    private ulong? _cmd_get;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cmd_get", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_get
     {
-      get { return _cmd_get; }
+      get { return _cmd_get?? default(ulong); }
       set { _cmd_get = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_getSpecified
+    {
+      get { return _cmd_get != null; }
+      set { if (value == (_cmd_get== null)) _cmd_get = value ? this.cmd_get : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_get() { return cmd_getSpecified; }
+    private void Resetcmd_get() { cmd_getSpecified = false; }
+    
 
-    private ulong _cmd_set = default(ulong);
+    private ulong? _cmd_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cmd_set", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_set
     {
-      get { return _cmd_set; }
+      get { return _cmd_set?? default(ulong); }
       set { _cmd_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_setSpecified
+    {
+      get { return _cmd_set != null; }
+      set { if (value == (_cmd_set== null)) _cmd_set = value ? this.cmd_set : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_set() { return cmd_setSpecified; }
+    private void Resetcmd_set() { cmd_setSpecified = false; }
+    
 
-    private ulong _cmd_flush = default(ulong);
+    private ulong? _cmd_flush;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cmd_flush", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong cmd_flush
     {
-      get { return _cmd_flush; }
+      get { return _cmd_flush?? default(ulong); }
       set { _cmd_flush = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cmd_flushSpecified
+    {
+      get { return _cmd_flush != null; }
+      set { if (value == (_cmd_flush== null)) _cmd_flush = value ? this.cmd_flush : (ulong?)null; }
+    }
+    private bool ShouldSerializecmd_flush() { return cmd_flushSpecified; }
+    private void Resetcmd_flush() { cmd_flushSpecified = false; }
+    
 
-    private ulong _get_hits = default(ulong);
+    private ulong? _get_hits;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"get_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_hits
     {
-      get { return _get_hits; }
+      get { return _get_hits?? default(ulong); }
       set { _get_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_hitsSpecified
+    {
+      get { return _get_hits != null; }
+      set { if (value == (_get_hits== null)) _get_hits = value ? this.get_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_hits() { return get_hitsSpecified; }
+    private void Resetget_hits() { get_hitsSpecified = false; }
+    
 
-    private ulong _get_misses = default(ulong);
+    private ulong? _get_misses;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"get_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong get_misses
     {
-      get { return _get_misses; }
+      get { return _get_misses?? default(ulong); }
       set { _get_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool get_missesSpecified
+    {
+      get { return _get_misses != null; }
+      set { if (value == (_get_misses== null)) _get_misses = value ? this.get_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializeget_misses() { return get_missesSpecified; }
+    private void Resetget_misses() { get_missesSpecified = false; }
+    
 
-    private ulong _delete_hits = default(ulong);
+    private ulong? _delete_hits;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"delete_hits", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_hits
     {
-      get { return _delete_hits; }
+      get { return _delete_hits?? default(ulong); }
       set { _delete_hits = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_hitsSpecified
+    {
+      get { return _delete_hits != null; }
+      set { if (value == (_delete_hits== null)) _delete_hits = value ? this.delete_hits : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_hits() { return delete_hitsSpecified; }
+    private void Resetdelete_hits() { delete_hitsSpecified = false; }
+    
 
-    private ulong _delete_misses = default(ulong);
+    private ulong? _delete_misses;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"delete_misses", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong delete_misses
     {
-      get { return _delete_misses; }
+      get { return _delete_misses?? default(ulong); }
       set { _delete_misses = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delete_missesSpecified
+    {
+      get { return _delete_misses != null; }
+      set { if (value == (_delete_misses== null)) _delete_misses = value ? this.delete_misses : (ulong?)null; }
+    }
+    private bool ShouldSerializedelete_misses() { return delete_missesSpecified; }
+    private void Resetdelete_misses() { delete_missesSpecified = false; }
+    
 
-    private ulong _bytes_read = default(ulong);
+    private ulong? _bytes_read;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"bytes_read", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_read
     {
-      get { return _bytes_read; }
+      get { return _bytes_read?? default(ulong); }
       set { _bytes_read = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_readSpecified
+    {
+      get { return _bytes_read != null; }
+      set { if (value == (_bytes_read== null)) _bytes_read = value ? this.bytes_read : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_read() { return bytes_readSpecified; }
+    private void Resetbytes_read() { bytes_readSpecified = false; }
+    
 
-    private ulong _bytes_written = default(ulong);
+    private ulong? _bytes_written;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"bytes_written", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_written
     {
-      get { return _bytes_written; }
+      get { return _bytes_written?? default(ulong); }
       set { _bytes_written = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_writtenSpecified
+    {
+      get { return _bytes_written != null; }
+      set { if (value == (_bytes_written== null)) _bytes_written = value ? this.bytes_written : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_written() { return bytes_writtenSpecified; }
+    private void Resetbytes_written() { bytes_writtenSpecified = false; }
+    
 
-    private ulong _limit_maxbytes = default(ulong);
+    private ulong? _limit_maxbytes;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"limit_maxbytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong limit_maxbytes
     {
-      get { return _limit_maxbytes; }
+      get { return _limit_maxbytes?? default(ulong); }
       set { _limit_maxbytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool limit_maxbytesSpecified
+    {
+      get { return _limit_maxbytes != null; }
+      set { if (value == (_limit_maxbytes== null)) _limit_maxbytes = value ? this.limit_maxbytes : (ulong?)null; }
+    }
+    private bool ShouldSerializelimit_maxbytes() { return limit_maxbytesSpecified; }
+    private void Resetlimit_maxbytes() { limit_maxbytesSpecified = false; }
+    
 
-    private ulong _curr_items = default(ulong);
+    private ulong? _curr_items;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"curr_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong curr_items
     {
-      get { return _curr_items; }
+      get { return _curr_items?? default(ulong); }
       set { _curr_items = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool curr_itemsSpecified
+    {
+      get { return _curr_items != null; }
+      set { if (value == (_curr_items== null)) _curr_items = value ? this.curr_items : (ulong?)null; }
+    }
+    private bool ShouldSerializecurr_items() { return curr_itemsSpecified; }
+    private void Resetcurr_items() { curr_itemsSpecified = false; }
+    
 
-    private ulong _evictions = default(ulong);
+    private ulong? _evictions;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"evictions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong evictions
     {
-      get { return _evictions; }
+      get { return _evictions?? default(ulong); }
       set { _evictions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool evictionsSpecified
+    {
+      get { return _evictions != null; }
+      set { if (value == (_evictions== null)) _evictions = value ? this.evictions : (ulong?)null; }
+    }
+    private bool ShouldSerializeevictions() { return evictionsSpecified; }
+    private void Resetevictions() { evictionsSpecified = false; }
+    
 
-    private ulong _bytes = default(ulong);
+    private ulong? _bytes;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes
     {
-      get { return _bytes; }
+      get { return _bytes?? default(ulong); }
       set { _bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytesSpecified
+    {
+      get { return _bytes != null; }
+      set { if (value == (_bytes== null)) _bytes = value ? this.bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes() { return bytesSpecified; }
+    private void Resetbytes() { bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1107,14 +1802,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgSQLStats() {}
     
 
-    private uint _schema_catalog = default(uint);
+    private uint? _schema_catalog;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"schema_catalog", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint schema_catalog
     {
-      get { return _schema_catalog; }
+      get { return _schema_catalog?? default(uint); }
       set { _schema_catalog = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_catalogSpecified
+    {
+      get { return _schema_catalog != null; }
+      set { if (value == (_schema_catalog== null)) _schema_catalog = value ? this.schema_catalog : (uint?)null; }
+    }
+    private bool ShouldSerializeschema_catalog() { return schema_catalogSpecified; }
+    private void Resetschema_catalog() { schema_catalogSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1126,86 +1830,167 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgSQLStatsResponse() {}
     
 
-    private uint _threads = default(uint);
+    private uint? _threads;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"threads", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads
     {
-      get { return _threads; }
+      get { return _threads?? default(uint); }
       set { _threads = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threadsSpecified
+    {
+      get { return _threads != null; }
+      set { if (value == (_threads== null)) _threads = value ? this.threads : (uint?)null; }
+    }
+    private bool ShouldSerializethreads() { return threadsSpecified; }
+    private void Resetthreads() { threadsSpecified = false; }
+    
 
-    private uint _threads_connected = default(uint);
+    private uint? _threads_connected;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"threads_connected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_connected
     {
-      get { return _threads_connected; }
+      get { return _threads_connected?? default(uint); }
       set { _threads_connected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_connectedSpecified
+    {
+      get { return _threads_connected != null; }
+      set { if (value == (_threads_connected== null)) _threads_connected = value ? this.threads_connected : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_connected() { return threads_connectedSpecified; }
+    private void Resetthreads_connected() { threads_connectedSpecified = false; }
+    
 
-    private uint _threads_active = default(uint);
+    private uint? _threads_active;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"threads_active", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint threads_active
     {
-      get { return _threads_active; }
+      get { return _threads_active?? default(uint); }
       set { _threads_active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool threads_activeSpecified
+    {
+      get { return _threads_active != null; }
+      set { if (value == (_threads_active== null)) _threads_active = value ? this.threads_active : (uint?)null; }
+    }
+    private bool ShouldSerializethreads_active() { return threads_activeSpecified; }
+    private void Resetthreads_active() { threads_activeSpecified = false; }
+    
 
-    private uint _operations_submitted = default(uint);
+    private uint? _operations_submitted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"operations_submitted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_submitted
     {
-      get { return _operations_submitted; }
+      get { return _operations_submitted?? default(uint); }
       set { _operations_submitted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_submittedSpecified
+    {
+      get { return _operations_submitted != null; }
+      set { if (value == (_operations_submitted== null)) _operations_submitted = value ? this.operations_submitted : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_submitted() { return operations_submittedSpecified; }
+    private void Resetoperations_submitted() { operations_submittedSpecified = false; }
+    
 
-    private uint _prepared_statements_executed = default(uint);
+    private uint? _prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint prepared_statements_executed
     {
-      get { return _prepared_statements_executed; }
+      get { return _prepared_statements_executed?? default(uint); }
       set { _prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prepared_statements_executedSpecified
+    {
+      get { return _prepared_statements_executed != null; }
+      set { if (value == (_prepared_statements_executed== null)) _prepared_statements_executed = value ? this.prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializeprepared_statements_executed() { return prepared_statements_executedSpecified; }
+    private void Resetprepared_statements_executed() { prepared_statements_executedSpecified = false; }
+    
 
-    private uint _non_prepared_statements_executed = default(uint);
+    private uint? _non_prepared_statements_executed;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"non_prepared_statements_executed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint non_prepared_statements_executed
     {
-      get { return _non_prepared_statements_executed; }
+      get { return _non_prepared_statements_executed?? default(uint); }
       set { _non_prepared_statements_executed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool non_prepared_statements_executedSpecified
+    {
+      get { return _non_prepared_statements_executed != null; }
+      set { if (value == (_non_prepared_statements_executed== null)) _non_prepared_statements_executed = value ? this.non_prepared_statements_executed : (uint?)null; }
+    }
+    private bool ShouldSerializenon_prepared_statements_executed() { return non_prepared_statements_executedSpecified; }
+    private void Resetnon_prepared_statements_executed() { non_prepared_statements_executedSpecified = false; }
+    
 
-    private uint _deadlock_retries = default(uint);
+    private uint? _deadlock_retries;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deadlock_retries", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deadlock_retries
     {
-      get { return _deadlock_retries; }
+      get { return _deadlock_retries?? default(uint); }
       set { _deadlock_retries = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deadlock_retriesSpecified
+    {
+      get { return _deadlock_retries != null; }
+      set { if (value == (_deadlock_retries== null)) _deadlock_retries = value ? this.deadlock_retries : (uint?)null; }
+    }
+    private bool ShouldSerializedeadlock_retries() { return deadlock_retriesSpecified; }
+    private void Resetdeadlock_retries() { deadlock_retriesSpecified = false; }
+    
 
-    private uint _operations_timed_out_in_queue = default(uint);
+    private uint? _operations_timed_out_in_queue;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"operations_timed_out_in_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint operations_timed_out_in_queue
     {
-      get { return _operations_timed_out_in_queue; }
+      get { return _operations_timed_out_in_queue?? default(uint); }
       set { _operations_timed_out_in_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operations_timed_out_in_queueSpecified
+    {
+      get { return _operations_timed_out_in_queue != null; }
+      set { if (value == (_operations_timed_out_in_queue== null)) _operations_timed_out_in_queue = value ? this.operations_timed_out_in_queue : (uint?)null; }
+    }
+    private bool ShouldSerializeoperations_timed_out_in_queue() { return operations_timed_out_in_queueSpecified; }
+    private void Resetoperations_timed_out_in_queue() { operations_timed_out_in_queueSpecified = false; }
+    
 
-    private uint _errors = default(uint);
+    private uint? _errors;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"errors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint errors
     {
-      get { return _errors; }
+      get { return _errors?? default(uint); }
       set { _errors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorsSpecified
+    {
+      get { return _errors != null; }
+      set { if (value == (_errors== null)) _errors = value ? this.errors : (uint?)null; }
+    }
+    private bool ShouldSerializeerrors() { return errorsSpecified; }
+    private void Reseterrors() { errorsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1217,41 +2002,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMAddFreeLicense() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip_public = default(uint);
+    private uint? _ip_public;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip_public", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip_public
     {
-      get { return _ip_public; }
+      get { return _ip_public?? default(uint); }
       set { _ip_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_publicSpecified
+    {
+      get { return _ip_public != null; }
+      set { if (value == (_ip_public== null)) _ip_public = value ? this.ip_public : (uint?)null; }
+    }
+    private bool ShouldSerializeip_public() { return ip_publicSpecified; }
+    private void Resetip_public() { ip_publicSpecified = false; }
+    
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private string _store_country_code = "";
+    private string _store_country_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"store_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string store_country_code
     {
-      get { return _store_country_code; }
+      get { return _store_country_code?? ""; }
       set { _store_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool store_country_codeSpecified
+    {
+      get { return _store_country_code != null; }
+      set { if (value == (_store_country_code== null)) _store_country_code = value ? this.store_country_code : (string)null; }
+    }
+    private bool ShouldSerializestore_country_code() { return store_country_codeSpecified; }
+    private void Resetstore_country_code() { store_country_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1263,32 +2084,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMAddFreeLicenseResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _purchase_result_detail = default(int);
+    private int? _purchase_result_detail;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"purchase_result_detail", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int purchase_result_detail
     {
-      get { return _purchase_result_detail; }
+      get { return _purchase_result_detail?? default(int); }
       set { _purchase_result_detail = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_result_detailSpecified
+    {
+      get { return _purchase_result_detail != null; }
+      set { if (value == (_purchase_result_detail== null)) _purchase_result_detail = value ? this.purchase_result_detail : (int?)null; }
+    }
+    private bool ShouldSerializepurchase_result_detail() { return purchase_result_detailSpecified; }
+    private void Resetpurchase_result_detail() { purchase_result_detailSpecified = false; }
+    
 
-    private ulong _transid = default(ulong);
+    private ulong? _transid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"transid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong transid
     {
-      get { return _transid; }
+      get { return _transid?? default(ulong); }
       set { _transid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transidSpecified
+    {
+      get { return _transid != null; }
+      set { if (value == (_transid== null)) _transid = value ? this.transid : (ulong?)null; }
+    }
+    private bool ShouldSerializetransid() { return transidSpecified; }
+    private void Resettransid() { transidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1317,59 +2165,113 @@ namespace SteamKit2.GC.TF2.Internal
     public CIPLocationInfo() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private float _latitude = default(float);
+    private float? _latitude;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"latitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float latitude
     {
-      get { return _latitude; }
+      get { return _latitude?? default(float); }
       set { _latitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool latitudeSpecified
+    {
+      get { return _latitude != null; }
+      set { if (value == (_latitude== null)) _latitude = value ? this.latitude : (float?)null; }
+    }
+    private bool ShouldSerializelatitude() { return latitudeSpecified; }
+    private void Resetlatitude() { latitudeSpecified = false; }
+    
 
-    private float _longitude = default(float);
+    private float? _longitude;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"longitude", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float longitude
     {
-      get { return _longitude; }
+      get { return _longitude?? default(float); }
       set { _longitude = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool longitudeSpecified
+    {
+      get { return _longitude != null; }
+      set { if (value == (_longitude== null)) _longitude = value ? this.longitude : (float?)null; }
+    }
+    private bool ShouldSerializelongitude() { return longitudeSpecified; }
+    private void Resetlongitude() { longitudeSpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private string _state = "";
+    private string _state;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string state
     {
-      get { return _state; }
+      get { return _state?? ""; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (string)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _city = "";
+    private string _city;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"city", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string city
     {
-      get { return _city; }
+      get { return _city?? ""; }
       set { _city = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool citySpecified
+    {
+      get { return _city != null; }
+      set { if (value == (_city== null)) _city = value ? this.city : (string)null; }
+    }
+    private bool ShouldSerializecity() { return citySpecified; }
+    private void Resetcity() { citySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1398,23 +2300,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgSystemStatsSchema() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _schema_kv = null;
+    private byte[] _schema_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"schema_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] schema_kv
     {
-      get { return _schema_kv; }
+      get { return _schema_kv?? null; }
       set { _schema_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_kvSpecified
+    {
+      get { return _schema_kv != null; }
+      set { if (value == (_schema_kv== null)) _schema_kv = value ? this.schema_kv : (byte[])null; }
+    }
+    private bool ShouldSerializeschema_kv() { return schema_kvSpecified; }
+    private void Resetschema_kv() { schema_kvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1436,122 +2356,239 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCMsgGetSystemStatsResponse() {}
     
 
-    private uint _gc_app_id = default(uint);
+    private uint? _gc_app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gc_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gc_app_id
     {
-      get { return _gc_app_id; }
+      get { return _gc_app_id?? default(uint); }
       set { _gc_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_app_idSpecified
+    {
+      get { return _gc_app_id != null; }
+      set { if (value == (_gc_app_id== null)) _gc_app_id = value ? this.gc_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegc_app_id() { return gc_app_idSpecified; }
+    private void Resetgc_app_id() { gc_app_idSpecified = false; }
+    
 
-    private byte[] _stats_kv = null;
+    private byte[] _stats_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stats_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] stats_kv
     {
-      get { return _stats_kv; }
+      get { return _stats_kv?? null; }
       set { _stats_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_kvSpecified
+    {
+      get { return _stats_kv != null; }
+      set { if (value == (_stats_kv== null)) _stats_kv = value ? this.stats_kv : (byte[])null; }
+    }
+    private bool ShouldSerializestats_kv() { return stats_kvSpecified; }
+    private void Resetstats_kv() { stats_kvSpecified = false; }
+    
 
-    private uint _active_jobs = default(uint);
+    private uint? _active_jobs;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"active_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_jobs
     {
-      get { return _active_jobs; }
+      get { return _active_jobs?? default(uint); }
       set { _active_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_jobsSpecified
+    {
+      get { return _active_jobs != null; }
+      set { if (value == (_active_jobs== null)) _active_jobs = value ? this.active_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_jobs() { return active_jobsSpecified; }
+    private void Resetactive_jobs() { active_jobsSpecified = false; }
+    
 
-    private uint _yielding_jobs = default(uint);
+    private uint? _yielding_jobs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"yielding_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint yielding_jobs
     {
-      get { return _yielding_jobs; }
+      get { return _yielding_jobs?? default(uint); }
       set { _yielding_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool yielding_jobsSpecified
+    {
+      get { return _yielding_jobs != null; }
+      set { if (value == (_yielding_jobs== null)) _yielding_jobs = value ? this.yielding_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializeyielding_jobs() { return yielding_jobsSpecified; }
+    private void Resetyielding_jobs() { yielding_jobsSpecified = false; }
+    
 
-    private uint _user_sessions = default(uint);
+    private uint? _user_sessions;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"user_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_sessions
     {
-      get { return _user_sessions; }
+      get { return _user_sessions?? default(uint); }
       set { _user_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_sessionsSpecified
+    {
+      get { return _user_sessions != null; }
+      set { if (value == (_user_sessions== null)) _user_sessions = value ? this.user_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_sessions() { return user_sessionsSpecified; }
+    private void Resetuser_sessions() { user_sessionsSpecified = false; }
+    
 
-    private uint _game_server_sessions = default(uint);
+    private uint? _game_server_sessions;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_server_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_sessions
     {
-      get { return _game_server_sessions; }
+      get { return _game_server_sessions?? default(uint); }
       set { _game_server_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_sessionsSpecified
+    {
+      get { return _game_server_sessions != null; }
+      set { if (value == (_game_server_sessions== null)) _game_server_sessions = value ? this.game_server_sessions : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_sessions() { return game_server_sessionsSpecified; }
+    private void Resetgame_server_sessions() { game_server_sessionsSpecified = false; }
+    
 
-    private uint _socaches = default(uint);
+    private uint? _socaches;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"socaches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches
     {
-      get { return _socaches; }
+      get { return _socaches?? default(uint); }
       set { _socaches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socachesSpecified
+    {
+      get { return _socaches != null; }
+      set { if (value == (_socaches== null)) _socaches = value ? this.socaches : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches() { return socachesSpecified; }
+    private void Resetsocaches() { socachesSpecified = false; }
+    
 
-    private uint _socaches_to_unload = default(uint);
+    private uint? _socaches_to_unload;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"socaches_to_unload", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_to_unload
     {
-      get { return _socaches_to_unload; }
+      get { return _socaches_to_unload?? default(uint); }
       set { _socaches_to_unload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_to_unloadSpecified
+    {
+      get { return _socaches_to_unload != null; }
+      set { if (value == (_socaches_to_unload== null)) _socaches_to_unload = value ? this.socaches_to_unload : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_to_unload() { return socaches_to_unloadSpecified; }
+    private void Resetsocaches_to_unload() { socaches_to_unloadSpecified = false; }
+    
 
-    private uint _socaches_loading = default(uint);
+    private uint? _socaches_loading;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"socaches_loading", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint socaches_loading
     {
-      get { return _socaches_loading; }
+      get { return _socaches_loading?? default(uint); }
       set { _socaches_loading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool socaches_loadingSpecified
+    {
+      get { return _socaches_loading != null; }
+      set { if (value == (_socaches_loading== null)) _socaches_loading = value ? this.socaches_loading : (uint?)null; }
+    }
+    private bool ShouldSerializesocaches_loading() { return socaches_loadingSpecified; }
+    private void Resetsocaches_loading() { socaches_loadingSpecified = false; }
+    
 
-    private uint _writeback_queue = default(uint);
+    private uint? _writeback_queue;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"writeback_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint writeback_queue
     {
-      get { return _writeback_queue; }
+      get { return _writeback_queue?? default(uint); }
       set { _writeback_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool writeback_queueSpecified
+    {
+      get { return _writeback_queue != null; }
+      set { if (value == (_writeback_queue== null)) _writeback_queue = value ? this.writeback_queue : (uint?)null; }
+    }
+    private bool ShouldSerializewriteback_queue() { return writeback_queueSpecified; }
+    private void Resetwriteback_queue() { writeback_queueSpecified = false; }
+    
 
-    private uint _steamid_locks = default(uint);
+    private uint? _steamid_locks;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"steamid_locks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamid_locks
     {
-      get { return _steamid_locks; }
+      get { return _steamid_locks?? default(uint); }
       set { _steamid_locks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_locksSpecified
+    {
+      get { return _steamid_locks != null; }
+      set { if (value == (_steamid_locks== null)) _steamid_locks = value ? this.steamid_locks : (uint?)null; }
+    }
+    private bool ShouldSerializesteamid_locks() { return steamid_locksSpecified; }
+    private void Resetsteamid_locks() { steamid_locksSpecified = false; }
+    
 
-    private uint _logon_queue = default(uint);
+    private uint? _logon_queue;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"logon_queue", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_queue
     {
-      get { return _logon_queue; }
+      get { return _logon_queue?? default(uint); }
       set { _logon_queue = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_queueSpecified
+    {
+      get { return _logon_queue != null; }
+      set { if (value == (_logon_queue== null)) _logon_queue = value ? this.logon_queue : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_queue() { return logon_queueSpecified; }
+    private void Resetlogon_queue() { logon_queueSpecified = false; }
+    
 
-    private uint _logon_jobs = default(uint);
+    private uint? _logon_jobs;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"logon_jobs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint logon_jobs
     {
-      get { return _logon_jobs; }
+      get { return _logon_jobs?? default(uint); }
       set { _logon_jobs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logon_jobsSpecified
+    {
+      get { return _logon_jobs != null; }
+      set { if (value == (_logon_jobs== null)) _logon_jobs = value ? this.logon_jobs : (uint?)null; }
+    }
+    private bool ShouldSerializelogon_jobs() { return logon_jobsSpecified; }
+    private void Resetlogon_jobs() { logon_jobsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1563,32 +2600,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMSendEmail() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private uint _email_format = default(uint);
+    private uint? _email_format;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(uint); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> _persona_name_tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken>();
     [global::ProtoBuf.ProtoMember(5, Name=@"persona_name_tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.PersonaNameReplacementToken> persona_name_tokens
@@ -1597,14 +2661,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _source_gc = default(uint);
+    private uint? _source_gc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"source_gc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_gc
     {
-      get { return _source_gc; }
+      get { return _source_gc?? default(uint); }
       set { _source_gc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_gcSpecified
+    {
+      get { return _source_gc != null; }
+      set { if (value == (_source_gc== null)) _source_gc = value ? this.source_gc : (uint?)null; }
+    }
+    private bool ShouldSerializesource_gc() { return source_gcSpecified; }
+    private void Resetsource_gc() { source_gcSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> _tokens = new global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken>();
     [global::ProtoBuf.ProtoMember(7, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAMSendEmail.ReplacementToken> tokens
@@ -1618,23 +2691,41 @@ namespace SteamKit2.GC.TF2.Internal
     public ReplacementToken() {}
     
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
 
-    private string _token_value = "";
+    private string _token_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_value
     {
-      get { return _token_value; }
+      get { return _token_value?? ""; }
       set { _token_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_valueSpecified
+    {
+      get { return _token_value != null; }
+      set { if (value == (_token_value== null)) _token_value = value ? this.token_value : (string)null; }
+    }
+    private bool ShouldSerializetoken_value() { return token_valueSpecified; }
+    private void Resettoken_value() { token_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1646,23 +2737,41 @@ namespace SteamKit2.GC.TF2.Internal
     public PersonaNameReplacementToken() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _token_name = "";
+    private string _token_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_name
     {
-      get { return _token_name; }
+      get { return _token_name?? ""; }
       set { _token_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_nameSpecified
+    {
+      get { return _token_name != null; }
+      set { if (value == (_token_name== null)) _token_name = value ? this.token_name : (string)null; }
+    }
+    private bool ShouldSerializetoken_name() { return token_nameSpecified; }
+    private void Resettoken_name() { token_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1679,14 +2788,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMSendEmailResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1698,41 +2816,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGetEmailTemplate() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _email_msg_type = default(uint);
+    private uint? _email_msg_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_msg_type
     {
-      get { return _email_msg_type; }
+      get { return _email_msg_type?? default(uint); }
       set { _email_msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_msg_typeSpecified
+    {
+      get { return _email_msg_type != null; }
+      set { if (value == (_email_msg_type== null)) _email_msg_type = value ? this.email_msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_msg_type() { return email_msg_typeSpecified; }
+    private void Resetemail_msg_type() { email_msg_typeSpecified = false; }
+    
 
-    private int _email_lang = default(int);
+    private int? _email_lang;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_lang", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_lang
     {
-      get { return _email_lang; }
+      get { return _email_lang?? default(int); }
       set { _email_lang = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_langSpecified
+    {
+      get { return _email_lang != null; }
+      set { if (value == (_email_lang== null)) _email_lang = value ? this.email_lang : (int?)null; }
+    }
+    private bool ShouldSerializeemail_lang() { return email_langSpecified; }
+    private void Resetemail_lang() { email_langSpecified = false; }
+    
 
-    private int _email_format = default(int);
+    private int? _email_format;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"email_format", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int email_format
     {
-      get { return _email_format; }
+      get { return _email_format?? default(int); }
       set { _email_format = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_formatSpecified
+    {
+      get { return _email_format != null; }
+      set { if (value == (_email_format== null)) _email_format = value ? this.email_format : (int?)null; }
+    }
+    private bool ShouldSerializeemail_format() { return email_formatSpecified; }
+    private void Resetemail_format() { email_formatSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1744,32 +2898,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGetEmailTemplateResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _template_exists = default(bool);
+    private bool? _template_exists;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"template_exists", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool template_exists
     {
-      get { return _template_exists; }
+      get { return _template_exists?? default(bool); }
       set { _template_exists = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool template_existsSpecified
+    {
+      get { return _template_exists != null; }
+      set { if (value == (_template_exists== null)) _template_exists = value ? this.template_exists : (bool?)null; }
+    }
+    private bool ShouldSerializetemplate_exists() { return template_existsSpecified; }
+    private void Resettemplate_exists() { template_existsSpecified = false; }
+    
 
-    private string _template = "";
+    private string _template;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"template", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string template
     {
-      get { return _template; }
+      get { return _template?? ""; }
       set { _template = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool templateSpecified
+    {
+      get { return _template != null; }
+      set { if (value == (_template== null)) _template = value ? this.template : (string)null; }
+    }
+    private bool ShouldSerializetemplate() { return templateSpecified; }
+    private void Resettemplate() { templateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1781,50 +2962,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMGrantGuestPasses2() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private int _passes_to_grant = default(int);
+    private int? _passes_to_grant;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"passes_to_grant", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int passes_to_grant
     {
-      get { return _passes_to_grant; }
+      get { return _passes_to_grant?? default(int); }
       set { _passes_to_grant = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_to_grantSpecified
+    {
+      get { return _passes_to_grant != null; }
+      set { if (value == (_passes_to_grant== null)) _passes_to_grant = value ? this.passes_to_grant : (int?)null; }
+    }
+    private bool ShouldSerializepasses_to_grant() { return passes_to_grantSpecified; }
+    private void Resetpasses_to_grant() { passes_to_grantSpecified = false; }
+    
 
-    private int _days_to_expiration = default(int);
+    private int? _days_to_expiration;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"days_to_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int days_to_expiration
     {
-      get { return _days_to_expiration; }
+      get { return _days_to_expiration?? default(int); }
       set { _days_to_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool days_to_expirationSpecified
+    {
+      get { return _days_to_expiration != null; }
+      set { if (value == (_days_to_expiration== null)) _days_to_expiration = value ? this.days_to_expiration : (int?)null; }
+    }
+    private bool ShouldSerializedays_to_expiration() { return days_to_expirationSpecified; }
+    private void Resetdays_to_expiration() { days_to_expirationSpecified = false; }
+    
 
-    private int _action = default(int);
+    private int? _action;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int action
     {
-      get { return _action; }
+      get { return _action?? default(int); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (int?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1836,23 +3062,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAMGrantGuestPasses2Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _passes_granted = (int)0;
+    private int? _passes_granted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"passes_granted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int passes_granted
     {
-      get { return _passes_granted; }
+      get { return _passes_granted?? (int)0; }
       set { _passes_granted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passes_grantedSpecified
+    {
+      get { return _passes_granted != null; }
+      set { if (value == (_passes_granted== null)) _passes_granted = value ? this.passes_granted : (int?)null; }
+    }
+    private bool ShouldSerializepasses_granted() { return passes_grantedSpecified; }
+    private void Resetpasses_granted() { passes_grantedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1864,23 +3108,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCSystemMsg_GetAccountDetails() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1892,284 +3154,563 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCSystemMsg_GetAccountDetails_Response() {}
     
 
-    private uint _eresult_deprecated = (uint)2;
+    private uint? _eresult_deprecated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult_deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult_deprecated
     {
-      get { return _eresult_deprecated; }
+      get { return _eresult_deprecated?? (uint)2; }
       set { _eresult_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_deprecatedSpecified
+    {
+      get { return _eresult_deprecated != null; }
+      set { if (value == (_eresult_deprecated== null)) _eresult_deprecated = value ? this.eresult_deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult_deprecated() { return eresult_deprecatedSpecified; }
+    private void Reseteresult_deprecated() { eresult_deprecatedSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private bool _is_profile_public = default(bool);
+    private bool? _is_profile_public;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_profile_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_profile_public
     {
-      get { return _is_profile_public; }
+      get { return _is_profile_public?? default(bool); }
       set { _is_profile_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_profile_publicSpecified
+    {
+      get { return _is_profile_public != null; }
+      set { if (value == (_is_profile_public== null)) _is_profile_public = value ? this.is_profile_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_profile_public() { return is_profile_publicSpecified; }
+    private void Resetis_profile_public() { is_profile_publicSpecified = false; }
+    
 
-    private bool _is_inventory_public = default(bool);
+    private bool? _is_inventory_public;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_inventory_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_inventory_public
     {
-      get { return _is_inventory_public; }
+      get { return _is_inventory_public?? default(bool); }
       set { _is_inventory_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_inventory_publicSpecified
+    {
+      get { return _is_inventory_public != null; }
+      set { if (value == (_is_inventory_public== null)) _is_inventory_public = value ? this.is_inventory_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_inventory_public() { return is_inventory_publicSpecified; }
+    private void Resetis_inventory_public() { is_inventory_publicSpecified = false; }
+    
 
-    private bool _is_vac_banned = default(bool);
+    private bool? _is_vac_banned;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_vac_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_vac_banned
     {
-      get { return _is_vac_banned; }
+      get { return _is_vac_banned?? default(bool); }
       set { _is_vac_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_vac_bannedSpecified
+    {
+      get { return _is_vac_banned != null; }
+      set { if (value == (_is_vac_banned== null)) _is_vac_banned = value ? this.is_vac_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_vac_banned() { return is_vac_bannedSpecified; }
+    private void Resetis_vac_banned() { is_vac_bannedSpecified = false; }
+    
 
-    private bool _is_cyber_cafe = default(bool);
+    private bool? _is_cyber_cafe;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_cyber_cafe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_cyber_cafe
     {
-      get { return _is_cyber_cafe; }
+      get { return _is_cyber_cafe?? default(bool); }
       set { _is_cyber_cafe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_cyber_cafeSpecified
+    {
+      get { return _is_cyber_cafe != null; }
+      set { if (value == (_is_cyber_cafe== null)) _is_cyber_cafe = value ? this.is_cyber_cafe : (bool?)null; }
+    }
+    private bool ShouldSerializeis_cyber_cafe() { return is_cyber_cafeSpecified; }
+    private void Resetis_cyber_cafe() { is_cyber_cafeSpecified = false; }
+    
 
-    private bool _is_school_account = default(bool);
+    private bool? _is_school_account;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_school_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_school_account
     {
-      get { return _is_school_account; }
+      get { return _is_school_account?? default(bool); }
       set { _is_school_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_school_accountSpecified
+    {
+      get { return _is_school_account != null; }
+      set { if (value == (_is_school_account== null)) _is_school_account = value ? this.is_school_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_school_account() { return is_school_accountSpecified; }
+    private void Resetis_school_account() { is_school_accountSpecified = false; }
+    
 
-    private bool _is_limited = default(bool);
+    private bool? _is_limited;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"is_limited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_limited
     {
-      get { return _is_limited; }
+      get { return _is_limited?? default(bool); }
       set { _is_limited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_limitedSpecified
+    {
+      get { return _is_limited != null; }
+      set { if (value == (_is_limited== null)) _is_limited = value ? this.is_limited : (bool?)null; }
+    }
+    private bool ShouldSerializeis_limited() { return is_limitedSpecified; }
+    private void Resetis_limited() { is_limitedSpecified = false; }
+    
 
-    private bool _is_subscribed = default(bool);
+    private bool? _is_subscribed;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_subscribed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_subscribed
     {
-      get { return _is_subscribed; }
+      get { return _is_subscribed?? default(bool); }
       set { _is_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_subscribedSpecified
+    {
+      get { return _is_subscribed != null; }
+      set { if (value == (_is_subscribed== null)) _is_subscribed = value ? this.is_subscribed : (bool?)null; }
+    }
+    private bool ShouldSerializeis_subscribed() { return is_subscribedSpecified; }
+    private void Resetis_subscribed() { is_subscribedSpecified = false; }
+    
 
-    private uint _package = default(uint);
+    private uint? _package;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"package", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package
     {
-      get { return _package; }
+      get { return _package?? default(uint); }
       set { _package = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageSpecified
+    {
+      get { return _package != null; }
+      set { if (value == (_package== null)) _package = value ? this.package : (uint?)null; }
+    }
+    private bool ShouldSerializepackage() { return packageSpecified; }
+    private void Resetpackage() { packageSpecified = false; }
+    
 
-    private bool _is_free_trial_account = default(bool);
+    private bool? _is_free_trial_account;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"is_free_trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_free_trial_account
     {
-      get { return _is_free_trial_account; }
+      get { return _is_free_trial_account?? default(bool); }
       set { _is_free_trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_free_trial_accountSpecified
+    {
+      get { return _is_free_trial_account != null; }
+      set { if (value == (_is_free_trial_account== null)) _is_free_trial_account = value ? this.is_free_trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializeis_free_trial_account() { return is_free_trial_accountSpecified; }
+    private void Resetis_free_trial_account() { is_free_trial_accountSpecified = false; }
+    
 
-    private uint _free_trial_expiration = default(uint);
+    private uint? _free_trial_expiration;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"free_trial_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint free_trial_expiration
     {
-      get { return _free_trial_expiration; }
+      get { return _free_trial_expiration?? default(uint); }
       set { _free_trial_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool free_trial_expirationSpecified
+    {
+      get { return _free_trial_expiration != null; }
+      set { if (value == (_free_trial_expiration== null)) _free_trial_expiration = value ? this.free_trial_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializefree_trial_expiration() { return free_trial_expirationSpecified; }
+    private void Resetfree_trial_expiration() { free_trial_expirationSpecified = false; }
+    
 
-    private bool _is_low_violence = default(bool);
+    private bool? _is_low_violence;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"is_low_violence", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_low_violence
     {
-      get { return _is_low_violence; }
+      get { return _is_low_violence?? default(bool); }
       set { _is_low_violence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_low_violenceSpecified
+    {
+      get { return _is_low_violence != null; }
+      set { if (value == (_is_low_violence== null)) _is_low_violence = value ? this.is_low_violence : (bool?)null; }
+    }
+    private bool ShouldSerializeis_low_violence() { return is_low_violenceSpecified; }
+    private void Resetis_low_violence() { is_low_violenceSpecified = false; }
+    
 
-    private bool _is_account_locked_down = default(bool);
+    private bool? _is_account_locked_down;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"is_account_locked_down", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_account_locked_down
     {
-      get { return _is_account_locked_down; }
+      get { return _is_account_locked_down?? default(bool); }
       set { _is_account_locked_down = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_account_locked_downSpecified
+    {
+      get { return _is_account_locked_down != null; }
+      set { if (value == (_is_account_locked_down== null)) _is_account_locked_down = value ? this.is_account_locked_down : (bool?)null; }
+    }
+    private bool ShouldSerializeis_account_locked_down() { return is_account_locked_downSpecified; }
+    private void Resetis_account_locked_down() { is_account_locked_downSpecified = false; }
+    
 
-    private bool _is_community_banned = default(bool);
+    private bool? _is_community_banned;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"is_community_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_community_banned
     {
-      get { return _is_community_banned; }
+      get { return _is_community_banned?? default(bool); }
       set { _is_community_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_community_bannedSpecified
+    {
+      get { return _is_community_banned != null; }
+      set { if (value == (_is_community_banned== null)) _is_community_banned = value ? this.is_community_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_community_banned() { return is_community_bannedSpecified; }
+    private void Resetis_community_banned() { is_community_bannedSpecified = false; }
+    
 
-    private bool _is_trade_banned = default(bool);
+    private bool? _is_trade_banned;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"is_trade_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_trade_banned
     {
-      get { return _is_trade_banned; }
+      get { return _is_trade_banned?? default(bool); }
       set { _is_trade_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_trade_bannedSpecified
+    {
+      get { return _is_trade_banned != null; }
+      set { if (value == (_is_trade_banned== null)) _is_trade_banned = value ? this.is_trade_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_trade_banned() { return is_trade_bannedSpecified; }
+    private void Resetis_trade_banned() { is_trade_bannedSpecified = false; }
+    
 
-    private uint _trade_ban_expiration = default(uint);
+    private uint? _trade_ban_expiration;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"trade_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_expiration
     {
-      get { return _trade_ban_expiration; }
+      get { return _trade_ban_expiration?? default(uint); }
       set { _trade_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_expirationSpecified
+    {
+      get { return _trade_ban_expiration != null; }
+      set { if (value == (_trade_ban_expiration== null)) _trade_ban_expiration = value ? this.trade_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_expiration() { return trade_ban_expirationSpecified; }
+    private void Resettrade_ban_expiration() { trade_ban_expirationSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _suspension_end_time = default(uint);
+    private uint? _suspension_end_time;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"suspension_end_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint suspension_end_time
     {
-      get { return _suspension_end_time; }
+      get { return _suspension_end_time?? default(uint); }
       set { _suspension_end_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool suspension_end_timeSpecified
+    {
+      get { return _suspension_end_time != null; }
+      set { if (value == (_suspension_end_time== null)) _suspension_end_time = value ? this.suspension_end_time : (uint?)null; }
+    }
+    private bool ShouldSerializesuspension_end_time() { return suspension_end_timeSpecified; }
+    private void Resetsuspension_end_time() { suspension_end_timeSpecified = false; }
+    
 
-    private string _currency = "";
+    private string _currency;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string currency
     {
-      get { return _currency; }
+      get { return _currency?? ""; }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (string)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private uint _steam_level = default(uint);
+    private uint? _steam_level;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"steam_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steam_level
     {
-      get { return _steam_level; }
+      get { return _steam_level?? default(uint); }
       set { _steam_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_levelSpecified
+    {
+      get { return _steam_level != null; }
+      set { if (value == (_steam_level== null)) _steam_level = value ? this.steam_level : (uint?)null; }
+    }
+    private bool ShouldSerializesteam_level() { return steam_levelSpecified; }
+    private void Resetsteam_level() { steam_levelSpecified = false; }
+    
 
-    private uint _friend_count = default(uint);
+    private uint? _friend_count;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"friend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint friend_count
     {
-      get { return _friend_count; }
+      get { return _friend_count?? default(uint); }
       set { _friend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_countSpecified
+    {
+      get { return _friend_count != null; }
+      set { if (value == (_friend_count== null)) _friend_count = value ? this.friend_count : (uint?)null; }
+    }
+    private bool ShouldSerializefriend_count() { return friend_countSpecified; }
+    private void Resetfriend_count() { friend_countSpecified = false; }
+    
 
-    private uint _account_creation_time = default(uint);
+    private uint? _account_creation_time;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"account_creation_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_creation_time
     {
-      get { return _account_creation_time; }
+      get { return _account_creation_time?? default(uint); }
       set { _account_creation_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_creation_timeSpecified
+    {
+      get { return _account_creation_time != null; }
+      set { if (value == (_account_creation_time== null)) _account_creation_time = value ? this.account_creation_time : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_creation_time() { return account_creation_timeSpecified; }
+    private void Resetaccount_creation_time() { account_creation_timeSpecified = false; }
+    
 
-    private bool _is_steamguard_enabled = default(bool);
+    private bool? _is_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"is_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_steamguard_enabled
     {
-      get { return _is_steamguard_enabled; }
+      get { return _is_steamguard_enabled?? default(bool); }
       set { _is_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_steamguard_enabledSpecified
+    {
+      get { return _is_steamguard_enabled != null; }
+      set { if (value == (_is_steamguard_enabled== null)) _is_steamguard_enabled = value ? this.is_steamguard_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_steamguard_enabled() { return is_steamguard_enabledSpecified; }
+    private void Resetis_steamguard_enabled() { is_steamguard_enabledSpecified = false; }
+    
 
-    private bool _is_phone_verified = default(bool);
+    private bool? _is_phone_verified;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"is_phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_verified
     {
-      get { return _is_phone_verified; }
+      get { return _is_phone_verified?? default(bool); }
       set { _is_phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_verifiedSpecified
+    {
+      get { return _is_phone_verified != null; }
+      set { if (value == (_is_phone_verified== null)) _is_phone_verified = value ? this.is_phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_verified() { return is_phone_verifiedSpecified; }
+    private void Resetis_phone_verified() { is_phone_verifiedSpecified = false; }
+    
 
-    private bool _is_two_factor_auth_enabled = default(bool);
+    private bool? _is_two_factor_auth_enabled;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"is_two_factor_auth_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_two_factor_auth_enabled
     {
-      get { return _is_two_factor_auth_enabled; }
+      get { return _is_two_factor_auth_enabled?? default(bool); }
       set { _is_two_factor_auth_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_two_factor_auth_enabledSpecified
+    {
+      get { return _is_two_factor_auth_enabled != null; }
+      set { if (value == (_is_two_factor_auth_enabled== null)) _is_two_factor_auth_enabled = value ? this.is_two_factor_auth_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_two_factor_auth_enabled() { return is_two_factor_auth_enabledSpecified; }
+    private void Resetis_two_factor_auth_enabled() { is_two_factor_auth_enabledSpecified = false; }
+    
 
-    private uint _two_factor_enabled_time = default(uint);
+    private uint? _two_factor_enabled_time;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"two_factor_enabled_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint two_factor_enabled_time
     {
-      get { return _two_factor_enabled_time; }
+      get { return _two_factor_enabled_time?? default(uint); }
       set { _two_factor_enabled_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool two_factor_enabled_timeSpecified
+    {
+      get { return _two_factor_enabled_time != null; }
+      set { if (value == (_two_factor_enabled_time== null)) _two_factor_enabled_time = value ? this.two_factor_enabled_time : (uint?)null; }
+    }
+    private bool ShouldSerializetwo_factor_enabled_time() { return two_factor_enabled_timeSpecified; }
+    private void Resettwo_factor_enabled_time() { two_factor_enabled_timeSpecified = false; }
+    
 
-    private uint _phone_verification_time = default(uint);
+    private uint? _phone_verification_time;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"phone_verification_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint phone_verification_time
     {
-      get { return _phone_verification_time; }
+      get { return _phone_verification_time?? default(uint); }
       set { _phone_verification_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_verification_timeSpecified
+    {
+      get { return _phone_verification_time != null; }
+      set { if (value == (_phone_verification_time== null)) _phone_verification_time = value ? this.phone_verification_time : (uint?)null; }
+    }
+    private bool ShouldSerializephone_verification_time() { return phone_verification_timeSpecified; }
+    private void Resetphone_verification_time() { phone_verification_timeSpecified = false; }
+    
 
-    private ulong _phone_id = default(ulong);
+    private ulong? _phone_id;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"phone_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong phone_id
     {
-      get { return _phone_id; }
+      get { return _phone_id?? default(ulong); }
       set { _phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_idSpecified
+    {
+      get { return _phone_id != null; }
+      set { if (value == (_phone_id== null)) _phone_id = value ? this.phone_id : (ulong?)null; }
+    }
+    private bool ShouldSerializephone_id() { return phone_idSpecified; }
+    private void Resetphone_id() { phone_idSpecified = false; }
+    
 
-    private bool _is_phone_identifying = default(bool);
+    private bool? _is_phone_identifying;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"is_phone_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_identifying
     {
-      get { return _is_phone_identifying; }
+      get { return _is_phone_identifying?? default(bool); }
       set { _is_phone_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_identifyingSpecified
+    {
+      get { return _is_phone_identifying != null; }
+      set { if (value == (_is_phone_identifying== null)) _is_phone_identifying = value ? this.is_phone_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_identifying() { return is_phone_identifyingSpecified; }
+    private void Resetis_phone_identifying() { is_phone_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2181,23 +3722,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCCheckClanMembership() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _clanid = default(uint);
+    private uint? _clanid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"clanid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint clanid
     {
-      get { return _clanid; }
+      get { return _clanid?? default(uint); }
       set { _clanid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clanidSpecified
+    {
+      get { return _clanid != null; }
+      set { if (value == (_clanid== null)) _clanid = value ? this.clanid : (uint?)null; }
+    }
+    private bool ShouldSerializeclanid() { return clanidSpecified; }
+    private void Resetclanid() { clanidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2209,14 +3768,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCCheckClanMembership_Response() {}
     
 
-    private bool _ismember = default(bool);
+    private bool? _ismember;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ismember", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ismember
     {
-      get { return _ismember; }
+      get { return _ismember?? default(bool); }
       set { _ismember = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ismemberSpecified
+    {
+      get { return _ismember != null; }
+      set { if (value == (_ismember== null)) _ismember = value ? this.ismember : (bool?)null; }
+    }
+    private bool ShouldSerializeismember() { return ismemberSpecified; }
+    private void Resetismember() { ismemberSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2264,23 +3832,41 @@ namespace SteamKit2.GC.TF2.Internal
     public PersonaName() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2297,23 +3883,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCCheckFriendship() {}
     
 
-    private ulong _steamid_left = default(ulong);
+    private ulong? _steamid_left;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_left", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_left
     {
-      get { return _steamid_left; }
+      get { return _steamid_left?? default(ulong); }
       set { _steamid_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_leftSpecified
+    {
+      get { return _steamid_left != null; }
+      set { if (value == (_steamid_left== null)) _steamid_left = value ? this.steamid_left : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_left() { return steamid_leftSpecified; }
+    private void Resetsteamid_left() { steamid_leftSpecified = false; }
+    
 
-    private ulong _steamid_right = default(ulong);
+    private ulong? _steamid_right;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_right", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_right
     {
-      get { return _steamid_right; }
+      get { return _steamid_right?? default(ulong); }
       set { _steamid_right = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_rightSpecified
+    {
+      get { return _steamid_right != null; }
+      set { if (value == (_steamid_right== null)) _steamid_right = value ? this.steamid_right : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_right() { return steamid_rightSpecified; }
+    private void Resetsteamid_right() { steamid_rightSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2325,23 +3929,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCCheckFriendship_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private bool _found_friendship = default(bool);
+    private bool? _found_friendship;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"found_friendship", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool found_friendship
     {
-      get { return _found_friendship; }
+      get { return _found_friendship?? default(bool); }
       set { _found_friendship = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool found_friendshipSpecified
+    {
+      get { return _found_friendship != null; }
+      set { if (value == (_found_friendship== null)) _found_friendship = value ? this.found_friendship : (bool?)null; }
+    }
+    private bool ShouldSerializefound_friendship() { return found_friendshipSpecified; }
+    private void Resetfound_friendship() { found_friendshipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2353,14 +3975,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMsgMasterSetDirectory() {}
     
 
-    private uint _master_dir_index = default(uint);
+    private uint? _master_dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"master_dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint master_dir_index
     {
-      get { return _master_dir_index; }
+      get { return _master_dir_index?? default(uint); }
       set { _master_dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool master_dir_indexSpecified
+    {
+      get { return _master_dir_index != null; }
+      set { if (value == (_master_dir_index== null)) _master_dir_index = value ? this.master_dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializemaster_dir_index() { return master_dir_indexSpecified; }
+    private void Resetmaster_dir_index() { master_dir_indexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> _dir = new global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC>();
     [global::ProtoBuf.ProtoMember(2, Name=@"dir", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCMsgMasterSetDirectory.SubGC> dir
@@ -2374,50 +4005,95 @@ namespace SteamKit2.GC.TF2.Internal
     public SubGC() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _box = "";
+    private string _box;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"box", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string box
     {
-      get { return _box; }
+      get { return _box?? ""; }
       set { _box = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool boxSpecified
+    {
+      get { return _box != null; }
+      set { if (value == (_box== null)) _box = value ? this.box : (string)null; }
+    }
+    private bool ShouldSerializebox() { return boxSpecified; }
+    private void Resetbox() { boxSpecified = false; }
+    
 
-    private string _command_line = "";
+    private string _command_line;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"command_line", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string command_line
     {
-      get { return _command_line; }
+      get { return _command_line?? ""; }
       set { _command_line = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool command_lineSpecified
+    {
+      get { return _command_line != null; }
+      set { if (value == (_command_line== null)) _command_line = value ? this.command_line : (string)null; }
+    }
+    private bool ShouldSerializecommand_line() { return command_lineSpecified; }
+    private void Resetcommand_line() { command_lineSpecified = false; }
+    
 
-    private string _gc_binary = "";
+    private string _gc_binary;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gc_binary", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gc_binary
     {
-      get { return _gc_binary; }
+      get { return _gc_binary?? ""; }
       set { _gc_binary = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gc_binarySpecified
+    {
+      get { return _gc_binary != null; }
+      set { if (value == (_gc_binary== null)) _gc_binary = value ? this.gc_binary : (string)null; }
+    }
+    private bool ShouldSerializegc_binary() { return gc_binarySpecified; }
+    private void Resetgc_binary() { gc_binarySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2434,14 +4110,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMsgMasterSetDirectory_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2453,14 +4138,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMsgWebAPIJobRequestForwardResponse() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2472,14 +4166,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCSystemMsg_GetPurchaseTrust_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2491,41 +4194,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCSystemMsg_GetPurchaseTrust_Response() {}
     
 
-    private bool _has_prior_purchase_history = default(bool);
+    private bool? _has_prior_purchase_history;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_prior_purchase_history", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_prior_purchase_history
     {
-      get { return _has_prior_purchase_history; }
+      get { return _has_prior_purchase_history?? default(bool); }
       set { _has_prior_purchase_history = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_prior_purchase_historySpecified
+    {
+      get { return _has_prior_purchase_history != null; }
+      set { if (value == (_has_prior_purchase_history== null)) _has_prior_purchase_history = value ? this.has_prior_purchase_history : (bool?)null; }
+    }
+    private bool ShouldSerializehas_prior_purchase_history() { return has_prior_purchase_historySpecified; }
+    private void Resethas_prior_purchase_history() { has_prior_purchase_historySpecified = false; }
+    
 
-    private bool _has_no_recent_password_resets = default(bool);
+    private bool? _has_no_recent_password_resets;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"has_no_recent_password_resets", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_no_recent_password_resets
     {
-      get { return _has_no_recent_password_resets; }
+      get { return _has_no_recent_password_resets?? default(bool); }
       set { _has_no_recent_password_resets = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_no_recent_password_resetsSpecified
+    {
+      get { return _has_no_recent_password_resets != null; }
+      set { if (value == (_has_no_recent_password_resets== null)) _has_no_recent_password_resets = value ? this.has_no_recent_password_resets : (bool?)null; }
+    }
+    private bool ShouldSerializehas_no_recent_password_resets() { return has_no_recent_password_resetsSpecified; }
+    private void Resethas_no_recent_password_resets() { has_no_recent_password_resetsSpecified = false; }
+    
 
-    private bool _is_wallet_cash_trusted = default(bool);
+    private bool? _is_wallet_cash_trusted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_wallet_cash_trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_wallet_cash_trusted
     {
-      get { return _is_wallet_cash_trusted; }
+      get { return _is_wallet_cash_trusted?? default(bool); }
       set { _is_wallet_cash_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_wallet_cash_trustedSpecified
+    {
+      get { return _is_wallet_cash_trusted != null; }
+      set { if (value == (_is_wallet_cash_trusted== null)) _is_wallet_cash_trusted = value ? this.is_wallet_cash_trusted : (bool?)null; }
+    }
+    private bool ShouldSerializeis_wallet_cash_trusted() { return is_wallet_cash_trustedSpecified; }
+    private void Resetis_wallet_cash_trusted() { is_wallet_cash_trustedSpecified = false; }
+    
 
-    private uint _time_all_trusted = default(uint);
+    private uint? _time_all_trusted;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_all_trusted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_all_trusted
     {
-      get { return _time_all_trusted; }
+      get { return _time_all_trusted?? default(uint); }
       set { _time_all_trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_all_trustedSpecified
+    {
+      get { return _time_all_trusted != null; }
+      set { if (value == (_time_all_trusted== null)) _time_all_trusted = value ? this.time_all_trusted : (uint?)null; }
+    }
+    private bool ShouldSerializetime_all_trusted() { return time_all_trustedSpecified; }
+    private void Resettime_all_trusted() { time_all_trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2537,50 +4276,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHAccountVacStatusChange() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _rtime_vacban_starts = default(uint);
+    private uint? _rtime_vacban_starts;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rtime_vacban_starts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime_vacban_starts
     {
-      get { return _rtime_vacban_starts; }
+      get { return _rtime_vacban_starts?? default(uint); }
       set { _rtime_vacban_starts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_vacban_startsSpecified
+    {
+      get { return _rtime_vacban_starts != null; }
+      set { if (value == (_rtime_vacban_starts== null)) _rtime_vacban_starts = value ? this.rtime_vacban_starts : (uint?)null; }
+    }
+    private bool ShouldSerializertime_vacban_starts() { return rtime_vacban_startsSpecified; }
+    private void Resetrtime_vacban_starts() { rtime_vacban_startsSpecified = false; }
+    
 
-    private bool _is_banned_now = default(bool);
+    private bool? _is_banned_now;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_banned_now", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_now
     {
-      get { return _is_banned_now; }
+      get { return _is_banned_now?? default(bool); }
       set { _is_banned_now = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_nowSpecified
+    {
+      get { return _is_banned_now != null; }
+      set { if (value == (_is_banned_now== null)) _is_banned_now = value ? this.is_banned_now : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_now() { return is_banned_nowSpecified; }
+    private void Resetis_banned_now() { is_banned_nowSpecified = false; }
+    
 
-    private bool _is_banned_future = default(bool);
+    private bool? _is_banned_future;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_banned_future", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned_future
     {
-      get { return _is_banned_future; }
+      get { return _is_banned_future?? default(bool); }
       set { _is_banned_future = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_banned_futureSpecified
+    {
+      get { return _is_banned_future != null; }
+      set { if (value == (_is_banned_future== null)) _is_banned_future = value ? this.is_banned_future : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned_future() { return is_banned_futureSpecified; }
+    private void Resetis_banned_future() { is_banned_futureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2592,41 +4376,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHAccountTradeBanStatusChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_banned = default(bool);
+    private bool? _is_banned;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_banned
     {
-      get { return _is_banned; }
+      get { return _is_banned?? default(bool); }
       set { _is_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_bannedSpecified
+    {
+      get { return _is_banned != null; }
+      set { if (value == (_is_banned== null)) _is_banned = value ? this.is_banned : (bool?)null; }
+    }
+    private bool ShouldSerializeis_banned() { return is_bannedSpecified; }
+    private void Resetis_banned() { is_bannedSpecified = false; }
+    
 
-    private uint _time_banned_until = default(uint);
+    private uint? _time_banned_until;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_banned_until", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_banned_until
     {
-      get { return _time_banned_until; }
+      get { return _time_banned_until?? default(uint); }
       set { _time_banned_until = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_banned_untilSpecified
+    {
+      get { return _time_banned_until != null; }
+      set { if (value == (_time_banned_until== null)) _time_banned_until = value ? this.time_banned_until : (uint?)null; }
+    }
+    private bool ShouldSerializetime_banned_until() { return time_banned_untilSpecified; }
+    private void Resettime_banned_until() { time_banned_untilSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2638,32 +4458,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHAccountLockStatusChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_locked = default(bool);
+    private bool? _is_locked;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_locked", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_locked
     {
-      get { return _is_locked; }
+      get { return _is_locked?? default(bool); }
       set { _is_locked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_lockedSpecified
+    {
+      get { return _is_locked != null; }
+      set { if (value == (_is_locked== null)) _is_locked = value ? this.is_locked : (bool?)null; }
+    }
+    private bool ShouldSerializeis_locked() { return is_lockedSpecified; }
+    private void Resetis_locked() { is_lockedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2675,32 +4522,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHVacVerificationChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_verified = default(bool);
+    private bool? _is_verified;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_verified
     {
-      get { return _is_verified; }
+      get { return _is_verified?? default(bool); }
       set { _is_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_verifiedSpecified
+    {
+      get { return _is_verified != null; }
+      set { if (value == (_is_verified== null)) _is_verified = value ? this.is_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_verified() { return is_verifiedSpecified; }
+    private void Resetis_verified() { is_verifiedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2712,50 +4586,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHAccountPhoneNumberChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _phone_id = default(ulong);
+    private ulong? _phone_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"phone_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong phone_id
     {
-      get { return _phone_id; }
+      get { return _phone_id?? default(ulong); }
       set { _phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_idSpecified
+    {
+      get { return _phone_id != null; }
+      set { if (value == (_phone_id== null)) _phone_id = value ? this.phone_id : (ulong?)null; }
+    }
+    private bool ShouldSerializephone_id() { return phone_idSpecified; }
+    private void Resetphone_id() { phone_idSpecified = false; }
+    
 
-    private bool _is_verified = default(bool);
+    private bool? _is_verified;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_verified
     {
-      get { return _is_verified; }
+      get { return _is_verified?? default(bool); }
       set { _is_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_verifiedSpecified
+    {
+      get { return _is_verified != null; }
+      set { if (value == (_is_verified== null)) _is_verified = value ? this.is_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_verified() { return is_verifiedSpecified; }
+    private void Resetis_verified() { is_verifiedSpecified = false; }
+    
 
-    private bool _is_identifying = default(bool);
+    private bool? _is_identifying;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_identifying
     {
-      get { return _is_identifying; }
+      get { return _is_identifying?? default(bool); }
       set { _is_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_identifyingSpecified
+    {
+      get { return _is_identifying != null; }
+      set { if (value == (_is_identifying== null)) _is_identifying = value ? this.is_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_identifying() { return is_identifyingSpecified; }
+    private void Resetis_identifying() { is_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2767,32 +4686,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHAccountTwoFactorChange() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _twofactor_enabled = default(bool);
+    private bool? _twofactor_enabled;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"twofactor_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool twofactor_enabled
     {
-      get { return _twofactor_enabled; }
+      get { return _twofactor_enabled?? default(bool); }
       set { _twofactor_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool twofactor_enabledSpecified
+    {
+      get { return _twofactor_enabled != null; }
+      set { if (value == (_twofactor_enabled== null)) _twofactor_enabled = value ? this.twofactor_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializetwofactor_enabled() { return twofactor_enabledSpecified; }
+    private void Resettwofactor_enabled() { twofactor_enabledSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2804,14 +4750,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGetPartnerAccountLink() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2823,23 +4778,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGetPartnerAccountLink_Response() {}
     
 
-    private uint _pwid = default(uint);
+    private uint? _pwid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"pwid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pwid
     {
-      get { return _pwid; }
+      get { return _pwid?? default(uint); }
       set { _pwid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pwidSpecified
+    {
+      get { return _pwid != null; }
+      set { if (value == (_pwid== null)) _pwid = value ? this.pwid : (uint?)null; }
+    }
+    private bool ShouldSerializepwid() { return pwidSpecified; }
+    private void Resetpwid() { pwidSpecified = false; }
+    
 
-    private uint _nexonid = default(uint);
+    private uint? _nexonid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"nexonid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint nexonid
     {
-      get { return _nexonid; }
+      get { return _nexonid?? default(uint); }
       set { _nexonid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nexonidSpecified
+    {
+      get { return _nexonid != null; }
+      set { if (value == (_nexonid== null)) _nexonid = value ? this.nexonid : (uint?)null; }
+    }
+    private bool ShouldSerializenexonid() { return nexonidSpecified; }
+    private void Resetnexonid() { nexonidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2858,41 +4831,77 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private CMsgGCRoutingInfo.RoutingMethod _method = CMsgGCRoutingInfo.RoutingMethod.RANDOM;
+    private CMsgGCRoutingInfo.RoutingMethod? _method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.RANDOM)]
     public CMsgGCRoutingInfo.RoutingMethod method
     {
-      get { return _method; }
+      get { return _method?? CMsgGCRoutingInfo.RoutingMethod.RANDOM; }
       set { _method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool methodSpecified
+    {
+      get { return _method != null; }
+      set { if (value == (_method== null)) _method = value ? this.method : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializemethod() { return methodSpecified; }
+    private void Resetmethod() { methodSpecified = false; }
+    
 
-    private CMsgGCRoutingInfo.RoutingMethod _fallback = CMsgGCRoutingInfo.RoutingMethod.DISCARD;
+    private CMsgGCRoutingInfo.RoutingMethod? _fallback;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"fallback", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCRoutingInfo.RoutingMethod.DISCARD)]
     public CMsgGCRoutingInfo.RoutingMethod fallback
     {
-      get { return _fallback; }
+      get { return _fallback?? CMsgGCRoutingInfo.RoutingMethod.DISCARD; }
       set { _fallback = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fallbackSpecified
+    {
+      get { return _fallback != null; }
+      set { if (value == (_fallback== null)) _fallback = value ? this.fallback : (CMsgGCRoutingInfo.RoutingMethod?)null; }
+    }
+    private bool ShouldSerializefallback() { return fallbackSpecified; }
+    private void Resetfallback() { fallbackSpecified = false; }
+    
 
-    private uint _protobuf_field = default(uint);
+    private uint? _protobuf_field;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"protobuf_field", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protobuf_field
     {
-      get { return _protobuf_field; }
+      get { return _protobuf_field?? default(uint); }
       set { _protobuf_field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protobuf_fieldSpecified
+    {
+      get { return _protobuf_field != null; }
+      set { if (value == (_protobuf_field== null)) _protobuf_field = value ? this.protobuf_field : (uint?)null; }
+    }
+    private bool ShouldSerializeprotobuf_field() { return protobuf_fieldSpecified; }
+    private void Resetprotobuf_field() { protobuf_fieldSpecified = false; }
+    
 
-    private string _webapi_param = "";
+    private string _webapi_param;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"webapi_param", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webapi_param
     {
-      get { return _webapi_param; }
+      get { return _webapi_param?? ""; }
       set { _webapi_param = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_paramSpecified
+    {
+      get { return _webapi_param != null; }
+      set { if (value == (_webapi_param== null)) _webapi_param = value ? this.webapi_param : (string)null; }
+    }
+    private bool ShouldSerializewebapi_param() { return webapi_paramSpecified; }
+    private void Resetwebapi_param() { webapi_paramSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"RoutingMethod", EnumPassthru=true)]
     public enum RoutingMethod
     {
@@ -2936,23 +4945,41 @@ namespace SteamKit2.GC.TF2.Internal
     public Entry() {}
     
 
-    private string _interface_name = "";
+    private string _interface_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"interface_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string interface_name
     {
-      get { return _interface_name; }
+      get { return _interface_name?? ""; }
       set { _interface_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool interface_nameSpecified
+    {
+      get { return _interface_name != null; }
+      set { if (value == (_interface_name== null)) _interface_name = value ? this.interface_name : (string)null; }
+    }
+    private bool ShouldSerializeinterface_name() { return interface_nameSpecified; }
+    private void Resetinterface_name() { interface_nameSpecified = false; }
+    
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -2990,14 +5017,23 @@ namespace SteamKit2.GC.TF2.Internal
     public Entry() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
     private CMsgGCRoutingInfo _routing = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3023,14 +5059,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMsgMasterSetWebAPIRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3042,14 +5087,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMsgMasterSetClientMsgRouting_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3075,14 +5129,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private CMsgGCMsgSetOptions.GCSQLVersion _gcsql_version = CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE;
+    private CMsgGCMsgSetOptions.GCSQLVersion? _gcsql_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"gcsql_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE)]
     public CMsgGCMsgSetOptions.GCSQLVersion gcsql_version
     {
-      get { return _gcsql_version; }
+      get { return _gcsql_version?? CMsgGCMsgSetOptions.GCSQLVersion.GCSQL_VERSION_BASELINE; }
       set { _gcsql_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gcsql_versionSpecified
+    {
+      get { return _gcsql_version != null; }
+      set { if (value == (_gcsql_version== null)) _gcsql_version = value ? this.gcsql_version : (CMsgGCMsgSetOptions.GCSQLVersion?)null; }
+    }
+    private bool ShouldSerializegcsql_version() { return gcsql_versionSpecified; }
+    private void Resetgcsql_version() { gcsql_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"MessageRange")]
   public partial class MessageRange : global::ProtoBuf.IExtensible
   {
@@ -3146,77 +5209,149 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCHUpdateSession() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private bool _online = default(bool);
+    private bool? _online;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"online", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool online
     {
-      get { return _online; }
+      get { return _online?? default(bool); }
       set { _online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onlineSpecified
+    {
+      get { return _online != null; }
+      set { if (value == (_online== null)) _online = value ? this.online : (bool?)null; }
+    }
+    private bool ShouldSerializeonline() { return onlineSpecified; }
+    private void Resetonline() { onlineSpecified = false; }
+    
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
 
-    private uint _server_addr = default(uint);
+    private uint? _server_addr;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_addr
     {
-      get { return _server_addr; }
+      get { return _server_addr?? default(uint); }
       set { _server_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_addrSpecified
+    {
+      get { return _server_addr != null; }
+      set { if (value == (_server_addr== null)) _server_addr = value ? this.server_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_addr() { return server_addrSpecified; }
+    private void Resetserver_addr() { server_addrSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _os_type = default(uint);
+    private uint? _os_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint os_type
     {
-      get { return _os_type; }
+      get { return _os_type?? default(uint); }
       set { _os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_typeSpecified
+    {
+      get { return _os_type != null; }
+      set { if (value == (_os_type== null)) _os_type = value ? this.os_type : (uint?)null; }
+    }
+    private bool ShouldSerializeos_type() { return os_typeSpecified; }
+    private void Resetos_type() { os_typeSpecified = false; }
+    
 
-    private uint _client_addr = default(uint);
+    private uint? _client_addr;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"client_addr", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_addr
     {
-      get { return _client_addr; }
+      get { return _client_addr?? default(uint); }
       set { _client_addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_addrSpecified
+    {
+      get { return _client_addr != null; }
+      set { if (value == (_client_addr== null)) _client_addr = value ? this.client_addr : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_addr() { return client_addrSpecified; }
+    private void Resetclient_addr() { client_addrSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> _extra_fields = new global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField>();
     [global::ProtoBuf.ProtoMember(9, Name=@"extra_fields", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCHUpdateSession.ExtraField> extra_fields
@@ -3230,23 +5365,41 @@ namespace SteamKit2.GC.TF2.Internal
     public ExtraField() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3263,23 +5416,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgNotificationOfSuspiciousActivity() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
     private CMsgNotificationOfSuspiciousActivity.MultipleGameInstances _multiple_instances = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"multiple_instances", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -3295,14 +5466,23 @@ namespace SteamKit2.GC.TF2.Internal
     public MultipleGameInstances() {}
     
 
-    private uint _app_instance_count = default(uint);
+    private uint? _app_instance_count;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_instance_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_instance_count
     {
-      get { return _app_instance_count; }
+      get { return _app_instance_count?? default(uint); }
       set { _app_instance_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_instance_countSpecified
+    {
+      get { return _app_instance_count != null; }
+      set { if (value == (_app_instance_count== null)) _app_instance_count = value ? this.app_instance_count : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_instance_count() { return app_instance_countSpecified; }
+    private void Resetapp_instance_count() { app_instance_countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _other_steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"other_steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> other_steamids

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGC.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: base_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.TF2.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCStorePurchaseInit_LineItem() {}
     
 
-    private uint _item_def_id = default(uint);
+    private uint? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(uint); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _cost_in_local_currency = default(uint);
+    private uint? _cost_in_local_currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cost_in_local_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cost_in_local_currency
     {
-      get { return _cost_in_local_currency; }
+      get { return _cost_in_local_currency?? default(uint); }
       set { _cost_in_local_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cost_in_local_currencySpecified
+    {
+      get { return _cost_in_local_currency != null; }
+      set { if (value == (_cost_in_local_currency== null)) _cost_in_local_currency = value ? this.cost_in_local_currency : (uint?)null; }
+    }
+    private bool ShouldSerializecost_in_local_currency() { return cost_in_local_currencySpecified; }
+    private void Resetcost_in_local_currency() { cost_in_local_currencySpecified = false; }
+    
 
-    private uint _purchase_type = default(uint);
+    private uint? _purchase_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"purchase_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint purchase_type
     {
-      get { return _purchase_type; }
+      get { return _purchase_type?? default(uint); }
       set { _purchase_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_typeSpecified
+    {
+      get { return _purchase_type != null; }
+      set { if (value == (_purchase_type== null)) _purchase_type = value ? this.purchase_type : (uint?)null; }
+    }
+    private bool ShouldSerializepurchase_type() { return purchase_typeSpecified; }
+    private void Resetpurchase_type() { purchase_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -64,32 +102,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseInit() {}
     
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> _line_items = new global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem>();
     [global::ProtoBuf.ProtoMember(4, Name=@"line_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGCStorePurchaseInit_LineItem> line_items
@@ -108,23 +173,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseInitResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -136,32 +219,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOPartyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -173,32 +283,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOLobbyInvite() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private string _sender_name = "";
+    private string _sender_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sender_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sender_name
     {
-      get { return _sender_name; }
+      get { return _sender_name?? ""; }
       set { _sender_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_nameSpecified
+    {
+      get { return _sender_name != null; }
+      set { if (value == (_sender_name== null)) _sender_name = value ? this.sender_name : (string)null; }
+    }
+    private bool ShouldSerializesender_name() { return sender_nameSpecified; }
+    private void Resetsender_name() { sender_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -210,14 +347,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSystemBroadcast() {}
     
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -229,14 +375,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgClientHello() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -248,14 +403,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgServerHello() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -267,23 +431,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgClientWelcome() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private byte[] _game_data = null;
+    private byte[] _game_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data
     {
-      get { return _game_data; }
+      get { return _game_data?? null; }
       set { _game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_dataSpecified
+    {
+      get { return _game_data != null; }
+      set { if (value == (_game_data== null)) _game_data = value ? this.game_data : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data() { return game_dataSpecified; }
+    private void Resetgame_data() { game_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -295,23 +477,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgServerWelcome() {}
     
 
-    private uint _min_allowed_version = default(uint);
+    private uint? _min_allowed_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"min_allowed_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint min_allowed_version
     {
-      get { return _min_allowed_version; }
+      get { return _min_allowed_version?? default(uint); }
       set { _min_allowed_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_allowed_versionSpecified
+    {
+      get { return _min_allowed_version != null; }
+      set { if (value == (_min_allowed_version== null)) _min_allowed_version = value ? this.min_allowed_version : (uint?)null; }
+    }
+    private bool ShouldSerializemin_allowed_version() { return min_allowed_versionSpecified; }
+    private void Resetmin_allowed_version() { min_allowed_versionSpecified = false; }
+    
 
-    private uint _active_version = default(uint);
+    private uint? _active_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"active_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_version
     {
-      get { return _active_version; }
+      get { return _active_version?? default(uint); }
       set { _active_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_versionSpecified
+    {
+      get { return _active_version != null; }
+      set { if (value == (_active_version== null)) _active_version = value ? this.active_version : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_version() { return active_versionSpecified; }
+    private void Resetactive_version() { active_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -323,14 +523,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgClientGoodbye() {}
     
 
-    private GCGoodbyeReason _reason = GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN;
+    private GCGoodbyeReason? _reason;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN)]
     public GCGoodbyeReason reason
     {
-      get { return _reason; }
+      get { return _reason?? GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN; }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (GCGoodbyeReason?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -342,14 +551,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgServerGoodbye() {}
     
 
-    private GCGoodbyeReason _reason = GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN;
+    private GCGoodbyeReason? _reason;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN)]
     public GCGoodbyeReason reason
     {
-      get { return _reason; }
+      get { return _reason?? GCGoodbyeReason.GCGoodbyeReason_GC_GOING_DOWN; }
       set { _reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reasonSpecified
+    {
+      get { return _reason != null; }
+      set { if (value == (_reason== null)) _reason = value ? this.reason : (GCGoodbyeReason?)null; }
+    }
+    private bool ShouldSerializereason() { return reasonSpecified; }
+    private void Resetreason() { reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -361,41 +579,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgInviteToParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private bool _as_coach = default(bool);
+    private bool? _as_coach;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"as_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool as_coach
     {
-      get { return _as_coach; }
+      get { return _as_coach?? default(bool); }
       set { _as_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool as_coachSpecified
+    {
+      get { return _as_coach != null; }
+      set { if (value == (_as_coach== null)) _as_coach = value ? this.as_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeas_coach() { return as_coachSpecified; }
+    private void Resetas_coach() { as_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -407,23 +661,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgInvitationCreated() {}
     
 
-    private ulong _group_id = default(ulong);
+    private ulong? _group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong group_id
     {
-      get { return _group_id; }
+      get { return _group_id?? default(ulong); }
       set { _group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool group_idSpecified
+    {
+      get { return _group_id != null; }
+      set { if (value == (_group_id== null)) _group_id = value ? this.group_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegroup_id() { return group_idSpecified; }
+    private void Resetgroup_id() { group_idSpecified = false; }
+    
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -435,50 +707,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgPartyInviteResponse() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private bool _accept = default(bool);
+    private bool? _accept;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accept", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accept
     {
-      get { return _accept; }
+      get { return _accept?? default(bool); }
       set { _accept = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acceptSpecified
+    {
+      get { return _accept != null; }
+      set { if (value == (_accept== null)) _accept = value ? this.accept : (bool?)null; }
+    }
+    private bool ShouldSerializeaccept() { return acceptSpecified; }
+    private void Resetaccept() { acceptSpecified = false; }
+    
 
-    private uint _client_version = default(uint);
+    private uint? _client_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_version
     {
-      get { return _client_version; }
+      get { return _client_version?? default(uint); }
       set { _client_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_versionSpecified
+    {
+      get { return _client_version != null; }
+      set { if (value == (_client_version== null)) _client_version = value ? this.client_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_version() { return client_versionSpecified; }
+    private void Resetclient_version() { client_versionSpecified = false; }
+    
 
-    private uint _team_id = default(uint);
+    private uint? _team_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"team_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint team_id
     {
-      get { return _team_id; }
+      get { return _team_id?? default(uint); }
       set { _team_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool team_idSpecified
+    {
+      get { return _team_id != null; }
+      set { if (value == (_team_id== null)) _team_id = value ? this.team_id : (uint?)null; }
+    }
+    private bool ShouldSerializeteam_id() { return team_idSpecified; }
+    private void Resetteam_id() { team_idSpecified = false; }
+    
 
-    private bool _as_coach = default(bool);
+    private bool? _as_coach;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"as_coach", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool as_coach
     {
-      get { return _as_coach; }
+      get { return _as_coach?? default(bool); }
       set { _as_coach = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool as_coachSpecified
+    {
+      get { return _as_coach != null; }
+      set { if (value == (_as_coach== null)) _as_coach = value ? this.as_coach : (bool?)null; }
+    }
+    private bool ShouldSerializeas_coach() { return as_coachSpecified; }
+    private void Resetas_coach() { as_coachSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -490,14 +807,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgKickFromParty() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -509,23 +835,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgLeaveParty() {}
     
 
-    private ulong _party_id = default(ulong);
+    private ulong? _party_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"party_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong party_id
     {
-      get { return _party_id; }
+      get { return _party_id?? default(ulong); }
       set { _party_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool party_idSpecified
+    {
+      get { return _party_id != null; }
+      set { if (value == (_party_id== null)) _party_id = value ? this.party_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeparty_id() { return party_idSpecified; }
+    private void Resetparty_id() { party_idSpecified = false; }
+    
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -547,14 +891,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgLANServerAvailable() {}
     
 
-    private ulong _lobby_id = default(ulong);
+    private ulong? _lobby_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"lobby_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lobby_id
     {
-      get { return _lobby_id; }
+      get { return _lobby_id?? default(ulong); }
       set { _lobby_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_idSpecified
+    {
+      get { return _lobby_id != null; }
+      set { if (value == (_lobby_id== null)) _lobby_id = value ? this.lobby_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelobby_id() { return lobby_idSpecified; }
+    private void Resetlobby_id() { lobby_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -566,185 +919,365 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconGameAccountClient() {}
     
 
-    private uint _additional_backpack_slots = (uint)0;
+    private uint? _additional_backpack_slots;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"additional_backpack_slots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint additional_backpack_slots
     {
-      get { return _additional_backpack_slots; }
+      get { return _additional_backpack_slots?? (uint)0; }
       set { _additional_backpack_slots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool additional_backpack_slotsSpecified
+    {
+      get { return _additional_backpack_slots != null; }
+      set { if (value == (_additional_backpack_slots== null)) _additional_backpack_slots = value ? this.additional_backpack_slots : (uint?)null; }
+    }
+    private bool ShouldSerializeadditional_backpack_slots() { return additional_backpack_slotsSpecified; }
+    private void Resetadditional_backpack_slots() { additional_backpack_slotsSpecified = false; }
+    
 
-    private bool _trial_account = (bool)false;
+    private bool? _trial_account;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trial_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool trial_account
     {
-      get { return _trial_account; }
+      get { return _trial_account?? (bool)false; }
       set { _trial_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trial_accountSpecified
+    {
+      get { return _trial_account != null; }
+      set { if (value == (_trial_account== null)) _trial_account = value ? this.trial_account : (bool?)null; }
+    }
+    private bool ShouldSerializetrial_account() { return trial_accountSpecified; }
+    private void Resettrial_account() { trial_accountSpecified = false; }
+    
 
-    private bool _need_to_choose_most_helpful_friend = default(bool);
+    private bool? _need_to_choose_most_helpful_friend;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"need_to_choose_most_helpful_friend", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool need_to_choose_most_helpful_friend
     {
-      get { return _need_to_choose_most_helpful_friend; }
+      get { return _need_to_choose_most_helpful_friend?? default(bool); }
       set { _need_to_choose_most_helpful_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool need_to_choose_most_helpful_friendSpecified
+    {
+      get { return _need_to_choose_most_helpful_friend != null; }
+      set { if (value == (_need_to_choose_most_helpful_friend== null)) _need_to_choose_most_helpful_friend = value ? this.need_to_choose_most_helpful_friend : (bool?)null; }
+    }
+    private bool ShouldSerializeneed_to_choose_most_helpful_friend() { return need_to_choose_most_helpful_friendSpecified; }
+    private void Resetneed_to_choose_most_helpful_friend() { need_to_choose_most_helpful_friendSpecified = false; }
+    
 
-    private bool _in_coaches_list = default(bool);
+    private bool? _in_coaches_list;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"in_coaches_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_coaches_list
     {
-      get { return _in_coaches_list; }
+      get { return _in_coaches_list?? default(bool); }
       set { _in_coaches_list = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_coaches_listSpecified
+    {
+      get { return _in_coaches_list != null; }
+      set { if (value == (_in_coaches_list== null)) _in_coaches_list = value ? this.in_coaches_list : (bool?)null; }
+    }
+    private bool ShouldSerializein_coaches_list() { return in_coaches_listSpecified; }
+    private void Resetin_coaches_list() { in_coaches_listSpecified = false; }
+    
 
-    private uint _trade_ban_expiration = default(uint);
+    private uint? _trade_ban_expiration;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"trade_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_ban_expiration
     {
-      get { return _trade_ban_expiration; }
+      get { return _trade_ban_expiration?? default(uint); }
       set { _trade_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_ban_expirationSpecified
+    {
+      get { return _trade_ban_expiration != null; }
+      set { if (value == (_trade_ban_expiration== null)) _trade_ban_expiration = value ? this.trade_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_ban_expiration() { return trade_ban_expirationSpecified; }
+    private void Resettrade_ban_expiration() { trade_ban_expirationSpecified = false; }
+    
 
-    private uint _duel_ban_expiration = default(uint);
+    private uint? _duel_ban_expiration;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"duel_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel_ban_expiration
     {
-      get { return _duel_ban_expiration; }
+      get { return _duel_ban_expiration?? default(uint); }
       set { _duel_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel_ban_expirationSpecified
+    {
+      get { return _duel_ban_expiration != null; }
+      set { if (value == (_duel_ban_expiration== null)) _duel_ban_expiration = value ? this.duel_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializeduel_ban_expiration() { return duel_ban_expirationSpecified; }
+    private void Resetduel_ban_expiration() { duel_ban_expirationSpecified = false; }
+    
 
-    private uint _preview_item_def = (uint)0;
+    private uint? _preview_item_def;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"preview_item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint preview_item_def
     {
-      get { return _preview_item_def; }
+      get { return _preview_item_def?? (uint)0; }
       set { _preview_item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_item_defSpecified
+    {
+      get { return _preview_item_def != null; }
+      set { if (value == (_preview_item_def== null)) _preview_item_def = value ? this.preview_item_def : (uint?)null; }
+    }
+    private bool ShouldSerializepreview_item_def() { return preview_item_defSpecified; }
+    private void Resetpreview_item_def() { preview_item_defSpecified = false; }
+    
 
-    private bool _phone_verified = (bool)false;
+    private bool? _phone_verified;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool phone_verified
     {
-      get { return _phone_verified; }
+      get { return _phone_verified?? (bool)false; }
       set { _phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_verifiedSpecified
+    {
+      get { return _phone_verified != null; }
+      set { if (value == (_phone_verified== null)) _phone_verified = value ? this.phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializephone_verified() { return phone_verifiedSpecified; }
+    private void Resetphone_verified() { phone_verifiedSpecified = false; }
+    
 
-    private uint _skill_rating_6v6 = default(uint);
+    private uint? _skill_rating_6v6;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"skill_rating_6v6", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating_6v6
     {
-      get { return _skill_rating_6v6; }
+      get { return _skill_rating_6v6?? default(uint); }
       set { _skill_rating_6v6 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_rating_6v6Specified
+    {
+      get { return _skill_rating_6v6 != null; }
+      set { if (value == (_skill_rating_6v6== null)) _skill_rating_6v6 = value ? this.skill_rating_6v6 : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating_6v6() { return skill_rating_6v6Specified; }
+    private void Resetskill_rating_6v6() { skill_rating_6v6Specified = false; }
+    
 
-    private uint _skill_rating_9v9 = default(uint);
+    private uint? _skill_rating_9v9;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"skill_rating_9v9", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating_9v9
     {
-      get { return _skill_rating_9v9; }
+      get { return _skill_rating_9v9?? default(uint); }
       set { _skill_rating_9v9 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_rating_9v9Specified
+    {
+      get { return _skill_rating_9v9 != null; }
+      set { if (value == (_skill_rating_9v9== null)) _skill_rating_9v9 = value ? this.skill_rating_9v9 : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating_9v9() { return skill_rating_9v9Specified; }
+    private void Resetskill_rating_9v9() { skill_rating_9v9Specified = false; }
+    
 
-    private bool _competitive_access = (bool)false;
+    private bool? _competitive_access;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"competitive_access", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool competitive_access
     {
-      get { return _competitive_access; }
+      get { return _competitive_access?? (bool)false; }
       set { _competitive_access = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool competitive_accessSpecified
+    {
+      get { return _competitive_access != null; }
+      set { if (value == (_competitive_access== null)) _competitive_access = value ? this.competitive_access : (bool?)null; }
+    }
+    private bool ShouldSerializecompetitive_access() { return competitive_accessSpecified; }
+    private void Resetcompetitive_access() { competitive_accessSpecified = false; }
+    
 
-    private uint _matchmaking_ranked_ban_expiration = default(uint);
+    private uint? _matchmaking_ranked_ban_expiration;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"matchmaking_ranked_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ranked_ban_expiration
     {
-      get { return _matchmaking_ranked_ban_expiration; }
+      get { return _matchmaking_ranked_ban_expiration?? default(uint); }
       set { _matchmaking_ranked_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ranked_ban_expirationSpecified
+    {
+      get { return _matchmaking_ranked_ban_expiration != null; }
+      set { if (value == (_matchmaking_ranked_ban_expiration== null)) _matchmaking_ranked_ban_expiration = value ? this.matchmaking_ranked_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ranked_ban_expiration() { return matchmaking_ranked_ban_expirationSpecified; }
+    private void Resetmatchmaking_ranked_ban_expiration() { matchmaking_ranked_ban_expirationSpecified = false; }
+    
 
-    private uint _matchmaking_ranked_low_priority_expiration = default(uint);
+    private uint? _matchmaking_ranked_low_priority_expiration;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"matchmaking_ranked_low_priority_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ranked_low_priority_expiration
     {
-      get { return _matchmaking_ranked_low_priority_expiration; }
+      get { return _matchmaking_ranked_low_priority_expiration?? default(uint); }
       set { _matchmaking_ranked_low_priority_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ranked_low_priority_expirationSpecified
+    {
+      get { return _matchmaking_ranked_low_priority_expiration != null; }
+      set { if (value == (_matchmaking_ranked_low_priority_expiration== null)) _matchmaking_ranked_low_priority_expiration = value ? this.matchmaking_ranked_low_priority_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ranked_low_priority_expiration() { return matchmaking_ranked_low_priority_expirationSpecified; }
+    private void Resetmatchmaking_ranked_low_priority_expiration() { matchmaking_ranked_low_priority_expirationSpecified = false; }
+    
 
-    private uint _matchmaking_ranked_ban_last_duration = default(uint);
+    private uint? _matchmaking_ranked_ban_last_duration;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"matchmaking_ranked_ban_last_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ranked_ban_last_duration
     {
-      get { return _matchmaking_ranked_ban_last_duration; }
+      get { return _matchmaking_ranked_ban_last_duration?? default(uint); }
       set { _matchmaking_ranked_ban_last_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ranked_ban_last_durationSpecified
+    {
+      get { return _matchmaking_ranked_ban_last_duration != null; }
+      set { if (value == (_matchmaking_ranked_ban_last_duration== null)) _matchmaking_ranked_ban_last_duration = value ? this.matchmaking_ranked_ban_last_duration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ranked_ban_last_duration() { return matchmaking_ranked_ban_last_durationSpecified; }
+    private void Resetmatchmaking_ranked_ban_last_duration() { matchmaking_ranked_ban_last_durationSpecified = false; }
+    
 
-    private uint _matchmaking_ranked_low_priority_last_duration = default(uint);
+    private uint? _matchmaking_ranked_low_priority_last_duration;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"matchmaking_ranked_low_priority_last_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_ranked_low_priority_last_duration
     {
-      get { return _matchmaking_ranked_low_priority_last_duration; }
+      get { return _matchmaking_ranked_low_priority_last_duration?? default(uint); }
       set { _matchmaking_ranked_low_priority_last_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_ranked_low_priority_last_durationSpecified
+    {
+      get { return _matchmaking_ranked_low_priority_last_duration != null; }
+      set { if (value == (_matchmaking_ranked_low_priority_last_duration== null)) _matchmaking_ranked_low_priority_last_duration = value ? this.matchmaking_ranked_low_priority_last_duration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_ranked_low_priority_last_duration() { return matchmaking_ranked_low_priority_last_durationSpecified; }
+    private void Resetmatchmaking_ranked_low_priority_last_duration() { matchmaking_ranked_low_priority_last_durationSpecified = false; }
+    
 
-    private uint _matchmaking_casual_ban_expiration = default(uint);
+    private uint? _matchmaking_casual_ban_expiration;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"matchmaking_casual_ban_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_casual_ban_expiration
     {
-      get { return _matchmaking_casual_ban_expiration; }
+      get { return _matchmaking_casual_ban_expiration?? default(uint); }
       set { _matchmaking_casual_ban_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_casual_ban_expirationSpecified
+    {
+      get { return _matchmaking_casual_ban_expiration != null; }
+      set { if (value == (_matchmaking_casual_ban_expiration== null)) _matchmaking_casual_ban_expiration = value ? this.matchmaking_casual_ban_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_casual_ban_expiration() { return matchmaking_casual_ban_expirationSpecified; }
+    private void Resetmatchmaking_casual_ban_expiration() { matchmaking_casual_ban_expirationSpecified = false; }
+    
 
-    private uint _matchmaking_casual_low_priority_expiration = default(uint);
+    private uint? _matchmaking_casual_low_priority_expiration;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"matchmaking_casual_low_priority_expiration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_casual_low_priority_expiration
     {
-      get { return _matchmaking_casual_low_priority_expiration; }
+      get { return _matchmaking_casual_low_priority_expiration?? default(uint); }
       set { _matchmaking_casual_low_priority_expiration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_casual_low_priority_expirationSpecified
+    {
+      get { return _matchmaking_casual_low_priority_expiration != null; }
+      set { if (value == (_matchmaking_casual_low_priority_expiration== null)) _matchmaking_casual_low_priority_expiration = value ? this.matchmaking_casual_low_priority_expiration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_casual_low_priority_expiration() { return matchmaking_casual_low_priority_expirationSpecified; }
+    private void Resetmatchmaking_casual_low_priority_expiration() { matchmaking_casual_low_priority_expirationSpecified = false; }
+    
 
-    private uint _matchmaking_casual_ban_last_duration = default(uint);
+    private uint? _matchmaking_casual_ban_last_duration;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"matchmaking_casual_ban_last_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_casual_ban_last_duration
     {
-      get { return _matchmaking_casual_ban_last_duration; }
+      get { return _matchmaking_casual_ban_last_duration?? default(uint); }
       set { _matchmaking_casual_ban_last_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_casual_ban_last_durationSpecified
+    {
+      get { return _matchmaking_casual_ban_last_duration != null; }
+      set { if (value == (_matchmaking_casual_ban_last_duration== null)) _matchmaking_casual_ban_last_duration = value ? this.matchmaking_casual_ban_last_duration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_casual_ban_last_duration() { return matchmaking_casual_ban_last_durationSpecified; }
+    private void Resetmatchmaking_casual_ban_last_duration() { matchmaking_casual_ban_last_durationSpecified = false; }
+    
 
-    private uint _matchmaking_casual_low_priority_last_duration = default(uint);
+    private uint? _matchmaking_casual_low_priority_last_duration;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"matchmaking_casual_low_priority_last_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matchmaking_casual_low_priority_last_duration
     {
-      get { return _matchmaking_casual_low_priority_last_duration; }
+      get { return _matchmaking_casual_low_priority_last_duration?? default(uint); }
       set { _matchmaking_casual_low_priority_last_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matchmaking_casual_low_priority_last_durationSpecified
+    {
+      get { return _matchmaking_casual_low_priority_last_duration != null; }
+      set { if (value == (_matchmaking_casual_low_priority_last_duration== null)) _matchmaking_casual_low_priority_last_duration = value ? this.matchmaking_casual_low_priority_last_duration : (uint?)null; }
+    }
+    private bool ShouldSerializematchmaking_casual_low_priority_last_duration() { return matchmaking_casual_low_priority_last_durationSpecified; }
+    private void Resetmatchmaking_casual_low_priority_last_duration() { matchmaking_casual_low_priority_last_durationSpecified = false; }
+    
 
-    private bool _phone_identifying = (bool)false;
+    private bool? _phone_identifying;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"phone_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool phone_identifying
     {
-      get { return _phone_identifying; }
+      get { return _phone_identifying?? (bool)false; }
       set { _phone_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool phone_identifyingSpecified
+    {
+      get { return _phone_identifying != null; }
+      set { if (value == (_phone_identifying== null)) _phone_identifying = value ? this.phone_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializephone_identifying() { return phone_identifyingSpecified; }
+    private void Resetphone_identifying() { phone_identifyingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -756,50 +1289,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOItemCriteriaCondition() {}
     
 
-    private int _op = default(int);
+    private int? _op;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"op", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int op
     {
-      get { return _op; }
+      get { return _op?? default(int); }
       set { _op = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opSpecified
+    {
+      get { return _op != null; }
+      set { if (value == (_op== null)) _op = value ? this.op : (int?)null; }
+    }
+    private bool ShouldSerializeop() { return opSpecified; }
+    private void Resetop() { opSpecified = false; }
+    
 
-    private string _field = "";
+    private string _field;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"field", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string field
     {
-      get { return _field; }
+      get { return _field?? ""; }
       set { _field = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fieldSpecified
+    {
+      get { return _field != null; }
+      set { if (value == (_field== null)) _field = value ? this.field : (string)null; }
+    }
+    private bool ShouldSerializefield() { return fieldSpecified; }
+    private void Resetfield() { fieldSpecified = false; }
+    
 
-    private bool _required = default(bool);
+    private bool? _required;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"required", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool required
     {
-      get { return _required; }
+      get { return _required?? default(bool); }
       set { _required = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requiredSpecified
+    {
+      get { return _required != null; }
+      set { if (value == (_required== null)) _required = value ? this.required : (bool?)null; }
+    }
+    private bool ShouldSerializerequired() { return requiredSpecified; }
+    private void Resetrequired() { requiredSpecified = false; }
+    
 
-    private float _float_value = default(float);
+    private float? _float_value;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"float_value", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float float_value
     {
-      get { return _float_value; }
+      get { return _float_value?? default(float); }
       set { _float_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool float_valueSpecified
+    {
+      get { return _float_value != null; }
+      set { if (value == (_float_value== null)) _float_value = value ? this.float_value : (float?)null; }
+    }
+    private bool ShouldSerializefloat_value() { return float_valueSpecified; }
+    private void Resetfloat_value() { float_valueSpecified = false; }
+    
 
-    private string _string_value = "";
+    private string _string_value;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"string_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string string_value
     {
-      get { return _string_value; }
+      get { return _string_value?? ""; }
       set { _string_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool string_valueSpecified
+    {
+      get { return _string_value != null; }
+      set { if (value == (_string_value== null)) _string_value = value ? this.string_value : (string)null; }
+    }
+    private bool ShouldSerializestring_value() { return string_valueSpecified; }
+    private void Resetstring_value() { string_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -811,68 +1389,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOItemCriteria() {}
     
 
-    private uint _item_level = default(uint);
+    private uint? _item_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_level
     {
-      get { return _item_level; }
+      get { return _item_level?? default(uint); }
       set { _item_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_levelSpecified
+    {
+      get { return _item_level != null; }
+      set { if (value == (_item_level== null)) _item_level = value ? this.item_level : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_level() { return item_levelSpecified; }
+    private void Resetitem_level() { item_levelSpecified = false; }
+    
 
-    private int _item_quality = default(int);
+    private int? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(int); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (int?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private bool _item_level_set = default(bool);
+    private bool? _item_level_set;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_level_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_level_set
     {
-      get { return _item_level_set; }
+      get { return _item_level_set?? default(bool); }
       set { _item_level_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_level_setSpecified
+    {
+      get { return _item_level_set != null; }
+      set { if (value == (_item_level_set== null)) _item_level_set = value ? this.item_level_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_level_set() { return item_level_setSpecified; }
+    private void Resetitem_level_set() { item_level_setSpecified = false; }
+    
 
-    private bool _item_quality_set = default(bool);
+    private bool? _item_quality_set;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"item_quality_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool item_quality_set
     {
-      get { return _item_quality_set; }
+      get { return _item_quality_set?? default(bool); }
       set { _item_quality_set = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_quality_setSpecified
+    {
+      get { return _item_quality_set != null; }
+      set { if (value == (_item_quality_set== null)) _item_quality_set = value ? this.item_quality_set : (bool?)null; }
+    }
+    private bool ShouldSerializeitem_quality_set() { return item_quality_setSpecified; }
+    private void Resetitem_quality_set() { item_quality_setSpecified = false; }
+    
 
-    private uint _initial_inventory = default(uint);
+    private uint? _initial_inventory;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initial_inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_inventory
     {
-      get { return _initial_inventory; }
+      get { return _initial_inventory?? default(uint); }
       set { _initial_inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_inventorySpecified
+    {
+      get { return _initial_inventory != null; }
+      set { if (value == (_initial_inventory== null)) _initial_inventory = value ? this.initial_inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_inventory() { return initial_inventorySpecified; }
+    private void Resetinitial_inventory() { initial_inventorySpecified = false; }
+    
 
-    private uint _initial_quantity = default(uint);
+    private uint? _initial_quantity;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"initial_quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_quantity
     {
-      get { return _initial_quantity; }
+      get { return _initial_quantity?? default(uint); }
       set { _initial_quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_quantitySpecified
+    {
+      get { return _initial_quantity != null; }
+      set { if (value == (_initial_quantity== null)) _initial_quantity = value ? this.initial_quantity : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_quantity() { return initial_quantitySpecified; }
+    private void Resetinitial_quantity() { initial_quantitySpecified = false; }
+    
 
-    private bool _ignore_enabled_flag = default(bool);
+    private bool? _ignore_enabled_flag;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"ignore_enabled_flag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ignore_enabled_flag
     {
-      get { return _ignore_enabled_flag; }
+      get { return _ignore_enabled_flag?? default(bool); }
       set { _ignore_enabled_flag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ignore_enabled_flagSpecified
+    {
+      get { return _ignore_enabled_flag != null; }
+      set { if (value == (_ignore_enabled_flag== null)) _ignore_enabled_flag = value ? this.ignore_enabled_flag : (bool?)null; }
+    }
+    private bool ShouldSerializeignore_enabled_flag() { return ignore_enabled_flagSpecified; }
+    private void Resetignore_enabled_flag() { ignore_enabled_flagSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteriaCondition> _conditions = new global::System.Collections.Generic.List<CSOItemCriteriaCondition>();
     [global::ProtoBuf.ProtoMember(9, Name=@"conditions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteriaCondition> conditions
@@ -881,23 +1522,41 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _recent_only = default(bool);
+    private bool? _recent_only;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"recent_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool recent_only
     {
-      get { return _recent_only; }
+      get { return _recent_only?? default(bool); }
       set { _recent_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recent_onlySpecified
+    {
+      get { return _recent_only != null; }
+      set { if (value == (_recent_only== null)) _recent_only = value ? this.recent_only : (bool?)null; }
+    }
+    private bool ShouldSerializerecent_only() { return recent_onlySpecified; }
+    private void Resetrecent_only() { recent_onlySpecified = false; }
+    
 
-    private string _tags = "";
+    private string _tags;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tags
     {
-      get { return _tags; }
+      get { return _tags?? ""; }
       set { _tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagsSpecified
+    {
+      get { return _tags != null; }
+      set { if (value == (_tags== null)) _tags = value ? this.tags : (string)null; }
+    }
+    private bool ShouldSerializetags() { return tagsSpecified; }
+    private void Resettags() { tagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -909,149 +1568,293 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOItemRecipe() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _n_a = "";
+    private string _n_a;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"n_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string n_a
     {
-      get { return _n_a; }
+      get { return _n_a?? ""; }
       set { _n_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool n_aSpecified
+    {
+      get { return _n_a != null; }
+      set { if (value == (_n_a== null)) _n_a = value ? this.n_a : (string)null; }
+    }
+    private bool ShouldSerializen_a() { return n_aSpecified; }
+    private void Resetn_a() { n_aSpecified = false; }
+    
 
-    private string _desc_inputs = "";
+    private string _desc_inputs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"desc_inputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_inputs
     {
-      get { return _desc_inputs; }
+      get { return _desc_inputs?? ""; }
       set { _desc_inputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_inputsSpecified
+    {
+      get { return _desc_inputs != null; }
+      set { if (value == (_desc_inputs== null)) _desc_inputs = value ? this.desc_inputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_inputs() { return desc_inputsSpecified; }
+    private void Resetdesc_inputs() { desc_inputsSpecified = false; }
+    
 
-    private string _desc_outputs = "";
+    private string _desc_outputs;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"desc_outputs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desc_outputs
     {
-      get { return _desc_outputs; }
+      get { return _desc_outputs?? ""; }
       set { _desc_outputs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desc_outputsSpecified
+    {
+      get { return _desc_outputs != null; }
+      set { if (value == (_desc_outputs== null)) _desc_outputs = value ? this.desc_outputs : (string)null; }
+    }
+    private bool ShouldSerializedesc_outputs() { return desc_outputsSpecified; }
+    private void Resetdesc_outputs() { desc_outputsSpecified = false; }
+    
 
-    private string _di_a = "";
+    private string _di_a;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"di_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_a
     {
-      get { return _di_a; }
+      get { return _di_a?? ""; }
       set { _di_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_aSpecified
+    {
+      get { return _di_a != null; }
+      set { if (value == (_di_a== null)) _di_a = value ? this.di_a : (string)null; }
+    }
+    private bool ShouldSerializedi_a() { return di_aSpecified; }
+    private void Resetdi_a() { di_aSpecified = false; }
+    
 
-    private string _di_b = "";
+    private string _di_b;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"di_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_b
     {
-      get { return _di_b; }
+      get { return _di_b?? ""; }
       set { _di_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_bSpecified
+    {
+      get { return _di_b != null; }
+      set { if (value == (_di_b== null)) _di_b = value ? this.di_b : (string)null; }
+    }
+    private bool ShouldSerializedi_b() { return di_bSpecified; }
+    private void Resetdi_b() { di_bSpecified = false; }
+    
 
-    private string _di_c = "";
+    private string _di_c;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"di_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string di_c
     {
-      get { return _di_c; }
+      get { return _di_c?? ""; }
       set { _di_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool di_cSpecified
+    {
+      get { return _di_c != null; }
+      set { if (value == (_di_c== null)) _di_c = value ? this.di_c : (string)null; }
+    }
+    private bool ShouldSerializedi_c() { return di_cSpecified; }
+    private void Resetdi_c() { di_cSpecified = false; }
+    
 
-    private string _do_a = "";
+    private string _do_a;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"do_a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_a
     {
-      get { return _do_a; }
+      get { return _do_a?? ""; }
       set { _do_a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_aSpecified
+    {
+      get { return _do_a != null; }
+      set { if (value == (_do_a== null)) _do_a = value ? this.do_a : (string)null; }
+    }
+    private bool ShouldSerializedo_a() { return do_aSpecified; }
+    private void Resetdo_a() { do_aSpecified = false; }
+    
 
-    private string _do_b = "";
+    private string _do_b;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"do_b", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_b
     {
-      get { return _do_b; }
+      get { return _do_b?? ""; }
       set { _do_b = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_bSpecified
+    {
+      get { return _do_b != null; }
+      set { if (value == (_do_b== null)) _do_b = value ? this.do_b : (string)null; }
+    }
+    private bool ShouldSerializedo_b() { return do_bSpecified; }
+    private void Resetdo_b() { do_bSpecified = false; }
+    
 
-    private string _do_c = "";
+    private string _do_c;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"do_c", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string do_c
     {
-      get { return _do_c; }
+      get { return _do_c?? ""; }
       set { _do_c = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool do_cSpecified
+    {
+      get { return _do_c != null; }
+      set { if (value == (_do_c== null)) _do_c = value ? this.do_c : (string)null; }
+    }
+    private bool ShouldSerializedo_c() { return do_cSpecified; }
+    private void Resetdo_c() { do_cSpecified = false; }
+    
 
-    private bool _requires_all_same_class = default(bool);
+    private bool? _requires_all_same_class;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"requires_all_same_class", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_class
     {
-      get { return _requires_all_same_class; }
+      get { return _requires_all_same_class?? default(bool); }
       set { _requires_all_same_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_classSpecified
+    {
+      get { return _requires_all_same_class != null; }
+      set { if (value == (_requires_all_same_class== null)) _requires_all_same_class = value ? this.requires_all_same_class : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_class() { return requires_all_same_classSpecified; }
+    private void Resetrequires_all_same_class() { requires_all_same_classSpecified = false; }
+    
 
-    private bool _requires_all_same_slot = default(bool);
+    private bool? _requires_all_same_slot;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"requires_all_same_slot", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_all_same_slot
     {
-      get { return _requires_all_same_slot; }
+      get { return _requires_all_same_slot?? default(bool); }
       set { _requires_all_same_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_all_same_slotSpecified
+    {
+      get { return _requires_all_same_slot != null; }
+      set { if (value == (_requires_all_same_slot== null)) _requires_all_same_slot = value ? this.requires_all_same_slot : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_all_same_slot() { return requires_all_same_slotSpecified; }
+    private void Resetrequires_all_same_slot() { requires_all_same_slotSpecified = false; }
+    
 
-    private int _class_usage_for_output = default(int);
+    private int? _class_usage_for_output;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"class_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int class_usage_for_output
     {
-      get { return _class_usage_for_output; }
+      get { return _class_usage_for_output?? default(int); }
       set { _class_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_usage_for_outputSpecified
+    {
+      get { return _class_usage_for_output != null; }
+      set { if (value == (_class_usage_for_output== null)) _class_usage_for_output = value ? this.class_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeclass_usage_for_output() { return class_usage_for_outputSpecified; }
+    private void Resetclass_usage_for_output() { class_usage_for_outputSpecified = false; }
+    
 
-    private int _slot_usage_for_output = default(int);
+    private int? _slot_usage_for_output;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"slot_usage_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int slot_usage_for_output
     {
-      get { return _slot_usage_for_output; }
+      get { return _slot_usage_for_output?? default(int); }
       set { _slot_usage_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_usage_for_outputSpecified
+    {
+      get { return _slot_usage_for_output != null; }
+      set { if (value == (_slot_usage_for_output== null)) _slot_usage_for_output = value ? this.slot_usage_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeslot_usage_for_output() { return slot_usage_for_outputSpecified; }
+    private void Resetslot_usage_for_output() { slot_usage_for_outputSpecified = false; }
+    
 
-    private int _set_for_output = default(int);
+    private int? _set_for_output;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"set_for_output", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int set_for_output
     {
-      get { return _set_for_output; }
+      get { return _set_for_output?? default(int); }
       set { _set_for_output = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool set_for_outputSpecified
+    {
+      get { return _set_for_output != null; }
+      set { if (value == (_set_for_output== null)) _set_for_output = value ? this.set_for_output : (int?)null; }
+    }
+    private bool ShouldSerializeset_for_output() { return set_for_outputSpecified; }
+    private void Resetset_for_output() { set_for_outputSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOItemCriteria> _input_items_criteria = new global::System.Collections.Generic.List<CSOItemCriteria>();
     [global::ProtoBuf.ProtoMember(20, Name=@"input_items_criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOItemCriteria> input_items_criteria
@@ -1084,14 +1887,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgDevNewItemRequest() {}
     
 
-    private ulong _receiver = default(ulong);
+    private ulong? _receiver;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"receiver", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong receiver
     {
-      get { return _receiver; }
+      get { return _receiver?? default(ulong); }
       set { _receiver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiverSpecified
+    {
+      get { return _receiver != null; }
+      set { if (value == (_receiver== null)) _receiver = value ? this.receiver : (ulong?)null; }
+    }
+    private bool ShouldSerializereceiver() { return receiverSpecified; }
+    private void Resetreceiver() { receiverSpecified = false; }
+    
 
     private CSOItemCriteria _criteria = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"criteria", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -1112,23 +1924,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgDevDebugRollLootRequest() {}
     
 
-    private ulong _receiver = default(ulong);
+    private ulong? _receiver;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"receiver", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong receiver
     {
-      get { return _receiver; }
+      get { return _receiver?? default(ulong); }
       set { _receiver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiverSpecified
+    {
+      get { return _receiver != null; }
+      set { if (value == (_receiver== null)) _receiver = value ? this.receiver : (ulong?)null; }
+    }
+    private bool ShouldSerializereceiver() { return receiverSpecified; }
+    private void Resetreceiver() { receiverSpecified = false; }
+    
 
-    private string _loot_list_name = "";
+    private string _loot_list_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"loot_list_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string loot_list_name
     {
-      get { return _loot_list_name; }
+      get { return _loot_list_name?? ""; }
       set { _loot_list_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool loot_list_nameSpecified
+    {
+      get { return _loot_list_name != null; }
+      set { if (value == (_loot_list_name== null)) _loot_list_name = value ? this.loot_list_name : (string)null; }
+    }
+    private bool ShouldSerializeloot_list_name() { return loot_list_nameSpecified; }
+    private void Resetloot_list_name() { loot_list_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1140,50 +1970,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgIncrementKillCountAttribute() {}
     
 
-    private ulong _killer_steam_id = default(ulong);
+    private ulong? _killer_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong killer_steam_id
     {
-      get { return _killer_steam_id; }
+      get { return _killer_steam_id?? default(ulong); }
       set { _killer_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_steam_idSpecified
+    {
+      get { return _killer_steam_id != null; }
+      set { if (value == (_killer_steam_id== null)) _killer_steam_id = value ? this.killer_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializekiller_steam_id() { return killer_steam_idSpecified; }
+    private void Resetkiller_steam_id() { killer_steam_idSpecified = false; }
+    
 
-    private ulong _victim_steam_id = default(ulong);
+    private ulong? _victim_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"victim_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong victim_steam_id
     {
-      get { return _victim_steam_id; }
+      get { return _victim_steam_id?? default(ulong); }
       set { _victim_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victim_steam_idSpecified
+    {
+      get { return _victim_steam_id != null; }
+      set { if (value == (_victim_steam_id== null)) _victim_steam_id = value ? this.victim_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializevictim_steam_id() { return victim_steam_idSpecified; }
+    private void Resetvictim_steam_id() { victim_steam_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private uint _increment_value = default(uint);
+    private uint? _increment_value;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"increment_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint increment_value
     {
-      get { return _increment_value; }
+      get { return _increment_value?? default(uint); }
       set { _increment_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool increment_valueSpecified
+    {
+      get { return _increment_value != null; }
+      set { if (value == (_increment_value== null)) _increment_value = value ? this.increment_value : (uint?)null; }
+    }
+    private bool ShouldSerializeincrement_value() { return increment_valueSpecified; }
+    private void Resetincrement_value() { increment_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1212,41 +2087,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgTrackUniquePlayerPairEvent() {}
     
 
-    private ulong _killer_steam_id = default(ulong);
+    private ulong? _killer_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong killer_steam_id
     {
-      get { return _killer_steam_id; }
+      get { return _killer_steam_id?? default(ulong); }
       set { _killer_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_steam_idSpecified
+    {
+      get { return _killer_steam_id != null; }
+      set { if (value == (_killer_steam_id== null)) _killer_steam_id = value ? this.killer_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializekiller_steam_id() { return killer_steam_idSpecified; }
+    private void Resetkiller_steam_id() { killer_steam_idSpecified = false; }
+    
 
-    private ulong _victim_steam_id = default(ulong);
+    private ulong? _victim_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"victim_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong victim_steam_id
     {
-      get { return _victim_steam_id; }
+      get { return _victim_steam_id?? default(ulong); }
       set { _victim_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool victim_steam_idSpecified
+    {
+      get { return _victim_steam_id != null; }
+      set { if (value == (_victim_steam_id== null)) _victim_steam_id = value ? this.victim_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializevictim_steam_id() { return victim_steam_idSpecified; }
+    private void Resetvictim_steam_id() { victim_steam_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1258,32 +2169,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyStrangeCountTransfer() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private ulong _item_src_item_id = default(ulong);
+    private ulong? _item_src_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_src_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_src_item_id
     {
-      get { return _item_src_item_id; }
+      get { return _item_src_item_id?? default(ulong); }
       set { _item_src_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_src_item_idSpecified
+    {
+      get { return _item_src_item_id != null; }
+      set { if (value == (_item_src_item_id== null)) _item_src_item_id = value ? this.item_src_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_src_item_id() { return item_src_item_idSpecified; }
+    private void Resetitem_src_item_id() { item_src_item_idSpecified = false; }
+    
 
-    private ulong _item_dest_item_id = default(ulong);
+    private ulong? _item_dest_item_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_dest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_dest_item_id
     {
-      get { return _item_dest_item_id; }
+      get { return _item_dest_item_id?? default(ulong); }
       set { _item_dest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_dest_item_idSpecified
+    {
+      get { return _item_dest_item_id != null; }
+      set { if (value == (_item_dest_item_id== null)) _item_dest_item_id = value ? this.item_dest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_dest_item_id() { return item_dest_item_idSpecified; }
+    private void Resetitem_dest_item_id() { item_dest_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1295,23 +2233,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyStrangePart() {}
     
 
-    private ulong _strange_part_item_id = default(ulong);
+    private ulong? _strange_part_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"strange_part_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong strange_part_item_id
     {
-      get { return _strange_part_item_id; }
+      get { return _strange_part_item_id?? default(ulong); }
       set { _strange_part_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_part_item_idSpecified
+    {
+      get { return _strange_part_item_id != null; }
+      set { if (value == (_strange_part_item_id== null)) _strange_part_item_id = value ? this.strange_part_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestrange_part_item_id() { return strange_part_item_idSpecified; }
+    private void Resetstrange_part_item_id() { strange_part_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1323,32 +2279,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyStrangeRestriction() {}
     
 
-    private ulong _strange_part_item_id = default(ulong);
+    private ulong? _strange_part_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"strange_part_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong strange_part_item_id
     {
-      get { return _strange_part_item_id; }
+      get { return _strange_part_item_id?? default(ulong); }
       set { _strange_part_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_part_item_idSpecified
+    {
+      get { return _strange_part_item_id != null; }
+      set { if (value == (_strange_part_item_id== null)) _strange_part_item_id = value ? this.strange_part_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestrange_part_item_id() { return strange_part_item_idSpecified; }
+    private void Resetstrange_part_item_id() { strange_part_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
 
-    private uint _strange_attr_index = default(uint);
+    private uint? _strange_attr_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"strange_attr_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strange_attr_index
     {
-      get { return _strange_attr_index; }
+      get { return _strange_attr_index?? default(uint); }
       set { _strange_attr_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_attr_indexSpecified
+    {
+      get { return _strange_attr_index != null; }
+      set { if (value == (_strange_attr_index== null)) _strange_attr_index = value ? this.strange_attr_index : (uint?)null; }
+    }
+    private bool ShouldSerializestrange_attr_index() { return strange_attr_indexSpecified; }
+    private void Resetstrange_attr_index() { strange_attr_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1360,23 +2343,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyUpgradeCard() {}
     
 
-    private ulong _upgrade_card_item_id = default(ulong);
+    private ulong? _upgrade_card_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upgrade_card_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upgrade_card_item_id
     {
-      get { return _upgrade_card_item_id; }
+      get { return _upgrade_card_item_id?? default(ulong); }
       set { _upgrade_card_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upgrade_card_item_idSpecified
+    {
+      get { return _upgrade_card_item_id != null; }
+      set { if (value == (_upgrade_card_item_id== null)) _upgrade_card_item_id = value ? this.upgrade_card_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeupgrade_card_item_id() { return upgrade_card_item_idSpecified; }
+    private void Resetupgrade_card_item_id() { upgrade_card_item_idSpecified = false; }
+    
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1388,32 +2389,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconItemAttribute() {}
     
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _value = default(uint);
+    private uint? _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint value
     {
-      get { return _value; }
+      get { return _value?? default(uint); }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (uint?)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private byte[] _value_bytes = null;
+    private byte[] _value_bytes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"value_bytes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] value_bytes
     {
-      get { return _value_bytes; }
+      get { return _value_bytes?? null; }
       set { _value_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool value_bytesSpecified
+    {
+      get { return _value_bytes != null; }
+      set { if (value == (_value_bytes== null)) _value_bytes = value ? this.value_bytes : (byte[])null; }
+    }
+    private bool ShouldSerializevalue_bytes() { return value_bytesSpecified; }
+    private void Resetvalue_bytes() { value_bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1425,23 +2453,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconItemEquipped() {}
     
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1453,104 +2499,203 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconItem() {}
     
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _flags = (uint)0;
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? (uint)0; }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
 
-    private string _custom_name = "";
+    private string _custom_name;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"custom_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_name
     {
-      get { return _custom_name; }
+      get { return _custom_name?? ""; }
       set { _custom_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_nameSpecified
+    {
+      get { return _custom_name != null; }
+      set { if (value == (_custom_name== null)) _custom_name = value ? this.custom_name : (string)null; }
+    }
+    private bool ShouldSerializecustom_name() { return custom_nameSpecified; }
+    private void Resetcustom_name() { custom_nameSpecified = false; }
+    
 
-    private string _custom_desc = "";
+    private string _custom_desc;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"custom_desc", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_desc
     {
-      get { return _custom_desc; }
+      get { return _custom_desc?? ""; }
       set { _custom_desc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_descSpecified
+    {
+      get { return _custom_desc != null; }
+      set { if (value == (_custom_desc== null)) _custom_desc = value ? this.custom_desc : (string)null; }
+    }
+    private bool ShouldSerializecustom_desc() { return custom_descSpecified; }
+    private void Resetcustom_desc() { custom_descSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemAttribute> _attribute = new global::System.Collections.Generic.List<CSOEconItemAttribute>();
     [global::ProtoBuf.ProtoMember(12, Name=@"attribute", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemAttribute> attribute
@@ -1568,41 +2713,77 @@ namespace SteamKit2.GC.TF2.Internal
       set { _interior_item = value; }
     }
 
-    private bool _in_use = (bool)false;
+    private bool? _in_use;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"in_use", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool in_use
     {
-      get { return _in_use; }
+      get { return _in_use?? (bool)false; }
       set { _in_use = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_useSpecified
+    {
+      get { return _in_use != null; }
+      set { if (value == (_in_use== null)) _in_use = value ? this.in_use : (bool?)null; }
+    }
+    private bool ShouldSerializein_use() { return in_useSpecified; }
+    private void Resetin_use() { in_useSpecified = false; }
+    
 
-    private uint _style = (uint)0;
+    private uint? _style;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"style", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint style
     {
-      get { return _style; }
+      get { return _style?? (uint)0; }
       set { _style = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool styleSpecified
+    {
+      get { return _style != null; }
+      set { if (value == (_style== null)) _style = value ? this.style : (uint?)null; }
+    }
+    private bool ShouldSerializestyle() { return styleSpecified; }
+    private void Resetstyle() { styleSpecified = false; }
+    
 
-    private ulong _original_id = (ulong)0;
+    private ulong? _original_id;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"original_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong original_id
     {
-      get { return _original_id; }
+      get { return _original_id?? (ulong)0; }
       set { _original_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_idSpecified
+    {
+      get { return _original_id != null; }
+      set { if (value == (_original_id== null)) _original_id = value ? this.original_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeoriginal_id() { return original_idSpecified; }
+    private void Resetoriginal_id() { original_idSpecified = false; }
+    
 
-    private bool _contains_equipped_state = default(bool);
+    private bool? _contains_equipped_state;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"contains_equipped_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool contains_equipped_state
     {
-      get { return _contains_equipped_state; }
+      get { return _contains_equipped_state?? default(bool); }
       set { _contains_equipped_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contains_equipped_stateSpecified
+    {
+      get { return _contains_equipped_state != null; }
+      set { if (value == (_contains_equipped_state== null)) _contains_equipped_state = value ? this.contains_equipped_state : (bool?)null; }
+    }
+    private bool ShouldSerializecontains_equipped_state() { return contains_equipped_stateSpecified; }
+    private void Resetcontains_equipped_state() { contains_equipped_stateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CSOEconItemEquipped> _equipped_state = new global::System.Collections.Generic.List<CSOEconItemEquipped>();
     [global::ProtoBuf.ProtoMember(18, Name=@"equipped_state", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CSOEconItemEquipped> equipped_state
@@ -1611,14 +2792,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private bool _contains_equipped_state_v2 = default(bool);
+    private bool? _contains_equipped_state_v2;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"contains_equipped_state_v2", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool contains_equipped_state_v2
     {
-      get { return _contains_equipped_state_v2; }
+      get { return _contains_equipped_state_v2?? default(bool); }
       set { _contains_equipped_state_v2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contains_equipped_state_v2Specified
+    {
+      get { return _contains_equipped_state_v2 != null; }
+      set { if (value == (_contains_equipped_state_v2== null)) _contains_equipped_state_v2 = value ? this.contains_equipped_state_v2 : (bool?)null; }
+    }
+    private bool ShouldSerializecontains_equipped_state_v2() { return contains_equipped_state_v2Specified; }
+    private void Resetcontains_equipped_state_v2() { contains_equipped_state_v2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1630,32 +2820,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgAdjustItemEquippedState() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _new_class = default(uint);
+    private uint? _new_class;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"new_class", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_class
     {
-      get { return _new_class; }
+      get { return _new_class?? default(uint); }
       set { _new_class = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_classSpecified
+    {
+      get { return _new_class != null; }
+      set { if (value == (_new_class== null)) _new_class = value ? this.new_class : (uint?)null; }
+    }
+    private bool ShouldSerializenew_class() { return new_classSpecified; }
+    private void Resetnew_class() { new_classSpecified = false; }
+    
 
-    private uint _new_slot = default(uint);
+    private uint? _new_slot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"new_slot", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_slot
     {
-      get { return _new_slot; }
+      get { return _new_slot?? default(uint); }
       set { _new_slot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_slotSpecified
+    {
+      get { return _new_slot != null; }
+      set { if (value == (_new_slot== null)) _new_slot = value ? this.new_slot : (uint?)null; }
+    }
+    private bool ShouldSerializenew_slot() { return new_slotSpecified; }
+    private void Resetnew_slot() { new_slotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1667,14 +2884,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSortItems() {}
     
 
-    private uint _sort_type = default(uint);
+    private uint? _sort_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sort_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_type
     {
-      get { return _sort_type; }
+      get { return _sort_type?? default(uint); }
       set { _sort_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_typeSpecified
+    {
+      get { return _sort_type != null; }
+      set { if (value == (_sort_type== null)) _sort_type = value ? this.sort_type : (uint?)null; }
+    }
+    private bool ShouldSerializesort_type() { return sort_typeSpecified; }
+    private void Resetsort_type() { sort_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1686,41 +2912,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconClaimCode() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _code_type = default(uint);
+    private uint? _code_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"code_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint code_type
     {
-      get { return _code_type; }
+      get { return _code_type?? default(uint); }
       set { _code_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool code_typeSpecified
+    {
+      get { return _code_type != null; }
+      set { if (value == (_code_type== null)) _code_type = value ? this.code_type : (uint?)null; }
+    }
+    private bool ShouldSerializecode_type() { return code_typeSpecified; }
+    private void Resetcode_type() { code_typeSpecified = false; }
+    
 
-    private uint _time_acquired = default(uint);
+    private uint? _time_acquired;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_acquired", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_acquired
     {
-      get { return _time_acquired; }
+      get { return _time_acquired?? default(uint); }
       set { _time_acquired = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_acquiredSpecified
+    {
+      get { return _time_acquired != null; }
+      set { if (value == (_time_acquired== null)) _time_acquired = value ? this.time_acquired : (uint?)null; }
+    }
+    private bool ShouldSerializetime_acquired() { return time_acquiredSpecified; }
+    private void Resettime_acquired() { time_acquiredSpecified = false; }
+    
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1732,14 +2994,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgStoreGetUserData() {}
     
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1751,86 +3022,167 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgStoreGetUserDataResponse() {}
     
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private string _country = "";
+    private string _country;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country
     {
-      get { return _country; }
+      get { return _country?? ""; }
       set { _country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countrySpecified
+    {
+      get { return _country != null; }
+      set { if (value == (_country== null)) _country = value ? this.country : (string)null; }
+    }
+    private bool ShouldSerializecountry() { return countrySpecified; }
+    private void Resetcountry() { countrySpecified = false; }
+    
 
-    private uint _price_sheet_version = default(uint);
+    private uint? _price_sheet_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_sheet_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_sheet_version
     {
-      get { return _price_sheet_version; }
+      get { return _price_sheet_version?? default(uint); }
       set { _price_sheet_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheet_versionSpecified
+    {
+      get { return _price_sheet_version != null; }
+      set { if (value == (_price_sheet_version== null)) _price_sheet_version = value ? this.price_sheet_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_sheet_version() { return price_sheet_versionSpecified; }
+    private void Resetprice_sheet_version() { price_sheet_versionSpecified = false; }
+    
 
-    private ulong _experiment_data = (ulong)0;
+    private ulong? _experiment_data;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"experiment_data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong experiment_data
     {
-      get { return _experiment_data; }
+      get { return _experiment_data?? (ulong)0; }
       set { _experiment_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool experiment_dataSpecified
+    {
+      get { return _experiment_data != null; }
+      set { if (value == (_experiment_data== null)) _experiment_data = value ? this.experiment_data : (ulong?)null; }
+    }
+    private bool ShouldSerializeexperiment_data() { return experiment_dataSpecified; }
+    private void Resetexperiment_data() { experiment_dataSpecified = false; }
+    
 
-    private int _featured_item_idx = default(int);
+    private int? _featured_item_idx;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"featured_item_idx", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int featured_item_idx
     {
-      get { return _featured_item_idx; }
+      get { return _featured_item_idx?? default(int); }
       set { _featured_item_idx = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool featured_item_idxSpecified
+    {
+      get { return _featured_item_idx != null; }
+      set { if (value == (_featured_item_idx== null)) _featured_item_idx = value ? this.featured_item_idx : (int?)null; }
+    }
+    private bool ShouldSerializefeatured_item_idx() { return featured_item_idxSpecified; }
+    private void Resetfeatured_item_idx() { featured_item_idxSpecified = false; }
+    
 
-    private bool _show_hat_descriptions = (bool)true;
+    private bool? _show_hat_descriptions;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"show_hat_descriptions", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool show_hat_descriptions
     {
-      get { return _show_hat_descriptions; }
+      get { return _show_hat_descriptions?? (bool)true; }
       set { _show_hat_descriptions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool show_hat_descriptionsSpecified
+    {
+      get { return _show_hat_descriptions != null; }
+      set { if (value == (_show_hat_descriptions== null)) _show_hat_descriptions = value ? this.show_hat_descriptions : (bool?)null; }
+    }
+    private bool ShouldSerializeshow_hat_descriptions() { return show_hat_descriptionsSpecified; }
+    private void Resetshow_hat_descriptions() { show_hat_descriptionsSpecified = false; }
+    
 
-    private byte[] _price_sheet = null;
+    private byte[] _price_sheet;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"price_sheet", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] price_sheet
     {
-      get { return _price_sheet; }
+      get { return _price_sheet?? null; }
       set { _price_sheet = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_sheetSpecified
+    {
+      get { return _price_sheet != null; }
+      set { if (value == (_price_sheet== null)) _price_sheet = value ? this.price_sheet : (byte[])null; }
+    }
+    private bool ShouldSerializeprice_sheet() { return price_sheetSpecified; }
+    private void Resetprice_sheet() { price_sheetSpecified = false; }
+    
 
-    private int _default_item_sort = (int)0;
+    private int? _default_item_sort;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"default_item_sort", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int default_item_sort
     {
-      get { return _default_item_sort; }
+      get { return _default_item_sort?? (int)0; }
       set { _default_item_sort = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool default_item_sortSpecified
+    {
+      get { return _default_item_sort != null; }
+      set { if (value == (_default_item_sort== null)) _default_item_sort = value ? this.default_item_sort : (int?)null; }
+    }
+    private bool ShouldSerializedefault_item_sort() { return default_item_sortSpecified; }
+    private void Resetdefault_item_sort() { default_item_sortSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _popular_items = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(10, Name=@"popular_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> popular_items
@@ -1849,41 +3201,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgUpdateItemSchema() {}
     
 
-    private byte[] _items_game = null;
+    private byte[] _items_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"items_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] items_game
     {
-      get { return _items_game; }
+      get { return _items_game?? null; }
       set { _items_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_gameSpecified
+    {
+      get { return _items_game != null; }
+      set { if (value == (_items_game== null)) _items_game = value ? this.items_game : (byte[])null; }
+    }
+    private bool ShouldSerializeitems_game() { return items_gameSpecified; }
+    private void Resetitems_game() { items_gameSpecified = false; }
+    
 
-    private uint _item_schema_version = default(uint);
+    private uint? _item_schema_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_schema_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_schema_version
     {
-      get { return _item_schema_version; }
+      get { return _item_schema_version?? default(uint); }
       set { _item_schema_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_schema_versionSpecified
+    {
+      get { return _item_schema_version != null; }
+      set { if (value == (_item_schema_version== null)) _item_schema_version = value ? this.item_schema_version : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_schema_version() { return item_schema_versionSpecified; }
+    private void Resetitem_schema_version() { item_schema_versionSpecified = false; }
+    
 
-    private string _items_game_url = "";
+    private string _items_game_url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"items_game_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string items_game_url
     {
-      get { return _items_game_url; }
+      get { return _items_game_url?? ""; }
       set { _items_game_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool items_game_urlSpecified
+    {
+      get { return _items_game_url != null; }
+      set { if (value == (_items_game_url== null)) _items_game_url = value ? this.items_game_url : (string)null; }
+    }
+    private bool ShouldSerializeitems_game_url() { return items_game_urlSpecified; }
+    private void Resetitems_game_url() { items_game_urlSpecified = false; }
+    
 
-    private byte[] _signature = null;
+    private byte[] _signature;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signature
     {
-      get { return _signature; }
+      get { return _signature?? null; }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (byte[])null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1895,14 +3283,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCError() {}
     
 
-    private string _error_text = "";
+    private string _error_text;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"error_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_text
     {
-      get { return _error_text; }
+      get { return _error_text?? ""; }
       set { _error_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_textSpecified
+    {
+      get { return _error_text != null; }
+      set { if (value == (_error_text== null)) _error_text = value ? this.error_text : (string)null; }
+    }
+    private bool ShouldSerializeerror_text() { return error_textSpecified; }
+    private void Reseterror_text() { error_textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1924,23 +3321,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgConVarValue() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1969,23 +3384,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgUseItem() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _gift__potential_targets = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"gift__potential_targets", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> gift__potential_targets
@@ -1994,32 +3427,59 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _duel__class_lock = default(uint);
+    private uint? _duel__class_lock;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"duel__class_lock", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duel__class_lock
     {
-      get { return _duel__class_lock; }
+      get { return _duel__class_lock?? default(uint); }
       set { _duel__class_lock = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duel__class_lockSpecified
+    {
+      get { return _duel__class_lock != null; }
+      set { if (value == (_duel__class_lock== null)) _duel__class_lock = value ? this.duel__class_lock : (uint?)null; }
+    }
+    private bool ShouldSerializeduel__class_lock() { return duel__class_lockSpecified; }
+    private void Resetduel__class_lock() { duel__class_lockSpecified = false; }
+    
 
-    private ulong _initiator_steam_id = default(ulong);
+    private ulong? _initiator_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"initiator_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong initiator_steam_id
     {
-      get { return _initiator_steam_id; }
+      get { return _initiator_steam_id?? default(ulong); }
       set { _initiator_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initiator_steam_idSpecified
+    {
+      get { return _initiator_steam_id != null; }
+      set { if (value == (_initiator_steam_id== null)) _initiator_steam_id = value ? this.initiator_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeinitiator_steam_id() { return initiator_steam_idSpecified; }
+    private void Resetinitiator_steam_id() { initiator_steam_idSpecified = false; }
+    
 
-    private bool _itempack__ack_immediately = default(bool);
+    private bool? _itempack__ack_immediately;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"itempack__ack_immediately", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool itempack__ack_immediately
     {
-      get { return _itempack__ack_immediately; }
+      get { return _itempack__ack_immediately?? default(bool); }
       set { _itempack__ack_immediately = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itempack__ack_immediatelySpecified
+    {
+      get { return _itempack__ack_immediately != null; }
+      set { if (value == (_itempack__ack_immediately== null)) _itempack__ack_immediately = value ? this.itempack__ack_immediately : (bool?)null; }
+    }
+    private bool ShouldSerializeitempack__ack_immediately() { return itempack__ack_immediatelySpecified; }
+    private void Resetitempack__ack_immediately() { itempack__ack_immediatelySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2031,32 +3491,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgReplayUploadedToYouTube() {}
     
 
-    private string _youtube_url = "";
+    private string _youtube_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"youtube_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_url
     {
-      get { return _youtube_url; }
+      get { return _youtube_url?? ""; }
       set { _youtube_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_urlSpecified
+    {
+      get { return _youtube_url != null; }
+      set { if (value == (_youtube_url== null)) _youtube_url = value ? this.youtube_url : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_url() { return youtube_urlSpecified; }
+    private void Resetyoutube_url() { youtube_urlSpecified = false; }
+    
 
-    private string _youtube_account_name = "";
+    private string _youtube_account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"youtube_account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_account_name
     {
-      get { return _youtube_account_name; }
+      get { return _youtube_account_name?? ""; }
       set { _youtube_account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_account_nameSpecified
+    {
+      get { return _youtube_account_name != null; }
+      set { if (value == (_youtube_account_name== null)) _youtube_account_name = value ? this.youtube_account_name : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_account_name() { return youtube_account_nameSpecified; }
+    private void Resetyoutube_account_name() { youtube_account_nameSpecified = false; }
+    
 
-    private ulong _session_id = default(ulong);
+    private ulong? _session_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong session_id
     {
-      get { return _session_id; }
+      get { return _session_id?? default(ulong); }
       set { _session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool session_idSpecified
+    {
+      get { return _session_id != null; }
+      set { if (value == (_session_id== null)) _session_id = value ? this.session_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesession_id() { return session_idSpecified; }
+    private void Resetsession_id() { session_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2068,14 +3555,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgConsumableExhausted() {}
     
 
-    private int _item_def_id = default(int);
+    private int? _item_def_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int item_def_id
     {
-      get { return _item_def_id; }
+      get { return _item_def_id?? default(int); }
       set { _item_def_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_idSpecified
+    {
+      get { return _item_def_id != null; }
+      set { if (value == (_item_def_id== null)) _item_def_id = value ? this.item_def_id : (int?)null; }
+    }
+    private bool ShouldSerializeitem_def_id() { return item_def_idSpecified; }
+    private void Resetitem_def_id() { item_def_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2087,86 +3583,167 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgItemAcknowledged() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _inventory = default(uint);
+    private uint? _inventory;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"inventory", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inventory
     {
-      get { return _inventory; }
+      get { return _inventory?? default(uint); }
       set { _inventory = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inventorySpecified
+    {
+      get { return _inventory != null; }
+      set { if (value == (_inventory== null)) _inventory = value ? this.inventory : (uint?)null; }
+    }
+    private bool ShouldSerializeinventory() { return inventorySpecified; }
+    private void Resetinventory() { inventorySpecified = false; }
+    
 
-    private uint _def_index = default(uint);
+    private uint? _def_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint def_index
     {
-      get { return _def_index; }
+      get { return _def_index?? default(uint); }
       set { _def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool def_indexSpecified
+    {
+      get { return _def_index != null; }
+      set { if (value == (_def_index== null)) _def_index = value ? this.def_index : (uint?)null; }
+    }
+    private bool ShouldSerializedef_index() { return def_indexSpecified; }
+    private void Resetdef_index() { def_indexSpecified = false; }
+    
 
-    private uint _quality = default(uint);
+    private uint? _quality;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quality
     {
-      get { return _quality; }
+      get { return _quality?? default(uint); }
       set { _quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qualitySpecified
+    {
+      get { return _quality != null; }
+      set { if (value == (_quality== null)) _quality = value ? this.quality : (uint?)null; }
+    }
+    private bool ShouldSerializequality() { return qualitySpecified; }
+    private void Resetquality() { qualitySpecified = false; }
+    
 
-    private uint _rarity = default(uint);
+    private uint? _rarity;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rarity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rarity
     {
-      get { return _rarity; }
+      get { return _rarity?? default(uint); }
       set { _rarity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raritySpecified
+    {
+      get { return _rarity != null; }
+      set { if (value == (_rarity== null)) _rarity = value ? this.rarity : (uint?)null; }
+    }
+    private bool ShouldSerializerarity() { return raritySpecified; }
+    private void Resetrarity() { raritySpecified = false; }
+    
 
-    private uint _origin = default(uint);
+    private uint? _origin;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"origin", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint origin
     {
-      get { return _origin; }
+      get { return _origin?? default(uint); }
       set { _origin = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool originSpecified
+    {
+      get { return _origin != null; }
+      set { if (value == (_origin== null)) _origin = value ? this.origin : (uint?)null; }
+    }
+    private bool ShouldSerializeorigin() { return originSpecified; }
+    private void Resetorigin() { originSpecified = false; }
+    
 
-    private uint _is_strange = default(uint);
+    private uint? _is_strange;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_strange", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint is_strange
     {
-      get { return _is_strange; }
+      get { return _is_strange?? default(uint); }
       set { _is_strange = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_strangeSpecified
+    {
+      get { return _is_strange != null; }
+      set { if (value == (_is_strange== null)) _is_strange = value ? this.is_strange : (uint?)null; }
+    }
+    private bool ShouldSerializeis_strange() { return is_strangeSpecified; }
+    private void Resetis_strange() { is_strangeSpecified = false; }
+    
 
-    private uint _is_unusual = default(uint);
+    private uint? _is_unusual;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_unusual", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint is_unusual
     {
-      get { return _is_unusual; }
+      get { return _is_unusual?? default(uint); }
       set { _is_unusual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_unusualSpecified
+    {
+      get { return _is_unusual != null; }
+      set { if (value == (_is_unusual== null)) _is_unusual = value ? this.is_unusual : (uint?)null; }
+    }
+    private bool ShouldSerializeis_unusual() { return is_unusualSpecified; }
+    private void Resetis_unusual() { is_unusualSpecified = false; }
+    
 
-    private float _wear = default(float);
+    private float? _wear;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"wear", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float wear
     {
-      get { return _wear; }
+      get { return _wear?? default(float); }
       set { _wear = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wearSpecified
+    {
+      get { return _wear != null; }
+      set { if (value == (_wear== null)) _wear = value ? this.wear : (float?)null; }
+    }
+    private bool ShouldSerializewear() { return wearSpecified; }
+    private void Resetwear() { wearSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2178,41 +3755,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSetPresetItemPosition() {}
     
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _preset_id = default(uint);
+    private uint? _preset_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"preset_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint preset_id
     {
-      get { return _preset_id; }
+      get { return _preset_id?? default(uint); }
       set { _preset_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preset_idSpecified
+    {
+      get { return _preset_id != null; }
+      set { if (value == (_preset_id== null)) _preset_id = value ? this.preset_id : (uint?)null; }
+    }
+    private bool ShouldSerializepreset_id() { return preset_idSpecified; }
+    private void Resetpreset_id() { preset_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2236,23 +3849,41 @@ namespace SteamKit2.GC.TF2.Internal
     public ItemPosition() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _position = default(uint);
+    private uint? _position;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint position
     {
-      get { return _position; }
+      get { return _position?? default(uint); }
       set { _position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool positionSpecified
+    {
+      get { return _position != null; }
+      set { if (value == (_position== null)) _position = value ? this.position : (uint?)null; }
+    }
+    private bool ShouldSerializeposition() { return positionSpecified; }
+    private void Resetposition() { positionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2269,41 +3900,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconItemPresetInstance() {}
     
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _preset_id = default(uint);
+    private uint? _preset_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"preset_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint preset_id
     {
-      get { return _preset_id; }
+      get { return _preset_id?? default(uint); }
       set { _preset_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preset_idSpecified
+    {
+      get { return _preset_id != null; }
+      set { if (value == (_preset_id== null)) _preset_id = value ? this.preset_id : (uint?)null; }
+    }
+    private bool ShouldSerializepreset_id() { return preset_idSpecified; }
+    private void Resetpreset_id() { preset_idSpecified = false; }
+    
 
-    private uint _slot_id = default(uint);
+    private uint? _slot_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"slot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint slot_id
     {
-      get { return _slot_id; }
+      get { return _slot_id?? default(uint); }
       set { _slot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool slot_idSpecified
+    {
+      get { return _slot_id != null; }
+      set { if (value == (_slot_id== null)) _slot_id = value ? this.slot_id : (uint?)null; }
+    }
+    private bool ShouldSerializeslot_id() { return slot_idSpecified; }
+    private void Resetslot_id() { slot_idSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2315,23 +3982,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSelectPresetForClass() {}
     
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _preset_id = default(uint);
+    private uint? _preset_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"preset_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint preset_id
     {
-      get { return _preset_id; }
+      get { return _preset_id?? default(uint); }
       set { _preset_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preset_idSpecified
+    {
+      get { return _preset_id != null; }
+      set { if (value == (_preset_id== null)) _preset_id = value ? this.preset_id : (uint?)null; }
+    }
+    private bool ShouldSerializepreset_id() { return preset_idSpecified; }
+    private void Resetpreset_id() { preset_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2343,32 +4028,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOClassPresetClientData() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _class_id = default(uint);
+    private uint? _class_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"class_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint class_id
     {
-      get { return _class_id; }
+      get { return _class_id?? default(uint); }
       set { _class_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool class_idSpecified
+    {
+      get { return _class_id != null; }
+      set { if (value == (_class_id== null)) _class_id = value ? this.class_id : (uint?)null; }
+    }
+    private bool ShouldSerializeclass_id() { return class_idSpecified; }
+    private void Resetclass_id() { class_idSpecified = false; }
+    
 
-    private uint _active_preset_id = default(uint);
+    private uint? _active_preset_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"active_preset_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_preset_id
     {
-      get { return _active_preset_id; }
+      get { return _active_preset_id?? default(uint); }
       set { _active_preset_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_preset_idSpecified
+    {
+      get { return _active_preset_id != null; }
+      set { if (value == (_active_preset_id== null)) _active_preset_id = value ? this.active_preset_id : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_preset_id() { return active_preset_idSpecified; }
+    private void Resetactive_preset_id() { active_preset_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2380,68 +4092,131 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCReportAbuse() {}
     
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
 
-    private ulong _gid = default(ulong);
+    private ulong? _gid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gid
     {
-      get { return _gid; }
+      get { return _gid?? default(ulong); }
       set { _gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gidSpecified
+    {
+      get { return _gid != null; }
+      set { if (value == (_gid== null)) _gid = value ? this.gid : (ulong?)null; }
+    }
+    private bool ShouldSerializegid() { return gidSpecified; }
+    private void Resetgid() { gidSpecified = false; }
+    
 
-    private uint _abuse_type = default(uint);
+    private uint? _abuse_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"abuse_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint abuse_type
     {
-      get { return _abuse_type; }
+      get { return _abuse_type?? default(uint); }
       set { _abuse_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool abuse_typeSpecified
+    {
+      get { return _abuse_type != null; }
+      set { if (value == (_abuse_type== null)) _abuse_type = value ? this.abuse_type : (uint?)null; }
+    }
+    private bool ShouldSerializeabuse_type() { return abuse_typeSpecified; }
+    private void Resetabuse_type() { abuse_typeSpecified = false; }
+    
 
-    private uint _content_type = default(uint);
+    private uint? _content_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"content_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint content_type
     {
-      get { return _content_type; }
+      get { return _content_type?? default(uint); }
       set { _content_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool content_typeSpecified
+    {
+      get { return _content_type != null; }
+      set { if (value == (_content_type== null)) _content_type = value ? this.content_type : (uint?)null; }
+    }
+    private bool ShouldSerializecontent_type() { return content_typeSpecified; }
+    private void Resetcontent_type() { content_typeSpecified = false; }
+    
 
-    private uint _target_game_server_ip = default(uint);
+    private uint? _target_game_server_ip;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"target_game_server_ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_game_server_ip
     {
-      get { return _target_game_server_ip; }
+      get { return _target_game_server_ip?? default(uint); }
       set { _target_game_server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_game_server_ipSpecified
+    {
+      get { return _target_game_server_ip != null; }
+      set { if (value == (_target_game_server_ip== null)) _target_game_server_ip = value ? this.target_game_server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_game_server_ip() { return target_game_server_ipSpecified; }
+    private void Resettarget_game_server_ip() { target_game_server_ipSpecified = false; }
+    
 
-    private uint _target_game_server_port = default(uint);
+    private uint? _target_game_server_port;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"target_game_server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint target_game_server_port
     {
-      get { return _target_game_server_port; }
+      get { return _target_game_server_port?? default(uint); }
       set { _target_game_server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_game_server_portSpecified
+    {
+      get { return _target_game_server_port != null; }
+      set { if (value == (_target_game_server_port== null)) _target_game_server_port = value ? this.target_game_server_port : (uint?)null; }
+    }
+    private bool ShouldSerializetarget_game_server_port() { return target_game_server_portSpecified; }
+    private void Resettarget_game_server_port() { target_game_server_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2453,32 +4228,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCReportAbuseResponse() {}
     
 
-    private ulong _target_steam_id = default(ulong);
+    private ulong? _target_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"target_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong target_steam_id
     {
-      get { return _target_steam_id; }
+      get { return _target_steam_id?? default(ulong); }
       set { _target_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_steam_idSpecified
+    {
+      get { return _target_steam_id != null; }
+      set { if (value == (_target_steam_id== null)) _target_steam_id = value ? this.target_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetarget_steam_id() { return target_steam_idSpecified; }
+    private void Resettarget_steam_id() { target_steam_idSpecified = false; }
+    
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2490,32 +4292,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCNameItemNotification() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private string _item_name_custom = "";
+    private string _item_name_custom;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_name_custom", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_name_custom
     {
-      get { return _item_name_custom; }
+      get { return _item_name_custom?? ""; }
       set { _item_name_custom = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_name_customSpecified
+    {
+      get { return _item_name_custom != null; }
+      set { if (value == (_item_name_custom== null)) _item_name_custom = value ? this.item_name_custom : (string)null; }
+    }
+    private bool ShouldSerializeitem_name_custom() { return item_name_customSpecified; }
+    private void Resetitem_name_custom() { item_name_customSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2527,23 +4356,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCClientDisplayNotification() {}
     
 
-    private string _notification_title_localization_key = "";
+    private string _notification_title_localization_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"notification_title_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_title_localization_key
     {
-      get { return _notification_title_localization_key; }
+      get { return _notification_title_localization_key?? ""; }
       set { _notification_title_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_title_localization_keySpecified
+    {
+      get { return _notification_title_localization_key != null; }
+      set { if (value == (_notification_title_localization_key== null)) _notification_title_localization_key = value ? this.notification_title_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_title_localization_key() { return notification_title_localization_keySpecified; }
+    private void Resetnotification_title_localization_key() { notification_title_localization_keySpecified = false; }
+    
 
-    private string _notification_body_localization_key = "";
+    private string _notification_body_localization_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"notification_body_localization_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string notification_body_localization_key
     {
-      get { return _notification_body_localization_key; }
+      get { return _notification_body_localization_key?? ""; }
       set { _notification_body_localization_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notification_body_localization_keySpecified
+    {
+      get { return _notification_body_localization_key != null; }
+      set { if (value == (_notification_body_localization_key== null)) _notification_body_localization_key = value ? this.notification_body_localization_key : (string)null; }
+    }
+    private bool ShouldSerializenotification_body_localization_key() { return notification_body_localization_keySpecified; }
+    private void Resetnotification_body_localization_key() { notification_body_localization_keySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _body_substring_keys = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"body_substring_keys", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> body_substring_keys
@@ -2569,14 +4416,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCShowItemsPickedUp() {}
     
 
-    private ulong _player_steamid = default(ulong);
+    private ulong? _player_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong player_steamid
     {
-      get { return _player_steamid; }
+      get { return _player_steamid?? default(ulong); }
       set { _player_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_steamidSpecified
+    {
+      get { return _player_steamid != null; }
+      set { if (value == (_player_steamid== null)) _player_steamid = value ? this.player_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeplayer_steamid() { return player_steamidSpecified; }
+    private void Resetplayer_steamid() { player_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2588,32 +4444,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgUpdatePeriodicEvent() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private uint _amount = default(uint);
+    private uint? _amount;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"amount", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint amount
     {
-      get { return _amount; }
+      get { return _amount?? default(uint); }
       set { _amount = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool amountSpecified
+    {
+      get { return _amount != null; }
+      set { if (value == (_amount== null)) _amount = value ? this.amount : (uint?)null; }
+    }
+    private bool ShouldSerializeamount() { return amountSpecified; }
+    private void Resetamount() { amountSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2625,41 +4508,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCIncrementKillCountResponse() {}
     
 
-    private uint _killer_account_id = default(uint);
+    private uint? _killer_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"killer_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint killer_account_id
     {
-      get { return _killer_account_id; }
+      get { return _killer_account_id?? default(uint); }
       set { _killer_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool killer_account_idSpecified
+    {
+      get { return _killer_account_id != null; }
+      set { if (value == (_killer_account_id== null)) _killer_account_id = value ? this.killer_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializekiller_account_id() { return killer_account_idSpecified; }
+    private void Resetkiller_account_id() { killer_account_idSpecified = false; }
+    
 
-    private uint _num_kills = default(uint);
+    private uint? _num_kills;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_kills", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_kills
     {
-      get { return _num_kills; }
+      get { return _num_kills?? default(uint); }
       set { _num_kills = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_killsSpecified
+    {
+      get { return _num_kills != null; }
+      set { if (value == (_num_kills== null)) _num_kills = value ? this.num_kills : (uint?)null; }
+    }
+    private bool ShouldSerializenum_kills() { return num_killsSpecified; }
+    private void Resetnum_kills() { num_killsSpecified = false; }
+    
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _level_type = default(uint);
+    private uint? _level_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"level_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level_type
     {
-      get { return _level_type; }
+      get { return _level_type?? default(uint); }
       set { _level_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool level_typeSpecified
+    {
+      get { return _level_type != null; }
+      set { if (value == (_level_type== null)) _level_type = value ? this.level_type : (uint?)null; }
+    }
+    private bool ShouldSerializelevel_type() { return level_typeSpecified; }
+    private void Resetlevel_type() { level_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2671,23 +4590,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRemoveStrangePart() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _strange_part_score_type = default(uint);
+    private uint? _strange_part_score_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"strange_part_score_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint strange_part_score_type
     {
-      get { return _strange_part_score_type; }
+      get { return _strange_part_score_type?? default(uint); }
       set { _strange_part_score_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strange_part_score_typeSpecified
+    {
+      get { return _strange_part_score_type != null; }
+      set { if (value == (_strange_part_score_type== null)) _strange_part_score_type = value ? this.strange_part_score_type : (uint?)null; }
+    }
+    private bool ShouldSerializestrange_part_score_type() { return strange_part_score_typeSpecified; }
+    private void Resetstrange_part_score_type() { strange_part_score_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2699,23 +4636,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRemoveUpgradeCard() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _attribute_index = default(uint);
+    private uint? _attribute_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"attribute_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint attribute_index
     {
-      get { return _attribute_index; }
+      get { return _attribute_index?? default(uint); }
       set { _attribute_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attribute_indexSpecified
+    {
+      get { return _attribute_index != null; }
+      set { if (value == (_attribute_index== null)) _attribute_index = value ? this.attribute_index : (uint?)null; }
+    }
+    private bool ShouldSerializeattribute_index() { return attribute_indexSpecified; }
+    private void Resetattribute_index() { attribute_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2727,14 +4682,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRemoveCustomizationAttributeSimple() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2746,14 +4710,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCResetStrangeScores() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2765,14 +4738,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCItemPreviewItemBoughtNotification() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2784,14 +4766,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseCancel() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2803,14 +4794,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseCancelResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2822,14 +4822,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseFinalize() {}
     
 
-    private ulong _txn_id = default(ulong);
+    private ulong? _txn_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"txn_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong txn_id
     {
-      get { return _txn_id; }
+      get { return _txn_id?? default(ulong); }
       set { _txn_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool txn_idSpecified
+    {
+      get { return _txn_id != null; }
+      set { if (value == (_txn_id== null)) _txn_id = value ? this.txn_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetxn_id() { return txn_idSpecified; }
+    private void Resettxn_id() { txn_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2841,14 +4850,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCStorePurchaseFinalizeResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_ids
@@ -2867,23 +4885,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCBannedWordListRequest() {}
     
 
-    private uint _ban_list_group_id = default(uint);
+    private uint? _ban_list_group_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ban_list_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ban_list_group_id
     {
-      get { return _ban_list_group_id; }
+      get { return _ban_list_group_id?? default(uint); }
       set { _ban_list_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_list_group_idSpecified
+    {
+      get { return _ban_list_group_id != null; }
+      set { if (value == (_ban_list_group_id== null)) _ban_list_group_id = value ? this.ban_list_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializeban_list_group_id() { return ban_list_group_idSpecified; }
+    private void Resetban_list_group_id() { ban_list_group_idSpecified = false; }
+    
 
-    private uint _word_id = default(uint);
+    private uint? _word_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"word_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint word_id
     {
-      get { return _word_id; }
+      get { return _word_id?? default(uint); }
       set { _word_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool word_idSpecified
+    {
+      get { return _word_id != null; }
+      set { if (value == (_word_id== null)) _word_id = value ? this.word_id : (uint?)null; }
+    }
+    private bool ShouldSerializeword_id() { return word_idSpecified; }
+    private void Resetword_id() { word_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2895,23 +4931,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCGiftedItems() {}
     
 
-    private ulong _gifter_steam_id = default(ulong);
+    private ulong? _gifter_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gifter_steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gifter_steam_id
     {
-      get { return _gifter_steam_id; }
+      get { return _gifter_steam_id?? default(ulong); }
       set { _gifter_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gifter_steam_idSpecified
+    {
+      get { return _gifter_steam_id != null; }
+      set { if (value == (_gifter_steam_id== null)) _gifter_steam_id = value ? this.gifter_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegifter_steam_id() { return gifter_steam_idSpecified; }
+    private void Resetgifter_steam_id() { gifter_steam_idSpecified = false; }
+    
 
-    private bool _was_random_person = default(bool);
+    private bool? _was_random_person;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"was_random_person", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_random_person
     {
-      get { return _was_random_person; }
+      get { return _was_random_person?? default(bool); }
       set { _was_random_person = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_random_personSpecified
+    {
+      get { return _was_random_person != null; }
+      set { if (value == (_was_random_person== null)) _was_random_person = value ? this.was_random_person : (bool?)null; }
+    }
+    private bool ShouldSerializewas_random_person() { return was_random_personSpecified; }
+    private void Resetwas_random_person() { was_random_personSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _recipient_account_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"recipient_account_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> recipient_account_ids
@@ -2930,23 +4984,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCCollectItem() {}
     
 
-    private ulong _collection_item_id = default(ulong);
+    private ulong? _collection_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"collection_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong collection_item_id
     {
-      get { return _collection_item_id; }
+      get { return _collection_item_id?? default(ulong); }
       set { _collection_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool collection_item_idSpecified
+    {
+      get { return _collection_item_id != null; }
+      set { if (value == (_collection_item_id== null)) _collection_item_id = value ? this.collection_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecollection_item_id() { return collection_item_idSpecified; }
+    private void Resetcollection_item_id() { collection_item_idSpecified = false; }
+    
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2958,14 +5030,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCClientMarketDataRequest() {}
     
 
-    private uint _user_currency = default(uint);
+    private uint? _user_currency;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_currency
     {
-      get { return _user_currency; }
+      get { return _user_currency?? default(uint); }
       set { _user_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_currencySpecified
+    {
+      get { return _user_currency != null; }
+      set { if (value == (_user_currency== null)) _user_currency = value ? this.user_currency : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_currency() { return user_currencySpecified; }
+    private void Resetuser_currency() { user_currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2977,41 +5058,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCClientMarketDataEntry() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _item_quality = default(uint);
+    private uint? _item_quality;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_quality", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_quality
     {
-      get { return _item_quality; }
+      get { return _item_quality?? default(uint); }
       set { _item_quality = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_qualitySpecified
+    {
+      get { return _item_quality != null; }
+      set { if (value == (_item_quality== null)) _item_quality = value ? this.item_quality : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_quality() { return item_qualitySpecified; }
+    private void Resetitem_quality() { item_qualitySpecified = false; }
+    
 
-    private uint _item_sell_listings = default(uint);
+    private uint? _item_sell_listings;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_sell_listings", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_sell_listings
     {
-      get { return _item_sell_listings; }
+      get { return _item_sell_listings?? default(uint); }
       set { _item_sell_listings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_sell_listingsSpecified
+    {
+      get { return _item_sell_listings != null; }
+      set { if (value == (_item_sell_listings== null)) _item_sell_listings = value ? this.item_sell_listings : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_sell_listings() { return item_sell_listingsSpecified; }
+    private void Resetitem_sell_listings() { item_sell_listingsSpecified = false; }
+    
 
-    private uint _price_in_local_currency = default(uint);
+    private uint? _price_in_local_currency;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_in_local_currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_in_local_currency
     {
-      get { return _price_in_local_currency; }
+      get { return _price_in_local_currency?? default(uint); }
       set { _price_in_local_currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_in_local_currencySpecified
+    {
+      get { return _price_in_local_currency != null; }
+      set { if (value == (_price_in_local_currency== null)) _price_in_local_currency = value ? this.price_in_local_currency : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_in_local_currency() { return price_in_local_currencySpecified; }
+    private void Resetprice_in_local_currency() { price_in_local_currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3040,23 +5157,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyToolToItem() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3068,23 +5203,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyToolToBaseItem() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
 
-    private uint _baseitem_def_index = default(uint);
+    private uint? _baseitem_def_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"baseitem_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint baseitem_def_index
     {
-      get { return _baseitem_def_index; }
+      get { return _baseitem_def_index?? default(uint); }
       set { _baseitem_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool baseitem_def_indexSpecified
+    {
+      get { return _baseitem_def_index != null; }
+      set { if (value == (_baseitem_def_index== null)) _baseitem_def_index = value ? this.baseitem_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializebaseitem_def_index() { return baseitem_def_indexSpecified; }
+    private void Resetbaseitem_def_index() { baseitem_def_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3096,23 +5249,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgRecipeComponent() {}
     
 
-    private ulong _subject_item_id = default(ulong);
+    private ulong? _subject_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subject_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subject_item_id
     {
-      get { return _subject_item_id; }
+      get { return _subject_item_id?? default(ulong); }
       set { _subject_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subject_item_idSpecified
+    {
+      get { return _subject_item_id != null; }
+      set { if (value == (_subject_item_id== null)) _subject_item_id = value ? this.subject_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesubject_item_id() { return subject_item_idSpecified; }
+    private void Resetsubject_item_id() { subject_item_idSpecified = false; }
+    
 
-    private ulong _attribute_index = default(ulong);
+    private ulong? _attribute_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"attribute_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong attribute_index
     {
-      get { return _attribute_index; }
+      get { return _attribute_index?? default(ulong); }
       set { _attribute_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool attribute_indexSpecified
+    {
+      get { return _attribute_index != null; }
+      set { if (value == (_attribute_index== null)) _attribute_index = value ? this.attribute_index : (ulong?)null; }
+    }
+    private bool ShouldSerializeattribute_index() { return attribute_indexSpecified; }
+    private void Resetattribute_index() { attribute_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3124,14 +5295,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgFulfillDynamicRecipeComponent() {}
     
 
-    private ulong _tool_item_id = default(ulong);
+    private ulong? _tool_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_item_id
     {
-      get { return _tool_item_id; }
+      get { return _tool_item_id?? default(ulong); }
       set { _tool_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_item_idSpecified
+    {
+      get { return _tool_item_id != null; }
+      set { if (value == (_tool_item_id== null)) _tool_item_id = value ? this.tool_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_item_id() { return tool_item_idSpecified; }
+    private void Resettool_item_id() { tool_item_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgRecipeComponent> _consumption_components = new global::System.Collections.Generic.List<CMsgRecipeComponent>();
     [global::ProtoBuf.ProtoMember(2, Name=@"consumption_components", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgRecipeComponent> consumption_components
@@ -3150,23 +5330,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSetItemEffectVerticalOffset() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private float _offset = default(float);
+    private float? _offset;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float offset
     {
-      get { return _offset; }
+      get { return _offset?? default(float); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (float?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3178,23 +5376,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSetHatEffectUseHeadOrigin() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private bool _use_head = default(bool);
+    private bool? _use_head;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"use_head", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_head
     {
-      get { return _use_head; }
+      get { return _use_head?? default(bool); }
       set { _use_head = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_headSpecified
+    {
+      get { return _use_head != null; }
+      set { if (value == (_use_head== null)) _use_head = value ? this.use_head : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_head() { return use_headSpecified; }
+    private void Resetuse_head() { use_headSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3206,23 +5422,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgDeliverGiftResponseGiver() {}
     
 
-    private uint _response_code = default(uint);
+    private uint? _response_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response_code
     {
-      get { return _response_code; }
+      get { return _response_code?? default(uint); }
       set { _response_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool response_codeSpecified
+    {
+      get { return _response_code != null; }
+      set { if (value == (_response_code== null)) _response_code = value ? this.response_code : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse_code() { return response_codeSpecified; }
+    private void Resetresponse_code() { response_codeSpecified = false; }
+    
 
-    private string _receiver_account_name = "";
+    private string _receiver_account_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"receiver_account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string receiver_account_name
     {
-      get { return _receiver_account_name; }
+      get { return _receiver_account_name?? ""; }
       set { _receiver_account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiver_account_nameSpecified
+    {
+      get { return _receiver_account_name != null; }
+      set { if (value == (_receiver_account_name== null)) _receiver_account_name = value ? this.receiver_account_name : (string)null; }
+    }
+    private bool ShouldSerializereceiver_account_name() { return receiver_account_nameSpecified; }
+    private void Resetreceiver_account_name() { receiver_account_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3234,41 +5468,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CSOEconGameAccountForGameServers() {}
     
 
-    private uint _skill_rating = default(uint);
+    private uint? _skill_rating;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"skill_rating", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating
     {
-      get { return _skill_rating; }
+      get { return _skill_rating?? default(uint); }
       set { _skill_rating = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_ratingSpecified
+    {
+      get { return _skill_rating != null; }
+      set { if (value == (_skill_rating== null)) _skill_rating = value ? this.skill_rating : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating() { return skill_ratingSpecified; }
+    private void Resetskill_rating() { skill_ratingSpecified = false; }
+    
 
-    private uint _skill_rating_6v6 = default(uint);
+    private uint? _skill_rating_6v6;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"skill_rating_6v6", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating_6v6
     {
-      get { return _skill_rating_6v6; }
+      get { return _skill_rating_6v6?? default(uint); }
       set { _skill_rating_6v6 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_rating_6v6Specified
+    {
+      get { return _skill_rating_6v6 != null; }
+      set { if (value == (_skill_rating_6v6== null)) _skill_rating_6v6 = value ? this.skill_rating_6v6 : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating_6v6() { return skill_rating_6v6Specified; }
+    private void Resetskill_rating_6v6() { skill_rating_6v6Specified = false; }
+    
 
-    private uint _skill_rating_9v9 = default(uint);
+    private uint? _skill_rating_9v9;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"skill_rating_9v9", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating_9v9
     {
-      get { return _skill_rating_9v9; }
+      get { return _skill_rating_9v9?? default(uint); }
       set { _skill_rating_9v9 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_rating_9v9Specified
+    {
+      get { return _skill_rating_9v9 != null; }
+      set { if (value == (_skill_rating_9v9== null)) _skill_rating_9v9 = value ? this.skill_rating_9v9 : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating_9v9() { return skill_rating_9v9Specified; }
+    private void Resetskill_rating_9v9() { skill_rating_9v9Specified = false; }
+    
 
-    private uint _skill_rating_12v12 = default(uint);
+    private uint? _skill_rating_12v12;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"skill_rating_12v12", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint skill_rating_12v12
     {
-      get { return _skill_rating_12v12; }
+      get { return _skill_rating_12v12?? default(uint); }
       set { _skill_rating_12v12 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool skill_rating_12v12Specified
+    {
+      get { return _skill_rating_12v12 != null; }
+      set { if (value == (_skill_rating_12v12== null)) _skill_rating_12v12 = value ? this.skill_rating_12v12 : (uint?)null; }
+    }
+    private bool ShouldSerializeskill_rating_12v12() { return skill_rating_12v12Specified; }
+    private void Resetskill_rating_12v12() { skill_rating_12v12Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3280,14 +5550,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CWorkshop_PopulateItemDescriptions_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> _languages = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock>();
     [global::ProtoBuf.ProtoMember(2, Name=@"languages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.ItemDescriptionsLanguageBlock> languages
@@ -3301,23 +5580,41 @@ namespace SteamKit2.GC.TF2.Internal
     public SingleItemDescription() {}
     
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
 
-    private string _item_description = "";
+    private string _item_description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_description
     {
-      get { return _item_description; }
+      get { return _item_description?? ""; }
       set { _item_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_descriptionSpecified
+    {
+      get { return _item_description != null; }
+      set { if (value == (_item_description== null)) _item_description = value ? this.item_description : (string)null; }
+    }
+    private bool ShouldSerializeitem_description() { return item_descriptionSpecified; }
+    private void Resetitem_description() { item_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3329,14 +5626,23 @@ namespace SteamKit2.GC.TF2.Internal
     public ItemDescriptionsLanguageBlock() {}
     
 
-    private string _language = "";
+    private string _language;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language
     {
-      get { return _language; }
+      get { return _language?? ""; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (string)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> _descriptions = new global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription>();
     [global::ProtoBuf.ProtoMember(2, Name=@"descriptions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_PopulateItemDescriptions_Request.SingleItemDescription> descriptions
@@ -3360,23 +5666,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CWorkshop_GetContributors_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3405,23 +5729,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CWorkshop_SetItemPaymentRules_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _gameitemid = default(uint);
+    private uint? _gameitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameitemid
     {
-      get { return _gameitemid; }
+      get { return _gameitemid?? default(uint); }
       set { _gameitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameitemidSpecified
+    {
+      get { return _gameitemid != null; }
+      set { if (value == (_gameitemid== null)) _gameitemid = value ? this.gameitemid : (uint?)null; }
+    }
+    private bool ShouldSerializegameitemid() { return gameitemidSpecified; }
+    private void Resetgameitemid() { gameitemidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> _associated_workshop_files = new global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule>();
     [global::ProtoBuf.ProtoMember(3, Name=@"associated_workshop_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CWorkshop_SetItemPaymentRules_Request.WorkshopItemPaymentRule> associated_workshop_files
@@ -3442,32 +5784,59 @@ namespace SteamKit2.GC.TF2.Internal
     public WorkshopItemPaymentRule() {}
     
 
-    private ulong _workshop_file_id = default(ulong);
+    private ulong? _workshop_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"workshop_file_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong workshop_file_id
     {
-      get { return _workshop_file_id; }
+      get { return _workshop_file_id?? default(ulong); }
       set { _workshop_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_file_idSpecified
+    {
+      get { return _workshop_file_id != null; }
+      set { if (value == (_workshop_file_id== null)) _workshop_file_id = value ? this.workshop_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeworkshop_file_id() { return workshop_file_idSpecified; }
+    private void Resetworkshop_file_id() { workshop_file_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3479,32 +5848,59 @@ namespace SteamKit2.GC.TF2.Internal
     public PartnerItemPaymentRule() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private float _revenue_percentage = default(float);
+    private float? _revenue_percentage;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revenue_percentage", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float revenue_percentage
     {
-      get { return _revenue_percentage; }
+      get { return _revenue_percentage?? default(float); }
       set { _revenue_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revenue_percentageSpecified
+    {
+      get { return _revenue_percentage != null; }
+      set { if (value == (_revenue_percentage== null)) _revenue_percentage = value ? this.revenue_percentage : (float?)null; }
+    }
+    private bool ShouldSerializerevenue_percentage() { return revenue_percentageSpecified; }
+    private void Resetrevenue_percentage() { revenue_percentageSpecified = false; }
+    
 
-    private string _rule_description = "";
+    private string _rule_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rule_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rule_description
     {
-      get { return _rule_description; }
+      get { return _rule_description?? ""; }
       set { _rule_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rule_descriptionSpecified
+    {
+      get { return _rule_description != null; }
+      set { if (value == (_rule_description== null)) _rule_description = value ? this.rule_description : (string)null; }
+    }
+    private bool ShouldSerializerule_description() { return rule_descriptionSpecified; }
+    private void Resetrule_description() { rule_descriptionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCEcon.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCEcon.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: econ_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.TF2.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgApplyAutograph() {}
     
 
-    private ulong _autograph_item_id = default(ulong);
+    private ulong? _autograph_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"autograph_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong autograph_item_id
     {
-      get { return _autograph_item_id; }
+      get { return _autograph_item_id?? default(ulong); }
       set { _autograph_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool autograph_item_idSpecified
+    {
+      get { return _autograph_item_id != null; }
+      set { if (value == (_autograph_item_id== null)) _autograph_item_id = value ? this.autograph_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeautograph_item_id() { return autograph_item_idSpecified; }
+    private void Resetautograph_item_id() { autograph_item_idSpecified = false; }
+    
 
-    private ulong _item_item_id = default(ulong);
+    private ulong? _item_item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_item_id
     {
-      get { return _item_item_id; }
+      get { return _item_item_id?? default(ulong); }
       set { _item_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_item_idSpecified
+    {
+      get { return _item_item_id != null; }
+      set { if (value == (_item_item_id== null)) _item_item_id = value ? this.item_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_item_id() { return item_item_idSpecified; }
+    private void Resetitem_item_id() { item_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,14 +66,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgEconPlayerStrangeCountAdjustment() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment> _strange_count_adjustments = new global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment>();
     [global::ProtoBuf.ProtoMember(2, Name=@"strange_count_adjustments", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgEconPlayerStrangeCountAdjustment.CStrangeCountAdjustment> strange_count_adjustments
@@ -67,32 +96,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CStrangeCountAdjustment() {}
     
 
-    private uint _event_type = default(uint);
+    private uint? _event_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"event_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_type
     {
-      get { return _event_type; }
+      get { return _event_type?? default(uint); }
       set { _event_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_typeSpecified
+    {
+      get { return _event_type != null; }
+      set { if (value == (_event_type== null)) _event_type = value ? this.event_type : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_type() { return event_typeSpecified; }
+    private void Resetevent_type() { event_typeSpecified = false; }
+    
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
 
-    private uint _adjustment = default(uint);
+    private uint? _adjustment;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"adjustment", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint adjustment
     {
-      get { return _adjustment; }
+      get { return _adjustment?? default(uint); }
       set { _adjustment = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool adjustmentSpecified
+    {
+      get { return _adjustment != null; }
+      set { if (value == (_adjustment== null)) _adjustment = value ? this.adjustment : (uint?)null; }
+    }
+    private bool ShouldSerializeadjustment() { return adjustmentSpecified; }
+    private void Resetadjustment() { adjustmentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -126,14 +182,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgRequestItemPurgatory_FinalizePurchaseResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -145,14 +210,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgRequestItemPurgatory_RefundPurchase() {}
     
 
-    private ulong _item_id = default(ulong);
+    private ulong? _item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong item_id
     {
-      get { return _item_id; }
+      get { return _item_id?? default(ulong); }
       set { _item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_idSpecified
+    {
+      get { return _item_id != null; }
+      set { if (value == (_item_id== null)) _item_id = value ? this.item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeitem_id() { return item_idSpecified; }
+    private void Resetitem_id() { item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -164,14 +238,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgRequestItemPurgatory_RefundPurchaseResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -200,23 +283,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRequestStoreSalesData() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _currency = default(uint);
+    private uint? _currency;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint currency
     {
-      get { return _currency; }
+      get { return _currency?? default(uint); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (uint?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -235,46 +336,82 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Price")]
   public partial class Price : global::ProtoBuf.IExtensible
   {
     public Price() {}
     
 
-    private uint _item_def = default(uint);
+    private uint? _item_def;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def
     {
-      get { return _item_def; }
+      get { return _item_def?? default(uint); }
       set { _item_def = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_defSpecified
+    {
+      get { return _item_def != null; }
+      set { if (value == (_item_def== null)) _item_def = value ? this.item_def : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def() { return item_defSpecified; }
+    private void Resetitem_def() { item_defSpecified = false; }
+    
 
-    private uint _price = default(uint);
+    private uint? _price;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"price", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price
     {
-      get { return _price; }
+      get { return _price?? default(uint); }
       set { _price = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool priceSpecified
+    {
+      get { return _price != null; }
+      set { if (value == (_price== null)) _price = value ? this.price : (uint?)null; }
+    }
+    private bool ShouldSerializeprice() { return priceSpecified; }
+    private void Resetprice() { priceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -291,23 +428,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRequestStoreSalesDataUpToDateResponse() {}
     
 
-    private uint _version = default(uint);
+    private uint? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint version
     {
-      get { return _version; }
+      get { return _version?? default(uint); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (uint?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -339,14 +494,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCGetUserSessionServer() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -358,14 +522,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCGetUserSessionServerResponse() {}
     
 
-    private ulong _server_steam_id = default(ulong);
+    private ulong? _server_steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_steam_id
     {
-      get { return _server_steam_id; }
+      get { return _server_steam_id?? default(ulong); }
       set { _server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_steam_idSpecified
+    {
+      get { return _server_steam_id != null; }
+      set { if (value == (_server_steam_id== null)) _server_steam_id = value ? this.server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_steam_id() { return server_steam_idSpecified; }
+    private void Resetserver_steam_id() { server_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -377,23 +550,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCGetUserServerMembers() {}
     
 
-    private uint _account_id = default(uint);
+    private uint? _account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_id
     {
-      get { return _account_id; }
+      get { return _account_id?? default(uint); }
       set { _account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_idSpecified
+    {
+      get { return _account_id != null; }
+      set { if (value == (_account_id== null)) _account_id = value ? this.account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_id() { return account_idSpecified; }
+    private void Resetaccount_id() { account_idSpecified = false; }
+    
 
-    private uint _max_spectators = default(uint);
+    private uint? _max_spectators;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_spectators", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_spectators
     {
-      get { return _max_spectators; }
+      get { return _max_spectators?? default(uint); }
       set { _max_spectators = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_spectatorsSpecified
+    {
+      get { return _max_spectators != null; }
+      set { if (value == (_max_spectators== null)) _max_spectators = value ? this.max_spectators : (uint?)null; }
+    }
+    private bool ShouldSerializemax_spectators() { return max_spectatorsSpecified; }
+    private void Resetmax_spectators() { max_spectatorsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -451,23 +642,41 @@ namespace SteamKit2.GC.TF2.Internal
     public Account() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private string _persona = "";
+    private string _persona;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona
     {
-      get { return _persona; }
+      get { return _persona?? ""; }
       set { _persona = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool personaSpecified
+    {
+      get { return _persona != null; }
+      set { if (value == (_persona== null)) _persona = value ? this.persona : (string)null; }
+    }
+    private bool ShouldSerializepersona() { return personaSpecified; }
+    private void Resetpersona() { personaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -484,23 +693,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCGrantSelfMadeItemToAccount() {}
     
 
-    private uint _item_def_index = default(uint);
+    private uint? _item_def_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"item_def_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint item_def_index
     {
-      get { return _item_def_index; }
+      get { return _item_def_index?? default(uint); }
       set { _item_def_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_def_indexSpecified
+    {
+      get { return _item_def_index != null; }
+      set { if (value == (_item_def_index== null)) _item_def_index = value ? this.item_def_index : (uint?)null; }
+    }
+    private bool ShouldSerializeitem_def_index() { return item_def_indexSpecified; }
+    private void Resetitem_def_index() { item_def_indexSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -512,23 +739,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCThankedByNewUser() {}
     
 
-    private uint _new_user_accountid = default(uint);
+    private uint? _new_user_accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"new_user_accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_user_accountid
     {
-      get { return _new_user_accountid; }
+      get { return _new_user_accountid?? default(uint); }
       set { _new_user_accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_user_accountidSpecified
+    {
+      get { return _new_user_accountid != null; }
+      set { if (value == (_new_user_accountid== null)) _new_user_accountid = value ? this.new_user_accountid : (uint?)null; }
+    }
+    private bool ShouldSerializenew_user_accountid() { return new_user_accountidSpecified; }
+    private void Resetnew_user_accountid() { new_user_accountidSpecified = false; }
+    
 
-    private uint _thanked_user_accountid = default(uint);
+    private uint? _thanked_user_accountid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"thanked_user_accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint thanked_user_accountid
     {
-      get { return _thanked_user_accountid; }
+      get { return _thanked_user_accountid?? default(uint); }
       set { _thanked_user_accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool thanked_user_accountidSpecified
+    {
+      get { return _thanked_user_accountid != null; }
+      set { if (value == (_thanked_user_accountid== null)) _thanked_user_accountid = value ? this.thanked_user_accountid : (uint?)null; }
+    }
+    private bool ShouldSerializethanked_user_accountid() { return thanked_user_accountidSpecified; }
+    private void Resetthanked_user_accountid() { thanked_user_accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -540,23 +785,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCShuffleCrateContents() {}
     
 
-    private ulong _crate_item_id = default(ulong);
+    private ulong? _crate_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"crate_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong crate_item_id
     {
-      get { return _crate_item_id; }
+      get { return _crate_item_id?? default(ulong); }
       set { _crate_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crate_item_idSpecified
+    {
+      get { return _crate_item_id != null; }
+      set { if (value == (_crate_item_id== null)) _crate_item_id = value ? this.crate_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecrate_item_id() { return crate_item_idSpecified; }
+    private void Resetcrate_item_id() { crate_item_idSpecified = false; }
+    
 
-    private string _user_code_string = "";
+    private string _user_code_string;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"user_code_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string user_code_string
     {
-      get { return _user_code_string; }
+      get { return _user_code_string?? ""; }
       set { _user_code_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_code_stringSpecified
+    {
+      get { return _user_code_string != null; }
+      set { if (value == (_user_code_string== null)) _user_code_string = value ? this.user_code_string : (string)null; }
+    }
+    private bool ShouldSerializeuser_code_string() { return user_code_stringSpecified; }
+    private void Resetuser_code_string() { user_code_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -568,41 +831,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCQuestObjective_Progress() {}
     
 
-    private ulong _quest_item_id = default(ulong);
+    private ulong? _quest_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_item_id
     {
-      get { return _quest_item_id; }
+      get { return _quest_item_id?? default(ulong); }
       set { _quest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_item_idSpecified
+    {
+      get { return _quest_item_id != null; }
+      set { if (value == (_quest_item_id== null)) _quest_item_id = value ? this.quest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_item_id() { return quest_item_idSpecified; }
+    private void Resetquest_item_id() { quest_item_idSpecified = false; }
+    
 
-    private uint _quest_attrib_index = default(uint);
+    private uint? _quest_attrib_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"quest_attrib_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quest_attrib_index
     {
-      get { return _quest_attrib_index; }
+      get { return _quest_attrib_index?? default(uint); }
       set { _quest_attrib_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_attrib_indexSpecified
+    {
+      get { return _quest_attrib_index != null; }
+      set { if (value == (_quest_attrib_index== null)) _quest_attrib_index = value ? this.quest_attrib_index : (uint?)null; }
+    }
+    private bool ShouldSerializequest_attrib_index() { return quest_attrib_indexSpecified; }
+    private void Resetquest_attrib_index() { quest_attrib_indexSpecified = false; }
+    
 
-    private uint _delta = default(uint);
+    private uint? _delta;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"delta", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint delta
     {
-      get { return _delta; }
+      get { return _delta?? default(uint); }
       set { _delta = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deltaSpecified
+    {
+      get { return _delta != null; }
+      set { if (value == (_delta== null)) _delta = value ? this.delta : (uint?)null; }
+    }
+    private bool ShouldSerializedelta() { return deltaSpecified; }
+    private void Resetdelta() { deltaSpecified = false; }
+    
 
-    private ulong _owner_steamid = default(ulong);
+    private ulong? _owner_steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner_steamid
     {
-      get { return _owner_steamid; }
+      get { return _owner_steamid?? default(ulong); }
       set { _owner_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_steamidSpecified
+    {
+      get { return _owner_steamid != null; }
+      set { if (value == (_owner_steamid== null)) _owner_steamid = value ? this.owner_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner_steamid() { return owner_steamidSpecified; }
+    private void Resetowner_steamid() { owner_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -614,50 +913,95 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCQuestObjective_PointsChange() {}
     
 
-    private ulong _quest_item_id = default(ulong);
+    private ulong? _quest_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_item_id
     {
-      get { return _quest_item_id; }
+      get { return _quest_item_id?? default(ulong); }
       set { _quest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_item_idSpecified
+    {
+      get { return _quest_item_id != null; }
+      set { if (value == (_quest_item_id== null)) _quest_item_id = value ? this.quest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_item_id() { return quest_item_idSpecified; }
+    private void Resetquest_item_id() { quest_item_idSpecified = false; }
+    
 
-    private uint _standard_points = default(uint);
+    private uint? _standard_points;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"standard_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint standard_points
     {
-      get { return _standard_points; }
+      get { return _standard_points?? default(uint); }
       set { _standard_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool standard_pointsSpecified
+    {
+      get { return _standard_points != null; }
+      set { if (value == (_standard_points== null)) _standard_points = value ? this.standard_points : (uint?)null; }
+    }
+    private bool ShouldSerializestandard_points() { return standard_pointsSpecified; }
+    private void Resetstandard_points() { standard_pointsSpecified = false; }
+    
 
-    private uint _bonus_points = default(uint);
+    private uint? _bonus_points;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bonus_points", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bonus_points
     {
-      get { return _bonus_points; }
+      get { return _bonus_points?? default(uint); }
       set { _bonus_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bonus_pointsSpecified
+    {
+      get { return _bonus_points != null; }
+      set { if (value == (_bonus_points== null)) _bonus_points = value ? this.bonus_points : (uint?)null; }
+    }
+    private bool ShouldSerializebonus_points() { return bonus_pointsSpecified; }
+    private void Resetbonus_points() { bonus_pointsSpecified = false; }
+    
 
-    private ulong _owner_steamid = default(ulong);
+    private ulong? _owner_steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner_steamid
     {
-      get { return _owner_steamid; }
+      get { return _owner_steamid?? default(ulong); }
       set { _owner_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_steamidSpecified
+    {
+      get { return _owner_steamid != null; }
+      set { if (value == (_owner_steamid== null)) _owner_steamid = value ? this.owner_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner_steamid() { return owner_steamidSpecified; }
+    private void Resetowner_steamid() { owner_steamidSpecified = false; }
+    
 
-    private bool _update_base_points = (bool)false;
+    private bool? _update_base_points;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"update_base_points", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool update_base_points
     {
-      get { return _update_base_points; }
+      get { return _update_base_points?? (bool)false; }
       set { _update_base_points = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_base_pointsSpecified
+    {
+      get { return _update_base_points != null; }
+      set { if (value == (_update_base_points== null)) _update_base_points = value ? this.update_base_points : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_base_points() { return update_base_pointsSpecified; }
+    private void Resetupdate_base_points() { update_base_pointsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -669,14 +1013,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCQuestComplete_Request() {}
     
 
-    private ulong _quest_item_id = default(ulong);
+    private ulong? _quest_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_item_id
     {
-      get { return _quest_item_id; }
+      get { return _quest_item_id?? default(ulong); }
       set { _quest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_item_idSpecified
+    {
+      get { return _quest_item_id != null; }
+      set { if (value == (_quest_item_id== null)) _quest_item_id = value ? this.quest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_item_id() { return quest_item_idSpecified; }
+    private void Resetquest_item_id() { quest_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -698,14 +1051,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCQuestObjective_RequestLoanerItems() {}
     
 
-    private ulong _quest_item_id = default(ulong);
+    private ulong? _quest_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_item_id
     {
-      get { return _quest_item_id; }
+      get { return _quest_item_id?? default(ulong); }
       set { _quest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_item_idSpecified
+    {
+      get { return _quest_item_id != null; }
+      set { if (value == (_quest_item_id== null)) _quest_item_id = value ? this.quest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_item_id() { return quest_item_idSpecified; }
+    private void Resetquest_item_id() { quest_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -744,14 +1106,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgCraftHalloweenOffering() {}
     
 
-    private ulong _tool_id = default(ulong);
+    private ulong? _tool_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_id
     {
-      get { return _tool_id; }
+      get { return _tool_id?? default(ulong); }
       set { _tool_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_idSpecified
+    {
+      get { return _tool_id != null; }
+      set { if (value == (_tool_id== null)) _tool_id = value ? this.tool_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_id() { return tool_idSpecified; }
+    private void Resettool_id() { tool_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_id = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_id
@@ -770,14 +1141,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgCraftCommonStatClock() {}
     
 
-    private ulong _tool_id = default(ulong);
+    private ulong? _tool_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tool_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong tool_id
     {
-      get { return _tool_id; }
+      get { return _tool_id?? default(ulong); }
       set { _tool_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_idSpecified
+    {
+      get { return _tool_id != null; }
+      set { if (value == (_tool_id== null)) _tool_id = value ? this.tool_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetool_id() { return tool_idSpecified; }
+    private void Resettool_id() { tool_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _item_id = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> item_id
@@ -796,14 +1176,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCQuestDiscard_Request() {}
     
 
-    private ulong _quest_item_id = default(ulong);
+    private ulong? _quest_item_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"quest_item_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong quest_item_id
     {
-      get { return _quest_item_id; }
+      get { return _quest_item_id?? default(ulong); }
       set { _quest_item_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quest_item_idSpecified
+    {
+      get { return _quest_item_id != null; }
+      set { if (value == (_quest_item_id== null)) _quest_item_id = value ? this.quest_item_id : (ulong?)null; }
+    }
+    private bool ShouldSerializequest_item_id() { return quest_item_idSpecified; }
+    private void Resetquest_item_id() { quest_item_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCSDK.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCSDK.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsdk_gcmessages.proto
 // Note: requires additional types generated from: steammessages.proto
 namespace SteamKit2.GC.TF2.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOIDOwner() {}
     
 
-    private uint _type = default(uint);
+    private uint? _type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint type
     {
-      get { return _type; }
+      get { return _type?? default(uint); }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (uint?)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private ulong _id = default(ulong);
+    private ulong? _id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong id
     {
-      get { return _id; }
+      get { return _id?? default(ulong); }
       set { _id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool idSpecified
+    {
+      get { return _id != null; }
+      set { if (value == (_id== null)) _id = value ? this.id : (ulong?)null; }
+    }
+    private bool ShouldSerializeid() { return idSpecified; }
+    private void Resetid() { idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,41 +66,77 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOSingleObject() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -91,14 +147,23 @@ namespace SteamKit2.GC.TF2.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -110,14 +175,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOMultipleObjects() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> _objects = new global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject>();
     [global::ProtoBuf.ProtoMember(2, Name=@"objects", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOMultipleObjects.SingleObject> objects
@@ -126,14 +200,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -144,37 +227,64 @@ namespace SteamKit2.GC.TF2.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"SingleObject")]
   public partial class SingleObject : global::ProtoBuf.IExtensible
   {
     public SingleObject() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
 
-    private byte[] _object_data = null;
+    private byte[] _object_data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] object_data
     {
-      get { return _object_data; }
+      get { return _object_data?? null; }
       set { _object_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool object_dataSpecified
+    {
+      get { return _object_data != null; }
+      set { if (value == (_object_data== null)) _object_data = value ? this.object_data : (byte[])null; }
+    }
+    private bool ShouldSerializeobject_data() { return object_dataSpecified; }
+    private void Resetobject_data() { object_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -191,14 +301,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheSubscribed() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgSOCacheSubscribed.SubscribedType> _objects = new global::System.Collections.Generic.List<CMsgSOCacheSubscribed.SubscribedType>();
     [global::ProtoBuf.ProtoMember(2, Name=@"objects", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgSOCacheSubscribed.SubscribedType> objects
@@ -207,14 +326,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -225,14 +353,23 @@ namespace SteamKit2.GC.TF2.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(6, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -241,28 +378,46 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"SubscribedType")]
   public partial class SubscribedType : global::ProtoBuf.IExtensible
   {
     public SubscribedType() {}
     
 
-    private int _type_id = default(int);
+    private int? _type_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"type_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int type_id
     {
-      get { return _type_id; }
+      get { return _type_id?? default(int); }
       set { _type_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool type_idSpecified
+    {
+      get { return _type_id != null; }
+      set { if (value == (_type_id== null)) _type_id = value ? this.type_id : (int?)null; }
+    }
+    private bool ShouldSerializetype_id() { return type_idSpecified; }
+    private void Resettype_id() { type_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _object_data = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"object_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> object_data
@@ -286,14 +441,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheSubscribedUpToDate() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -304,14 +468,23 @@ namespace SteamKit2.GC.TF2.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(4, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -320,14 +493,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -339,14 +521,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheUnsubscribed() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -358,23 +549,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheSubscriptionCheck() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -385,14 +594,23 @@ namespace SteamKit2.GC.TF2.Internal
       set { _owner_soid = value; }
     }
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _service_list = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"service_list", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> service_list
@@ -401,14 +619,23 @@ namespace SteamKit2.GC.TF2.Internal
     }
   
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -420,14 +647,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheSubscriptionRefresh() {}
     
 
-    private ulong _owner = default(ulong);
+    private ulong? _owner;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner
     {
-      get { return _owner; }
+      get { return _owner?? default(ulong); }
       set { _owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ownerSpecified
+    {
+      get { return _owner != null; }
+      set { if (value == (_owner== null)) _owner = value ? this.owner : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner() { return ownerSpecified; }
+    private void Resetowner() { ownerSpecified = false; }
+    
 
     private CMsgSOIDOwner _owner_soid = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_soid", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -448,14 +684,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgSOCacheVersion() {}
     
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -467,23 +712,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCMultiplexMessage() {}
     
 
-    private uint _msgtype = default(uint);
+    private uint? _msgtype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msgtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgtype
     {
-      get { return _msgtype; }
+      get { return _msgtype?? default(uint); }
       set { _msgtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgtypeSpecified
+    {
+      get { return _msgtype != null; }
+      set { if (value == (_msgtype== null)) _msgtype = value ? this.msgtype : (uint?)null; }
+    }
+    private bool ShouldSerializemsgtype() { return msgtypeSpecified; }
+    private void Resetmsgtype() { msgtypeSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamids
@@ -502,32 +765,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCToGCMsgMasterAck() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
 
-    private string _process_name = "";
+    private string _process_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"process_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string process_name
     {
-      get { return _process_name; }
+      get { return _process_name?? ""; }
       set { _process_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool process_nameSpecified
+    {
+      get { return _process_name != null; }
+      set { if (value == (_process_name== null)) _process_name = value ? this.process_name : (string)null; }
+    }
+    private bool ShouldSerializeprocess_name() { return process_nameSpecified; }
+    private void Resetprocess_name() { process_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _type_instances = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(5, Name=@"type_instances", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> type_instances
@@ -546,14 +836,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCToGCMsgMasterAck_Response() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -577,23 +876,41 @@ namespace SteamKit2.GC.TF2.Internal
     public GCInfo() {}
     
 
-    private uint _dir_index = default(uint);
+    private uint? _dir_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"dir_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint dir_index
     {
-      get { return _dir_index; }
+      get { return _dir_index?? default(uint); }
       set { _dir_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dir_indexSpecified
+    {
+      get { return _dir_index != null; }
+      set { if (value == (_dir_index== null)) _dir_index = value ? this.dir_index : (uint?)null; }
+    }
+    private bool ShouldSerializedir_index() { return dir_indexSpecified; }
+    private void Resetdir_index() { dir_indexSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -610,32 +927,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCToGCMsgRouted() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private ulong _sender_id = default(ulong);
+    private ulong? _sender_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sender_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sender_id
     {
-      get { return _sender_id; }
+      get { return _sender_id?? default(ulong); }
       set { _sender_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sender_idSpecified
+    {
+      get { return _sender_id != null; }
+      set { if (value == (_sender_id== null)) _sender_id = value ? this.sender_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesender_id() { return sender_idSpecified; }
+    private void Resetsender_id() { sender_idSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -647,23 +991,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CGCToGCMsgRoutedReply() {}
     
 
-    private uint _msg_type = default(uint);
+    private uint? _msg_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"msg_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msg_type
     {
-      get { return _msg_type; }
+      get { return _msg_type?? default(uint); }
       set { _msg_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msg_typeSpecified
+    {
+      get { return _msg_type != null; }
+      set { if (value == (_msg_type== null)) _msg_type = value ? this.msg_type : (uint?)null; }
+    }
+    private bool ShouldSerializemsg_type() { return msg_typeSpecified; }
+    private void Resetmsg_type() { msg_typeSpecified = false; }
+    
 
-    private byte[] _net_message = null;
+    private byte[] _net_message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"net_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] net_message
     {
-      get { return _net_message; }
+      get { return _net_message?? null; }
       set { _net_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool net_messageSpecified
+    {
+      get { return _net_message != null; }
+      set { if (value == (_net_message== null)) _net_message = value ? this.net_message : (byte[])null; }
+    }
+    private bool ShouldSerializenet_message() { return net_messageSpecified; }
+    private void Resetnet_message() { net_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -687,32 +1049,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgUpdate() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private bool _trusted = default(bool);
+    private bool? _trusted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trusted
     {
-      get { return _trusted; }
+      get { return _trusted?? default(bool); }
       set { _trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trustedSpecified
+    {
+      get { return _trusted != null; }
+      set { if (value == (_trusted== null)) _trusted = value ? this.trusted : (bool?)null; }
+    }
+    private bool ShouldSerializetrusted() { return trustedSpecified; }
+    private void Resettrusted() { trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -729,14 +1118,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRequestSubGCSessionInfo() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -748,23 +1146,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCRequestSubGCSessionInfoResponse() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private bool _trusted = default(bool);
+    private bool? _trusted;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trusted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool trusted
     {
-      get { return _trusted; }
+      get { return _trusted?? default(bool); }
       set { _trusted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trustedSpecified
+    {
+      get { return _trusted != null; }
+      set { if (value == (_trusted== null)) _trusted = value ? this.trusted : (bool?)null; }
+    }
+    private bool ShouldSerializetrusted() { return trustedSpecified; }
+    private void Resettrusted() { trustedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -776,14 +1192,23 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCIncrementRecruitmentLevel() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -804,23 +1229,41 @@ namespace SteamKit2.GC.TF2.Internal
       set { _soid = value; }
     }
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -832,59 +1275,113 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgConnectionStatus() {}
     
 
-    private GCConnectionStatus _status = GCConnectionStatus.GCConnectionStatus_HAVE_SESSION;
+    private GCConnectionStatus? _status;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(GCConnectionStatus.GCConnectionStatus_HAVE_SESSION)]
     public GCConnectionStatus status
     {
-      get { return _status; }
+      get { return _status?? GCConnectionStatus.GCConnectionStatus_HAVE_SESSION; }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (GCConnectionStatus?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
 
-    private uint _client_session_need = default(uint);
+    private uint? _client_session_need;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_session_need", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_session_need
     {
-      get { return _client_session_need; }
+      get { return _client_session_need?? default(uint); }
       set { _client_session_need = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_session_needSpecified
+    {
+      get { return _client_session_need != null; }
+      set { if (value == (_client_session_need== null)) _client_session_need = value ? this.client_session_need : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_session_need() { return client_session_needSpecified; }
+    private void Resetclient_session_need() { client_session_needSpecified = false; }
+    
 
-    private int _queue_position = default(int);
+    private int? _queue_position;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"queue_position", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_position
     {
-      get { return _queue_position; }
+      get { return _queue_position?? default(int); }
       set { _queue_position = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_positionSpecified
+    {
+      get { return _queue_position != null; }
+      set { if (value == (_queue_position== null)) _queue_position = value ? this.queue_position : (int?)null; }
+    }
+    private bool ShouldSerializequeue_position() { return queue_positionSpecified; }
+    private void Resetqueue_position() { queue_positionSpecified = false; }
+    
 
-    private int _queue_size = default(int);
+    private int? _queue_size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"queue_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int queue_size
     {
-      get { return _queue_size; }
+      get { return _queue_size?? default(int); }
       set { _queue_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool queue_sizeSpecified
+    {
+      get { return _queue_size != null; }
+      set { if (value == (_queue_size== null)) _queue_size = value ? this.queue_size : (int?)null; }
+    }
+    private bool ShouldSerializequeue_size() { return queue_sizeSpecified; }
+    private void Resetqueue_size() { queue_sizeSpecified = false; }
+    
 
-    private int _wait_seconds = default(int);
+    private int? _wait_seconds;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"wait_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int wait_seconds
     {
-      get { return _wait_seconds; }
+      get { return _wait_seconds?? default(int); }
       set { _wait_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wait_secondsSpecified
+    {
+      get { return _wait_seconds != null; }
+      set { if (value == (_wait_seconds== null)) _wait_seconds = value ? this.wait_seconds : (int?)null; }
+    }
+    private bool ShouldSerializewait_seconds() { return wait_secondsSpecified; }
+    private void Resetwait_seconds() { wait_secondsSpecified = false; }
+    
 
-    private int _estimated_wait_seconds_remaining = default(int);
+    private int? _estimated_wait_seconds_remaining;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"estimated_wait_seconds_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int estimated_wait_seconds_remaining
     {
-      get { return _estimated_wait_seconds_remaining; }
+      get { return _estimated_wait_seconds_remaining?? default(int); }
       set { _estimated_wait_seconds_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estimated_wait_seconds_remainingSpecified
+    {
+      get { return _estimated_wait_seconds_remaining != null; }
+      set { if (value == (_estimated_wait_seconds_remaining== null)) _estimated_wait_seconds_remaining = value ? this.estimated_wait_seconds_remaining : (int?)null; }
+    }
+    private bool ShouldSerializeestimated_wait_seconds_remaining() { return estimated_wait_seconds_remainingSpecified; }
+    private void Resetestimated_wait_seconds_remaining() { estimated_wait_seconds_remainingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -896,32 +1393,59 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCSOCacheSubscribe() {}
     
 
-    private ulong _subscriber = default(ulong);
+    private ulong? _subscriber;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subscriber", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscriber
     {
-      get { return _subscriber; }
+      get { return _subscriber?? default(ulong); }
       set { _subscriber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscriberSpecified
+    {
+      get { return _subscriber != null; }
+      set { if (value == (_subscriber== null)) _subscriber = value ? this.subscriber : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscriber() { return subscriberSpecified; }
+    private void Resetsubscriber() { subscriberSpecified = false; }
+    
 
-    private ulong _subscribe_to = default(ulong);
+    private ulong? _subscribe_to;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"subscribe_to", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscribe_to
     {
-      get { return _subscribe_to; }
+      get { return _subscribe_to?? default(ulong); }
       set { _subscribe_to = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscribe_toSpecified
+    {
+      get { return _subscribe_to != null; }
+      set { if (value == (_subscribe_to== null)) _subscribe_to = value ? this.subscribe_to : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscribe_to() { return subscribe_toSpecified; }
+    private void Resetsubscribe_to() { subscribe_toSpecified = false; }
+    
 
-    private ulong _sync_version = default(ulong);
+    private ulong? _sync_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sync_version", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sync_version
     {
-      get { return _sync_version; }
+      get { return _sync_version?? default(ulong); }
       set { _sync_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sync_versionSpecified
+    {
+      get { return _sync_version != null; }
+      set { if (value == (_sync_version== null)) _sync_version = value ? this.sync_version : (ulong?)null; }
+    }
+    private bool ShouldSerializesync_version() { return sync_versionSpecified; }
+    private void Resetsync_version() { sync_versionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions> _have_versions = new global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions>();
     [global::ProtoBuf.ProtoMember(4, Name=@"have_versions", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGCToGCSOCacheSubscribe.CMsgHaveVersions> have_versions
@@ -935,23 +1459,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgHaveVersions() {}
     
 
-    private uint _service_id = default(uint);
+    private uint? _service_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"service_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint service_id
     {
-      get { return _service_id; }
+      get { return _service_id?? default(uint); }
       set { _service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool service_idSpecified
+    {
+      get { return _service_id != null; }
+      set { if (value == (_service_id== null)) _service_id = value ? this.service_id : (uint?)null; }
+    }
+    private bool ShouldSerializeservice_id() { return service_idSpecified; }
+    private void Resetservice_id() { service_idSpecified = false; }
+    
 
-    private ulong _version = default(ulong);
+    private ulong? _version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong version
     {
-      get { return _version; }
+      get { return _version?? default(ulong); }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (ulong?)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -968,23 +1510,41 @@ namespace SteamKit2.GC.TF2.Internal
     public CMsgGCToGCSOCacheUnsubscribe() {}
     
 
-    private ulong _subscriber = default(ulong);
+    private ulong? _subscriber;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"subscriber", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong subscriber
     {
-      get { return _subscriber; }
+      get { return _subscriber?? default(ulong); }
       set { _subscriber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscriberSpecified
+    {
+      get { return _subscriber != null; }
+      set { if (value == (_subscriber== null)) _subscriber = value ? this.subscriber : (ulong?)null; }
+    }
+    private bool ShouldSerializesubscriber() { return subscriberSpecified; }
+    private void Resetsubscriber() { subscriberSpecified = false; }
+    
 
-    private ulong _unsubscribe_from = default(ulong);
+    private ulong? _unsubscribe_from;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"unsubscribe_from", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong unsubscribe_from
     {
-      get { return _unsubscribe_from; }
+      get { return _unsubscribe_from?? default(ulong); }
       set { _unsubscribe_from = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unsubscribe_fromSpecified
+    {
+      get { return _unsubscribe_from != null; }
+      set { if (value == (_unsubscribe_from== null)) _unsubscribe_from = value ? this.unsubscribe_from : (ulong?)null; }
+    }
+    private bool ShouldSerializeunsubscribe_from() { return unsubscribe_fromSpecified; }
+    private void Resetunsubscribe_from() { unsubscribe_fromSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCSystem.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/GC/TF2/SteamMsgGCSystem.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: gcsystemmsgs.proto
 namespace SteamKit2.GC.TF2.Internal
 {

--- a/SteamKit2/SteamKit2/Base/Generated/SteamMsgAppTicket.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamMsgAppTicket.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: encrypted_app_ticket.proto
 namespace SteamKit2.Internal
 {
@@ -17,50 +19,95 @@ namespace SteamKit2.Internal
     public EncryptedAppTicket() {}
     
 
-    private uint _ticket_version_no = default(uint);
+    private uint? _ticket_version_no;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ticket_version_no", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ticket_version_no
     {
-      get { return _ticket_version_no; }
+      get { return _ticket_version_no?? default(uint); }
       set { _ticket_version_no = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_version_noSpecified
+    {
+      get { return _ticket_version_no != null; }
+      set { if (value == (_ticket_version_no== null)) _ticket_version_no = value ? this.ticket_version_no : (uint?)null; }
+    }
+    private bool ShouldSerializeticket_version_no() { return ticket_version_noSpecified; }
+    private void Resetticket_version_no() { ticket_version_noSpecified = false; }
+    
 
-    private uint _crc_encryptedticket = default(uint);
+    private uint? _crc_encryptedticket;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"crc_encryptedticket", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_encryptedticket
     {
-      get { return _crc_encryptedticket; }
+      get { return _crc_encryptedticket?? default(uint); }
       set { _crc_encryptedticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_encryptedticketSpecified
+    {
+      get { return _crc_encryptedticket != null; }
+      set { if (value == (_crc_encryptedticket== null)) _crc_encryptedticket = value ? this.crc_encryptedticket : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_encryptedticket() { return crc_encryptedticketSpecified; }
+    private void Resetcrc_encryptedticket() { crc_encryptedticketSpecified = false; }
+    
 
-    private uint _cb_encrypteduserdata = default(uint);
+    private uint? _cb_encrypteduserdata;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cb_encrypteduserdata", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cb_encrypteduserdata
     {
-      get { return _cb_encrypteduserdata; }
+      get { return _cb_encrypteduserdata?? default(uint); }
       set { _cb_encrypteduserdata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_encrypteduserdataSpecified
+    {
+      get { return _cb_encrypteduserdata != null; }
+      set { if (value == (_cb_encrypteduserdata== null)) _cb_encrypteduserdata = value ? this.cb_encrypteduserdata : (uint?)null; }
+    }
+    private bool ShouldSerializecb_encrypteduserdata() { return cb_encrypteduserdataSpecified; }
+    private void Resetcb_encrypteduserdata() { cb_encrypteduserdataSpecified = false; }
+    
 
-    private uint _cb_encrypted_appownershipticket = default(uint);
+    private uint? _cb_encrypted_appownershipticket;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cb_encrypted_appownershipticket", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cb_encrypted_appownershipticket
     {
-      get { return _cb_encrypted_appownershipticket; }
+      get { return _cb_encrypted_appownershipticket?? default(uint); }
       set { _cb_encrypted_appownershipticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cb_encrypted_appownershipticketSpecified
+    {
+      get { return _cb_encrypted_appownershipticket != null; }
+      set { if (value == (_cb_encrypted_appownershipticket== null)) _cb_encrypted_appownershipticket = value ? this.cb_encrypted_appownershipticket : (uint?)null; }
+    }
+    private bool ShouldSerializecb_encrypted_appownershipticket() { return cb_encrypted_appownershipticketSpecified; }
+    private void Resetcb_encrypted_appownershipticket() { cb_encrypted_appownershipticketSpecified = false; }
+    
 
-    private byte[] _encrypted_ticket = null;
+    private byte[] _encrypted_ticket;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"encrypted_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] encrypted_ticket
     {
-      get { return _encrypted_ticket; }
+      get { return _encrypted_ticket?? null; }
       set { _encrypted_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encrypted_ticketSpecified
+    {
+      get { return _encrypted_ticket != null; }
+      set { if (value == (_encrypted_ticket== null)) _encrypted_ticket = value ? this.encrypted_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeencrypted_ticket() { return encrypted_ticketSpecified; }
+    private void Resetencrypted_ticket() { encrypted_ticketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/SteamMsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamMsgBase.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_base.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.Internal
@@ -18,185 +20,365 @@ namespace SteamKit2.Internal
     public CMsgProtoBufHeader() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private int _client_sessionid = default(int);
+    private int? _client_sessionid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int client_sessionid
     {
-      get { return _client_sessionid; }
+      get { return _client_sessionid?? default(int); }
       set { _client_sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_sessionidSpecified
+    {
+      get { return _client_sessionid != null; }
+      set { if (value == (_client_sessionid== null)) _client_sessionid = value ? this.client_sessionid : (int?)null; }
+    }
+    private bool ShouldSerializeclient_sessionid() { return client_sessionidSpecified; }
+    private void Resetclient_sessionid() { client_sessionidSpecified = false; }
+    
 
-    private uint _routing_appid = default(uint);
+    private uint? _routing_appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"routing_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint routing_appid
     {
-      get { return _routing_appid; }
+      get { return _routing_appid?? default(uint); }
       set { _routing_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_appidSpecified
+    {
+      get { return _routing_appid != null; }
+      set { if (value == (_routing_appid== null)) _routing_appid = value ? this.routing_appid : (uint?)null; }
+    }
+    private bool ShouldSerializerouting_appid() { return routing_appidSpecified; }
+    private void Resetrouting_appid() { routing_appidSpecified = false; }
+    
 
-    private ulong _jobid_source = (ulong)18446744073709551615;
+    private ulong? _jobid_source;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"jobid_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong jobid_source
     {
-      get { return _jobid_source; }
+      get { return _jobid_source?? (ulong)18446744073709551615; }
       set { _jobid_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool jobid_sourceSpecified
+    {
+      get { return _jobid_source != null; }
+      set { if (value == (_jobid_source== null)) _jobid_source = value ? this.jobid_source : (ulong?)null; }
+    }
+    private bool ShouldSerializejobid_source() { return jobid_sourceSpecified; }
+    private void Resetjobid_source() { jobid_sourceSpecified = false; }
+    
 
-    private ulong _jobid_target = (ulong)18446744073709551615;
+    private ulong? _jobid_target;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"jobid_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong jobid_target
     {
-      get { return _jobid_target; }
+      get { return _jobid_target?? (ulong)18446744073709551615; }
       set { _jobid_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool jobid_targetSpecified
+    {
+      get { return _jobid_target != null; }
+      set { if (value == (_jobid_target== null)) _jobid_target = value ? this.jobid_target : (ulong?)null; }
+    }
+    private bool ShouldSerializejobid_target() { return jobid_targetSpecified; }
+    private void Resetjobid_target() { jobid_targetSpecified = false; }
+    
 
-    private string _target_job_name = "";
+    private string _target_job_name;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"target_job_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string target_job_name
     {
-      get { return _target_job_name; }
+      get { return _target_job_name?? ""; }
       set { _target_job_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool target_job_nameSpecified
+    {
+      get { return _target_job_name != null; }
+      set { if (value == (_target_job_name== null)) _target_job_name = value ? this.target_job_name : (string)null; }
+    }
+    private bool ShouldSerializetarget_job_name() { return target_job_nameSpecified; }
+    private void Resettarget_job_name() { target_job_nameSpecified = false; }
+    
 
-    private int _seq_num = default(int);
+    private int? _seq_num;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"seq_num", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int seq_num
     {
-      get { return _seq_num; }
+      get { return _seq_num?? default(int); }
       set { _seq_num = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seq_numSpecified
+    {
+      get { return _seq_num != null; }
+      set { if (value == (_seq_num== null)) _seq_num = value ? this.seq_num : (int?)null; }
+    }
+    private bool ShouldSerializeseq_num() { return seq_numSpecified; }
+    private void Resetseq_num() { seq_numSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _error_message = "";
+    private string _error_message;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"error_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_message
     {
-      get { return _error_message; }
+      get { return _error_message?? ""; }
       set { _error_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_messageSpecified
+    {
+      get { return _error_message != null; }
+      set { if (value == (_error_message== null)) _error_message = value ? this.error_message : (string)null; }
+    }
+    private bool ShouldSerializeerror_message() { return error_messageSpecified; }
+    private void Reseterror_message() { error_messageSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _auth_account_flags = default(uint);
+    private uint? _auth_account_flags;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"auth_account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint auth_account_flags
     {
-      get { return _auth_account_flags; }
+      get { return _auth_account_flags?? default(uint); }
       set { _auth_account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_account_flagsSpecified
+    {
+      get { return _auth_account_flags != null; }
+      set { if (value == (_auth_account_flags== null)) _auth_account_flags = value ? this.auth_account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeauth_account_flags() { return auth_account_flagsSpecified; }
+    private void Resetauth_account_flags() { auth_account_flagsSpecified = false; }
+    
 
-    private uint _token_source = default(uint);
+    private uint? _token_source;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"token_source", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint token_source
     {
-      get { return _token_source; }
+      get { return _token_source?? default(uint); }
       set { _token_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_sourceSpecified
+    {
+      get { return _token_source != null; }
+      set { if (value == (_token_source== null)) _token_source = value ? this.token_source : (uint?)null; }
+    }
+    private bool ShouldSerializetoken_source() { return token_sourceSpecified; }
+    private void Resettoken_source() { token_sourceSpecified = false; }
+    
 
-    private bool _admin_spoofing_user = default(bool);
+    private bool? _admin_spoofing_user;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"admin_spoofing_user", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool admin_spoofing_user
     {
-      get { return _admin_spoofing_user; }
+      get { return _admin_spoofing_user?? default(bool); }
       set { _admin_spoofing_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool admin_spoofing_userSpecified
+    {
+      get { return _admin_spoofing_user != null; }
+      set { if (value == (_admin_spoofing_user== null)) _admin_spoofing_user = value ? this.admin_spoofing_user : (bool?)null; }
+    }
+    private bool ShouldSerializeadmin_spoofing_user() { return admin_spoofing_userSpecified; }
+    private void Resetadmin_spoofing_user() { admin_spoofing_userSpecified = false; }
+    
 
-    private int _transport_error = (int)1;
+    private int? _transport_error;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"transport_error", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)1)]
     public int transport_error
     {
-      get { return _transport_error; }
+      get { return _transport_error?? (int)1; }
       set { _transport_error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transport_errorSpecified
+    {
+      get { return _transport_error != null; }
+      set { if (value == (_transport_error== null)) _transport_error = value ? this.transport_error : (int?)null; }
+    }
+    private bool ShouldSerializetransport_error() { return transport_errorSpecified; }
+    private void Resettransport_error() { transport_errorSpecified = false; }
+    
 
-    private ulong _messageid = (ulong)18446744073709551615;
+    private ulong? _messageid;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"messageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong messageid
     {
-      get { return _messageid; }
+      get { return _messageid?? (ulong)18446744073709551615; }
       set { _messageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageidSpecified
+    {
+      get { return _messageid != null; }
+      set { if (value == (_messageid== null)) _messageid = value ? this.messageid : (ulong?)null; }
+    }
+    private bool ShouldSerializemessageid() { return messageidSpecified; }
+    private void Resetmessageid() { messageidSpecified = false; }
+    
 
-    private uint _publisher_group_id = default(uint);
+    private uint? _publisher_group_id;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"publisher_group_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint publisher_group_id
     {
-      get { return _publisher_group_id; }
+      get { return _publisher_group_id?? default(uint); }
       set { _publisher_group_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publisher_group_idSpecified
+    {
+      get { return _publisher_group_id != null; }
+      set { if (value == (_publisher_group_id== null)) _publisher_group_id = value ? this.publisher_group_id : (uint?)null; }
+    }
+    private bool ShouldSerializepublisher_group_id() { return publisher_group_idSpecified; }
+    private void Resetpublisher_group_id() { publisher_group_idSpecified = false; }
+    
 
-    private uint _sysid = default(uint);
+    private uint? _sysid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"sysid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sysid
     {
-      get { return _sysid; }
+      get { return _sysid?? default(uint); }
       set { _sysid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sysidSpecified
+    {
+      get { return _sysid != null; }
+      set { if (value == (_sysid== null)) _sysid = value ? this.sysid : (uint?)null; }
+    }
+    private bool ShouldSerializesysid() { return sysidSpecified; }
+    private void Resetsysid() { sysidSpecified = false; }
+    
 
-    private ulong _trace_tag = default(ulong);
+    private ulong? _trace_tag;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"trace_tag", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong trace_tag
     {
-      get { return _trace_tag; }
+      get { return _trace_tag?? default(ulong); }
       set { _trace_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trace_tagSpecified
+    {
+      get { return _trace_tag != null; }
+      set { if (value == (_trace_tag== null)) _trace_tag = value ? this.trace_tag : (ulong?)null; }
+    }
+    private bool ShouldSerializetrace_tag() { return trace_tagSpecified; }
+    private void Resettrace_tag() { trace_tagSpecified = false; }
+    
 
-    private uint _webapi_key_id = default(uint);
+    private uint? _webapi_key_id;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"webapi_key_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint webapi_key_id
     {
-      get { return _webapi_key_id; }
+      get { return _webapi_key_id?? default(uint); }
       set { _webapi_key_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_key_idSpecified
+    {
+      get { return _webapi_key_id != null; }
+      set { if (value == (_webapi_key_id== null)) _webapi_key_id = value ? this.webapi_key_id : (uint?)null; }
+    }
+    private bool ShouldSerializewebapi_key_id() { return webapi_key_idSpecified; }
+    private void Resetwebapi_key_id() { webapi_key_idSpecified = false; }
+    
 
-    private bool _is_from_external_source = default(bool);
+    private bool? _is_from_external_source;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"is_from_external_source", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_from_external_source
     {
-      get { return _is_from_external_source; }
+      get { return _is_from_external_source?? default(bool); }
       set { _is_from_external_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_from_external_sourceSpecified
+    {
+      get { return _is_from_external_source != null; }
+      set { if (value == (_is_from_external_source== null)) _is_from_external_source = value ? this.is_from_external_source : (bool?)null; }
+    }
+    private bool ShouldSerializeis_from_external_source() { return is_from_external_sourceSpecified; }
+    private void Resetis_from_external_source() { is_from_external_sourceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -208,23 +390,41 @@ namespace SteamKit2.Internal
     public CMsgMulti() {}
     
 
-    private uint _size_unzipped = default(uint);
+    private uint? _size_unzipped;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"size_unzipped", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint size_unzipped
     {
-      get { return _size_unzipped; }
+      get { return _size_unzipped?? default(uint); }
       set { _size_unzipped = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool size_unzippedSpecified
+    {
+      get { return _size_unzipped != null; }
+      set { if (value == (_size_unzipped== null)) _size_unzipped = value ? this.size_unzipped : (uint?)null; }
+    }
+    private bool ShouldSerializesize_unzipped() { return size_unzippedSpecified; }
+    private void Resetsize_unzipped() { size_unzippedSpecified = false; }
+    
 
-    private byte[] _message_body = null;
+    private byte[] _message_body;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message_body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] message_body
     {
-      get { return _message_body; }
+      get { return _message_body?? null; }
       set { _message_body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_bodySpecified
+    {
+      get { return _message_body != null; }
+      set { if (value == (_message_body== null)) _message_body = value ? this.message_body : (byte[])null; }
+    }
+    private bool ShouldSerializemessage_body() { return message_bodySpecified; }
+    private void Resetmessage_body() { message_bodySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -236,14 +436,23 @@ namespace SteamKit2.Internal
     public CMsgProtobufWrapped() {}
     
 
-    private byte[] _message_body = null;
+    private byte[] _message_body;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"message_body", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] message_body
     {
-      get { return _message_body; }
+      get { return _message_body?? null; }
       set { _message_body = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_bodySpecified
+    {
+      get { return _message_body != null; }
+      set { if (value == (_message_body== null)) _message_body = value ? this.message_body : (byte[])null; }
+    }
+    private bool ShouldSerializemessage_body() { return message_bodySpecified; }
+    private void Resetmessage_body() { message_bodySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -255,68 +464,131 @@ namespace SteamKit2.Internal
     public CMsgAuthTicket() {}
     
 
-    private uint _estate = default(uint);
+    private uint? _estate;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"estate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint estate
     {
-      get { return _estate; }
+      get { return _estate?? default(uint); }
       set { _estate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estateSpecified
+    {
+      get { return _estate != null; }
+      set { if (value == (_estate== null)) _estate = value ? this.estate : (uint?)null; }
+    }
+    private bool ShouldSerializeestate() { return estateSpecified; }
+    private void Resetestate() { estateSpecified = false; }
+    
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private uint _h_steam_pipe = default(uint);
+    private uint? _h_steam_pipe;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"h_steam_pipe", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint h_steam_pipe
     {
-      get { return _h_steam_pipe; }
+      get { return _h_steam_pipe?? default(uint); }
       set { _h_steam_pipe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool h_steam_pipeSpecified
+    {
+      get { return _h_steam_pipe != null; }
+      set { if (value == (_h_steam_pipe== null)) _h_steam_pipe = value ? this.h_steam_pipe : (uint?)null; }
+    }
+    private bool ShouldSerializeh_steam_pipe() { return h_steam_pipeSpecified; }
+    private void Reseth_steam_pipe() { h_steam_pipeSpecified = false; }
+    
 
-    private uint _ticket_crc = default(uint);
+    private uint? _ticket_crc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ticket_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ticket_crc
     {
-      get { return _ticket_crc; }
+      get { return _ticket_crc?? default(uint); }
       set { _ticket_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_crcSpecified
+    {
+      get { return _ticket_crc != null; }
+      set { if (value == (_ticket_crc== null)) _ticket_crc = value ? this.ticket_crc : (uint?)null; }
+    }
+    private bool ShouldSerializeticket_crc() { return ticket_crcSpecified; }
+    private void Resetticket_crc() { ticket_crcSpecified = false; }
+    
 
-    private byte[] _ticket = null;
+    private byte[] _ticket;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? null; }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -328,113 +600,221 @@ namespace SteamKit2.Internal
     public CCDDBAppDetailCommon() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _icon = "";
+    private string _icon;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"icon", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string icon
     {
-      get { return _icon; }
+      get { return _icon?? ""; }
       set { _icon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool iconSpecified
+    {
+      get { return _icon != null; }
+      set { if (value == (_icon== null)) _icon = value ? this.icon : (string)null; }
+    }
+    private bool ShouldSerializeicon() { return iconSpecified; }
+    private void Reseticon() { iconSpecified = false; }
+    
 
-    private string _logo = "";
+    private string _logo;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"logo", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string logo
     {
-      get { return _logo; }
+      get { return _logo?? ""; }
       set { _logo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logoSpecified
+    {
+      get { return _logo != null; }
+      set { if (value == (_logo== null)) _logo = value ? this.logo : (string)null; }
+    }
+    private bool ShouldSerializelogo() { return logoSpecified; }
+    private void Resetlogo() { logoSpecified = false; }
+    
 
-    private string _logo_small = "";
+    private string _logo_small;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"logo_small", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string logo_small
     {
-      get { return _logo_small; }
+      get { return _logo_small?? ""; }
       set { _logo_small = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logo_smallSpecified
+    {
+      get { return _logo_small != null; }
+      set { if (value == (_logo_small== null)) _logo_small = value ? this.logo_small : (string)null; }
+    }
+    private bool ShouldSerializelogo_small() { return logo_smallSpecified; }
+    private void Resetlogo_small() { logo_smallSpecified = false; }
+    
 
-    private bool _tool = default(bool);
+    private bool? _tool;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"tool", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tool
     {
-      get { return _tool; }
+      get { return _tool?? default(bool); }
       set { _tool = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool toolSpecified
+    {
+      get { return _tool != null; }
+      set { if (value == (_tool== null)) _tool = value ? this.tool : (bool?)null; }
+    }
+    private bool ShouldSerializetool() { return toolSpecified; }
+    private void Resettool() { toolSpecified = false; }
+    
 
-    private bool _demo = default(bool);
+    private bool? _demo;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"demo", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool demo
     {
-      get { return _demo; }
+      get { return _demo?? default(bool); }
       set { _demo = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool demoSpecified
+    {
+      get { return _demo != null; }
+      set { if (value == (_demo== null)) _demo = value ? this.demo : (bool?)null; }
+    }
+    private bool ShouldSerializedemo() { return demoSpecified; }
+    private void Resetdemo() { demoSpecified = false; }
+    
 
-    private bool _media = default(bool);
+    private bool? _media;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"media", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool media
     {
-      get { return _media; }
+      get { return _media?? default(bool); }
       set { _media = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mediaSpecified
+    {
+      get { return _media != null; }
+      set { if (value == (_media== null)) _media = value ? this.media : (bool?)null; }
+    }
+    private bool ShouldSerializemedia() { return mediaSpecified; }
+    private void Resetmedia() { mediaSpecified = false; }
+    
 
-    private bool _community_visible_stats = default(bool);
+    private bool? _community_visible_stats;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"community_visible_stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool community_visible_stats
     {
-      get { return _community_visible_stats; }
+      get { return _community_visible_stats?? default(bool); }
       set { _community_visible_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool community_visible_statsSpecified
+    {
+      get { return _community_visible_stats != null; }
+      set { if (value == (_community_visible_stats== null)) _community_visible_stats = value ? this.community_visible_stats : (bool?)null; }
+    }
+    private bool ShouldSerializecommunity_visible_stats() { return community_visible_statsSpecified; }
+    private void Resetcommunity_visible_stats() { community_visible_statsSpecified = false; }
+    
 
-    private string _friendly_name = "";
+    private string _friendly_name;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"friendly_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string friendly_name
     {
-      get { return _friendly_name; }
+      get { return _friendly_name?? ""; }
       set { _friendly_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendly_nameSpecified
+    {
+      get { return _friendly_name != null; }
+      set { if (value == (_friendly_name== null)) _friendly_name = value ? this.friendly_name : (string)null; }
+    }
+    private bool ShouldSerializefriendly_name() { return friendly_nameSpecified; }
+    private void Resetfriendly_name() { friendly_nameSpecified = false; }
+    
 
-    private string _propagation = "";
+    private string _propagation;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"propagation", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string propagation
     {
-      get { return _propagation; }
+      get { return _propagation?? ""; }
       set { _propagation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool propagationSpecified
+    {
+      get { return _propagation != null; }
+      set { if (value == (_propagation== null)) _propagation = value ? this.propagation : (string)null; }
+    }
+    private bool ShouldSerializepropagation() { return propagationSpecified; }
+    private void Resetpropagation() { propagationSpecified = false; }
+    
 
-    private bool _has_adult_content = default(bool);
+    private bool? _has_adult_content;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"has_adult_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_adult_content
     {
-      get { return _has_adult_content; }
+      get { return _has_adult_content?? default(bool); }
       set { _has_adult_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_adult_contentSpecified
+    {
+      get { return _has_adult_content != null; }
+      set { if (value == (_has_adult_content== null)) _has_adult_content = value ? this.has_adult_content : (bool?)null; }
+    }
+    private bool ShouldSerializehas_adult_content() { return has_adult_contentSpecified; }
+    private void Resethas_adult_content() { has_adult_contentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -446,140 +826,275 @@ namespace SteamKit2.Internal
     public CMsgAppRights() {}
     
 
-    private bool _edit_info = default(bool);
+    private bool? _edit_info;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"edit_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool edit_info
     {
-      get { return _edit_info; }
+      get { return _edit_info?? default(bool); }
       set { _edit_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool edit_infoSpecified
+    {
+      get { return _edit_info != null; }
+      set { if (value == (_edit_info== null)) _edit_info = value ? this.edit_info : (bool?)null; }
+    }
+    private bool ShouldSerializeedit_info() { return edit_infoSpecified; }
+    private void Resetedit_info() { edit_infoSpecified = false; }
+    
 
-    private bool _publish = default(bool);
+    private bool? _publish;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publish", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool publish
     {
-      get { return _publish; }
+      get { return _publish?? default(bool); }
       set { _publish = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishSpecified
+    {
+      get { return _publish != null; }
+      set { if (value == (_publish== null)) _publish = value ? this.publish : (bool?)null; }
+    }
+    private bool ShouldSerializepublish() { return publishSpecified; }
+    private void Resetpublish() { publishSpecified = false; }
+    
 
-    private bool _view_error_data = default(bool);
+    private bool? _view_error_data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"view_error_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool view_error_data
     {
-      get { return _view_error_data; }
+      get { return _view_error_data?? default(bool); }
       set { _view_error_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool view_error_dataSpecified
+    {
+      get { return _view_error_data != null; }
+      set { if (value == (_view_error_data== null)) _view_error_data = value ? this.view_error_data : (bool?)null; }
+    }
+    private bool ShouldSerializeview_error_data() { return view_error_dataSpecified; }
+    private void Resetview_error_data() { view_error_dataSpecified = false; }
+    
 
-    private bool _download = default(bool);
+    private bool? _download;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"download", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool download
     {
-      get { return _download; }
+      get { return _download?? default(bool); }
       set { _download = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool downloadSpecified
+    {
+      get { return _download != null; }
+      set { if (value == (_download== null)) _download = value ? this.download : (bool?)null; }
+    }
+    private bool ShouldSerializedownload() { return downloadSpecified; }
+    private void Resetdownload() { downloadSpecified = false; }
+    
 
-    private bool _upload_cdkeys = default(bool);
+    private bool? _upload_cdkeys;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"upload_cdkeys", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool upload_cdkeys
     {
-      get { return _upload_cdkeys; }
+      get { return _upload_cdkeys?? default(bool); }
       set { _upload_cdkeys = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_cdkeysSpecified
+    {
+      get { return _upload_cdkeys != null; }
+      set { if (value == (_upload_cdkeys== null)) _upload_cdkeys = value ? this.upload_cdkeys : (bool?)null; }
+    }
+    private bool ShouldSerializeupload_cdkeys() { return upload_cdkeysSpecified; }
+    private void Resetupload_cdkeys() { upload_cdkeysSpecified = false; }
+    
 
-    private bool _generate_cdkeys = default(bool);
+    private bool? _generate_cdkeys;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"generate_cdkeys", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool generate_cdkeys
     {
-      get { return _generate_cdkeys; }
+      get { return _generate_cdkeys?? default(bool); }
       set { _generate_cdkeys = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool generate_cdkeysSpecified
+    {
+      get { return _generate_cdkeys != null; }
+      set { if (value == (_generate_cdkeys== null)) _generate_cdkeys = value ? this.generate_cdkeys : (bool?)null; }
+    }
+    private bool ShouldSerializegenerate_cdkeys() { return generate_cdkeysSpecified; }
+    private void Resetgenerate_cdkeys() { generate_cdkeysSpecified = false; }
+    
 
-    private bool _view_financials = default(bool);
+    private bool? _view_financials;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"view_financials", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool view_financials
     {
-      get { return _view_financials; }
+      get { return _view_financials?? default(bool); }
       set { _view_financials = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool view_financialsSpecified
+    {
+      get { return _view_financials != null; }
+      set { if (value == (_view_financials== null)) _view_financials = value ? this.view_financials : (bool?)null; }
+    }
+    private bool ShouldSerializeview_financials() { return view_financialsSpecified; }
+    private void Resetview_financials() { view_financialsSpecified = false; }
+    
 
-    private bool _manage_ceg = default(bool);
+    private bool? _manage_ceg;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"manage_ceg", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool manage_ceg
     {
-      get { return _manage_ceg; }
+      get { return _manage_ceg?? default(bool); }
       set { _manage_ceg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manage_cegSpecified
+    {
+      get { return _manage_ceg != null; }
+      set { if (value == (_manage_ceg== null)) _manage_ceg = value ? this.manage_ceg : (bool?)null; }
+    }
+    private bool ShouldSerializemanage_ceg() { return manage_cegSpecified; }
+    private void Resetmanage_ceg() { manage_cegSpecified = false; }
+    
 
-    private bool _manage_signing = default(bool);
+    private bool? _manage_signing;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"manage_signing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool manage_signing
     {
-      get { return _manage_signing; }
+      get { return _manage_signing?? default(bool); }
       set { _manage_signing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manage_signingSpecified
+    {
+      get { return _manage_signing != null; }
+      set { if (value == (_manage_signing== null)) _manage_signing = value ? this.manage_signing : (bool?)null; }
+    }
+    private bool ShouldSerializemanage_signing() { return manage_signingSpecified; }
+    private void Resetmanage_signing() { manage_signingSpecified = false; }
+    
 
-    private bool _manage_cdkeys = default(bool);
+    private bool? _manage_cdkeys;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"manage_cdkeys", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool manage_cdkeys
     {
-      get { return _manage_cdkeys; }
+      get { return _manage_cdkeys?? default(bool); }
       set { _manage_cdkeys = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manage_cdkeysSpecified
+    {
+      get { return _manage_cdkeys != null; }
+      set { if (value == (_manage_cdkeys== null)) _manage_cdkeys = value ? this.manage_cdkeys : (bool?)null; }
+    }
+    private bool ShouldSerializemanage_cdkeys() { return manage_cdkeysSpecified; }
+    private void Resetmanage_cdkeys() { manage_cdkeysSpecified = false; }
+    
 
-    private bool _edit_marketing = default(bool);
+    private bool? _edit_marketing;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"edit_marketing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool edit_marketing
     {
-      get { return _edit_marketing; }
+      get { return _edit_marketing?? default(bool); }
       set { _edit_marketing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool edit_marketingSpecified
+    {
+      get { return _edit_marketing != null; }
+      set { if (value == (_edit_marketing== null)) _edit_marketing = value ? this.edit_marketing : (bool?)null; }
+    }
+    private bool ShouldSerializeedit_marketing() { return edit_marketingSpecified; }
+    private void Resetedit_marketing() { edit_marketingSpecified = false; }
+    
 
-    private bool _economy_support = default(bool);
+    private bool? _economy_support;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"economy_support", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool economy_support
     {
-      get { return _economy_support; }
+      get { return _economy_support?? default(bool); }
       set { _economy_support = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool economy_supportSpecified
+    {
+      get { return _economy_support != null; }
+      set { if (value == (_economy_support== null)) _economy_support = value ? this.economy_support : (bool?)null; }
+    }
+    private bool ShouldSerializeeconomy_support() { return economy_supportSpecified; }
+    private void Reseteconomy_support() { economy_supportSpecified = false; }
+    
 
-    private bool _economy_support_supervisor = default(bool);
+    private bool? _economy_support_supervisor;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"economy_support_supervisor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool economy_support_supervisor
     {
-      get { return _economy_support_supervisor; }
+      get { return _economy_support_supervisor?? default(bool); }
       set { _economy_support_supervisor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool economy_support_supervisorSpecified
+    {
+      get { return _economy_support_supervisor != null; }
+      set { if (value == (_economy_support_supervisor== null)) _economy_support_supervisor = value ? this.economy_support_supervisor : (bool?)null; }
+    }
+    private bool ShouldSerializeeconomy_support_supervisor() { return economy_support_supervisorSpecified; }
+    private void Reseteconomy_support_supervisor() { economy_support_supervisorSpecified = false; }
+    
 
-    private bool _manage_pricing = default(bool);
+    private bool? _manage_pricing;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"manage_pricing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool manage_pricing
     {
-      get { return _manage_pricing; }
+      get { return _manage_pricing?? default(bool); }
       set { _manage_pricing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manage_pricingSpecified
+    {
+      get { return _manage_pricing != null; }
+      set { if (value == (_manage_pricing== null)) _manage_pricing = value ? this.manage_pricing : (bool?)null; }
+    }
+    private bool ShouldSerializemanage_pricing() { return manage_pricingSpecified; }
+    private void Resetmanage_pricing() { manage_pricingSpecified = false; }
+    
 
-    private bool _broadcast_live = default(bool);
+    private bool? _broadcast_live;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"broadcast_live", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool broadcast_live
     {
-      get { return _broadcast_live; }
+      get { return _broadcast_live?? default(bool); }
       set { _broadcast_live = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_liveSpecified
+    {
+      get { return _broadcast_live != null; }
+      set { if (value == (_broadcast_live== null)) _broadcast_live = value ? this.broadcast_live : (bool?)null; }
+    }
+    private bool ShouldSerializebroadcast_live() { return broadcast_liveSpecified; }
+    private void Resetbroadcast_live() { broadcast_liveSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_clientserver.proto
 // Note: requires additional types generated from: steammessages_base.proto
 // Note: requires additional types generated from: encrypted_app_ticket.proto
@@ -29,23 +31,41 @@ namespace SteamKit2.Internal
     public CMsgClientUDSP2PSessionStarted() {}
     
 
-    private ulong _steamid_remote = default(ulong);
+    private ulong? _steamid_remote;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_remote", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_remote
     {
-      get { return _steamid_remote; }
+      get { return _steamid_remote?? default(ulong); }
       set { _steamid_remote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_remoteSpecified
+    {
+      get { return _steamid_remote != null; }
+      set { if (value == (_steamid_remote== null)) _steamid_remote = value ? this.steamid_remote : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_remote() { return steamid_remoteSpecified; }
+    private void Resetsteamid_remote() { steamid_remoteSpecified = false; }
+    
 
-    private int _appid = default(int);
+    private int? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int appid
     {
-      get { return _appid; }
+      get { return _appid?? default(int); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (int?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -57,95 +77,185 @@ namespace SteamKit2.Internal
     public CMsgClientUDSP2PSessionEnded() {}
     
 
-    private ulong _steamid_remote = default(ulong);
+    private ulong? _steamid_remote;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_remote", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_remote
     {
-      get { return _steamid_remote; }
+      get { return _steamid_remote?? default(ulong); }
       set { _steamid_remote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_remoteSpecified
+    {
+      get { return _steamid_remote != null; }
+      set { if (value == (_steamid_remote== null)) _steamid_remote = value ? this.steamid_remote : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_remote() { return steamid_remoteSpecified; }
+    private void Resetsteamid_remote() { steamid_remoteSpecified = false; }
+    
 
-    private int _appid = default(int);
+    private int? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int appid
     {
-      get { return _appid; }
+      get { return _appid?? default(int); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (int?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private int _session_length_sec = default(int);
+    private int? _session_length_sec;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"session_length_sec", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int session_length_sec
     {
-      get { return _session_length_sec; }
+      get { return _session_length_sec?? default(int); }
       set { _session_length_sec = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool session_length_secSpecified
+    {
+      get { return _session_length_sec != null; }
+      set { if (value == (_session_length_sec== null)) _session_length_sec = value ? this.session_length_sec : (int?)null; }
+    }
+    private bool ShouldSerializesession_length_sec() { return session_length_secSpecified; }
+    private void Resetsession_length_sec() { session_length_secSpecified = false; }
+    
 
-    private int _session_error = default(int);
+    private int? _session_error;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"session_error", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int session_error
     {
-      get { return _session_error; }
+      get { return _session_error?? default(int); }
       set { _session_error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool session_errorSpecified
+    {
+      get { return _session_error != null; }
+      set { if (value == (_session_error== null)) _session_error = value ? this.session_error : (int?)null; }
+    }
+    private bool ShouldSerializesession_error() { return session_errorSpecified; }
+    private void Resetsession_error() { session_errorSpecified = false; }
+    
 
-    private int _nattype = default(int);
+    private int? _nattype;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"nattype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int nattype
     {
-      get { return _nattype; }
+      get { return _nattype?? default(int); }
       set { _nattype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nattypeSpecified
+    {
+      get { return _nattype != null; }
+      set { if (value == (_nattype== null)) _nattype = value ? this.nattype : (int?)null; }
+    }
+    private bool ShouldSerializenattype() { return nattypeSpecified; }
+    private void Resetnattype() { nattypeSpecified = false; }
+    
 
-    private int _bytes_recv = default(int);
+    private int? _bytes_recv;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"bytes_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bytes_recv
     {
-      get { return _bytes_recv; }
+      get { return _bytes_recv?? default(int); }
       set { _bytes_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_recvSpecified
+    {
+      get { return _bytes_recv != null; }
+      set { if (value == (_bytes_recv== null)) _bytes_recv = value ? this.bytes_recv : (int?)null; }
+    }
+    private bool ShouldSerializebytes_recv() { return bytes_recvSpecified; }
+    private void Resetbytes_recv() { bytes_recvSpecified = false; }
+    
 
-    private int _bytes_sent = default(int);
+    private int? _bytes_sent;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"bytes_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bytes_sent
     {
-      get { return _bytes_sent; }
+      get { return _bytes_sent?? default(int); }
       set { _bytes_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_sentSpecified
+    {
+      get { return _bytes_sent != null; }
+      set { if (value == (_bytes_sent== null)) _bytes_sent = value ? this.bytes_sent : (int?)null; }
+    }
+    private bool ShouldSerializebytes_sent() { return bytes_sentSpecified; }
+    private void Resetbytes_sent() { bytes_sentSpecified = false; }
+    
 
-    private int _bytes_sent_relay = default(int);
+    private int? _bytes_sent_relay;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"bytes_sent_relay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bytes_sent_relay
     {
-      get { return _bytes_sent_relay; }
+      get { return _bytes_sent_relay?? default(int); }
       set { _bytes_sent_relay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_sent_relaySpecified
+    {
+      get { return _bytes_sent_relay != null; }
+      set { if (value == (_bytes_sent_relay== null)) _bytes_sent_relay = value ? this.bytes_sent_relay : (int?)null; }
+    }
+    private bool ShouldSerializebytes_sent_relay() { return bytes_sent_relaySpecified; }
+    private void Resetbytes_sent_relay() { bytes_sent_relaySpecified = false; }
+    
 
-    private int _bytes_recv_relay = default(int);
+    private int? _bytes_recv_relay;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"bytes_recv_relay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bytes_recv_relay
     {
-      get { return _bytes_recv_relay; }
+      get { return _bytes_recv_relay?? default(int); }
       set { _bytes_recv_relay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_recv_relaySpecified
+    {
+      get { return _bytes_recv_relay != null; }
+      set { if (value == (_bytes_recv_relay== null)) _bytes_recv_relay = value ? this.bytes_recv_relay : (int?)null; }
+    }
+    private bool ShouldSerializebytes_recv_relay() { return bytes_recv_relaySpecified; }
+    private void Resetbytes_recv_relay() { bytes_recv_relaySpecified = false; }
+    
 
-    private int _time_to_connect_ms = default(int);
+    private int? _time_to_connect_ms;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"time_to_connect_ms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int time_to_connect_ms
     {
-      get { return _time_to_connect_ms; }
+      get { return _time_to_connect_ms?? default(int); }
       set { _time_to_connect_ms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_to_connect_msSpecified
+    {
+      get { return _time_to_connect_ms != null; }
+      set { if (value == (_time_to_connect_ms== null)) _time_to_connect_ms = value ? this.time_to_connect_ms : (int?)null; }
+    }
+    private bool ShouldSerializetime_to_connect_ms() { return time_to_connect_msSpecified; }
+    private void Resettime_to_connect_ms() { time_to_connect_msSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -157,32 +267,59 @@ namespace SteamKit2.Internal
     public CMsgClientRegisterAuthTicketWithCM() {}
     
 
-    private uint _protocol_version = default(uint);
+    private uint? _protocol_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"protocol_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protocol_version
     {
-      get { return _protocol_version; }
+      get { return _protocol_version?? default(uint); }
       set { _protocol_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protocol_versionSpecified
+    {
+      get { return _protocol_version != null; }
+      set { if (value == (_protocol_version== null)) _protocol_version = value ? this.protocol_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprotocol_version() { return protocol_versionSpecified; }
+    private void Resetprotocol_version() { protocol_versionSpecified = false; }
+    
 
-    private byte[] _ticket = null;
+    private byte[] _ticket;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? null; }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
 
-    private ulong _client_instance_id = default(ulong);
+    private ulong? _client_instance_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_instance_id
     {
-      get { return _client_instance_id; }
+      get { return _client_instance_id?? default(ulong); }
       set { _client_instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_instance_idSpecified
+    {
+      get { return _client_instance_id != null; }
+      set { if (value == (_client_instance_id== null)) _client_instance_id = value ? this.client_instance_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_instance_id() { return client_instance_idSpecified; }
+    private void Resetclient_instance_id() { client_instance_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -194,77 +331,149 @@ namespace SteamKit2.Internal
     public CMsgClientTicketAuthComplete() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private uint _estate = default(uint);
+    private uint? _estate;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"estate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint estate
     {
-      get { return _estate; }
+      get { return _estate?? default(uint); }
       set { _estate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estateSpecified
+    {
+      get { return _estate != null; }
+      set { if (value == (_estate== null)) _estate = value ? this.estate : (uint?)null; }
+    }
+    private bool ShouldSerializeestate() { return estateSpecified; }
+    private void Resetestate() { estateSpecified = false; }
+    
 
-    private uint _eauth_session_response = default(uint);
+    private uint? _eauth_session_response;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"eauth_session_response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eauth_session_response
     {
-      get { return _eauth_session_response; }
+      get { return _eauth_session_response?? default(uint); }
       set { _eauth_session_response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eauth_session_responseSpecified
+    {
+      get { return _eauth_session_response != null; }
+      set { if (value == (_eauth_session_response== null)) _eauth_session_response = value ? this.eauth_session_response : (uint?)null; }
+    }
+    private bool ShouldSerializeeauth_session_response() { return eauth_session_responseSpecified; }
+    private void Reseteauth_session_response() { eauth_session_responseSpecified = false; }
+    
 
-    private byte[] _DEPRECATED_ticket = null;
+    private byte[] _DEPRECATED_ticket;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"DEPRECATED_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] DEPRECATED_ticket
     {
-      get { return _DEPRECATED_ticket; }
+      get { return _DEPRECATED_ticket?? null; }
       set { _DEPRECATED_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool DEPRECATED_ticketSpecified
+    {
+      get { return _DEPRECATED_ticket != null; }
+      set { if (value == (_DEPRECATED_ticket== null)) _DEPRECATED_ticket = value ? this.DEPRECATED_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeDEPRECATED_ticket() { return DEPRECATED_ticketSpecified; }
+    private void ResetDEPRECATED_ticket() { DEPRECATED_ticketSpecified = false; }
+    
 
-    private uint _ticket_crc = default(uint);
+    private uint? _ticket_crc;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ticket_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ticket_crc
     {
-      get { return _ticket_crc; }
+      get { return _ticket_crc?? default(uint); }
       set { _ticket_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_crcSpecified
+    {
+      get { return _ticket_crc != null; }
+      set { if (value == (_ticket_crc== null)) _ticket_crc = value ? this.ticket_crc : (uint?)null; }
+    }
+    private bool ShouldSerializeticket_crc() { return ticket_crcSpecified; }
+    private void Resetticket_crc() { ticket_crcSpecified = false; }
+    
 
-    private uint _ticket_sequence = default(uint);
+    private uint? _ticket_sequence;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"ticket_sequence", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ticket_sequence
     {
-      get { return _ticket_sequence; }
+      get { return _ticket_sequence?? default(uint); }
       set { _ticket_sequence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticket_sequenceSpecified
+    {
+      get { return _ticket_sequence != null; }
+      set { if (value == (_ticket_sequence== null)) _ticket_sequence = value ? this.ticket_sequence : (uint?)null; }
+    }
+    private bool ShouldSerializeticket_sequence() { return ticket_sequenceSpecified; }
+    private void Resetticket_sequence() { ticket_sequenceSpecified = false; }
+    
 
-    private ulong _owner_steam_id = default(ulong);
+    private ulong? _owner_steam_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"owner_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner_steam_id
     {
-      get { return _owner_steam_id; }
+      get { return _owner_steam_id?? default(ulong); }
       set { _owner_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_steam_idSpecified
+    {
+      get { return _owner_steam_id != null; }
+      set { if (value == (_owner_steam_id== null)) _owner_steam_id = value ? this.owner_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner_steam_id() { return owner_steam_idSpecified; }
+    private void Resetowner_steam_id() { owner_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -276,419 +485,833 @@ namespace SteamKit2.Internal
     public CMsgClientLogon() {}
     
 
-    private uint _protocol_version = default(uint);
+    private uint? _protocol_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"protocol_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protocol_version
     {
-      get { return _protocol_version; }
+      get { return _protocol_version?? default(uint); }
       set { _protocol_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protocol_versionSpecified
+    {
+      get { return _protocol_version != null; }
+      set { if (value == (_protocol_version== null)) _protocol_version = value ? this.protocol_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprotocol_version() { return protocol_versionSpecified; }
+    private void Resetprotocol_version() { protocol_versionSpecified = false; }
+    
 
-    private uint _obfustucated_private_ip = default(uint);
+    private uint? _obfustucated_private_ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"obfustucated_private_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint obfustucated_private_ip
     {
-      get { return _obfustucated_private_ip; }
+      get { return _obfustucated_private_ip?? default(uint); }
       set { _obfustucated_private_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool obfustucated_private_ipSpecified
+    {
+      get { return _obfustucated_private_ip != null; }
+      set { if (value == (_obfustucated_private_ip== null)) _obfustucated_private_ip = value ? this.obfustucated_private_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeobfustucated_private_ip() { return obfustucated_private_ipSpecified; }
+    private void Resetobfustucated_private_ip() { obfustucated_private_ipSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private uint _last_session_id = default(uint);
+    private uint? _last_session_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"last_session_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_session_id
     {
-      get { return _last_session_id; }
+      get { return _last_session_id?? default(uint); }
       set { _last_session_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_session_idSpecified
+    {
+      get { return _last_session_id != null; }
+      set { if (value == (_last_session_id== null)) _last_session_id = value ? this.last_session_id : (uint?)null; }
+    }
+    private bool ShouldSerializelast_session_id() { return last_session_idSpecified; }
+    private void Resetlast_session_id() { last_session_idSpecified = false; }
+    
 
-    private uint _client_package_version = default(uint);
+    private uint? _client_package_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"client_package_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_package_version
     {
-      get { return _client_package_version; }
+      get { return _client_package_version?? default(uint); }
       set { _client_package_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_package_versionSpecified
+    {
+      get { return _client_package_version != null; }
+      set { if (value == (_client_package_version== null)) _client_package_version = value ? this.client_package_version : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_package_version() { return client_package_versionSpecified; }
+    private void Resetclient_package_version() { client_package_versionSpecified = false; }
+    
 
-    private string _client_language = "";
+    private string _client_language;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"client_language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string client_language
     {
-      get { return _client_language; }
+      get { return _client_language?? ""; }
       set { _client_language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_languageSpecified
+    {
+      get { return _client_language != null; }
+      set { if (value == (_client_language== null)) _client_language = value ? this.client_language : (string)null; }
+    }
+    private bool ShouldSerializeclient_language() { return client_languageSpecified; }
+    private void Resetclient_language() { client_languageSpecified = false; }
+    
 
-    private uint _client_os_type = default(uint);
+    private uint? _client_os_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"client_os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_os_type
     {
-      get { return _client_os_type; }
+      get { return _client_os_type?? default(uint); }
       set { _client_os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_os_typeSpecified
+    {
+      get { return _client_os_type != null; }
+      set { if (value == (_client_os_type== null)) _client_os_type = value ? this.client_os_type : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_os_type() { return client_os_typeSpecified; }
+    private void Resetclient_os_type() { client_os_typeSpecified = false; }
+    
 
-    private bool _should_remember_password = (bool)false;
+    private bool? _should_remember_password;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"should_remember_password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool should_remember_password
     {
-      get { return _should_remember_password; }
+      get { return _should_remember_password?? (bool)false; }
       set { _should_remember_password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool should_remember_passwordSpecified
+    {
+      get { return _should_remember_password != null; }
+      set { if (value == (_should_remember_password== null)) _should_remember_password = value ? this.should_remember_password : (bool?)null; }
+    }
+    private bool ShouldSerializeshould_remember_password() { return should_remember_passwordSpecified; }
+    private void Resetshould_remember_password() { should_remember_passwordSpecified = false; }
+    
 
-    private string _wine_version = "";
+    private string _wine_version;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"wine_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string wine_version
     {
-      get { return _wine_version; }
+      get { return _wine_version?? ""; }
       set { _wine_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool wine_versionSpecified
+    {
+      get { return _wine_version != null; }
+      set { if (value == (_wine_version== null)) _wine_version = value ? this.wine_version : (string)null; }
+    }
+    private bool ShouldSerializewine_version() { return wine_versionSpecified; }
+    private void Resetwine_version() { wine_versionSpecified = false; }
+    
 
-    private uint _ping_ms_from_cell_search = default(uint);
+    private uint? _ping_ms_from_cell_search;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"ping_ms_from_cell_search", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ping_ms_from_cell_search
     {
-      get { return _ping_ms_from_cell_search; }
+      get { return _ping_ms_from_cell_search?? default(uint); }
       set { _ping_ms_from_cell_search = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ping_ms_from_cell_searchSpecified
+    {
+      get { return _ping_ms_from_cell_search != null; }
+      set { if (value == (_ping_ms_from_cell_search== null)) _ping_ms_from_cell_search = value ? this.ping_ms_from_cell_search : (uint?)null; }
+    }
+    private bool ShouldSerializeping_ms_from_cell_search() { return ping_ms_from_cell_searchSpecified; }
+    private void Resetping_ms_from_cell_search() { ping_ms_from_cell_searchSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
 
-    private uint _qos_level = default(uint);
+    private uint? _qos_level;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"qos_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint qos_level
     {
-      get { return _qos_level; }
+      get { return _qos_level?? default(uint); }
       set { _qos_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool qos_levelSpecified
+    {
+      get { return _qos_level != null; }
+      set { if (value == (_qos_level== null)) _qos_level = value ? this.qos_level : (uint?)null; }
+    }
+    private bool ShouldSerializeqos_level() { return qos_levelSpecified; }
+    private void Resetqos_level() { qos_levelSpecified = false; }
+    
 
-    private ulong _client_supplied_steam_id = default(ulong);
+    private ulong? _client_supplied_steam_id;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"client_supplied_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_supplied_steam_id
     {
-      get { return _client_supplied_steam_id; }
+      get { return _client_supplied_steam_id?? default(ulong); }
       set { _client_supplied_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_supplied_steam_idSpecified
+    {
+      get { return _client_supplied_steam_id != null; }
+      set { if (value == (_client_supplied_steam_id== null)) _client_supplied_steam_id = value ? this.client_supplied_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_supplied_steam_id() { return client_supplied_steam_idSpecified; }
+    private void Resetclient_supplied_steam_id() { client_supplied_steam_idSpecified = false; }
+    
 
-    private byte[] _machine_id = null;
+    private byte[] _machine_id;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"machine_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] machine_id
     {
-      get { return _machine_id; }
+      get { return _machine_id?? null; }
       set { _machine_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_idSpecified
+    {
+      get { return _machine_id != null; }
+      set { if (value == (_machine_id== null)) _machine_id = value ? this.machine_id : (byte[])null; }
+    }
+    private bool ShouldSerializemachine_id() { return machine_idSpecified; }
+    private void Resetmachine_id() { machine_idSpecified = false; }
+    
 
-    private uint _launcher_type = (uint)0;
+    private uint? _launcher_type;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"launcher_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint launcher_type
     {
-      get { return _launcher_type; }
+      get { return _launcher_type?? (uint)0; }
       set { _launcher_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool launcher_typeSpecified
+    {
+      get { return _launcher_type != null; }
+      set { if (value == (_launcher_type== null)) _launcher_type = value ? this.launcher_type : (uint?)null; }
+    }
+    private bool ShouldSerializelauncher_type() { return launcher_typeSpecified; }
+    private void Resetlauncher_type() { launcher_typeSpecified = false; }
+    
 
-    private uint _ui_mode = (uint)0;
+    private uint? _ui_mode;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"ui_mode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint ui_mode
     {
-      get { return _ui_mode; }
+      get { return _ui_mode?? (uint)0; }
       set { _ui_mode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ui_modeSpecified
+    {
+      get { return _ui_mode != null; }
+      set { if (value == (_ui_mode== null)) _ui_mode = value ? this.ui_mode : (uint?)null; }
+    }
+    private bool ShouldSerializeui_mode() { return ui_modeSpecified; }
+    private void Resetui_mode() { ui_modeSpecified = false; }
+    
 
-    private byte[] _steam2_auth_ticket = null;
+    private byte[] _steam2_auth_ticket;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"steam2_auth_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] steam2_auth_ticket
     {
-      get { return _steam2_auth_ticket; }
+      get { return _steam2_auth_ticket?? null; }
       set { _steam2_auth_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam2_auth_ticketSpecified
+    {
+      get { return _steam2_auth_ticket != null; }
+      set { if (value == (_steam2_auth_ticket== null)) _steam2_auth_ticket = value ? this.steam2_auth_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializesteam2_auth_ticket() { return steam2_auth_ticketSpecified; }
+    private void Resetsteam2_auth_ticket() { steam2_auth_ticketSpecified = false; }
+    
 
-    private string _email_address = "";
+    private string _email_address;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"email_address", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string email_address
     {
-      get { return _email_address; }
+      get { return _email_address?? ""; }
       set { _email_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_addressSpecified
+    {
+      get { return _email_address != null; }
+      set { if (value == (_email_address== null)) _email_address = value ? this.email_address : (string)null; }
+    }
+    private bool ShouldSerializeemail_address() { return email_addressSpecified; }
+    private void Resetemail_address() { email_addressSpecified = false; }
+    
 
-    private uint _rtime32_account_creation = default(uint);
+    private uint? _rtime32_account_creation;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"rtime32_account_creation", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_account_creation
     {
-      get { return _rtime32_account_creation; }
+      get { return _rtime32_account_creation?? default(uint); }
       set { _rtime32_account_creation = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_account_creationSpecified
+    {
+      get { return _rtime32_account_creation != null; }
+      set { if (value == (_rtime32_account_creation== null)) _rtime32_account_creation = value ? this.rtime32_account_creation : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_account_creation() { return rtime32_account_creationSpecified; }
+    private void Resetrtime32_account_creation() { rtime32_account_creationSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(51, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _game_server_token = "";
+    private string _game_server_token;
     [global::ProtoBuf.ProtoMember(52, IsRequired = false, Name=@"game_server_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_server_token
     {
-      get { return _game_server_token; }
+      get { return _game_server_token?? ""; }
       set { _game_server_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_tokenSpecified
+    {
+      get { return _game_server_token != null; }
+      set { if (value == (_game_server_token== null)) _game_server_token = value ? this.game_server_token : (string)null; }
+    }
+    private bool ShouldSerializegame_server_token() { return game_server_tokenSpecified; }
+    private void Resetgame_server_token() { game_server_tokenSpecified = false; }
+    
 
-    private string _login_key = "";
+    private string _login_key;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"login_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string login_key
     {
-      get { return _login_key; }
+      get { return _login_key?? ""; }
       set { _login_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool login_keySpecified
+    {
+      get { return _login_key != null; }
+      set { if (value == (_login_key== null)) _login_key = value ? this.login_key : (string)null; }
+    }
+    private bool ShouldSerializelogin_key() { return login_keySpecified; }
+    private void Resetlogin_key() { login_keySpecified = false; }
+    
 
-    private bool _was_converted_deprecated_msg = (bool)false;
+    private bool? _was_converted_deprecated_msg;
     [global::ProtoBuf.ProtoMember(70, IsRequired = false, Name=@"was_converted_deprecated_msg", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool was_converted_deprecated_msg
     {
-      get { return _was_converted_deprecated_msg; }
+      get { return _was_converted_deprecated_msg?? (bool)false; }
       set { _was_converted_deprecated_msg = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_converted_deprecated_msgSpecified
+    {
+      get { return _was_converted_deprecated_msg != null; }
+      set { if (value == (_was_converted_deprecated_msg== null)) _was_converted_deprecated_msg = value ? this.was_converted_deprecated_msg : (bool?)null; }
+    }
+    private bool ShouldSerializewas_converted_deprecated_msg() { return was_converted_deprecated_msgSpecified; }
+    private void Resetwas_converted_deprecated_msg() { was_converted_deprecated_msgSpecified = false; }
+    
 
-    private string _anon_user_target_account_name = "";
+    private string _anon_user_target_account_name;
     [global::ProtoBuf.ProtoMember(80, IsRequired = false, Name=@"anon_user_target_account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string anon_user_target_account_name
     {
-      get { return _anon_user_target_account_name; }
+      get { return _anon_user_target_account_name?? ""; }
       set { _anon_user_target_account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool anon_user_target_account_nameSpecified
+    {
+      get { return _anon_user_target_account_name != null; }
+      set { if (value == (_anon_user_target_account_name== null)) _anon_user_target_account_name = value ? this.anon_user_target_account_name : (string)null; }
+    }
+    private bool ShouldSerializeanon_user_target_account_name() { return anon_user_target_account_nameSpecified; }
+    private void Resetanon_user_target_account_name() { anon_user_target_account_nameSpecified = false; }
+    
 
-    private ulong _resolved_user_steam_id = default(ulong);
+    private ulong? _resolved_user_steam_id;
     [global::ProtoBuf.ProtoMember(81, IsRequired = false, Name=@"resolved_user_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong resolved_user_steam_id
     {
-      get { return _resolved_user_steam_id; }
+      get { return _resolved_user_steam_id?? default(ulong); }
       set { _resolved_user_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resolved_user_steam_idSpecified
+    {
+      get { return _resolved_user_steam_id != null; }
+      set { if (value == (_resolved_user_steam_id== null)) _resolved_user_steam_id = value ? this.resolved_user_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeresolved_user_steam_id() { return resolved_user_steam_idSpecified; }
+    private void Resetresolved_user_steam_id() { resolved_user_steam_idSpecified = false; }
+    
 
-    private int _eresult_sentryfile = default(int);
+    private int? _eresult_sentryfile;
     [global::ProtoBuf.ProtoMember(82, IsRequired = false, Name=@"eresult_sentryfile", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int eresult_sentryfile
     {
-      get { return _eresult_sentryfile; }
+      get { return _eresult_sentryfile?? default(int); }
       set { _eresult_sentryfile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_sentryfileSpecified
+    {
+      get { return _eresult_sentryfile != null; }
+      set { if (value == (_eresult_sentryfile== null)) _eresult_sentryfile = value ? this.eresult_sentryfile : (int?)null; }
+    }
+    private bool ShouldSerializeeresult_sentryfile() { return eresult_sentryfileSpecified; }
+    private void Reseteresult_sentryfile() { eresult_sentryfileSpecified = false; }
+    
 
-    private byte[] _sha_sentryfile = null;
+    private byte[] _sha_sentryfile;
     [global::ProtoBuf.ProtoMember(83, IsRequired = false, Name=@"sha_sentryfile", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_sentryfile
     {
-      get { return _sha_sentryfile; }
+      get { return _sha_sentryfile?? null; }
       set { _sha_sentryfile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_sentryfileSpecified
+    {
+      get { return _sha_sentryfile != null; }
+      set { if (value == (_sha_sentryfile== null)) _sha_sentryfile = value ? this.sha_sentryfile : (byte[])null; }
+    }
+    private bool ShouldSerializesha_sentryfile() { return sha_sentryfileSpecified; }
+    private void Resetsha_sentryfile() { sha_sentryfileSpecified = false; }
+    
 
-    private string _auth_code = "";
+    private string _auth_code;
     [global::ProtoBuf.ProtoMember(84, IsRequired = false, Name=@"auth_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string auth_code
     {
-      get { return _auth_code; }
+      get { return _auth_code?? ""; }
       set { _auth_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_codeSpecified
+    {
+      get { return _auth_code != null; }
+      set { if (value == (_auth_code== null)) _auth_code = value ? this.auth_code : (string)null; }
+    }
+    private bool ShouldSerializeauth_code() { return auth_codeSpecified; }
+    private void Resetauth_code() { auth_codeSpecified = false; }
+    
 
-    private int _otp_type = default(int);
+    private int? _otp_type;
     [global::ProtoBuf.ProtoMember(85, IsRequired = false, Name=@"otp_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int otp_type
     {
-      get { return _otp_type; }
+      get { return _otp_type?? default(int); }
       set { _otp_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_typeSpecified
+    {
+      get { return _otp_type != null; }
+      set { if (value == (_otp_type== null)) _otp_type = value ? this.otp_type : (int?)null; }
+    }
+    private bool ShouldSerializeotp_type() { return otp_typeSpecified; }
+    private void Resetotp_type() { otp_typeSpecified = false; }
+    
 
-    private uint _otp_value = default(uint);
+    private uint? _otp_value;
     [global::ProtoBuf.ProtoMember(86, IsRequired = false, Name=@"otp_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_value
     {
-      get { return _otp_value; }
+      get { return _otp_value?? default(uint); }
       set { _otp_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_valueSpecified
+    {
+      get { return _otp_value != null; }
+      set { if (value == (_otp_value== null)) _otp_value = value ? this.otp_value : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_value() { return otp_valueSpecified; }
+    private void Resetotp_value() { otp_valueSpecified = false; }
+    
 
-    private string _otp_identifier = "";
+    private string _otp_identifier;
     [global::ProtoBuf.ProtoMember(87, IsRequired = false, Name=@"otp_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string otp_identifier
     {
-      get { return _otp_identifier; }
+      get { return _otp_identifier?? ""; }
       set { _otp_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_identifierSpecified
+    {
+      get { return _otp_identifier != null; }
+      set { if (value == (_otp_identifier== null)) _otp_identifier = value ? this.otp_identifier : (string)null; }
+    }
+    private bool ShouldSerializeotp_identifier() { return otp_identifierSpecified; }
+    private void Resetotp_identifier() { otp_identifierSpecified = false; }
+    
 
-    private bool _steam2_ticket_request = default(bool);
+    private bool? _steam2_ticket_request;
     [global::ProtoBuf.ProtoMember(88, IsRequired = false, Name=@"steam2_ticket_request", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool steam2_ticket_request
     {
-      get { return _steam2_ticket_request; }
+      get { return _steam2_ticket_request?? default(bool); }
       set { _steam2_ticket_request = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam2_ticket_requestSpecified
+    {
+      get { return _steam2_ticket_request != null; }
+      set { if (value == (_steam2_ticket_request== null)) _steam2_ticket_request = value ? this.steam2_ticket_request : (bool?)null; }
+    }
+    private bool ShouldSerializesteam2_ticket_request() { return steam2_ticket_requestSpecified; }
+    private void Resetsteam2_ticket_request() { steam2_ticket_requestSpecified = false; }
+    
 
-    private byte[] _sony_psn_ticket = null;
+    private byte[] _sony_psn_ticket;
     [global::ProtoBuf.ProtoMember(90, IsRequired = false, Name=@"sony_psn_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sony_psn_ticket
     {
-      get { return _sony_psn_ticket; }
+      get { return _sony_psn_ticket?? null; }
       set { _sony_psn_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sony_psn_ticketSpecified
+    {
+      get { return _sony_psn_ticket != null; }
+      set { if (value == (_sony_psn_ticket== null)) _sony_psn_ticket = value ? this.sony_psn_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializesony_psn_ticket() { return sony_psn_ticketSpecified; }
+    private void Resetsony_psn_ticket() { sony_psn_ticketSpecified = false; }
+    
 
-    private string _sony_psn_service_id = "";
+    private string _sony_psn_service_id;
     [global::ProtoBuf.ProtoMember(91, IsRequired = false, Name=@"sony_psn_service_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sony_psn_service_id
     {
-      get { return _sony_psn_service_id; }
+      get { return _sony_psn_service_id?? ""; }
       set { _sony_psn_service_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sony_psn_service_idSpecified
+    {
+      get { return _sony_psn_service_id != null; }
+      set { if (value == (_sony_psn_service_id== null)) _sony_psn_service_id = value ? this.sony_psn_service_id : (string)null; }
+    }
+    private bool ShouldSerializesony_psn_service_id() { return sony_psn_service_idSpecified; }
+    private void Resetsony_psn_service_id() { sony_psn_service_idSpecified = false; }
+    
 
-    private bool _create_new_psn_linked_account_if_needed = (bool)false;
+    private bool? _create_new_psn_linked_account_if_needed;
     [global::ProtoBuf.ProtoMember(92, IsRequired = false, Name=@"create_new_psn_linked_account_if_needed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool create_new_psn_linked_account_if_needed
     {
-      get { return _create_new_psn_linked_account_if_needed; }
+      get { return _create_new_psn_linked_account_if_needed?? (bool)false; }
       set { _create_new_psn_linked_account_if_needed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool create_new_psn_linked_account_if_neededSpecified
+    {
+      get { return _create_new_psn_linked_account_if_needed != null; }
+      set { if (value == (_create_new_psn_linked_account_if_needed== null)) _create_new_psn_linked_account_if_needed = value ? this.create_new_psn_linked_account_if_needed : (bool?)null; }
+    }
+    private bool ShouldSerializecreate_new_psn_linked_account_if_needed() { return create_new_psn_linked_account_if_neededSpecified; }
+    private void Resetcreate_new_psn_linked_account_if_needed() { create_new_psn_linked_account_if_neededSpecified = false; }
+    
 
-    private string _sony_psn_name = "";
+    private string _sony_psn_name;
     [global::ProtoBuf.ProtoMember(93, IsRequired = false, Name=@"sony_psn_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sony_psn_name
     {
-      get { return _sony_psn_name; }
+      get { return _sony_psn_name?? ""; }
       set { _sony_psn_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sony_psn_nameSpecified
+    {
+      get { return _sony_psn_name != null; }
+      set { if (value == (_sony_psn_name== null)) _sony_psn_name = value ? this.sony_psn_name : (string)null; }
+    }
+    private bool ShouldSerializesony_psn_name() { return sony_psn_nameSpecified; }
+    private void Resetsony_psn_name() { sony_psn_nameSpecified = false; }
+    
 
-    private int _game_server_app_id = default(int);
+    private int? _game_server_app_id;
     [global::ProtoBuf.ProtoMember(94, IsRequired = false, Name=@"game_server_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int game_server_app_id
     {
-      get { return _game_server_app_id; }
+      get { return _game_server_app_id?? default(int); }
       set { _game_server_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_app_idSpecified
+    {
+      get { return _game_server_app_id != null; }
+      set { if (value == (_game_server_app_id== null)) _game_server_app_id = value ? this.game_server_app_id : (int?)null; }
+    }
+    private bool ShouldSerializegame_server_app_id() { return game_server_app_idSpecified; }
+    private void Resetgame_server_app_id() { game_server_app_idSpecified = false; }
+    
 
-    private bool _steamguard_dont_remember_computer = default(bool);
+    private bool? _steamguard_dont_remember_computer;
     [global::ProtoBuf.ProtoMember(95, IsRequired = false, Name=@"steamguard_dont_remember_computer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool steamguard_dont_remember_computer
     {
-      get { return _steamguard_dont_remember_computer; }
+      get { return _steamguard_dont_remember_computer?? default(bool); }
       set { _steamguard_dont_remember_computer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_dont_remember_computerSpecified
+    {
+      get { return _steamguard_dont_remember_computer != null; }
+      set { if (value == (_steamguard_dont_remember_computer== null)) _steamguard_dont_remember_computer = value ? this.steamguard_dont_remember_computer : (bool?)null; }
+    }
+    private bool ShouldSerializesteamguard_dont_remember_computer() { return steamguard_dont_remember_computerSpecified; }
+    private void Resetsteamguard_dont_remember_computer() { steamguard_dont_remember_computerSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(96, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
 
-    private string _machine_name_userchosen = "";
+    private string _machine_name_userchosen;
     [global::ProtoBuf.ProtoMember(97, IsRequired = false, Name=@"machine_name_userchosen", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name_userchosen
     {
-      get { return _machine_name_userchosen; }
+      get { return _machine_name_userchosen?? ""; }
       set { _machine_name_userchosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_name_userchosenSpecified
+    {
+      get { return _machine_name_userchosen != null; }
+      set { if (value == (_machine_name_userchosen== null)) _machine_name_userchosen = value ? this.machine_name_userchosen : (string)null; }
+    }
+    private bool ShouldSerializemachine_name_userchosen() { return machine_name_userchosenSpecified; }
+    private void Resetmachine_name_userchosen() { machine_name_userchosenSpecified = false; }
+    
 
-    private string _country_override = "";
+    private string _country_override;
     [global::ProtoBuf.ProtoMember(98, IsRequired = false, Name=@"country_override", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_override
     {
-      get { return _country_override; }
+      get { return _country_override?? ""; }
       set { _country_override = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_overrideSpecified
+    {
+      get { return _country_override != null; }
+      set { if (value == (_country_override== null)) _country_override = value ? this.country_override : (string)null; }
+    }
+    private bool ShouldSerializecountry_override() { return country_overrideSpecified; }
+    private void Resetcountry_override() { country_overrideSpecified = false; }
+    
 
-    private bool _is_steam_box = default(bool);
+    private bool? _is_steam_box;
     [global::ProtoBuf.ProtoMember(99, IsRequired = false, Name=@"is_steam_box", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_steam_box
     {
-      get { return _is_steam_box; }
+      get { return _is_steam_box?? default(bool); }
       set { _is_steam_box = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_steam_boxSpecified
+    {
+      get { return _is_steam_box != null; }
+      set { if (value == (_is_steam_box== null)) _is_steam_box = value ? this.is_steam_box : (bool?)null; }
+    }
+    private bool ShouldSerializeis_steam_box() { return is_steam_boxSpecified; }
+    private void Resetis_steam_box() { is_steam_boxSpecified = false; }
+    
 
-    private ulong _client_instance_id = default(ulong);
+    private ulong? _client_instance_id;
     [global::ProtoBuf.ProtoMember(100, IsRequired = false, Name=@"client_instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_instance_id
     {
-      get { return _client_instance_id; }
+      get { return _client_instance_id?? default(ulong); }
       set { _client_instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_instance_idSpecified
+    {
+      get { return _client_instance_id != null; }
+      set { if (value == (_client_instance_id== null)) _client_instance_id = value ? this.client_instance_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_instance_id() { return client_instance_idSpecified; }
+    private void Resetclient_instance_id() { client_instance_idSpecified = false; }
+    
 
-    private string _two_factor_code = "";
+    private string _two_factor_code;
     [global::ProtoBuf.ProtoMember(101, IsRequired = false, Name=@"two_factor_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string two_factor_code
     {
-      get { return _two_factor_code; }
+      get { return _two_factor_code?? ""; }
       set { _two_factor_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool two_factor_codeSpecified
+    {
+      get { return _two_factor_code != null; }
+      set { if (value == (_two_factor_code== null)) _two_factor_code = value ? this.two_factor_code : (string)null; }
+    }
+    private bool ShouldSerializetwo_factor_code() { return two_factor_codeSpecified; }
+    private void Resettwo_factor_code() { two_factor_codeSpecified = false; }
+    
 
-    private bool _supports_rate_limit_response = default(bool);
+    private bool? _supports_rate_limit_response;
     [global::ProtoBuf.ProtoMember(102, IsRequired = false, Name=@"supports_rate_limit_response", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool supports_rate_limit_response
     {
-      get { return _supports_rate_limit_response; }
+      get { return _supports_rate_limit_response?? default(bool); }
       set { _supports_rate_limit_response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supports_rate_limit_responseSpecified
+    {
+      get { return _supports_rate_limit_response != null; }
+      set { if (value == (_supports_rate_limit_response== null)) _supports_rate_limit_response = value ? this.supports_rate_limit_response : (bool?)null; }
+    }
+    private bool ShouldSerializesupports_rate_limit_response() { return supports_rate_limit_responseSpecified; }
+    private void Resetsupports_rate_limit_response() { supports_rate_limit_responseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -700,203 +1323,401 @@ namespace SteamKit2.Internal
     public CMsgClientLogonResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _out_of_game_heartbeat_seconds = default(int);
+    private int? _out_of_game_heartbeat_seconds;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"out_of_game_heartbeat_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int out_of_game_heartbeat_seconds
     {
-      get { return _out_of_game_heartbeat_seconds; }
+      get { return _out_of_game_heartbeat_seconds?? default(int); }
       set { _out_of_game_heartbeat_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool out_of_game_heartbeat_secondsSpecified
+    {
+      get { return _out_of_game_heartbeat_seconds != null; }
+      set { if (value == (_out_of_game_heartbeat_seconds== null)) _out_of_game_heartbeat_seconds = value ? this.out_of_game_heartbeat_seconds : (int?)null; }
+    }
+    private bool ShouldSerializeout_of_game_heartbeat_seconds() { return out_of_game_heartbeat_secondsSpecified; }
+    private void Resetout_of_game_heartbeat_seconds() { out_of_game_heartbeat_secondsSpecified = false; }
+    
 
-    private int _in_game_heartbeat_seconds = default(int);
+    private int? _in_game_heartbeat_seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"in_game_heartbeat_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int in_game_heartbeat_seconds
     {
-      get { return _in_game_heartbeat_seconds; }
+      get { return _in_game_heartbeat_seconds?? default(int); }
       set { _in_game_heartbeat_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_game_heartbeat_secondsSpecified
+    {
+      get { return _in_game_heartbeat_seconds != null; }
+      set { if (value == (_in_game_heartbeat_seconds== null)) _in_game_heartbeat_seconds = value ? this.in_game_heartbeat_seconds : (int?)null; }
+    }
+    private bool ShouldSerializein_game_heartbeat_seconds() { return in_game_heartbeat_secondsSpecified; }
+    private void Resetin_game_heartbeat_seconds() { in_game_heartbeat_secondsSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
 
-    private uint _rtime32_server_time = default(uint);
+    private uint? _rtime32_server_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rtime32_server_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_server_time
     {
-      get { return _rtime32_server_time; }
+      get { return _rtime32_server_time?? default(uint); }
       set { _rtime32_server_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_server_timeSpecified
+    {
+      get { return _rtime32_server_time != null; }
+      set { if (value == (_rtime32_server_time== null)) _rtime32_server_time = value ? this.rtime32_server_time : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_server_time() { return rtime32_server_timeSpecified; }
+    private void Resetrtime32_server_time() { rtime32_server_timeSpecified = false; }
+    
 
-    private uint _account_flags = default(uint);
+    private uint? _account_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_flags
     {
-      get { return _account_flags; }
+      get { return _account_flags?? default(uint); }
       set { _account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_flagsSpecified
+    {
+      get { return _account_flags != null; }
+      set { if (value == (_account_flags== null)) _account_flags = value ? this.account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_flags() { return account_flagsSpecified; }
+    private void Resetaccount_flags() { account_flagsSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private string _email_domain = "";
+    private string _email_domain;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"email_domain", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string email_domain
     {
-      get { return _email_domain; }
+      get { return _email_domain?? ""; }
       set { _email_domain = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_domainSpecified
+    {
+      get { return _email_domain != null; }
+      set { if (value == (_email_domain== null)) _email_domain = value ? this.email_domain : (string)null; }
+    }
+    private bool ShouldSerializeemail_domain() { return email_domainSpecified; }
+    private void Resetemail_domain() { email_domainSpecified = false; }
+    
 
-    private byte[] _steam2_ticket = null;
+    private byte[] _steam2_ticket;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"steam2_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] steam2_ticket
     {
-      get { return _steam2_ticket; }
+      get { return _steam2_ticket?? null; }
       set { _steam2_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam2_ticketSpecified
+    {
+      get { return _steam2_ticket != null; }
+      set { if (value == (_steam2_ticket== null)) _steam2_ticket = value ? this.steam2_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializesteam2_ticket() { return steam2_ticketSpecified; }
+    private void Resetsteam2_ticket() { steam2_ticketSpecified = false; }
+    
 
-    private int _eresult_extended = default(int);
+    private int? _eresult_extended;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"eresult_extended", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int eresult_extended
     {
-      get { return _eresult_extended; }
+      get { return _eresult_extended?? default(int); }
       set { _eresult_extended = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_extendedSpecified
+    {
+      get { return _eresult_extended != null; }
+      set { if (value == (_eresult_extended== null)) _eresult_extended = value ? this.eresult_extended : (int?)null; }
+    }
+    private bool ShouldSerializeeresult_extended() { return eresult_extendedSpecified; }
+    private void Reseteresult_extended() { eresult_extendedSpecified = false; }
+    
 
-    private string _webapi_authenticate_user_nonce = "";
+    private string _webapi_authenticate_user_nonce;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"webapi_authenticate_user_nonce", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webapi_authenticate_user_nonce
     {
-      get { return _webapi_authenticate_user_nonce; }
+      get { return _webapi_authenticate_user_nonce?? ""; }
       set { _webapi_authenticate_user_nonce = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_authenticate_user_nonceSpecified
+    {
+      get { return _webapi_authenticate_user_nonce != null; }
+      set { if (value == (_webapi_authenticate_user_nonce== null)) _webapi_authenticate_user_nonce = value ? this.webapi_authenticate_user_nonce : (string)null; }
+    }
+    private bool ShouldSerializewebapi_authenticate_user_nonce() { return webapi_authenticate_user_nonceSpecified; }
+    private void Resetwebapi_authenticate_user_nonce() { webapi_authenticate_user_nonceSpecified = false; }
+    
 
-    private uint _cell_id_ping_threshold = default(uint);
+    private uint? _cell_id_ping_threshold;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"cell_id_ping_threshold", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id_ping_threshold
     {
-      get { return _cell_id_ping_threshold; }
+      get { return _cell_id_ping_threshold?? default(uint); }
       set { _cell_id_ping_threshold = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_id_ping_thresholdSpecified
+    {
+      get { return _cell_id_ping_threshold != null; }
+      set { if (value == (_cell_id_ping_threshold== null)) _cell_id_ping_threshold = value ? this.cell_id_ping_threshold : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id_ping_threshold() { return cell_id_ping_thresholdSpecified; }
+    private void Resetcell_id_ping_threshold() { cell_id_ping_thresholdSpecified = false; }
+    
 
-    private bool _use_pics = default(bool);
+    private bool? _use_pics;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"use_pics", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_pics
     {
-      get { return _use_pics; }
+      get { return _use_pics?? default(bool); }
       set { _use_pics = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_picsSpecified
+    {
+      get { return _use_pics != null; }
+      set { if (value == (_use_pics== null)) _use_pics = value ? this.use_pics : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_pics() { return use_picsSpecified; }
+    private void Resetuse_pics() { use_picsSpecified = false; }
+    
 
-    private string _vanity_url = "";
+    private string _vanity_url;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"vanity_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vanity_url
     {
-      get { return _vanity_url; }
+      get { return _vanity_url?? ""; }
       set { _vanity_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vanity_urlSpecified
+    {
+      get { return _vanity_url != null; }
+      set { if (value == (_vanity_url== null)) _vanity_url = value ? this.vanity_url : (string)null; }
+    }
+    private bool ShouldSerializevanity_url() { return vanity_urlSpecified; }
+    private void Resetvanity_url() { vanity_urlSpecified = false; }
+    
 
-    private ulong _client_supplied_steamid = default(ulong);
+    private ulong? _client_supplied_steamid;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"client_supplied_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_supplied_steamid
     {
-      get { return _client_supplied_steamid; }
+      get { return _client_supplied_steamid?? default(ulong); }
       set { _client_supplied_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_supplied_steamidSpecified
+    {
+      get { return _client_supplied_steamid != null; }
+      set { if (value == (_client_supplied_steamid== null)) _client_supplied_steamid = value ? this.client_supplied_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_supplied_steamid() { return client_supplied_steamidSpecified; }
+    private void Resetclient_supplied_steamid() { client_supplied_steamidSpecified = false; }
+    
 
-    private string _ip_country_code = "";
+    private string _ip_country_code;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"ip_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ip_country_code
     {
-      get { return _ip_country_code; }
+      get { return _ip_country_code?? ""; }
       set { _ip_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_country_codeSpecified
+    {
+      get { return _ip_country_code != null; }
+      set { if (value == (_ip_country_code== null)) _ip_country_code = value ? this.ip_country_code : (string)null; }
+    }
+    private bool ShouldSerializeip_country_code() { return ip_country_codeSpecified; }
+    private void Resetip_country_code() { ip_country_codeSpecified = false; }
+    
 
-    private byte[] _parental_settings = null;
+    private byte[] _parental_settings;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"parental_settings", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] parental_settings
     {
-      get { return _parental_settings; }
+      get { return _parental_settings?? null; }
       set { _parental_settings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parental_settingsSpecified
+    {
+      get { return _parental_settings != null; }
+      set { if (value == (_parental_settings== null)) _parental_settings = value ? this.parental_settings : (byte[])null; }
+    }
+    private bool ShouldSerializeparental_settings() { return parental_settingsSpecified; }
+    private void Resetparental_settings() { parental_settingsSpecified = false; }
+    
 
-    private byte[] _parental_setting_signature = null;
+    private byte[] _parental_setting_signature;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"parental_setting_signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] parental_setting_signature
     {
-      get { return _parental_setting_signature; }
+      get { return _parental_setting_signature?? null; }
       set { _parental_setting_signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool parental_setting_signatureSpecified
+    {
+      get { return _parental_setting_signature != null; }
+      set { if (value == (_parental_setting_signature== null)) _parental_setting_signature = value ? this.parental_setting_signature : (byte[])null; }
+    }
+    private bool ShouldSerializeparental_setting_signature() { return parental_setting_signatureSpecified; }
+    private void Resetparental_setting_signature() { parental_setting_signatureSpecified = false; }
+    
 
-    private int _count_loginfailures_to_migrate = default(int);
+    private int? _count_loginfailures_to_migrate;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"count_loginfailures_to_migrate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int count_loginfailures_to_migrate
     {
-      get { return _count_loginfailures_to_migrate; }
+      get { return _count_loginfailures_to_migrate?? default(int); }
       set { _count_loginfailures_to_migrate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_loginfailures_to_migrateSpecified
+    {
+      get { return _count_loginfailures_to_migrate != null; }
+      set { if (value == (_count_loginfailures_to_migrate== null)) _count_loginfailures_to_migrate = value ? this.count_loginfailures_to_migrate : (int?)null; }
+    }
+    private bool ShouldSerializecount_loginfailures_to_migrate() { return count_loginfailures_to_migrateSpecified; }
+    private void Resetcount_loginfailures_to_migrate() { count_loginfailures_to_migrateSpecified = false; }
+    
 
-    private int _count_disconnects_to_migrate = default(int);
+    private int? _count_disconnects_to_migrate;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"count_disconnects_to_migrate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int count_disconnects_to_migrate
     {
-      get { return _count_disconnects_to_migrate; }
+      get { return _count_disconnects_to_migrate?? default(int); }
       set { _count_disconnects_to_migrate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_disconnects_to_migrateSpecified
+    {
+      get { return _count_disconnects_to_migrate != null; }
+      set { if (value == (_count_disconnects_to_migrate== null)) _count_disconnects_to_migrate = value ? this.count_disconnects_to_migrate : (int?)null; }
+    }
+    private bool ShouldSerializecount_disconnects_to_migrate() { return count_disconnects_to_migrateSpecified; }
+    private void Resetcount_disconnects_to_migrate() { count_disconnects_to_migrateSpecified = false; }
+    
 
-    private int _ogs_data_report_time_window = default(int);
+    private int? _ogs_data_report_time_window;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"ogs_data_report_time_window", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ogs_data_report_time_window
     {
-      get { return _ogs_data_report_time_window; }
+      get { return _ogs_data_report_time_window?? default(int); }
       set { _ogs_data_report_time_window = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ogs_data_report_time_windowSpecified
+    {
+      get { return _ogs_data_report_time_window != null; }
+      set { if (value == (_ogs_data_report_time_window== null)) _ogs_data_report_time_window = value ? this.ogs_data_report_time_window : (int?)null; }
+    }
+    private bool ShouldSerializeogs_data_report_time_window() { return ogs_data_report_time_windowSpecified; }
+    private void Resetogs_data_report_time_window() { ogs_data_report_time_windowSpecified = false; }
+    
 
-    private ulong _client_instance_id = default(ulong);
+    private ulong? _client_instance_id;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"client_instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_instance_id
     {
-      get { return _client_instance_id; }
+      get { return _client_instance_id?? default(ulong); }
       set { _client_instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_instance_idSpecified
+    {
+      get { return _client_instance_id != null; }
+      set { if (value == (_client_instance_id== null)) _client_instance_id = value ? this.client_instance_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_instance_id() { return client_instance_idSpecified; }
+    private void Resetclient_instance_id() { client_instance_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -918,23 +1739,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestWebAPIAuthenticateUserNonceResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _webapi_authenticate_user_nonce = "";
+    private string _webapi_authenticate_user_nonce;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"webapi_authenticate_user_nonce", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webapi_authenticate_user_nonce
     {
-      get { return _webapi_authenticate_user_nonce; }
+      get { return _webapi_authenticate_user_nonce?? ""; }
       set { _webapi_authenticate_user_nonce = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webapi_authenticate_user_nonceSpecified
+    {
+      get { return _webapi_authenticate_user_nonce != null; }
+      set { if (value == (_webapi_authenticate_user_nonce== null)) _webapi_authenticate_user_nonce = value ? this.webapi_authenticate_user_nonce : (string)null; }
+    }
+    private bool ShouldSerializewebapi_authenticate_user_nonce() { return webapi_authenticate_user_nonceSpecified; }
+    private void Resetwebapi_authenticate_user_nonce() { webapi_authenticate_user_nonceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -956,14 +1795,23 @@ namespace SteamKit2.Internal
     public CMsgClientLoggedOff() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -999,41 +1847,77 @@ namespace SteamKit2.Internal
     public CMsgClientP2PConnectionInfo() {}
     
 
-    private ulong _steam_id_dest = default(ulong);
+    private ulong? _steam_id_dest;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_dest", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_dest
     {
-      get { return _steam_id_dest; }
+      get { return _steam_id_dest?? default(ulong); }
       set { _steam_id_dest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_destSpecified
+    {
+      get { return _steam_id_dest != null; }
+      set { if (value == (_steam_id_dest== null)) _steam_id_dest = value ? this.steam_id_dest : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_dest() { return steam_id_destSpecified; }
+    private void Resetsteam_id_dest() { steam_id_destSpecified = false; }
+    
 
-    private ulong _steam_id_src = default(ulong);
+    private ulong? _steam_id_src;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_src", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_src
     {
-      get { return _steam_id_src; }
+      get { return _steam_id_src?? default(ulong); }
       set { _steam_id_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_srcSpecified
+    {
+      get { return _steam_id_src != null; }
+      set { if (value == (_steam_id_src== null)) _steam_id_src = value ? this.steam_id_src : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_src() { return steam_id_srcSpecified; }
+    private void Resetsteam_id_src() { steam_id_srcSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private byte[] _candidate = null;
+    private byte[] _candidate;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"candidate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] candidate
     {
-      get { return _candidate; }
+      get { return _candidate?? null; }
       set { _candidate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool candidateSpecified
+    {
+      get { return _candidate != null; }
+      set { if (value == (_candidate== null)) _candidate = value ? this.candidate : (byte[])null; }
+    }
+    private bool ShouldSerializecandidate() { return candidateSpecified; }
+    private void Resetcandidate() { candidateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1045,41 +1929,77 @@ namespace SteamKit2.Internal
     public CMsgClientP2PConnectionFailInfo() {}
     
 
-    private ulong _steam_id_dest = default(ulong);
+    private ulong? _steam_id_dest;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_dest", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_dest
     {
-      get { return _steam_id_dest; }
+      get { return _steam_id_dest?? default(ulong); }
       set { _steam_id_dest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_destSpecified
+    {
+      get { return _steam_id_dest != null; }
+      set { if (value == (_steam_id_dest== null)) _steam_id_dest = value ? this.steam_id_dest : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_dest() { return steam_id_destSpecified; }
+    private void Resetsteam_id_dest() { steam_id_destSpecified = false; }
+    
 
-    private ulong _steam_id_src = default(ulong);
+    private ulong? _steam_id_src;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_src", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_src
     {
-      get { return _steam_id_src; }
+      get { return _steam_id_src?? default(ulong); }
       set { _steam_id_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_srcSpecified
+    {
+      get { return _steam_id_src != null; }
+      set { if (value == (_steam_id_src== null)) _steam_id_src = value ? this.steam_id_src : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_src() { return steam_id_srcSpecified; }
+    private void Resetsteam_id_src() { steam_id_srcSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _ep2p_session_error = default(uint);
+    private uint? _ep2p_session_error;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ep2p_session_error", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ep2p_session_error
     {
-      get { return _ep2p_session_error; }
+      get { return _ep2p_session_error?? default(uint); }
       set { _ep2p_session_error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ep2p_session_errorSpecified
+    {
+      get { return _ep2p_session_error != null; }
+      set { if (value == (_ep2p_session_error== null)) _ep2p_session_error = value ? this.ep2p_session_error : (uint?)null; }
+    }
+    private bool ShouldSerializeep2p_session_error() { return ep2p_session_errorSpecified; }
+    private void Resetep2p_session_error() { ep2p_session_errorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1091,14 +2011,23 @@ namespace SteamKit2.Internal
     public CMsgClientGetAppOwnershipTicket() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1110,32 +2039,59 @@ namespace SteamKit2.Internal
     public CMsgClientGetAppOwnershipTicketResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private byte[] _ticket = null;
+    private byte[] _ticket;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? null; }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1147,14 +2103,23 @@ namespace SteamKit2.Internal
     public CMsgClientSessionToken() {}
     
 
-    private ulong _token = default(ulong);
+    private ulong? _token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong token
     {
-      get { return _token; }
+      get { return _token?? default(ulong); }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (ulong?)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1166,14 +2131,23 @@ namespace SteamKit2.Internal
     public CMsgClientGameConnectTokens() {}
     
 
-    private uint _max_tokens_to_keep = (uint)10;
+    private uint? _max_tokens_to_keep;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"max_tokens_to_keep", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)10)]
     public uint max_tokens_to_keep
     {
-      get { return _max_tokens_to_keep; }
+      get { return _max_tokens_to_keep?? (uint)10; }
       set { _max_tokens_to_keep = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_tokens_to_keepSpecified
+    {
+      get { return _max_tokens_to_keep != null; }
+      set { if (value == (_max_tokens_to_keep== null)) _max_tokens_to_keep = value ? this.max_tokens_to_keep : (uint?)null; }
+    }
+    private bool ShouldSerializemax_tokens_to_keep() { return max_tokens_to_keepSpecified; }
+    private void Resetmax_tokens_to_keep() { max_tokens_to_keepSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<byte[]> _tokens = new global::System.Collections.Generic.List<byte[]>();
     [global::ProtoBuf.ProtoMember(2, Name=@"tokens", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<byte[]> tokens
@@ -1192,68 +2166,131 @@ namespace SteamKit2.Internal
     public CMsgGSServerType() {}
     
 
-    private uint _app_id_served = default(uint);
+    private uint? _app_id_served;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id_served", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id_served
     {
-      get { return _app_id_served; }
+      get { return _app_id_served?? default(uint); }
       set { _app_id_served = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_id_servedSpecified
+    {
+      get { return _app_id_served != null; }
+      set { if (value == (_app_id_served== null)) _app_id_served = value ? this.app_id_served : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id_served() { return app_id_servedSpecified; }
+    private void Resetapp_id_served() { app_id_servedSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private uint _game_ip_address = default(uint);
+    private uint? _game_ip_address;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_ip_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_ip_address
     {
-      get { return _game_ip_address; }
+      get { return _game_ip_address?? default(uint); }
       set { _game_ip_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_ip_addressSpecified
+    {
+      get { return _game_ip_address != null; }
+      set { if (value == (_game_ip_address== null)) _game_ip_address = value ? this.game_ip_address : (uint?)null; }
+    }
+    private bool ShouldSerializegame_ip_address() { return game_ip_addressSpecified; }
+    private void Resetgame_ip_address() { game_ip_addressSpecified = false; }
+    
 
-    private uint _game_port = default(uint);
+    private uint? _game_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_port
     {
-      get { return _game_port; }
+      get { return _game_port?? default(uint); }
       set { _game_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_portSpecified
+    {
+      get { return _game_port != null; }
+      set { if (value == (_game_port== null)) _game_port = value ? this.game_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_port() { return game_portSpecified; }
+    private void Resetgame_port() { game_portSpecified = false; }
+    
 
-    private string _game_dir = "";
+    private string _game_dir;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_dir", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_dir
     {
-      get { return _game_dir; }
+      get { return _game_dir?? ""; }
       set { _game_dir = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_dirSpecified
+    {
+      get { return _game_dir != null; }
+      set { if (value == (_game_dir== null)) _game_dir = value ? this.game_dir : (string)null; }
+    }
+    private bool ShouldSerializegame_dir() { return game_dirSpecified; }
+    private void Resetgame_dir() { game_dirSpecified = false; }
+    
 
-    private string _game_version = "";
+    private string _game_version;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"game_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_version
     {
-      get { return _game_version; }
+      get { return _game_version?? ""; }
       set { _game_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_versionSpecified
+    {
+      get { return _game_version != null; }
+      set { if (value == (_game_version== null)) _game_version = value ? this.game_version : (string)null; }
+    }
+    private bool ShouldSerializegame_version() { return game_versionSpecified; }
+    private void Resetgame_version() { game_versionSpecified = false; }
+    
 
-    private uint _game_query_port = default(uint);
+    private uint? _game_query_port;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_query_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_query_port
     {
-      get { return _game_query_port; }
+      get { return _game_query_port?? default(uint); }
       set { _game_query_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_query_portSpecified
+    {
+      get { return _game_query_port != null; }
+      set { if (value == (_game_query_port== null)) _game_query_port = value ? this.game_query_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_query_port() { return game_query_portSpecified; }
+    private void Resetgame_query_port() { game_query_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1265,14 +2302,23 @@ namespace SteamKit2.Internal
     public CMsgGSStatusReply() {}
     
 
-    private bool _is_secure = default(bool);
+    private bool? _is_secure;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_secure", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_secure
     {
-      get { return _is_secure; }
+      get { return _is_secure?? default(bool); }
       set { _is_secure = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_secureSpecified
+    {
+      get { return _is_secure != null; }
+      set { if (value == (_is_secure== null)) _is_secure = value ? this.is_secure : (bool?)null; }
+    }
+    private bool ShouldSerializeis_secure() { return is_secureSpecified; }
+    private void Resetis_secure() { is_secureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1296,32 +2342,59 @@ namespace SteamKit2.Internal
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1338,32 +2411,59 @@ namespace SteamKit2.Internal
     public CMsgGSUserPlaying() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1375,14 +2475,23 @@ namespace SteamKit2.Internal
     public CMsgGSDisconnectNotice() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1401,199 +2510,388 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _client_os_type = default(uint);
+    private uint? _client_os_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_os_type
     {
-      get { return _client_os_type; }
+      get { return _client_os_type?? default(uint); }
       set { _client_os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_os_typeSpecified
+    {
+      get { return _client_os_type != null; }
+      set { if (value == (_client_os_type== null)) _client_os_type = value ? this.client_os_type : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_os_type() { return client_os_typeSpecified; }
+    private void Resetclient_os_type() { client_os_typeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"GamePlayed")]
   public partial class GamePlayed : global::ProtoBuf.IExtensible
   {
     public GamePlayed() {}
     
 
-    private ulong _steam_id_gs = default(ulong);
+    private ulong? _steam_id_gs;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_gs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_gs
     {
-      get { return _steam_id_gs; }
+      get { return _steam_id_gs?? default(ulong); }
       set { _steam_id_gs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_gsSpecified
+    {
+      get { return _steam_id_gs != null; }
+      set { if (value == (_steam_id_gs== null)) _steam_id_gs = value ? this.steam_id_gs : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_gs() { return steam_id_gsSpecified; }
+    private void Resetsteam_id_gs() { steam_id_gsSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private uint _game_ip_address = default(uint);
+    private uint? _game_ip_address;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_ip_address", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_ip_address
     {
-      get { return _game_ip_address; }
+      get { return _game_ip_address?? default(uint); }
       set { _game_ip_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_ip_addressSpecified
+    {
+      get { return _game_ip_address != null; }
+      set { if (value == (_game_ip_address== null)) _game_ip_address = value ? this.game_ip_address : (uint?)null; }
+    }
+    private bool ShouldSerializegame_ip_address() { return game_ip_addressSpecified; }
+    private void Resetgame_ip_address() { game_ip_addressSpecified = false; }
+    
 
-    private uint _game_port = default(uint);
+    private uint? _game_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_port
     {
-      get { return _game_port; }
+      get { return _game_port?? default(uint); }
       set { _game_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_portSpecified
+    {
+      get { return _game_port != null; }
+      set { if (value == (_game_port== null)) _game_port = value ? this.game_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_port() { return game_portSpecified; }
+    private void Resetgame_port() { game_portSpecified = false; }
+    
 
-    private bool _is_secure = default(bool);
+    private bool? _is_secure;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_secure", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_secure
     {
-      get { return _is_secure; }
+      get { return _is_secure?? default(bool); }
       set { _is_secure = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_secureSpecified
+    {
+      get { return _is_secure != null; }
+      set { if (value == (_is_secure== null)) _is_secure = value ? this.is_secure : (bool?)null; }
+    }
+    private bool ShouldSerializeis_secure() { return is_secureSpecified; }
+    private void Resetis_secure() { is_secureSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
 
-    private string _game_extra_info = "";
+    private string _game_extra_info;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_extra_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_extra_info
     {
-      get { return _game_extra_info; }
+      get { return _game_extra_info?? ""; }
       set { _game_extra_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_extra_infoSpecified
+    {
+      get { return _game_extra_info != null; }
+      set { if (value == (_game_extra_info== null)) _game_extra_info = value ? this.game_extra_info : (string)null; }
+    }
+    private bool ShouldSerializegame_extra_info() { return game_extra_infoSpecified; }
+    private void Resetgame_extra_info() { game_extra_infoSpecified = false; }
+    
 
-    private byte[] _game_data_blob = null;
+    private byte[] _game_data_blob;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"game_data_blob", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data_blob
     {
-      get { return _game_data_blob; }
+      get { return _game_data_blob?? null; }
       set { _game_data_blob = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_data_blobSpecified
+    {
+      get { return _game_data_blob != null; }
+      set { if (value == (_game_data_blob== null)) _game_data_blob = value ? this.game_data_blob : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data_blob() { return game_data_blobSpecified; }
+    private void Resetgame_data_blob() { game_data_blobSpecified = false; }
+    
 
-    private uint _process_id = default(uint);
+    private uint? _process_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"process_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint process_id
     {
-      get { return _process_id; }
+      get { return _process_id?? default(uint); }
       set { _process_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool process_idSpecified
+    {
+      get { return _process_id != null; }
+      set { if (value == (_process_id== null)) _process_id = value ? this.process_id : (uint?)null; }
+    }
+    private bool ShouldSerializeprocess_id() { return process_idSpecified; }
+    private void Resetprocess_id() { process_idSpecified = false; }
+    
 
-    private uint _streaming_provider_id = default(uint);
+    private uint? _streaming_provider_id;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"streaming_provider_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint streaming_provider_id
     {
-      get { return _streaming_provider_id; }
+      get { return _streaming_provider_id?? default(uint); }
       set { _streaming_provider_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool streaming_provider_idSpecified
+    {
+      get { return _streaming_provider_id != null; }
+      set { if (value == (_streaming_provider_id== null)) _streaming_provider_id = value ? this.streaming_provider_id : (uint?)null; }
+    }
+    private bool ShouldSerializestreaming_provider_id() { return streaming_provider_idSpecified; }
+    private void Resetstreaming_provider_id() { streaming_provider_idSpecified = false; }
+    
 
-    private uint _game_flags = default(uint);
+    private uint? _game_flags;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"game_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_flags
     {
-      get { return _game_flags; }
+      get { return _game_flags?? default(uint); }
       set { _game_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_flagsSpecified
+    {
+      get { return _game_flags != null; }
+      set { if (value == (_game_flags== null)) _game_flags = value ? this.game_flags : (uint?)null; }
+    }
+    private bool ShouldSerializegame_flags() { return game_flagsSpecified; }
+    private void Resetgame_flags() { game_flagsSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
 
-    private string _vr_hmd_vendor = "";
+    private string _vr_hmd_vendor;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"vr_hmd_vendor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vr_hmd_vendor
     {
-      get { return _vr_hmd_vendor; }
+      get { return _vr_hmd_vendor?? ""; }
       set { _vr_hmd_vendor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vr_hmd_vendorSpecified
+    {
+      get { return _vr_hmd_vendor != null; }
+      set { if (value == (_vr_hmd_vendor== null)) _vr_hmd_vendor = value ? this.vr_hmd_vendor : (string)null; }
+    }
+    private bool ShouldSerializevr_hmd_vendor() { return vr_hmd_vendorSpecified; }
+    private void Resetvr_hmd_vendor() { vr_hmd_vendorSpecified = false; }
+    
 
-    private string _vr_hmd_model = "";
+    private string _vr_hmd_model;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"vr_hmd_model", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vr_hmd_model
     {
-      get { return _vr_hmd_model; }
+      get { return _vr_hmd_model?? ""; }
       set { _vr_hmd_model = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vr_hmd_modelSpecified
+    {
+      get { return _vr_hmd_model != null; }
+      set { if (value == (_vr_hmd_model== null)) _vr_hmd_model = value ? this.vr_hmd_model : (string)null; }
+    }
+    private bool ShouldSerializevr_hmd_model() { return vr_hmd_modelSpecified; }
+    private void Resetvr_hmd_model() { vr_hmd_modelSpecified = false; }
+    
 
-    private uint _launch_option_type = (uint)0;
+    private uint? _launch_option_type;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"launch_option_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint launch_option_type
     {
-      get { return _launch_option_type; }
+      get { return _launch_option_type?? (uint)0; }
       set { _launch_option_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool launch_option_typeSpecified
+    {
+      get { return _launch_option_type != null; }
+      set { if (value == (_launch_option_type== null)) _launch_option_type = value ? this.launch_option_type : (uint?)null; }
+    }
+    private bool ShouldSerializelaunch_option_type() { return launch_option_typeSpecified; }
+    private void Resetlaunch_option_type() { launch_option_typeSpecified = false; }
+    
 
-    private int _primary_controller_type = (int)-1;
+    private int? _primary_controller_type;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"primary_controller_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)-1)]
     public int primary_controller_type
     {
-      get { return _primary_controller_type; }
+      get { return _primary_controller_type?? (int)-1; }
       set { _primary_controller_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool primary_controller_typeSpecified
+    {
+      get { return _primary_controller_type != null; }
+      set { if (value == (_primary_controller_type== null)) _primary_controller_type = value ? this.primary_controller_type : (int?)null; }
+    }
+    private bool ShouldSerializeprimary_controller_type() { return primary_controller_typeSpecified; }
+    private void Resetprimary_controller_type() { primary_controller_typeSpecified = false; }
+    
 
-    private string _primary_steam_controller_serial = "";
+    private string _primary_steam_controller_serial;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"primary_steam_controller_serial", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string primary_steam_controller_serial
     {
-      get { return _primary_steam_controller_serial; }
+      get { return _primary_steam_controller_serial?? ""; }
       set { _primary_steam_controller_serial = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool primary_steam_controller_serialSpecified
+    {
+      get { return _primary_steam_controller_serial != null; }
+      set { if (value == (_primary_steam_controller_serial== null)) _primary_steam_controller_serial = value ? this.primary_steam_controller_serial : (string)null; }
+    }
+    private bool ShouldSerializeprimary_steam_controller_serial() { return primary_steam_controller_serialSpecified; }
+    private void Resetprimary_steam_controller_serial() { primary_steam_controller_serialSpecified = false; }
+    
 
-    private uint _total_steam_controller_count = (uint)0;
+    private uint? _total_steam_controller_count;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"total_steam_controller_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint total_steam_controller_count
     {
-      get { return _total_steam_controller_count; }
+      get { return _total_steam_controller_count?? (uint)0; }
       set { _total_steam_controller_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_steam_controller_countSpecified
+    {
+      get { return _total_steam_controller_count != null; }
+      set { if (value == (_total_steam_controller_count== null)) _total_steam_controller_count = value ? this.total_steam_controller_count : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_steam_controller_count() { return total_steam_controller_countSpecified; }
+    private void Resettotal_steam_controller_count() { total_steam_controller_countSpecified = false; }
+    
 
-    private uint _total_non_steam_controller_count = (uint)0;
+    private uint? _total_non_steam_controller_count;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"total_non_steam_controller_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint total_non_steam_controller_count
     {
-      get { return _total_non_steam_controller_count; }
+      get { return _total_non_steam_controller_count?? (uint)0; }
       set { _total_non_steam_controller_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_non_steam_controller_countSpecified
+    {
+      get { return _total_non_steam_controller_count != null; }
+      set { if (value == (_total_non_steam_controller_count== null)) _total_non_steam_controller_count = value ? this.total_non_steam_controller_count : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_non_steam_controller_count() { return total_non_steam_controller_countSpecified; }
+    private void Resettotal_non_steam_controller_count() { total_non_steam_controller_countSpecified = false; }
+    
 
-    private ulong _controller_workshop_file_id = (ulong)0;
+    private ulong? _controller_workshop_file_id;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"controller_workshop_file_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(@"0")]
     public ulong controller_workshop_file_id
     {
-      get { return _controller_workshop_file_id; }
+      get { return _controller_workshop_file_id?? (ulong)0; }
       set { _controller_workshop_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_workshop_file_idSpecified
+    {
+      get { return _controller_workshop_file_id != null; }
+      set { if (value == (_controller_workshop_file_id== null)) _controller_workshop_file_id = value ? this.controller_workshop_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecontroller_workshop_file_id() { return controller_workshop_file_idSpecified; }
+    private void Resetcontroller_workshop_file_id() { controller_workshop_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1610,23 +2908,41 @@ namespace SteamKit2.Internal
     public CMsgGSApprove() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _owner_steam_id = default(ulong);
+    private ulong? _owner_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner_steam_id
     {
-      get { return _owner_steam_id; }
+      get { return _owner_steam_id?? default(ulong); }
       set { _owner_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_steam_idSpecified
+    {
+      get { return _owner_steam_id != null; }
+      set { if (value == (_owner_steam_id== null)) _owner_steam_id = value ? this.owner_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner_steam_id() { return owner_steam_idSpecified; }
+    private void Resetowner_steam_id() { owner_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1638,32 +2954,59 @@ namespace SteamKit2.Internal
     public CMsgGSDeny() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private int _edeny_reason = default(int);
+    private int? _edeny_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"edeny_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int edeny_reason
     {
-      get { return _edeny_reason; }
+      get { return _edeny_reason?? default(int); }
       set { _edeny_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool edeny_reasonSpecified
+    {
+      get { return _edeny_reason != null; }
+      set { if (value == (_edeny_reason== null)) _edeny_reason = value ? this.edeny_reason : (int?)null; }
+    }
+    private bool ShouldSerializeedeny_reason() { return edeny_reasonSpecified; }
+    private void Resetedeny_reason() { edeny_reasonSpecified = false; }
+    
 
-    private string _deny_string = "";
+    private string _deny_string;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"deny_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string deny_string
     {
-      get { return _deny_string; }
+      get { return _deny_string?? ""; }
       set { _deny_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deny_stringSpecified
+    {
+      get { return _deny_string != null; }
+      set { if (value == (_deny_string== null)) _deny_string = value ? this.deny_string : (string)null; }
+    }
+    private bool ShouldSerializedeny_string() { return deny_stringSpecified; }
+    private void Resetdeny_string() { deny_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1675,23 +3018,41 @@ namespace SteamKit2.Internal
     public CMsgGSKick() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private int _edeny_reason = default(int);
+    private int? _edeny_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"edeny_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int edeny_reason
     {
-      get { return _edeny_reason; }
+      get { return _edeny_reason?? default(int); }
       set { _edeny_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool edeny_reasonSpecified
+    {
+      get { return _edeny_reason != null; }
+      set { if (value == (_edeny_reason== null)) _edeny_reason = value ? this.edeny_reason : (int?)null; }
+    }
+    private bool ShouldSerializeedeny_reason() { return edeny_reasonSpecified; }
+    private void Resetedeny_reason() { edeny_reasonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1703,32 +3064,59 @@ namespace SteamKit2.Internal
     public CMsgClientAuthList() {}
     
 
-    private uint _tokens_left = default(uint);
+    private uint? _tokens_left;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tokens_left", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint tokens_left
     {
-      get { return _tokens_left; }
+      get { return _tokens_left?? default(uint); }
       set { _tokens_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokens_leftSpecified
+    {
+      get { return _tokens_left != null; }
+      set { if (value == (_tokens_left== null)) _tokens_left = value ? this.tokens_left : (uint?)null; }
+    }
+    private bool ShouldSerializetokens_left() { return tokens_leftSpecified; }
+    private void Resettokens_left() { tokens_leftSpecified = false; }
+    
 
-    private uint _last_request_seq = default(uint);
+    private uint? _last_request_seq;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_request_seq", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_request_seq
     {
-      get { return _last_request_seq; }
+      get { return _last_request_seq?? default(uint); }
       set { _last_request_seq = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_request_seqSpecified
+    {
+      get { return _last_request_seq != null; }
+      set { if (value == (_last_request_seq== null)) _last_request_seq = value ? this.last_request_seq : (uint?)null; }
+    }
+    private bool ShouldSerializelast_request_seq() { return last_request_seqSpecified; }
+    private void Resetlast_request_seq() { last_request_seqSpecified = false; }
+    
 
-    private uint _last_request_seq_from_server = default(uint);
+    private uint? _last_request_seq_from_server;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"last_request_seq_from_server", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_request_seq_from_server
     {
-      get { return _last_request_seq_from_server; }
+      get { return _last_request_seq_from_server?? default(uint); }
       set { _last_request_seq_from_server = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_request_seq_from_serverSpecified
+    {
+      get { return _last_request_seq_from_server != null; }
+      set { if (value == (_last_request_seq_from_server== null)) _last_request_seq_from_server = value ? this.last_request_seq_from_server : (uint?)null; }
+    }
+    private bool ShouldSerializelast_request_seq_from_server() { return last_request_seq_from_serverSpecified; }
+    private void Resetlast_request_seq_from_server() { last_request_seq_from_serverSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgAuthTicket> _tickets = new global::System.Collections.Generic.List<CMsgAuthTicket>();
     [global::ProtoBuf.ProtoMember(4, Name=@"tickets", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgAuthTicket> tickets
@@ -1744,14 +3132,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _message_sequence = default(uint);
+    private uint? _message_sequence;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"message_sequence", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint message_sequence
     {
-      get { return _message_sequence; }
+      get { return _message_sequence?? default(uint); }
       set { _message_sequence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_sequenceSpecified
+    {
+      get { return _message_sequence != null; }
+      set { if (value == (_message_sequence== null)) _message_sequence = value ? this.message_sequence : (uint?)null; }
+    }
+    private bool ShouldSerializemessage_sequence() { return message_sequenceSpecified; }
+    private void Resetmessage_sequence() { message_sequenceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1777,14 +3174,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _message_sequence = default(uint);
+    private uint? _message_sequence;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"message_sequence", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint message_sequence
     {
-      get { return _message_sequence; }
+      get { return _message_sequence?? default(uint); }
       set { _message_sequence = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool message_sequenceSpecified
+    {
+      get { return _message_sequence != null; }
+      set { if (value == (_message_sequence== null)) _message_sequence = value ? this.message_sequence : (uint?)null; }
+    }
+    private bool ShouldSerializemessage_sequence() { return message_sequenceSpecified; }
+    private void Resetmessage_sequence() { message_sequenceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1796,14 +3202,23 @@ namespace SteamKit2.Internal
     public CMsgClientFriendsList() {}
     
 
-    private bool _bincremental = default(bool);
+    private bool? _bincremental;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"bincremental", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bincremental
     {
-      get { return _bincremental; }
+      get { return _bincremental?? default(bool); }
       set { _bincremental = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bincrementalSpecified
+    {
+      get { return _bincremental != null; }
+      set { if (value == (_bincremental== null)) _bincremental = value ? this.bincremental : (bool?)null; }
+    }
+    private bool ShouldSerializebincremental() { return bincrementalSpecified; }
+    private void Resetbincremental() { bincrementalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientFriendsList.Friend> _friends = new global::System.Collections.Generic.List<CMsgClientFriendsList.Friend>();
     [global::ProtoBuf.ProtoMember(2, Name=@"friends", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientFriendsList.Friend> friends
@@ -1812,55 +3227,100 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _max_friend_count = default(uint);
+    private uint? _max_friend_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"max_friend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_friend_count
     {
-      get { return _max_friend_count; }
+      get { return _max_friend_count?? default(uint); }
       set { _max_friend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_friend_countSpecified
+    {
+      get { return _max_friend_count != null; }
+      set { if (value == (_max_friend_count== null)) _max_friend_count = value ? this.max_friend_count : (uint?)null; }
+    }
+    private bool ShouldSerializemax_friend_count() { return max_friend_countSpecified; }
+    private void Resetmax_friend_count() { max_friend_countSpecified = false; }
+    
 
-    private uint _active_friend_count = default(uint);
+    private uint? _active_friend_count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"active_friend_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint active_friend_count
     {
-      get { return _active_friend_count; }
+      get { return _active_friend_count?? default(uint); }
       set { _active_friend_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool active_friend_countSpecified
+    {
+      get { return _active_friend_count != null; }
+      set { if (value == (_active_friend_count== null)) _active_friend_count = value ? this.active_friend_count : (uint?)null; }
+    }
+    private bool ShouldSerializeactive_friend_count() { return active_friend_countSpecified; }
+    private void Resetactive_friend_count() { active_friend_countSpecified = false; }
+    
 
-    private bool _friends_limit_hit = default(bool);
+    private bool? _friends_limit_hit;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"friends_limit_hit", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool friends_limit_hit
     {
-      get { return _friends_limit_hit; }
+      get { return _friends_limit_hit?? default(bool); }
       set { _friends_limit_hit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friends_limit_hitSpecified
+    {
+      get { return _friends_limit_hit != null; }
+      set { if (value == (_friends_limit_hit== null)) _friends_limit_hit = value ? this.friends_limit_hit : (bool?)null; }
+    }
+    private bool ShouldSerializefriends_limit_hit() { return friends_limit_hitSpecified; }
+    private void Resetfriends_limit_hit() { friends_limit_hitSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Friend")]
   public partial class Friend : global::ProtoBuf.IExtensible
   {
     public Friend() {}
     
 
-    private ulong _ulfriendid = default(ulong);
+    private ulong? _ulfriendid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ulfriendid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ulfriendid
     {
-      get { return _ulfriendid; }
+      get { return _ulfriendid?? default(ulong); }
       set { _ulfriendid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ulfriendidSpecified
+    {
+      get { return _ulfriendid != null; }
+      set { if (value == (_ulfriendid== null)) _ulfriendid = value ? this.ulfriendid : (ulong?)null; }
+    }
+    private bool ShouldSerializeulfriendid() { return ulfriendidSpecified; }
+    private void Resetulfriendid() { ulfriendidSpecified = false; }
+    
 
-    private uint _efriendrelationship = default(uint);
+    private uint? _efriendrelationship;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"efriendrelationship", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint efriendrelationship
     {
-      get { return _efriendrelationship; }
+      get { return _efriendrelationship?? default(uint); }
       set { _efriendrelationship = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool efriendrelationshipSpecified
+    {
+      get { return _efriendrelationship != null; }
+      set { if (value == (_efriendrelationship== null)) _efriendrelationship = value ? this.efriendrelationship : (uint?)null; }
+    }
+    private bool ShouldSerializeefriendrelationship() { return efriendrelationshipSpecified; }
+    private void Resetefriendrelationship() { efriendrelationshipSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1877,23 +3337,41 @@ namespace SteamKit2.Internal
     public CMsgClientFriendsGroupsList() {}
     
 
-    private bool _bremoval = default(bool);
+    private bool? _bremoval;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"bremoval", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bremoval
     {
-      get { return _bremoval; }
+      get { return _bremoval?? default(bool); }
       set { _bremoval = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bremovalSpecified
+    {
+      get { return _bremoval != null; }
+      set { if (value == (_bremoval== null)) _bremoval = value ? this.bremoval : (bool?)null; }
+    }
+    private bool ShouldSerializebremoval() { return bremovalSpecified; }
+    private void Resetbremoval() { bremovalSpecified = false; }
+    
 
-    private bool _bincremental = default(bool);
+    private bool? _bincremental;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bincremental", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bincremental
     {
-      get { return _bincremental; }
+      get { return _bincremental?? default(bool); }
       set { _bincremental = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bincrementalSpecified
+    {
+      get { return _bincremental != null; }
+      set { if (value == (_bincremental== null)) _bincremental = value ? this.bincremental : (bool?)null; }
+    }
+    private bool ShouldSerializebincremental() { return bincrementalSpecified; }
+    private void Resetbincremental() { bincrementalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientFriendsGroupsList.FriendGroup> _friendGroups = new global::System.Collections.Generic.List<CMsgClientFriendsGroupsList.FriendGroup>();
     [global::ProtoBuf.ProtoMember(3, Name=@"friendGroups", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientFriendsGroupsList.FriendGroup> friendGroups
@@ -1914,23 +3392,41 @@ namespace SteamKit2.Internal
     public FriendGroup() {}
     
 
-    private int _nGroupID = default(int);
+    private int? _nGroupID;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"nGroupID", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int nGroupID
     {
-      get { return _nGroupID; }
+      get { return _nGroupID?? default(int); }
       set { _nGroupID = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nGroupIDSpecified
+    {
+      get { return _nGroupID != null; }
+      set { if (value == (_nGroupID== null)) _nGroupID = value ? this.nGroupID : (int?)null; }
+    }
+    private bool ShouldSerializenGroupID() { return nGroupIDSpecified; }
+    private void ResetnGroupID() { nGroupIDSpecified = false; }
+    
 
-    private string _strGroupName = "";
+    private string _strGroupName;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"strGroupName", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string strGroupName
     {
-      get { return _strGroupName; }
+      get { return _strGroupName?? ""; }
       set { _strGroupName = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool strGroupNameSpecified
+    {
+      get { return _strGroupName != null; }
+      set { if (value == (_strGroupName== null)) _strGroupName = value ? this.strGroupName : (string)null; }
+    }
+    private bool ShouldSerializestrGroupName() { return strGroupNameSpecified; }
+    private void ResetstrGroupName() { strGroupNameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1942,23 +3438,41 @@ namespace SteamKit2.Internal
     public FriendGroupsMembership() {}
     
 
-    private ulong _ulSteamID = default(ulong);
+    private ulong? _ulSteamID;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ulSteamID", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ulSteamID
     {
-      get { return _ulSteamID; }
+      get { return _ulSteamID?? default(ulong); }
       set { _ulSteamID = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ulSteamIDSpecified
+    {
+      get { return _ulSteamID != null; }
+      set { if (value == (_ulSteamID== null)) _ulSteamID = value ? this.ulSteamID : (ulong?)null; }
+    }
+    private bool ShouldSerializeulSteamID() { return ulSteamIDSpecified; }
+    private void ResetulSteamID() { ulSteamIDSpecified = false; }
+    
 
-    private int _nGroupID = default(int);
+    private int? _nGroupID;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"nGroupID", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int nGroupID
     {
-      get { return _nGroupID; }
+      get { return _nGroupID?? default(int); }
       set { _nGroupID = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nGroupIDSpecified
+    {
+      get { return _nGroupID != null; }
+      set { if (value == (_nGroupID== null)) _nGroupID = value ? this.nGroupID : (int?)null; }
+    }
+    private bool ShouldSerializenGroupID() { return nGroupIDSpecified; }
+    private void ResetnGroupID() { nGroupIDSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1975,23 +3489,41 @@ namespace SteamKit2.Internal
     public CMsgClientPlayerNicknameList() {}
     
 
-    private bool _removal = default(bool);
+    private bool? _removal;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"removal", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool removal
     {
-      get { return _removal; }
+      get { return _removal?? default(bool); }
       set { _removal = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool removalSpecified
+    {
+      get { return _removal != null; }
+      set { if (value == (_removal== null)) _removal = value ? this.removal : (bool?)null; }
+    }
+    private bool ShouldSerializeremoval() { return removalSpecified; }
+    private void Resetremoval() { removalSpecified = false; }
+    
 
-    private bool _incremental = default(bool);
+    private bool? _incremental;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"incremental", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool incremental
     {
-      get { return _incremental; }
+      get { return _incremental?? default(bool); }
       set { _incremental = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incrementalSpecified
+    {
+      get { return _incremental != null; }
+      set { if (value == (_incremental== null)) _incremental = value ? this.incremental : (bool?)null; }
+    }
+    private bool ShouldSerializeincremental() { return incrementalSpecified; }
+    private void Resetincremental() { incrementalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientPlayerNicknameList.PlayerNickname> _nicknames = new global::System.Collections.Generic.List<CMsgClientPlayerNicknameList.PlayerNickname>();
     [global::ProtoBuf.ProtoMember(3, Name=@"nicknames", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientPlayerNicknameList.PlayerNickname> nicknames
@@ -2005,23 +3537,41 @@ namespace SteamKit2.Internal
     public PlayerNickname() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _nickname = "";
+    private string _nickname;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"nickname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string nickname
     {
-      get { return _nickname; }
+      get { return _nickname?? ""; }
       set { _nickname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nicknameSpecified
+    {
+      get { return _nickname != null; }
+      set { if (value == (_nickname== null)) _nickname = value ? this.nickname : (string)null; }
+    }
+    private bool ShouldSerializenickname() { return nicknameSpecified; }
+    private void Resetnickname() { nicknameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2038,23 +3588,41 @@ namespace SteamKit2.Internal
     public CMsgClientSetPlayerNickname() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _nickname = "";
+    private string _nickname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"nickname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string nickname
     {
-      get { return _nickname; }
+      get { return _nickname?? ""; }
       set { _nickname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nicknameSpecified
+    {
+      get { return _nickname != null; }
+      set { if (value == (_nickname== null)) _nickname = value ? this.nickname : (string)null; }
+    }
+    private bool ShouldSerializenickname() { return nicknameSpecified; }
+    private void Resetnickname() { nicknameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2066,14 +3634,23 @@ namespace SteamKit2.Internal
     public CMsgClientSetPlayerNicknameResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2085,14 +3662,23 @@ namespace SteamKit2.Internal
     public CMsgClientLicenseList() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientLicenseList.License> _licenses = new global::System.Collections.Generic.List<CMsgClientLicenseList.License>();
     [global::ProtoBuf.ProtoMember(2, Name=@"licenses", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientLicenseList.License> licenses
@@ -2106,149 +3692,293 @@ namespace SteamKit2.Internal
     public License() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _time_next_process = default(uint);
+    private uint? _time_next_process;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_next_process", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_next_process
     {
-      get { return _time_next_process; }
+      get { return _time_next_process?? default(uint); }
       set { _time_next_process = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_next_processSpecified
+    {
+      get { return _time_next_process != null; }
+      set { if (value == (_time_next_process== null)) _time_next_process = value ? this.time_next_process : (uint?)null; }
+    }
+    private bool ShouldSerializetime_next_process() { return time_next_processSpecified; }
+    private void Resettime_next_process() { time_next_processSpecified = false; }
+    
 
-    private int _minute_limit = default(int);
+    private int? _minute_limit;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"minute_limit", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int minute_limit
     {
-      get { return _minute_limit; }
+      get { return _minute_limit?? default(int); }
       set { _minute_limit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool minute_limitSpecified
+    {
+      get { return _minute_limit != null; }
+      set { if (value == (_minute_limit== null)) _minute_limit = value ? this.minute_limit : (int?)null; }
+    }
+    private bool ShouldSerializeminute_limit() { return minute_limitSpecified; }
+    private void Resetminute_limit() { minute_limitSpecified = false; }
+    
 
-    private int _minutes_used = default(int);
+    private int? _minutes_used;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"minutes_used", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int minutes_used
     {
-      get { return _minutes_used; }
+      get { return _minutes_used?? default(int); }
       set { _minutes_used = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool minutes_usedSpecified
+    {
+      get { return _minutes_used != null; }
+      set { if (value == (_minutes_used== null)) _minutes_used = value ? this.minutes_used : (int?)null; }
+    }
+    private bool ShouldSerializeminutes_used() { return minutes_usedSpecified; }
+    private void Resetminutes_used() { minutes_usedSpecified = false; }
+    
 
-    private uint _payment_method = default(uint);
+    private uint? _payment_method;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"payment_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint payment_method
     {
-      get { return _payment_method; }
+      get { return _payment_method?? default(uint); }
       set { _payment_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payment_methodSpecified
+    {
+      get { return _payment_method != null; }
+      set { if (value == (_payment_method== null)) _payment_method = value ? this.payment_method : (uint?)null; }
+    }
+    private bool ShouldSerializepayment_method() { return payment_methodSpecified; }
+    private void Resetpayment_method() { payment_methodSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private string _purchase_country_code = "";
+    private string _purchase_country_code;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"purchase_country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string purchase_country_code
     {
-      get { return _purchase_country_code; }
+      get { return _purchase_country_code?? ""; }
       set { _purchase_country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_country_codeSpecified
+    {
+      get { return _purchase_country_code != null; }
+      set { if (value == (_purchase_country_code== null)) _purchase_country_code = value ? this.purchase_country_code : (string)null; }
+    }
+    private bool ShouldSerializepurchase_country_code() { return purchase_country_codeSpecified; }
+    private void Resetpurchase_country_code() { purchase_country_codeSpecified = false; }
+    
 
-    private uint _license_type = default(uint);
+    private uint? _license_type;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"license_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint license_type
     {
-      get { return _license_type; }
+      get { return _license_type?? default(uint); }
       set { _license_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool license_typeSpecified
+    {
+      get { return _license_type != null; }
+      set { if (value == (_license_type== null)) _license_type = value ? this.license_type : (uint?)null; }
+    }
+    private bool ShouldSerializelicense_type() { return license_typeSpecified; }
+    private void Resetlicense_type() { license_typeSpecified = false; }
+    
 
-    private int _territory_code = default(int);
+    private int? _territory_code;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"territory_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int territory_code
     {
-      get { return _territory_code; }
+      get { return _territory_code?? default(int); }
       set { _territory_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool territory_codeSpecified
+    {
+      get { return _territory_code != null; }
+      set { if (value == (_territory_code== null)) _territory_code = value ? this.territory_code : (int?)null; }
+    }
+    private bool ShouldSerializeterritory_code() { return territory_codeSpecified; }
+    private void Resetterritory_code() { territory_codeSpecified = false; }
+    
 
-    private int _change_number = default(int);
+    private int? _change_number;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(int); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (int?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
 
-    private uint _initial_period = default(uint);
+    private uint? _initial_period;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"initial_period", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_period
     {
-      get { return _initial_period; }
+      get { return _initial_period?? default(uint); }
       set { _initial_period = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_periodSpecified
+    {
+      get { return _initial_period != null; }
+      set { if (value == (_initial_period== null)) _initial_period = value ? this.initial_period : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_period() { return initial_periodSpecified; }
+    private void Resetinitial_period() { initial_periodSpecified = false; }
+    
 
-    private uint _initial_time_unit = default(uint);
+    private uint? _initial_time_unit;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"initial_time_unit", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint initial_time_unit
     {
-      get { return _initial_time_unit; }
+      get { return _initial_time_unit?? default(uint); }
       set { _initial_time_unit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool initial_time_unitSpecified
+    {
+      get { return _initial_time_unit != null; }
+      set { if (value == (_initial_time_unit== null)) _initial_time_unit = value ? this.initial_time_unit : (uint?)null; }
+    }
+    private bool ShouldSerializeinitial_time_unit() { return initial_time_unitSpecified; }
+    private void Resetinitial_time_unit() { initial_time_unitSpecified = false; }
+    
 
-    private uint _renewal_period = default(uint);
+    private uint? _renewal_period;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"renewal_period", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint renewal_period
     {
-      get { return _renewal_period; }
+      get { return _renewal_period?? default(uint); }
       set { _renewal_period = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool renewal_periodSpecified
+    {
+      get { return _renewal_period != null; }
+      set { if (value == (_renewal_period== null)) _renewal_period = value ? this.renewal_period : (uint?)null; }
+    }
+    private bool ShouldSerializerenewal_period() { return renewal_periodSpecified; }
+    private void Resetrenewal_period() { renewal_periodSpecified = false; }
+    
 
-    private uint _renewal_time_unit = default(uint);
+    private uint? _renewal_time_unit;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"renewal_time_unit", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint renewal_time_unit
     {
-      get { return _renewal_time_unit; }
+      get { return _renewal_time_unit?? default(uint); }
       set { _renewal_time_unit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool renewal_time_unitSpecified
+    {
+      get { return _renewal_time_unit != null; }
+      set { if (value == (_renewal_time_unit== null)) _renewal_time_unit = value ? this.renewal_time_unit : (uint?)null; }
+    }
+    private bool ShouldSerializerenewal_time_unit() { return renewal_time_unitSpecified; }
+    private void Resetrenewal_time_unit() { renewal_time_unitSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2265,50 +3995,95 @@ namespace SteamKit2.Internal
     public CMsgClientLBSSetScore() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _leaderboard_id = default(int);
+    private int? _leaderboard_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_id
     {
-      get { return _leaderboard_id; }
+      get { return _leaderboard_id?? default(int); }
       set { _leaderboard_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_idSpecified
+    {
+      get { return _leaderboard_id != null; }
+      set { if (value == (_leaderboard_id== null)) _leaderboard_id = value ? this.leaderboard_id : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_id() { return leaderboard_idSpecified; }
+    private void Resetleaderboard_id() { leaderboard_idSpecified = false; }
+    
 
-    private int _score = default(int);
+    private int? _score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int score
     {
-      get { return _score; }
+      get { return _score?? default(int); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (int?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private byte[] _details = null;
+    private byte[] _details;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"details", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] details
     {
-      get { return _details; }
+      get { return _details?? null; }
       set { _details = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool detailsSpecified
+    {
+      get { return _details != null; }
+      set { if (value == (_details== null)) _details = value ? this.details : (byte[])null; }
+    }
+    private bool ShouldSerializedetails() { return detailsSpecified; }
+    private void Resetdetails() { detailsSpecified = false; }
+    
 
-    private int _upload_score_method = default(int);
+    private int? _upload_score_method;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"upload_score_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int upload_score_method
     {
-      get { return _upload_score_method; }
+      get { return _upload_score_method?? default(int); }
       set { _upload_score_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_score_methodSpecified
+    {
+      get { return _upload_score_method != null; }
+      set { if (value == (_upload_score_method== null)) _upload_score_method = value ? this.upload_score_method : (int?)null; }
+    }
+    private bool ShouldSerializeupload_score_method() { return upload_score_methodSpecified; }
+    private void Resetupload_score_method() { upload_score_methodSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2320,50 +4095,95 @@ namespace SteamKit2.Internal
     public CMsgClientLBSSetScoreResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _leaderboard_entry_count = default(int);
+    private int? _leaderboard_entry_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_entry_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_entry_count
     {
-      get { return _leaderboard_entry_count; }
+      get { return _leaderboard_entry_count?? default(int); }
       set { _leaderboard_entry_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_entry_countSpecified
+    {
+      get { return _leaderboard_entry_count != null; }
+      set { if (value == (_leaderboard_entry_count== null)) _leaderboard_entry_count = value ? this.leaderboard_entry_count : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_entry_count() { return leaderboard_entry_countSpecified; }
+    private void Resetleaderboard_entry_count() { leaderboard_entry_countSpecified = false; }
+    
 
-    private bool _score_changed = default(bool);
+    private bool? _score_changed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score_changed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool score_changed
     {
-      get { return _score_changed; }
+      get { return _score_changed?? default(bool); }
       set { _score_changed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool score_changedSpecified
+    {
+      get { return _score_changed != null; }
+      set { if (value == (_score_changed== null)) _score_changed = value ? this.score_changed : (bool?)null; }
+    }
+    private bool ShouldSerializescore_changed() { return score_changedSpecified; }
+    private void Resetscore_changed() { score_changedSpecified = false; }
+    
 
-    private int _global_rank_previous = default(int);
+    private int? _global_rank_previous;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"global_rank_previous", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int global_rank_previous
     {
-      get { return _global_rank_previous; }
+      get { return _global_rank_previous?? default(int); }
       set { _global_rank_previous = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool global_rank_previousSpecified
+    {
+      get { return _global_rank_previous != null; }
+      set { if (value == (_global_rank_previous== null)) _global_rank_previous = value ? this.global_rank_previous : (int?)null; }
+    }
+    private bool ShouldSerializeglobal_rank_previous() { return global_rank_previousSpecified; }
+    private void Resetglobal_rank_previous() { global_rank_previousSpecified = false; }
+    
 
-    private int _global_rank_new = default(int);
+    private int? _global_rank_new;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"global_rank_new", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int global_rank_new
     {
-      get { return _global_rank_new; }
+      get { return _global_rank_new?? default(int); }
       set { _global_rank_new = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool global_rank_newSpecified
+    {
+      get { return _global_rank_new != null; }
+      set { if (value == (_global_rank_new== null)) _global_rank_new = value ? this.global_rank_new : (int?)null; }
+    }
+    private bool ShouldSerializeglobal_rank_new() { return global_rank_newSpecified; }
+    private void Resetglobal_rank_new() { global_rank_newSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2375,32 +4195,59 @@ namespace SteamKit2.Internal
     public CMsgClientLBSSetUGC() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _leaderboard_id = default(int);
+    private int? _leaderboard_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_id
     {
-      get { return _leaderboard_id; }
+      get { return _leaderboard_id?? default(int); }
       set { _leaderboard_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_idSpecified
+    {
+      get { return _leaderboard_id != null; }
+      set { if (value == (_leaderboard_id== null)) _leaderboard_id = value ? this.leaderboard_id : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_id() { return leaderboard_idSpecified; }
+    private void Resetleaderboard_id() { leaderboard_idSpecified = false; }
+    
 
-    private ulong _ugc_id = default(ulong);
+    private ulong? _ugc_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ugc_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_id
     {
-      get { return _ugc_id; }
+      get { return _ugc_id?? default(ulong); }
       set { _ugc_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_idSpecified
+    {
+      get { return _ugc_id != null; }
+      set { if (value == (_ugc_id== null)) _ugc_id = value ? this.ugc_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_id() { return ugc_idSpecified; }
+    private void Resetugc_id() { ugc_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2412,14 +4259,23 @@ namespace SteamKit2.Internal
     public CMsgClientLBSSetUGCResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2431,50 +4287,95 @@ namespace SteamKit2.Internal
     public CMsgClientLBSFindOrCreateLB() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _leaderboard_sort_method = default(int);
+    private int? _leaderboard_sort_method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_sort_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_sort_method
     {
-      get { return _leaderboard_sort_method; }
+      get { return _leaderboard_sort_method?? default(int); }
       set { _leaderboard_sort_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_sort_methodSpecified
+    {
+      get { return _leaderboard_sort_method != null; }
+      set { if (value == (_leaderboard_sort_method== null)) _leaderboard_sort_method = value ? this.leaderboard_sort_method : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_sort_method() { return leaderboard_sort_methodSpecified; }
+    private void Resetleaderboard_sort_method() { leaderboard_sort_methodSpecified = false; }
+    
 
-    private int _leaderboard_display_type = default(int);
+    private int? _leaderboard_display_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"leaderboard_display_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_display_type
     {
-      get { return _leaderboard_display_type; }
+      get { return _leaderboard_display_type?? default(int); }
       set { _leaderboard_display_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_display_typeSpecified
+    {
+      get { return _leaderboard_display_type != null; }
+      set { if (value == (_leaderboard_display_type== null)) _leaderboard_display_type = value ? this.leaderboard_display_type : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_display_type() { return leaderboard_display_typeSpecified; }
+    private void Resetleaderboard_display_type() { leaderboard_display_typeSpecified = false; }
+    
 
-    private bool _create_if_not_found = default(bool);
+    private bool? _create_if_not_found;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"create_if_not_found", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool create_if_not_found
     {
-      get { return _create_if_not_found; }
+      get { return _create_if_not_found?? default(bool); }
       set { _create_if_not_found = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool create_if_not_foundSpecified
+    {
+      get { return _create_if_not_found != null; }
+      set { if (value == (_create_if_not_found== null)) _create_if_not_found = value ? this.create_if_not_found : (bool?)null; }
+    }
+    private bool ShouldSerializecreate_if_not_found() { return create_if_not_foundSpecified; }
+    private void Resetcreate_if_not_found() { create_if_not_foundSpecified = false; }
+    
 
-    private string _leaderboard_name = "";
+    private string _leaderboard_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"leaderboard_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string leaderboard_name
     {
-      get { return _leaderboard_name; }
+      get { return _leaderboard_name?? ""; }
       set { _leaderboard_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_nameSpecified
+    {
+      get { return _leaderboard_name != null; }
+      set { if (value == (_leaderboard_name== null)) _leaderboard_name = value ? this.leaderboard_name : (string)null; }
+    }
+    private bool ShouldSerializeleaderboard_name() { return leaderboard_nameSpecified; }
+    private void Resetleaderboard_name() { leaderboard_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2486,59 +4387,113 @@ namespace SteamKit2.Internal
     public CMsgClientLBSFindOrCreateLBResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _leaderboard_id = default(int);
+    private int? _leaderboard_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_id
     {
-      get { return _leaderboard_id; }
+      get { return _leaderboard_id?? default(int); }
       set { _leaderboard_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_idSpecified
+    {
+      get { return _leaderboard_id != null; }
+      set { if (value == (_leaderboard_id== null)) _leaderboard_id = value ? this.leaderboard_id : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_id() { return leaderboard_idSpecified; }
+    private void Resetleaderboard_id() { leaderboard_idSpecified = false; }
+    
 
-    private int _leaderboard_entry_count = default(int);
+    private int? _leaderboard_entry_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"leaderboard_entry_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_entry_count
     {
-      get { return _leaderboard_entry_count; }
+      get { return _leaderboard_entry_count?? default(int); }
       set { _leaderboard_entry_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_entry_countSpecified
+    {
+      get { return _leaderboard_entry_count != null; }
+      set { if (value == (_leaderboard_entry_count== null)) _leaderboard_entry_count = value ? this.leaderboard_entry_count : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_entry_count() { return leaderboard_entry_countSpecified; }
+    private void Resetleaderboard_entry_count() { leaderboard_entry_countSpecified = false; }
+    
 
-    private int _leaderboard_sort_method = (int)0;
+    private int? _leaderboard_sort_method;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"leaderboard_sort_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int leaderboard_sort_method
     {
-      get { return _leaderboard_sort_method; }
+      get { return _leaderboard_sort_method?? (int)0; }
       set { _leaderboard_sort_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_sort_methodSpecified
+    {
+      get { return _leaderboard_sort_method != null; }
+      set { if (value == (_leaderboard_sort_method== null)) _leaderboard_sort_method = value ? this.leaderboard_sort_method : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_sort_method() { return leaderboard_sort_methodSpecified; }
+    private void Resetleaderboard_sort_method() { leaderboard_sort_methodSpecified = false; }
+    
 
-    private int _leaderboard_display_type = (int)0;
+    private int? _leaderboard_display_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"leaderboard_display_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int leaderboard_display_type
     {
-      get { return _leaderboard_display_type; }
+      get { return _leaderboard_display_type?? (int)0; }
       set { _leaderboard_display_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_display_typeSpecified
+    {
+      get { return _leaderboard_display_type != null; }
+      set { if (value == (_leaderboard_display_type== null)) _leaderboard_display_type = value ? this.leaderboard_display_type : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_display_type() { return leaderboard_display_typeSpecified; }
+    private void Resetleaderboard_display_type() { leaderboard_display_typeSpecified = false; }
+    
 
-    private string _leaderboard_name = "";
+    private string _leaderboard_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"leaderboard_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string leaderboard_name
     {
-      get { return _leaderboard_name; }
+      get { return _leaderboard_name?? ""; }
       set { _leaderboard_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_nameSpecified
+    {
+      get { return _leaderboard_name != null; }
+      set { if (value == (_leaderboard_name== null)) _leaderboard_name = value ? this.leaderboard_name : (string)null; }
+    }
+    private bool ShouldSerializeleaderboard_name() { return leaderboard_nameSpecified; }
+    private void Resetleaderboard_name() { leaderboard_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2550,50 +4505,95 @@ namespace SteamKit2.Internal
     public CMsgClientLBSGetLBEntries() {}
     
 
-    private int _app_id = default(int);
+    private int? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(int); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (int?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _leaderboard_id = default(int);
+    private int? _leaderboard_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_id
     {
-      get { return _leaderboard_id; }
+      get { return _leaderboard_id?? default(int); }
       set { _leaderboard_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_idSpecified
+    {
+      get { return _leaderboard_id != null; }
+      set { if (value == (_leaderboard_id== null)) _leaderboard_id = value ? this.leaderboard_id : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_id() { return leaderboard_idSpecified; }
+    private void Resetleaderboard_id() { leaderboard_idSpecified = false; }
+    
 
-    private int _range_start = default(int);
+    private int? _range_start;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"range_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int range_start
     {
-      get { return _range_start; }
+      get { return _range_start?? default(int); }
       set { _range_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool range_startSpecified
+    {
+      get { return _range_start != null; }
+      set { if (value == (_range_start== null)) _range_start = value ? this.range_start : (int?)null; }
+    }
+    private bool ShouldSerializerange_start() { return range_startSpecified; }
+    private void Resetrange_start() { range_startSpecified = false; }
+    
 
-    private int _range_end = default(int);
+    private int? _range_end;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"range_end", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int range_end
     {
-      get { return _range_end; }
+      get { return _range_end?? default(int); }
       set { _range_end = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool range_endSpecified
+    {
+      get { return _range_end != null; }
+      set { if (value == (_range_end== null)) _range_end = value ? this.range_end : (int?)null; }
+    }
+    private bool ShouldSerializerange_end() { return range_endSpecified; }
+    private void Resetrange_end() { range_endSpecified = false; }
+    
 
-    private int _leaderboard_data_request = default(int);
+    private int? _leaderboard_data_request;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"leaderboard_data_request", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_data_request
     {
-      get { return _leaderboard_data_request; }
+      get { return _leaderboard_data_request?? default(int); }
       set { _leaderboard_data_request = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_data_requestSpecified
+    {
+      get { return _leaderboard_data_request != null; }
+      set { if (value == (_leaderboard_data_request== null)) _leaderboard_data_request = value ? this.leaderboard_data_request : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_data_request() { return leaderboard_data_requestSpecified; }
+    private void Resetleaderboard_data_request() { leaderboard_data_requestSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(6, Name=@"steamids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamids
@@ -2612,23 +4612,41 @@ namespace SteamKit2.Internal
     public CMsgClientLBSGetLBEntriesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _leaderboard_entry_count = default(int);
+    private int? _leaderboard_entry_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"leaderboard_entry_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int leaderboard_entry_count
     {
-      get { return _leaderboard_entry_count; }
+      get { return _leaderboard_entry_count?? default(int); }
       set { _leaderboard_entry_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool leaderboard_entry_countSpecified
+    {
+      get { return _leaderboard_entry_count != null; }
+      set { if (value == (_leaderboard_entry_count== null)) _leaderboard_entry_count = value ? this.leaderboard_entry_count : (int?)null; }
+    }
+    private bool ShouldSerializeleaderboard_entry_count() { return leaderboard_entry_countSpecified; }
+    private void Resetleaderboard_entry_count() { leaderboard_entry_countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientLBSGetLBEntriesResponse.Entry> _entries = new global::System.Collections.Generic.List<CMsgClientLBSGetLBEntriesResponse.Entry>();
     [global::ProtoBuf.ProtoMember(3, Name=@"entries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientLBSGetLBEntriesResponse.Entry> entries
@@ -2642,50 +4660,95 @@ namespace SteamKit2.Internal
     public Entry() {}
     
 
-    private ulong _steam_id_user = default(ulong);
+    private ulong? _steam_id_user;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_user", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_user
     {
-      get { return _steam_id_user; }
+      get { return _steam_id_user?? default(ulong); }
       set { _steam_id_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_userSpecified
+    {
+      get { return _steam_id_user != null; }
+      set { if (value == (_steam_id_user== null)) _steam_id_user = value ? this.steam_id_user : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_user() { return steam_id_userSpecified; }
+    private void Resetsteam_id_user() { steam_id_userSpecified = false; }
+    
 
-    private int _global_rank = default(int);
+    private int? _global_rank;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"global_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int global_rank
     {
-      get { return _global_rank; }
+      get { return _global_rank?? default(int); }
       set { _global_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool global_rankSpecified
+    {
+      get { return _global_rank != null; }
+      set { if (value == (_global_rank== null)) _global_rank = value ? this.global_rank : (int?)null; }
+    }
+    private bool ShouldSerializeglobal_rank() { return global_rankSpecified; }
+    private void Resetglobal_rank() { global_rankSpecified = false; }
+    
 
-    private int _score = default(int);
+    private int? _score;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int score
     {
-      get { return _score; }
+      get { return _score?? default(int); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (int?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private byte[] _details = null;
+    private byte[] _details;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"details", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] details
     {
-      get { return _details; }
+      get { return _details?? null; }
       set { _details = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool detailsSpecified
+    {
+      get { return _details != null; }
+      set { if (value == (_details== null)) _details = value ? this.details : (byte[])null; }
+    }
+    private bool ShouldSerializedetails() { return detailsSpecified; }
+    private void Resetdetails() { detailsSpecified = false; }
+    
 
-    private ulong _ugc_id = default(ulong);
+    private ulong? _ugc_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ugc_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugc_id
     {
-      get { return _ugc_id; }
+      get { return _ugc_id?? default(ulong); }
       set { _ugc_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugc_idSpecified
+    {
+      get { return _ugc_id != null; }
+      set { if (value == (_ugc_id== null)) _ugc_id = value ? this.ugc_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeugc_id() { return ugc_idSpecified; }
+    private void Resetugc_id() { ugc_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2702,113 +4765,221 @@ namespace SteamKit2.Internal
     public CMsgClientAccountInfo() {}
     
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private string _ip_country = "";
+    private string _ip_country;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip_country", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ip_country
     {
-      get { return _ip_country; }
+      get { return _ip_country?? ""; }
       set { _ip_country = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_countrySpecified
+    {
+      get { return _ip_country != null; }
+      set { if (value == (_ip_country== null)) _ip_country = value ? this.ip_country : (string)null; }
+    }
+    private bool ShouldSerializeip_country() { return ip_countrySpecified; }
+    private void Resetip_country() { ip_countrySpecified = false; }
+    
 
-    private int _count_authed_computers = default(int);
+    private int? _count_authed_computers;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"count_authed_computers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int count_authed_computers
     {
-      get { return _count_authed_computers; }
+      get { return _count_authed_computers?? default(int); }
       set { _count_authed_computers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_authed_computersSpecified
+    {
+      get { return _count_authed_computers != null; }
+      set { if (value == (_count_authed_computers== null)) _count_authed_computers = value ? this.count_authed_computers : (int?)null; }
+    }
+    private bool ShouldSerializecount_authed_computers() { return count_authed_computersSpecified; }
+    private void Resetcount_authed_computers() { count_authed_computersSpecified = false; }
+    
 
-    private uint _account_flags = default(uint);
+    private uint? _account_flags;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint account_flags
     {
-      get { return _account_flags; }
+      get { return _account_flags?? default(uint); }
       set { _account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_flagsSpecified
+    {
+      get { return _account_flags != null; }
+      set { if (value == (_account_flags== null)) _account_flags = value ? this.account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeaccount_flags() { return account_flagsSpecified; }
+    private void Resetaccount_flags() { account_flagsSpecified = false; }
+    
 
-    private ulong _facebook_id = default(ulong);
+    private ulong? _facebook_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"facebook_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong facebook_id
     {
-      get { return _facebook_id; }
+      get { return _facebook_id?? default(ulong); }
       set { _facebook_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool facebook_idSpecified
+    {
+      get { return _facebook_id != null; }
+      set { if (value == (_facebook_id== null)) _facebook_id = value ? this.facebook_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefacebook_id() { return facebook_idSpecified; }
+    private void Resetfacebook_id() { facebook_idSpecified = false; }
+    
 
-    private string _facebook_name = "";
+    private string _facebook_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"facebook_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string facebook_name
     {
-      get { return _facebook_name; }
+      get { return _facebook_name?? ""; }
       set { _facebook_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool facebook_nameSpecified
+    {
+      get { return _facebook_name != null; }
+      set { if (value == (_facebook_name== null)) _facebook_name = value ? this.facebook_name : (string)null; }
+    }
+    private bool ShouldSerializefacebook_name() { return facebook_nameSpecified; }
+    private void Resetfacebook_name() { facebook_nameSpecified = false; }
+    
 
-    private bool _steamguard_notify_newmachines = default(bool);
+    private bool? _steamguard_notify_newmachines;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"steamguard_notify_newmachines", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool steamguard_notify_newmachines
     {
-      get { return _steamguard_notify_newmachines; }
+      get { return _steamguard_notify_newmachines?? default(bool); }
       set { _steamguard_notify_newmachines = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_notify_newmachinesSpecified
+    {
+      get { return _steamguard_notify_newmachines != null; }
+      set { if (value == (_steamguard_notify_newmachines== null)) _steamguard_notify_newmachines = value ? this.steamguard_notify_newmachines : (bool?)null; }
+    }
+    private bool ShouldSerializesteamguard_notify_newmachines() { return steamguard_notify_newmachinesSpecified; }
+    private void Resetsteamguard_notify_newmachines() { steamguard_notify_newmachinesSpecified = false; }
+    
 
-    private string _steamguard_machine_name_user_chosen = "";
+    private string _steamguard_machine_name_user_chosen;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"steamguard_machine_name_user_chosen", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string steamguard_machine_name_user_chosen
     {
-      get { return _steamguard_machine_name_user_chosen; }
+      get { return _steamguard_machine_name_user_chosen?? ""; }
       set { _steamguard_machine_name_user_chosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_machine_name_user_chosenSpecified
+    {
+      get { return _steamguard_machine_name_user_chosen != null; }
+      set { if (value == (_steamguard_machine_name_user_chosen== null)) _steamguard_machine_name_user_chosen = value ? this.steamguard_machine_name_user_chosen : (string)null; }
+    }
+    private bool ShouldSerializesteamguard_machine_name_user_chosen() { return steamguard_machine_name_user_chosenSpecified; }
+    private void Resetsteamguard_machine_name_user_chosen() { steamguard_machine_name_user_chosenSpecified = false; }
+    
 
-    private bool _is_phone_verified = default(bool);
+    private bool? _is_phone_verified;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"is_phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_verified
     {
-      get { return _is_phone_verified; }
+      get { return _is_phone_verified?? default(bool); }
       set { _is_phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_verifiedSpecified
+    {
+      get { return _is_phone_verified != null; }
+      set { if (value == (_is_phone_verified== null)) _is_phone_verified = value ? this.is_phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_verified() { return is_phone_verifiedSpecified; }
+    private void Resetis_phone_verified() { is_phone_verifiedSpecified = false; }
+    
 
-    private uint _two_factor_state = default(uint);
+    private uint? _two_factor_state;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"two_factor_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint two_factor_state
     {
-      get { return _two_factor_state; }
+      get { return _two_factor_state?? default(uint); }
       set { _two_factor_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool two_factor_stateSpecified
+    {
+      get { return _two_factor_state != null; }
+      set { if (value == (_two_factor_state== null)) _two_factor_state = value ? this.two_factor_state : (uint?)null; }
+    }
+    private bool ShouldSerializetwo_factor_state() { return two_factor_stateSpecified; }
+    private void Resettwo_factor_state() { two_factor_stateSpecified = false; }
+    
 
-    private bool _is_phone_identifying = default(bool);
+    private bool? _is_phone_identifying;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"is_phone_identifying", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_identifying
     {
-      get { return _is_phone_identifying; }
+      get { return _is_phone_identifying?? default(bool); }
       set { _is_phone_identifying = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_identifyingSpecified
+    {
+      get { return _is_phone_identifying != null; }
+      set { if (value == (_is_phone_identifying== null)) _is_phone_identifying = value ? this.is_phone_identifying : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_identifying() { return is_phone_identifyingSpecified; }
+    private void Resetis_phone_identifying() { is_phone_identifyingSpecified = false; }
+    
 
-    private bool _is_phone_needing_reverify = default(bool);
+    private bool? _is_phone_needing_reverify;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"is_phone_needing_reverify", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_needing_reverify
     {
-      get { return _is_phone_needing_reverify; }
+      get { return _is_phone_needing_reverify?? default(bool); }
       set { _is_phone_needing_reverify = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_needing_reverifySpecified
+    {
+      get { return _is_phone_needing_reverify != null; }
+      set { if (value == (_is_phone_needing_reverify== null)) _is_phone_needing_reverify = value ? this.is_phone_needing_reverify : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_needing_reverify() { return is_phone_needing_reverifySpecified; }
+    private void Resetis_phone_needing_reverify() { is_phone_needing_reverifySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2832,32 +5003,59 @@ namespace SteamKit2.Internal
     public AppMinutesPlayedData() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _forever = default(int);
+    private int? _forever;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"forever", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int forever
     {
-      get { return _forever; }
+      get { return _forever?? default(int); }
       set { _forever = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool foreverSpecified
+    {
+      get { return _forever != null; }
+      set { if (value == (_forever== null)) _forever = value ? this.forever : (int?)null; }
+    }
+    private bool ShouldSerializeforever() { return foreverSpecified; }
+    private void Resetforever() { foreverSpecified = false; }
+    
 
-    private int _last_two_weeks = default(int);
+    private int? _last_two_weeks;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"last_two_weeks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int last_two_weeks
     {
-      get { return _last_two_weeks; }
+      get { return _last_two_weeks?? default(int); }
       set { _last_two_weeks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_two_weeksSpecified
+    {
+      get { return _last_two_weeks != null; }
+      set { if (value == (_last_two_weeks== null)) _last_two_weeks = value ? this.last_two_weeks : (int?)null; }
+    }
+    private bool ShouldSerializelast_two_weeks() { return last_two_weeksSpecified; }
+    private void Resetlast_two_weeks() { last_two_weeksSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2874,41 +5072,77 @@ namespace SteamKit2.Internal
     public CMsgClientIsLimitedAccount() {}
     
 
-    private bool _bis_limited_account = default(bool);
+    private bool? _bis_limited_account;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"bis_limited_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bis_limited_account
     {
-      get { return _bis_limited_account; }
+      get { return _bis_limited_account?? default(bool); }
       set { _bis_limited_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bis_limited_accountSpecified
+    {
+      get { return _bis_limited_account != null; }
+      set { if (value == (_bis_limited_account== null)) _bis_limited_account = value ? this.bis_limited_account : (bool?)null; }
+    }
+    private bool ShouldSerializebis_limited_account() { return bis_limited_accountSpecified; }
+    private void Resetbis_limited_account() { bis_limited_accountSpecified = false; }
+    
 
-    private bool _bis_community_banned = default(bool);
+    private bool? _bis_community_banned;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bis_community_banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bis_community_banned
     {
-      get { return _bis_community_banned; }
+      get { return _bis_community_banned?? default(bool); }
       set { _bis_community_banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bis_community_bannedSpecified
+    {
+      get { return _bis_community_banned != null; }
+      set { if (value == (_bis_community_banned== null)) _bis_community_banned = value ? this.bis_community_banned : (bool?)null; }
+    }
+    private bool ShouldSerializebis_community_banned() { return bis_community_bannedSpecified; }
+    private void Resetbis_community_banned() { bis_community_bannedSpecified = false; }
+    
 
-    private bool _bis_locked_account = default(bool);
+    private bool? _bis_locked_account;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"bis_locked_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bis_locked_account
     {
-      get { return _bis_locked_account; }
+      get { return _bis_locked_account?? default(bool); }
       set { _bis_locked_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bis_locked_accountSpecified
+    {
+      get { return _bis_locked_account != null; }
+      set { if (value == (_bis_locked_account== null)) _bis_locked_account = value ? this.bis_locked_account : (bool?)null; }
+    }
+    private bool ShouldSerializebis_locked_account() { return bis_locked_accountSpecified; }
+    private void Resetbis_locked_account() { bis_locked_accountSpecified = false; }
+    
 
-    private bool _bis_limited_account_allowed_to_invite_friends = default(bool);
+    private bool? _bis_limited_account_allowed_to_invite_friends;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bis_limited_account_allowed_to_invite_friends", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool bis_limited_account_allowed_to_invite_friends
     {
-      get { return _bis_limited_account_allowed_to_invite_friends; }
+      get { return _bis_limited_account_allowed_to_invite_friends?? default(bool); }
       set { _bis_limited_account_allowed_to_invite_friends = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bis_limited_account_allowed_to_invite_friendsSpecified
+    {
+      get { return _bis_limited_account_allowed_to_invite_friends != null; }
+      set { if (value == (_bis_limited_account_allowed_to_invite_friends== null)) _bis_limited_account_allowed_to_invite_friends = value ? this.bis_limited_account_allowed_to_invite_friends : (bool?)null; }
+    }
+    private bool ShouldSerializebis_limited_account_allowed_to_invite_friends() { return bis_limited_account_allowed_to_invite_friendsSpecified; }
+    private void Resetbis_limited_account_allowed_to_invite_friends() { bis_limited_account_allowed_to_invite_friendsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2920,14 +5154,23 @@ namespace SteamKit2.Internal
     public CMsgClientRequestFriendData() {}
     
 
-    private uint _persona_state_requested = default(uint);
+    private uint? _persona_state_requested;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona_state_requested", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint persona_state_requested
     {
-      get { return _persona_state_requested; }
+      get { return _persona_state_requested?? default(uint); }
       set { _persona_state_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_state_requestedSpecified
+    {
+      get { return _persona_state_requested != null; }
+      set { if (value == (_persona_state_requested== null)) _persona_state_requested = value ? this.persona_state_requested : (uint?)null; }
+    }
+    private bool ShouldSerializepersona_state_requested() { return persona_state_requestedSpecified; }
+    private void Resetpersona_state_requested() { persona_state_requestedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _friends = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"friends", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> friends
@@ -2946,59 +5189,113 @@ namespace SteamKit2.Internal
     public CMsgClientChangeStatus() {}
     
 
-    private uint _persona_state = default(uint);
+    private uint? _persona_state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint persona_state
     {
-      get { return _persona_state; }
+      get { return _persona_state?? default(uint); }
       set { _persona_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_stateSpecified
+    {
+      get { return _persona_state != null; }
+      set { if (value == (_persona_state== null)) _persona_state = value ? this.persona_state : (uint?)null; }
+    }
+    private bool ShouldSerializepersona_state() { return persona_stateSpecified; }
+    private void Resetpersona_state() { persona_stateSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private bool _is_auto_generated_name = default(bool);
+    private bool? _is_auto_generated_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_auto_generated_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_auto_generated_name
     {
-      get { return _is_auto_generated_name; }
+      get { return _is_auto_generated_name?? default(bool); }
       set { _is_auto_generated_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_auto_generated_nameSpecified
+    {
+      get { return _is_auto_generated_name != null; }
+      set { if (value == (_is_auto_generated_name== null)) _is_auto_generated_name = value ? this.is_auto_generated_name : (bool?)null; }
+    }
+    private bool ShouldSerializeis_auto_generated_name() { return is_auto_generated_nameSpecified; }
+    private void Resetis_auto_generated_name() { is_auto_generated_nameSpecified = false; }
+    
 
-    private bool _high_priority = default(bool);
+    private bool? _high_priority;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"high_priority", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool high_priority
     {
-      get { return _high_priority; }
+      get { return _high_priority?? default(bool); }
       set { _high_priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool high_prioritySpecified
+    {
+      get { return _high_priority != null; }
+      set { if (value == (_high_priority== null)) _high_priority = value ? this.high_priority : (bool?)null; }
+    }
+    private bool ShouldSerializehigh_priority() { return high_prioritySpecified; }
+    private void Resethigh_priority() { high_prioritySpecified = false; }
+    
 
-    private bool _persona_set_by_user = default(bool);
+    private bool? _persona_set_by_user;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"persona_set_by_user", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool persona_set_by_user
     {
-      get { return _persona_set_by_user; }
+      get { return _persona_set_by_user?? default(bool); }
       set { _persona_set_by_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_set_by_userSpecified
+    {
+      get { return _persona_set_by_user != null; }
+      set { if (value == (_persona_set_by_user== null)) _persona_set_by_user = value ? this.persona_set_by_user : (bool?)null; }
+    }
+    private bool ShouldSerializepersona_set_by_user() { return persona_set_by_userSpecified; }
+    private void Resetpersona_set_by_user() { persona_set_by_userSpecified = false; }
+    
 
-    private uint _persona_state_flags = (uint)0;
+    private uint? _persona_state_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"persona_state_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint persona_state_flags
     {
-      get { return _persona_state_flags; }
+      get { return _persona_state_flags?? (uint)0; }
       set { _persona_state_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_state_flagsSpecified
+    {
+      get { return _persona_state_flags != null; }
+      set { if (value == (_persona_state_flags== null)) _persona_state_flags = value ? this.persona_state_flags : (uint?)null; }
+    }
+    private bool ShouldSerializepersona_state_flags() { return persona_state_flagsSpecified; }
+    private void Resetpersona_state_flags() { persona_state_flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3010,23 +5307,41 @@ namespace SteamKit2.Internal
     public CMsgPersonaChangeResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3038,14 +5353,23 @@ namespace SteamKit2.Internal
     public CMsgClientPersonaState() {}
     
 
-    private uint _status_flags = default(uint);
+    private uint? _status_flags;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"status_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint status_flags
     {
-      get { return _status_flags; }
+      get { return _status_flags?? default(uint); }
       set { _status_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_flagsSpecified
+    {
+      get { return _status_flags != null; }
+      set { if (value == (_status_flags== null)) _status_flags = value ? this.status_flags : (uint?)null; }
+    }
+    private bool ShouldSerializestatus_flags() { return status_flagsSpecified; }
+    private void Resetstatus_flags() { status_flagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientPersonaState.Friend> _friends = new global::System.Collections.Generic.List<CMsgClientPersonaState.Friend>();
     [global::ProtoBuf.ProtoMember(2, Name=@"friends", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientPersonaState.Friend> friends
@@ -3059,203 +5383,401 @@ namespace SteamKit2.Internal
     public Friend() {}
     
 
-    private ulong _friendid = default(ulong);
+    private ulong? _friendid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"friendid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong friendid
     {
-      get { return _friendid; }
+      get { return _friendid?? default(ulong); }
       set { _friendid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendidSpecified
+    {
+      get { return _friendid != null; }
+      set { if (value == (_friendid== null)) _friendid = value ? this.friendid : (ulong?)null; }
+    }
+    private bool ShouldSerializefriendid() { return friendidSpecified; }
+    private void Resetfriendid() { friendidSpecified = false; }
+    
 
-    private uint _persona_state = default(uint);
+    private uint? _persona_state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint persona_state
     {
-      get { return _persona_state; }
+      get { return _persona_state?? default(uint); }
       set { _persona_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_stateSpecified
+    {
+      get { return _persona_state != null; }
+      set { if (value == (_persona_state== null)) _persona_state = value ? this.persona_state : (uint?)null; }
+    }
+    private bool ShouldSerializepersona_state() { return persona_stateSpecified; }
+    private void Resetpersona_state() { persona_stateSpecified = false; }
+    
 
-    private uint _game_played_app_id = default(uint);
+    private uint? _game_played_app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_played_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_played_app_id
     {
-      get { return _game_played_app_id; }
+      get { return _game_played_app_id?? default(uint); }
       set { _game_played_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_played_app_idSpecified
+    {
+      get { return _game_played_app_id != null; }
+      set { if (value == (_game_played_app_id== null)) _game_played_app_id = value ? this.game_played_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializegame_played_app_id() { return game_played_app_idSpecified; }
+    private void Resetgame_played_app_id() { game_played_app_idSpecified = false; }
+    
 
-    private uint _game_server_ip = default(uint);
+    private uint? _game_server_ip;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_ip
     {
-      get { return _game_server_ip; }
+      get { return _game_server_ip?? default(uint); }
       set { _game_server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_ipSpecified
+    {
+      get { return _game_server_ip != null; }
+      set { if (value == (_game_server_ip== null)) _game_server_ip = value ? this.game_server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_ip() { return game_server_ipSpecified; }
+    private void Resetgame_server_ip() { game_server_ipSpecified = false; }
+    
 
-    private uint _game_server_port = default(uint);
+    private uint? _game_server_port;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_port
     {
-      get { return _game_server_port; }
+      get { return _game_server_port?? default(uint); }
       set { _game_server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_portSpecified
+    {
+      get { return _game_server_port != null; }
+      set { if (value == (_game_server_port== null)) _game_server_port = value ? this.game_server_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_port() { return game_server_portSpecified; }
+    private void Resetgame_server_port() { game_server_portSpecified = false; }
+    
 
-    private uint _persona_state_flags = default(uint);
+    private uint? _persona_state_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"persona_state_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint persona_state_flags
     {
-      get { return _persona_state_flags; }
+      get { return _persona_state_flags?? default(uint); }
       set { _persona_state_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_state_flagsSpecified
+    {
+      get { return _persona_state_flags != null; }
+      set { if (value == (_persona_state_flags== null)) _persona_state_flags = value ? this.persona_state_flags : (uint?)null; }
+    }
+    private bool ShouldSerializepersona_state_flags() { return persona_state_flagsSpecified; }
+    private void Resetpersona_state_flags() { persona_state_flagsSpecified = false; }
+    
 
-    private uint _online_session_instances = default(uint);
+    private uint? _online_session_instances;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"online_session_instances", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint online_session_instances
     {
-      get { return _online_session_instances; }
+      get { return _online_session_instances?? default(uint); }
       set { _online_session_instances = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool online_session_instancesSpecified
+    {
+      get { return _online_session_instances != null; }
+      set { if (value == (_online_session_instances== null)) _online_session_instances = value ? this.online_session_instances : (uint?)null; }
+    }
+    private bool ShouldSerializeonline_session_instances() { return online_session_instancesSpecified; }
+    private void Resetonline_session_instances() { online_session_instancesSpecified = false; }
+    
 
-    private uint _published_instance_id = default(uint);
+    private uint? _published_instance_id;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"published_instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint published_instance_id
     {
-      get { return _published_instance_id; }
+      get { return _published_instance_id?? default(uint); }
       set { _published_instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_instance_idSpecified
+    {
+      get { return _published_instance_id != null; }
+      set { if (value == (_published_instance_id== null)) _published_instance_id = value ? this.published_instance_id : (uint?)null; }
+    }
+    private bool ShouldSerializepublished_instance_id() { return published_instance_idSpecified; }
+    private void Resetpublished_instance_id() { published_instance_idSpecified = false; }
+    
 
-    private bool _persona_set_by_user = default(bool);
+    private bool? _persona_set_by_user;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"persona_set_by_user", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool persona_set_by_user
     {
-      get { return _persona_set_by_user; }
+      get { return _persona_set_by_user?? default(bool); }
       set { _persona_set_by_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_set_by_userSpecified
+    {
+      get { return _persona_set_by_user != null; }
+      set { if (value == (_persona_set_by_user== null)) _persona_set_by_user = value ? this.persona_set_by_user : (bool?)null; }
+    }
+    private bool ShouldSerializepersona_set_by_user() { return persona_set_by_userSpecified; }
+    private void Resetpersona_set_by_user() { persona_set_by_userSpecified = false; }
+    
 
-    private string _player_name = "";
+    private string _player_name;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"player_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string player_name
     {
-      get { return _player_name; }
+      get { return _player_name?? ""; }
       set { _player_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_nameSpecified
+    {
+      get { return _player_name != null; }
+      set { if (value == (_player_name== null)) _player_name = value ? this.player_name : (string)null; }
+    }
+    private bool ShouldSerializeplayer_name() { return player_nameSpecified; }
+    private void Resetplayer_name() { player_nameSpecified = false; }
+    
 
-    private uint _query_port = default(uint);
+    private uint? _query_port;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"query_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint query_port
     {
-      get { return _query_port; }
+      get { return _query_port?? default(uint); }
       set { _query_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_portSpecified
+    {
+      get { return _query_port != null; }
+      set { if (value == (_query_port== null)) _query_port = value ? this.query_port : (uint?)null; }
+    }
+    private bool ShouldSerializequery_port() { return query_portSpecified; }
+    private void Resetquery_port() { query_portSpecified = false; }
+    
 
-    private ulong _steamid_source = default(ulong);
+    private ulong? _steamid_source;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"steamid_source", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_source
     {
-      get { return _steamid_source; }
+      get { return _steamid_source?? default(ulong); }
       set { _steamid_source = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_sourceSpecified
+    {
+      get { return _steamid_source != null; }
+      set { if (value == (_steamid_source== null)) _steamid_source = value ? this.steamid_source : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_source() { return steamid_sourceSpecified; }
+    private void Resetsteamid_source() { steamid_sourceSpecified = false; }
+    
 
-    private byte[] _avatar_hash = null;
+    private byte[] _avatar_hash;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"avatar_hash", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] avatar_hash
     {
-      get { return _avatar_hash; }
+      get { return _avatar_hash?? null; }
       set { _avatar_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avatar_hashSpecified
+    {
+      get { return _avatar_hash != null; }
+      set { if (value == (_avatar_hash== null)) _avatar_hash = value ? this.avatar_hash : (byte[])null; }
+    }
+    private bool ShouldSerializeavatar_hash() { return avatar_hashSpecified; }
+    private void Resetavatar_hash() { avatar_hashSpecified = false; }
+    
 
-    private uint _last_logoff = default(uint);
+    private uint? _last_logoff;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"last_logoff", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_logoff
     {
-      get { return _last_logoff; }
+      get { return _last_logoff?? default(uint); }
       set { _last_logoff = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_logoffSpecified
+    {
+      get { return _last_logoff != null; }
+      set { if (value == (_last_logoff== null)) _last_logoff = value ? this.last_logoff : (uint?)null; }
+    }
+    private bool ShouldSerializelast_logoff() { return last_logoffSpecified; }
+    private void Resetlast_logoff() { last_logoffSpecified = false; }
+    
 
-    private uint _last_logon = default(uint);
+    private uint? _last_logon;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"last_logon", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_logon
     {
-      get { return _last_logon; }
+      get { return _last_logon?? default(uint); }
       set { _last_logon = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_logonSpecified
+    {
+      get { return _last_logon != null; }
+      set { if (value == (_last_logon== null)) _last_logon = value ? this.last_logon : (uint?)null; }
+    }
+    private bool ShouldSerializelast_logon() { return last_logonSpecified; }
+    private void Resetlast_logon() { last_logonSpecified = false; }
+    
 
-    private uint _clan_rank = default(uint);
+    private uint? _clan_rank;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"clan_rank", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint clan_rank
     {
-      get { return _clan_rank; }
+      get { return _clan_rank?? default(uint); }
       set { _clan_rank = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clan_rankSpecified
+    {
+      get { return _clan_rank != null; }
+      set { if (value == (_clan_rank== null)) _clan_rank = value ? this.clan_rank : (uint?)null; }
+    }
+    private bool ShouldSerializeclan_rank() { return clan_rankSpecified; }
+    private void Resetclan_rank() { clan_rankSpecified = false; }
+    
 
-    private string _game_name = "";
+    private string _game_name;
     [global::ProtoBuf.ProtoMember(55, IsRequired = false, Name=@"game_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_name
     {
-      get { return _game_name; }
+      get { return _game_name?? ""; }
       set { _game_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_nameSpecified
+    {
+      get { return _game_name != null; }
+      set { if (value == (_game_name== null)) _game_name = value ? this.game_name : (string)null; }
+    }
+    private bool ShouldSerializegame_name() { return game_nameSpecified; }
+    private void Resetgame_name() { game_nameSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private byte[] _game_data_blob = null;
+    private byte[] _game_data_blob;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"game_data_blob", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] game_data_blob
     {
-      get { return _game_data_blob; }
+      get { return _game_data_blob?? null; }
       set { _game_data_blob = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_data_blobSpecified
+    {
+      get { return _game_data_blob != null; }
+      set { if (value == (_game_data_blob== null)) _game_data_blob = value ? this.game_data_blob : (byte[])null; }
+    }
+    private bool ShouldSerializegame_data_blob() { return game_data_blobSpecified; }
+    private void Resetgame_data_blob() { game_data_blobSpecified = false; }
+    
 
-    private string _clan_tag = "";
+    private string _clan_tag;
     [global::ProtoBuf.ProtoMember(65, IsRequired = false, Name=@"clan_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string clan_tag
     {
-      get { return _clan_tag; }
+      get { return _clan_tag?? ""; }
       set { _clan_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clan_tagSpecified
+    {
+      get { return _clan_tag != null; }
+      set { if (value == (_clan_tag== null)) _clan_tag = value ? this.clan_tag : (string)null; }
+    }
+    private bool ShouldSerializeclan_tag() { return clan_tagSpecified; }
+    private void Resetclan_tag() { clan_tagSpecified = false; }
+    
 
-    private string _facebook_name = "";
+    private string _facebook_name;
     [global::ProtoBuf.ProtoMember(66, IsRequired = false, Name=@"facebook_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string facebook_name
     {
-      get { return _facebook_name; }
+      get { return _facebook_name?? ""; }
       set { _facebook_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool facebook_nameSpecified
+    {
+      get { return _facebook_name != null; }
+      set { if (value == (_facebook_name== null)) _facebook_name = value ? this.facebook_name : (string)null; }
+    }
+    private bool ShouldSerializefacebook_name() { return facebook_nameSpecified; }
+    private void Resetfacebook_name() { facebook_nameSpecified = false; }
+    
 
-    private ulong _facebook_id = default(ulong);
+    private ulong? _facebook_id;
     [global::ProtoBuf.ProtoMember(67, IsRequired = false, Name=@"facebook_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong facebook_id
     {
-      get { return _facebook_id; }
+      get { return _facebook_id?? default(ulong); }
       set { _facebook_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool facebook_idSpecified
+    {
+      get { return _facebook_id != null; }
+      set { if (value == (_facebook_id== null)) _facebook_id = value ? this.facebook_id : (ulong?)null; }
+    }
+    private bool ShouldSerializefacebook_id() { return facebook_idSpecified; }
+    private void Resetfacebook_id() { facebook_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3272,14 +5794,23 @@ namespace SteamKit2.Internal
     public CMsgClientFriendProfileInfo() {}
     
 
-    private ulong _steamid_friend = default(ulong);
+    private ulong? _steamid_friend;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_friend", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_friend
     {
-      get { return _steamid_friend; }
+      get { return _steamid_friend?? default(ulong); }
       set { _steamid_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_friendSpecified
+    {
+      get { return _steamid_friend != null; }
+      set { if (value == (_steamid_friend== null)) _steamid_friend = value ? this.steamid_friend : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_friend() { return steamid_friendSpecified; }
+    private void Resetsteamid_friend() { steamid_friendSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3291,86 +5822,167 @@ namespace SteamKit2.Internal
     public CMsgClientFriendProfileInfoResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steamid_friend = default(ulong);
+    private ulong? _steamid_friend;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_friend", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_friend
     {
-      get { return _steamid_friend; }
+      get { return _steamid_friend?? default(ulong); }
       set { _steamid_friend = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_friendSpecified
+    {
+      get { return _steamid_friend != null; }
+      set { if (value == (_steamid_friend== null)) _steamid_friend = value ? this.steamid_friend : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_friend() { return steamid_friendSpecified; }
+    private void Resetsteamid_friend() { steamid_friendSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private string _real_name = "";
+    private string _real_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"real_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string real_name
     {
-      get { return _real_name; }
+      get { return _real_name?? ""; }
       set { _real_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool real_nameSpecified
+    {
+      get { return _real_name != null; }
+      set { if (value == (_real_name== null)) _real_name = value ? this.real_name : (string)null; }
+    }
+    private bool ShouldSerializereal_name() { return real_nameSpecified; }
+    private void Resetreal_name() { real_nameSpecified = false; }
+    
 
-    private string _city_name = "";
+    private string _city_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"city_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string city_name
     {
-      get { return _city_name; }
+      get { return _city_name?? ""; }
       set { _city_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool city_nameSpecified
+    {
+      get { return _city_name != null; }
+      set { if (value == (_city_name== null)) _city_name = value ? this.city_name : (string)null; }
+    }
+    private bool ShouldSerializecity_name() { return city_nameSpecified; }
+    private void Resetcity_name() { city_nameSpecified = false; }
+    
 
-    private string _state_name = "";
+    private string _state_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"state_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string state_name
     {
-      get { return _state_name; }
+      get { return _state_name?? ""; }
       set { _state_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool state_nameSpecified
+    {
+      get { return _state_name != null; }
+      set { if (value == (_state_name== null)) _state_name = value ? this.state_name : (string)null; }
+    }
+    private bool ShouldSerializestate_name() { return state_nameSpecified; }
+    private void Resetstate_name() { state_nameSpecified = false; }
+    
 
-    private string _country_name = "";
+    private string _country_name;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"country_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_name
     {
-      get { return _country_name; }
+      get { return _country_name?? ""; }
       set { _country_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_nameSpecified
+    {
+      get { return _country_name != null; }
+      set { if (value == (_country_name== null)) _country_name = value ? this.country_name : (string)null; }
+    }
+    private bool ShouldSerializecountry_name() { return country_nameSpecified; }
+    private void Resetcountry_name() { country_nameSpecified = false; }
+    
 
-    private string _headline = "";
+    private string _headline;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"headline", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string headline
     {
-      get { return _headline; }
+      get { return _headline?? ""; }
       set { _headline = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool headlineSpecified
+    {
+      get { return _headline != null; }
+      set { if (value == (_headline== null)) _headline = value ? this.headline : (string)null; }
+    }
+    private bool ShouldSerializeheadline() { return headlineSpecified; }
+    private void Resetheadline() { headlineSpecified = false; }
+    
 
-    private string _summary = "";
+    private string _summary;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"summary", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string summary
     {
-      get { return _summary; }
+      get { return _summary?? ""; }
       set { _summary = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool summarySpecified
+    {
+      get { return _summary != null; }
+      set { if (value == (_summary== null)) _summary = value ? this.summary : (string)null; }
+    }
+    private bool ShouldSerializesummary() { return summarySpecified; }
+    private void Resetsummary() { summarySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3394,32 +6006,59 @@ namespace SteamKit2.Internal
     public Server() {}
     
 
-    private uint _server_type = default(uint);
+    private uint? _server_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_type
     {
-      get { return _server_type; }
+      get { return _server_type?? default(uint); }
       set { _server_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_typeSpecified
+    {
+      get { return _server_type != null; }
+      set { if (value == (_server_type== null)) _server_type = value ? this.server_type : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_type() { return server_typeSpecified; }
+    private void Resetserver_type() { server_typeSpecified = false; }
+    
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3448,23 +6087,41 @@ namespace SteamKit2.Internal
     public StatsToSend() {}
     
 
-    private uint _client_stat = default(uint);
+    private uint? _client_stat;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_stat", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_stat
     {
-      get { return _client_stat; }
+      get { return _client_stat?? default(uint); }
       set { _client_stat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_statSpecified
+    {
+      get { return _client_stat != null; }
+      set { if (value == (_client_stat== null)) _client_stat = value ? this.client_stat : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_stat() { return client_statSpecified; }
+    private void Resetclient_stat() { client_statSpecified = false; }
+    
 
-    private uint _stat_aggregate_method = default(uint);
+    private uint? _stat_aggregate_method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_aggregate_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_aggregate_method
     {
-      get { return _stat_aggregate_method; }
+      get { return _stat_aggregate_method?? default(uint); }
       set { _stat_aggregate_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_aggregate_methodSpecified
+    {
+      get { return _stat_aggregate_method != null; }
+      set { if (value == (_stat_aggregate_method== null)) _stat_aggregate_method = value ? this.stat_aggregate_method : (uint?)null; }
+    }
+    private bool ShouldSerializestat_aggregate_method() { return stat_aggregate_methodSpecified; }
+    private void Resetstat_aggregate_method() { stat_aggregate_methodSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3493,59 +6150,113 @@ namespace SteamKit2.Internal
     public StatDetail() {}
     
 
-    private uint _client_stat = default(uint);
+    private uint? _client_stat;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"client_stat", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_stat
     {
-      get { return _client_stat; }
+      get { return _client_stat?? default(uint); }
       set { _client_stat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_statSpecified
+    {
+      get { return _client_stat != null; }
+      set { if (value == (_client_stat== null)) _client_stat = value ? this.client_stat : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_stat() { return client_statSpecified; }
+    private void Resetclient_stat() { client_statSpecified = false; }
+    
 
-    private long _ll_value = default(long);
+    private long? _ll_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ll_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(long))]
     public long ll_value
     {
-      get { return _ll_value; }
+      get { return _ll_value?? default(long); }
       set { _ll_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ll_valueSpecified
+    {
+      get { return _ll_value != null; }
+      set { if (value == (_ll_value== null)) _ll_value = value ? this.ll_value : (long?)null; }
+    }
+    private bool ShouldSerializell_value() { return ll_valueSpecified; }
+    private void Resetll_value() { ll_valueSpecified = false; }
+    
 
-    private uint _time_of_day = default(uint);
+    private uint? _time_of_day;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_of_day", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_of_day
     {
-      get { return _time_of_day; }
+      get { return _time_of_day?? default(uint); }
       set { _time_of_day = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_of_daySpecified
+    {
+      get { return _time_of_day != null; }
+      set { if (value == (_time_of_day== null)) _time_of_day = value ? this.time_of_day : (uint?)null; }
+    }
+    private bool ShouldSerializetime_of_day() { return time_of_daySpecified; }
+    private void Resettime_of_day() { time_of_daySpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private uint _depot_id = default(uint);
+    private uint? _depot_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"depot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depot_id
     {
-      get { return _depot_id; }
+      get { return _depot_id?? default(uint); }
       set { _depot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_idSpecified
+    {
+      get { return _depot_id != null; }
+      set { if (value == (_depot_id== null)) _depot_id = value ? this.depot_id : (uint?)null; }
+    }
+    private bool ShouldSerializedepot_id() { return depot_idSpecified; }
+    private void Resetdepot_id() { depot_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3562,77 +6273,149 @@ namespace SteamKit2.Internal
     public CMsgClientMMSCreateLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _max_members = default(int);
+    private int? _max_members;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(int); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (int?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
 
-    private int _lobby_type = default(int);
+    private int? _lobby_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(int); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (int?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _lobby_flags = default(int);
+    private int? _lobby_flags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_flags
     {
-      get { return _lobby_flags; }
+      get { return _lobby_flags?? default(int); }
       set { _lobby_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_flagsSpecified
+    {
+      get { return _lobby_flags != null; }
+      set { if (value == (_lobby_flags== null)) _lobby_flags = value ? this.lobby_flags : (int?)null; }
+    }
+    private bool ShouldSerializelobby_flags() { return lobby_flagsSpecified; }
+    private void Resetlobby_flags() { lobby_flagsSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
 
-    private string _persona_name_owner = "";
+    private string _persona_name_owner;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"persona_name_owner", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name_owner
     {
-      get { return _persona_name_owner; }
+      get { return _persona_name_owner?? ""; }
       set { _persona_name_owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_name_ownerSpecified
+    {
+      get { return _persona_name_owner != null; }
+      set { if (value == (_persona_name_owner== null)) _persona_name_owner = value ? this.persona_name_owner : (string)null; }
+    }
+    private bool ShouldSerializepersona_name_owner() { return persona_name_ownerSpecified; }
+    private void Resetpersona_name_owner() { persona_name_ownerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3644,32 +6427,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSCreateLobbyResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3681,32 +6491,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSJoinLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3718,77 +6555,149 @@ namespace SteamKit2.Internal
     public CMsgClientMMSJoinLobbyResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _chat_room_enter_response = default(int);
+    private int? _chat_room_enter_response;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"chat_room_enter_response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int chat_room_enter_response
     {
-      get { return _chat_room_enter_response; }
+      get { return _chat_room_enter_response?? default(int); }
       set { _chat_room_enter_response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_room_enter_responseSpecified
+    {
+      get { return _chat_room_enter_response != null; }
+      set { if (value == (_chat_room_enter_response== null)) _chat_room_enter_response = value ? this.chat_room_enter_response : (int?)null; }
+    }
+    private bool ShouldSerializechat_room_enter_response() { return chat_room_enter_responseSpecified; }
+    private void Resetchat_room_enter_response() { chat_room_enter_responseSpecified = false; }
+    
 
-    private int _max_members = default(int);
+    private int? _max_members;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(int); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (int?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
 
-    private int _lobby_type = default(int);
+    private int? _lobby_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(int); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (int?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _lobby_flags = default(int);
+    private int? _lobby_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lobby_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_flags
     {
-      get { return _lobby_flags; }
+      get { return _lobby_flags?? default(int); }
       set { _lobby_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_flagsSpecified
+    {
+      get { return _lobby_flags != null; }
+      set { if (value == (_lobby_flags== null)) _lobby_flags = value ? this.lobby_flags : (int?)null; }
+    }
+    private bool ShouldSerializelobby_flags() { return lobby_flagsSpecified; }
+    private void Resetlobby_flags() { lobby_flagsSpecified = false; }
+    
 
-    private ulong _steam_id_owner = default(ulong);
+    private ulong? _steam_id_owner;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"steam_id_owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_owner
     {
-      get { return _steam_id_owner; }
+      get { return _steam_id_owner?? default(ulong); }
       set { _steam_id_owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_ownerSpecified
+    {
+      get { return _steam_id_owner != null; }
+      set { if (value == (_steam_id_owner== null)) _steam_id_owner = value ? this.steam_id_owner : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_owner() { return steam_id_ownerSpecified; }
+    private void Resetsteam_id_owner() { steam_id_ownerSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientMMSJoinLobbyResponse.Member> _members = new global::System.Collections.Generic.List<CMsgClientMMSJoinLobbyResponse.Member>();
     [global::ProtoBuf.ProtoMember(9, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientMMSJoinLobbyResponse.Member> members
@@ -3802,32 +6711,59 @@ namespace SteamKit2.Internal
     public Member() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3844,23 +6780,41 @@ namespace SteamKit2.Internal
     public CMsgClientMMSLeaveLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3872,32 +6826,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSLeaveLobbyResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3909,41 +6890,77 @@ namespace SteamKit2.Internal
     public CMsgClientMMSGetLobbyList() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _num_lobbies_requested = default(int);
+    private int? _num_lobbies_requested;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_lobbies_requested", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_lobbies_requested
     {
-      get { return _num_lobbies_requested; }
+      get { return _num_lobbies_requested?? default(int); }
       set { _num_lobbies_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_lobbies_requestedSpecified
+    {
+      get { return _num_lobbies_requested != null; }
+      set { if (value == (_num_lobbies_requested== null)) _num_lobbies_requested = value ? this.num_lobbies_requested : (int?)null; }
+    }
+    private bool ShouldSerializenum_lobbies_requested() { return num_lobbies_requestedSpecified; }
+    private void Resetnum_lobbies_requested() { num_lobbies_requestedSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private uint _public_ip = default(uint);
+    private uint? _public_ip;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"public_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ip
     {
-      get { return _public_ip; }
+      get { return _public_ip?? default(uint); }
       set { _public_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipSpecified
+    {
+      get { return _public_ip != null; }
+      set { if (value == (_public_ip== null)) _public_ip = value ? this.public_ip : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ip() { return public_ipSpecified; }
+    private void Resetpublic_ip() { public_ipSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientMMSGetLobbyList.Filter> _filters = new global::System.Collections.Generic.List<CMsgClientMMSGetLobbyList.Filter>();
     [global::ProtoBuf.ProtoMember(6, Name=@"filters", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientMMSGetLobbyList.Filter> filters
@@ -3957,41 +6974,77 @@ namespace SteamKit2.Internal
     public Filter() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
 
-    private int _comparision = default(int);
+    private int? _comparision;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"comparision", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int comparision
     {
-      get { return _comparision; }
+      get { return _comparision?? default(int); }
       set { _comparision = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool comparisionSpecified
+    {
+      get { return _comparision != null; }
+      set { if (value == (_comparision== null)) _comparision = value ? this.comparision : (int?)null; }
+    }
+    private bool ShouldSerializecomparision() { return comparisionSpecified; }
+    private void Resetcomparision() { comparisionSpecified = false; }
+    
 
-    private int _filter_type = default(int);
+    private int? _filter_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int filter_type
     {
-      get { return _filter_type; }
+      get { return _filter_type?? default(int); }
       set { _filter_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_typeSpecified
+    {
+      get { return _filter_type != null; }
+      set { if (value == (_filter_type== null)) _filter_type = value ? this.filter_type : (int?)null; }
+    }
+    private bool ShouldSerializefilter_type() { return filter_typeSpecified; }
+    private void Resetfilter_type() { filter_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4008,23 +7061,41 @@ namespace SteamKit2.Internal
     public CMsgClientMMSGetLobbyListResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientMMSGetLobbyListResponse.Lobby> _lobbies = new global::System.Collections.Generic.List<CMsgClientMMSGetLobbyListResponse.Lobby>();
     [global::ProtoBuf.ProtoMember(4, Name=@"lobbies", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientMMSGetLobbyListResponse.Lobby> lobbies
@@ -4038,77 +7109,149 @@ namespace SteamKit2.Internal
     public Lobby() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private int _max_members = default(int);
+    private int? _max_members;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(int); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (int?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
 
-    private int _lobby_type = default(int);
+    private int? _lobby_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(int); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (int?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _lobby_flags = default(int);
+    private int? _lobby_flags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_flags
     {
-      get { return _lobby_flags; }
+      get { return _lobby_flags?? default(int); }
       set { _lobby_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_flagsSpecified
+    {
+      get { return _lobby_flags != null; }
+      set { if (value == (_lobby_flags== null)) _lobby_flags = value ? this.lobby_flags : (int?)null; }
+    }
+    private bool ShouldSerializelobby_flags() { return lobby_flagsSpecified; }
+    private void Resetlobby_flags() { lobby_flagsSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
 
-    private int _num_members = default(int);
+    private int? _num_members;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_members
     {
-      get { return _num_members; }
+      get { return _num_members?? default(int); }
       set { _num_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_membersSpecified
+    {
+      get { return _num_members != null; }
+      set { if (value == (_num_members== null)) _num_members = value ? this.num_members : (int?)null; }
+    }
+    private bool ShouldSerializenum_members() { return num_membersSpecified; }
+    private void Resetnum_members() { num_membersSpecified = false; }
+    
 
-    private float _distance = default(float);
+    private float? _distance;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"distance", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float distance
     {
-      get { return _distance; }
+      get { return _distance?? default(float); }
       set { _distance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool distanceSpecified
+    {
+      get { return _distance != null; }
+      set { if (value == (_distance== null)) _distance = value ? this.distance : (float?)null; }
+    }
+    private bool ShouldSerializedistance() { return distanceSpecified; }
+    private void Resetdistance() { distanceSpecified = false; }
+    
 
-    private long _weight = default(long);
+    private long? _weight;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"weight", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(long))]
     public long weight
     {
-      get { return _weight; }
+      get { return _weight?? default(long); }
       set { _weight = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool weightSpecified
+    {
+      get { return _weight != null; }
+      set { if (value == (_weight== null)) _weight = value ? this.weight : (long?)null; }
+    }
+    private bool ShouldSerializeweight() { return weightSpecified; }
+    private void Resetweight() { weightSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4125,68 +7268,131 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyData() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_member = default(ulong);
+    private ulong? _steam_id_member;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_member", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_member
     {
-      get { return _steam_id_member; }
+      get { return _steam_id_member?? default(ulong); }
       set { _steam_id_member = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_memberSpecified
+    {
+      get { return _steam_id_member != null; }
+      set { if (value == (_steam_id_member== null)) _steam_id_member = value ? this.steam_id_member : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_member() { return steam_id_memberSpecified; }
+    private void Resetsteam_id_member() { steam_id_memberSpecified = false; }
+    
 
-    private int _max_members = default(int);
+    private int? _max_members;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(int); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (int?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
 
-    private int _lobby_type = default(int);
+    private int? _lobby_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(int); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (int?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _lobby_flags = default(int);
+    private int? _lobby_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lobby_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_flags
     {
-      get { return _lobby_flags; }
+      get { return _lobby_flags?? default(int); }
       set { _lobby_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_flagsSpecified
+    {
+      get { return _lobby_flags != null; }
+      set { if (value == (_lobby_flags== null)) _lobby_flags = value ? this.lobby_flags : (int?)null; }
+    }
+    private bool ShouldSerializelobby_flags() { return lobby_flagsSpecified; }
+    private void Resetlobby_flags() { lobby_flagsSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4198,32 +7404,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyDataResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4235,23 +7468,41 @@ namespace SteamKit2.Internal
     public CMsgClientMMSGetLobbyData() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4263,77 +7514,149 @@ namespace SteamKit2.Internal
     public CMsgClientMMSLobbyData() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _num_members = default(int);
+    private int? _num_members;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_members
     {
-      get { return _num_members; }
+      get { return _num_members?? default(int); }
       set { _num_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_membersSpecified
+    {
+      get { return _num_members != null; }
+      set { if (value == (_num_members== null)) _num_members = value ? this.num_members : (int?)null; }
+    }
+    private bool ShouldSerializenum_members() { return num_membersSpecified; }
+    private void Resetnum_members() { num_membersSpecified = false; }
+    
 
-    private int _max_members = default(int);
+    private int? _max_members;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"max_members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_members
     {
-      get { return _max_members; }
+      get { return _max_members?? default(int); }
       set { _max_members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_membersSpecified
+    {
+      get { return _max_members != null; }
+      set { if (value == (_max_members== null)) _max_members = value ? this.max_members : (int?)null; }
+    }
+    private bool ShouldSerializemax_members() { return max_membersSpecified; }
+    private void Resetmax_members() { max_membersSpecified = false; }
+    
 
-    private int _lobby_type = default(int);
+    private int? _lobby_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"lobby_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_type
     {
-      get { return _lobby_type; }
+      get { return _lobby_type?? default(int); }
       set { _lobby_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_typeSpecified
+    {
+      get { return _lobby_type != null; }
+      set { if (value == (_lobby_type== null)) _lobby_type = value ? this.lobby_type : (int?)null; }
+    }
+    private bool ShouldSerializelobby_type() { return lobby_typeSpecified; }
+    private void Resetlobby_type() { lobby_typeSpecified = false; }
+    
 
-    private int _lobby_flags = default(int);
+    private int? _lobby_flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lobby_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lobby_flags
     {
-      get { return _lobby_flags; }
+      get { return _lobby_flags?? default(int); }
       set { _lobby_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_flagsSpecified
+    {
+      get { return _lobby_flags != null; }
+      set { if (value == (_lobby_flags== null)) _lobby_flags = value ? this.lobby_flags : (int?)null; }
+    }
+    private bool ShouldSerializelobby_flags() { return lobby_flagsSpecified; }
+    private void Resetlobby_flags() { lobby_flagsSpecified = false; }
+    
 
-    private ulong _steam_id_owner = default(ulong);
+    private ulong? _steam_id_owner;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"steam_id_owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_owner
     {
-      get { return _steam_id_owner; }
+      get { return _steam_id_owner?? default(ulong); }
       set { _steam_id_owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_ownerSpecified
+    {
+      get { return _steam_id_owner != null; }
+      set { if (value == (_steam_id_owner== null)) _steam_id_owner = value ? this.steam_id_owner : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_owner() { return steam_id_ownerSpecified; }
+    private void Resetsteam_id_owner() { steam_id_ownerSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientMMSLobbyData.Member> _members = new global::System.Collections.Generic.List<CMsgClientMMSLobbyData.Member>();
     [global::ProtoBuf.ProtoMember(9, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientMMSLobbyData.Member> members
@@ -4342,46 +7665,82 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _lobby_cellid = default(uint);
+    private uint? _lobby_cellid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"lobby_cellid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lobby_cellid
     {
-      get { return _lobby_cellid; }
+      get { return _lobby_cellid?? default(uint); }
       set { _lobby_cellid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_cellidSpecified
+    {
+      get { return _lobby_cellid != null; }
+      set { if (value == (_lobby_cellid== null)) _lobby_cellid = value ? this.lobby_cellid : (uint?)null; }
+    }
+    private bool ShouldSerializelobby_cellid() { return lobby_cellidSpecified; }
+    private void Resetlobby_cellid() { lobby_cellidSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Member")]
   public partial class Member : global::ProtoBuf.IExtensible
   {
     public Member() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private byte[] _metadata = null;
+    private byte[] _metadata;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? null; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (byte[])null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4398,41 +7757,77 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSendLobbyChatMsg() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_target = default(ulong);
+    private ulong? _steam_id_target;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_target", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_target
     {
-      get { return _steam_id_target; }
+      get { return _steam_id_target?? default(ulong); }
       set { _steam_id_target = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_targetSpecified
+    {
+      get { return _steam_id_target != null; }
+      set { if (value == (_steam_id_target== null)) _steam_id_target = value ? this.steam_id_target : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_target() { return steam_id_targetSpecified; }
+    private void Resetsteam_id_target() { steam_id_targetSpecified = false; }
+    
 
-    private byte[] _lobby_message = null;
+    private byte[] _lobby_message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] lobby_message
     {
-      get { return _lobby_message; }
+      get { return _lobby_message?? null; }
       set { _lobby_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_messageSpecified
+    {
+      get { return _lobby_message != null; }
+      set { if (value == (_lobby_message== null)) _lobby_message = value ? this.lobby_message : (byte[])null; }
+    }
+    private bool ShouldSerializelobby_message() { return lobby_messageSpecified; }
+    private void Resetlobby_message() { lobby_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4444,41 +7839,77 @@ namespace SteamKit2.Internal
     public CMsgClientMMSLobbyChatMsg() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_sender = default(ulong);
+    private ulong? _steam_id_sender;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_sender", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_sender
     {
-      get { return _steam_id_sender; }
+      get { return _steam_id_sender?? default(ulong); }
       set { _steam_id_sender = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_senderSpecified
+    {
+      get { return _steam_id_sender != null; }
+      set { if (value == (_steam_id_sender== null)) _steam_id_sender = value ? this.steam_id_sender : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_sender() { return steam_id_senderSpecified; }
+    private void Resetsteam_id_sender() { steam_id_senderSpecified = false; }
+    
 
-    private byte[] _lobby_message = null;
+    private byte[] _lobby_message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"lobby_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] lobby_message
     {
-      get { return _lobby_message; }
+      get { return _lobby_message?? null; }
       set { _lobby_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lobby_messageSpecified
+    {
+      get { return _lobby_message != null; }
+      set { if (value == (_lobby_message== null)) _lobby_message = value ? this.lobby_message : (byte[])null; }
+    }
+    private bool ShouldSerializelobby_message() { return lobby_messageSpecified; }
+    private void Resetlobby_message() { lobby_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4490,32 +7921,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyOwner() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_new_owner = default(ulong);
+    private ulong? _steam_id_new_owner;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_new_owner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_new_owner
     {
-      get { return _steam_id_new_owner; }
+      get { return _steam_id_new_owner?? default(ulong); }
       set { _steam_id_new_owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_new_ownerSpecified
+    {
+      get { return _steam_id_new_owner != null; }
+      set { if (value == (_steam_id_new_owner== null)) _steam_id_new_owner = value ? this.steam_id_new_owner : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_new_owner() { return steam_id_new_ownerSpecified; }
+    private void Resetsteam_id_new_owner() { steam_id_new_ownerSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4527,32 +7985,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyOwnerResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4564,32 +8049,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyLinked() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_lobby2 = default(ulong);
+    private ulong? _steam_id_lobby2;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_lobby2", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby2
     {
-      get { return _steam_id_lobby2; }
+      get { return _steam_id_lobby2?? default(ulong); }
       set { _steam_id_lobby2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobby2Specified
+    {
+      get { return _steam_id_lobby2 != null; }
+      set { if (value == (_steam_id_lobby2== null)) _steam_id_lobby2 = value ? this.steam_id_lobby2 : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby2() { return steam_id_lobby2Specified; }
+    private void Resetsteam_id_lobby2() { steam_id_lobby2Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4601,50 +8113,95 @@ namespace SteamKit2.Internal
     public CMsgClientMMSSetLobbyGameServer() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private uint _game_server_ip = default(uint);
+    private uint? _game_server_ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_ip
     {
-      get { return _game_server_ip; }
+      get { return _game_server_ip?? default(uint); }
       set { _game_server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_ipSpecified
+    {
+      get { return _game_server_ip != null; }
+      set { if (value == (_game_server_ip== null)) _game_server_ip = value ? this.game_server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_ip() { return game_server_ipSpecified; }
+    private void Resetgame_server_ip() { game_server_ipSpecified = false; }
+    
 
-    private uint _game_server_port = default(uint);
+    private uint? _game_server_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_port
     {
-      get { return _game_server_port; }
+      get { return _game_server_port?? default(uint); }
       set { _game_server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_portSpecified
+    {
+      get { return _game_server_port != null; }
+      set { if (value == (_game_server_port== null)) _game_server_port = value ? this.game_server_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_port() { return game_server_portSpecified; }
+    private void Resetgame_server_port() { game_server_portSpecified = false; }
+    
 
-    private ulong _game_server_steam_id = default(ulong);
+    private ulong? _game_server_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_server_steam_id
     {
-      get { return _game_server_steam_id; }
+      get { return _game_server_steam_id?? default(ulong); }
       set { _game_server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_steam_idSpecified
+    {
+      get { return _game_server_steam_id != null; }
+      set { if (value == (_game_server_steam_id== null)) _game_server_steam_id = value ? this.game_server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_server_steam_id() { return game_server_steam_idSpecified; }
+    private void Resetgame_server_steam_id() { game_server_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4656,50 +8213,95 @@ namespace SteamKit2.Internal
     public CMsgClientMMSLobbyGameServerSet() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private uint _game_server_ip = default(uint);
+    private uint? _game_server_ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_ip
     {
-      get { return _game_server_ip; }
+      get { return _game_server_ip?? default(uint); }
       set { _game_server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_ipSpecified
+    {
+      get { return _game_server_ip != null; }
+      set { if (value == (_game_server_ip== null)) _game_server_ip = value ? this.game_server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_ip() { return game_server_ipSpecified; }
+    private void Resetgame_server_ip() { game_server_ipSpecified = false; }
+    
 
-    private uint _game_server_port = default(uint);
+    private uint? _game_server_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_server_port
     {
-      get { return _game_server_port; }
+      get { return _game_server_port?? default(uint); }
       set { _game_server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_portSpecified
+    {
+      get { return _game_server_port != null; }
+      set { if (value == (_game_server_port== null)) _game_server_port = value ? this.game_server_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_server_port() { return game_server_portSpecified; }
+    private void Resetgame_server_port() { game_server_portSpecified = false; }
+    
 
-    private ulong _game_server_steam_id = default(ulong);
+    private ulong? _game_server_steam_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"game_server_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_server_steam_id
     {
-      get { return _game_server_steam_id; }
+      get { return _game_server_steam_id?? default(ulong); }
       set { _game_server_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_server_steam_idSpecified
+    {
+      get { return _game_server_steam_id != null; }
+      set { if (value == (_game_server_steam_id== null)) _game_server_steam_id = value ? this.game_server_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_server_steam_id() { return game_server_steam_idSpecified; }
+    private void Resetgame_server_steam_id() { game_server_steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4711,41 +8313,77 @@ namespace SteamKit2.Internal
     public CMsgClientMMSUserJoinedLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_user = default(ulong);
+    private ulong? _steam_id_user;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_user", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_user
     {
-      get { return _steam_id_user; }
+      get { return _steam_id_user?? default(ulong); }
       set { _steam_id_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_userSpecified
+    {
+      get { return _steam_id_user != null; }
+      set { if (value == (_steam_id_user== null)) _steam_id_user = value ? this.steam_id_user : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_user() { return steam_id_userSpecified; }
+    private void Resetsteam_id_user() { steam_id_userSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4757,41 +8395,77 @@ namespace SteamKit2.Internal
     public CMsgClientMMSUserLeftLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_user = default(ulong);
+    private ulong? _steam_id_user;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_user", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_user
     {
-      get { return _steam_id_user; }
+      get { return _steam_id_user?? default(ulong); }
       set { _steam_id_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_userSpecified
+    {
+      get { return _steam_id_user != null; }
+      set { if (value == (_steam_id_user== null)) _steam_id_user = value ? this.steam_id_user : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_user() { return steam_id_userSpecified; }
+    private void Resetsteam_id_user() { steam_id_userSpecified = false; }
+    
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4803,32 +8477,59 @@ namespace SteamKit2.Internal
     public CMsgClientMMSInviteToLobby() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _steam_id_lobby = default(ulong);
+    private ulong? _steam_id_lobby;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_lobby", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_lobby
     {
-      get { return _steam_id_lobby; }
+      get { return _steam_id_lobby?? default(ulong); }
       set { _steam_id_lobby = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_lobbySpecified
+    {
+      get { return _steam_id_lobby != null; }
+      set { if (value == (_steam_id_lobby== null)) _steam_id_lobby = value ? this.steam_id_lobby : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_lobby() { return steam_id_lobbySpecified; }
+    private void Resetsteam_id_lobby() { steam_id_lobbySpecified = false; }
+    
 
-    private ulong _steam_id_user_invited = default(ulong);
+    private ulong? _steam_id_user_invited;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_user_invited", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_user_invited
     {
-      get { return _steam_id_user_invited; }
+      get { return _steam_id_user_invited?? default(ulong); }
       set { _steam_id_user_invited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_user_invitedSpecified
+    {
+      get { return _steam_id_user_invited != null; }
+      set { if (value == (_steam_id_user_invited== null)) _steam_id_user_invited = value ? this.steam_id_user_invited : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_user_invited() { return steam_id_user_invitedSpecified; }
+    private void Resetsteam_id_user_invited() { steam_id_user_invitedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4840,32 +8541,59 @@ namespace SteamKit2.Internal
     public CMsgClientUDSInviteToGame() {}
     
 
-    private ulong _steam_id_dest = default(ulong);
+    private ulong? _steam_id_dest;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_dest", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_dest
     {
-      get { return _steam_id_dest; }
+      get { return _steam_id_dest?? default(ulong); }
       set { _steam_id_dest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_destSpecified
+    {
+      get { return _steam_id_dest != null; }
+      set { if (value == (_steam_id_dest== null)) _steam_id_dest = value ? this.steam_id_dest : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_dest() { return steam_id_destSpecified; }
+    private void Resetsteam_id_dest() { steam_id_destSpecified = false; }
+    
 
-    private ulong _steam_id_src = default(ulong);
+    private ulong? _steam_id_src;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_src", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_src
     {
-      get { return _steam_id_src; }
+      get { return _steam_id_src?? default(ulong); }
       set { _steam_id_src = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_srcSpecified
+    {
+      get { return _steam_id_src != null; }
+      set { if (value == (_steam_id_src== null)) _steam_id_src = value ? this.steam_id_src : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_src() { return steam_id_srcSpecified; }
+    private void Resetsteam_id_src() { steam_id_srcSpecified = false; }
+    
 
-    private string _connect_string = "";
+    private string _connect_string;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"connect_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string connect_string
     {
-      get { return _connect_string; }
+      get { return _connect_string?? ""; }
       set { _connect_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_stringSpecified
+    {
+      get { return _connect_string != null; }
+      set { if (value == (_connect_string== null)) _connect_string = value ? this.connect_string : (string)null; }
+    }
+    private bool ShouldSerializeconnect_string() { return connect_stringSpecified; }
+    private void Resetconnect_string() { connect_stringSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4877,68 +8605,131 @@ namespace SteamKit2.Internal
     public CMsgClientChatInvite() {}
     
 
-    private ulong _steam_id_invited = default(ulong);
+    private ulong? _steam_id_invited;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_invited", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_invited
     {
-      get { return _steam_id_invited; }
+      get { return _steam_id_invited?? default(ulong); }
       set { _steam_id_invited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_invitedSpecified
+    {
+      get { return _steam_id_invited != null; }
+      set { if (value == (_steam_id_invited== null)) _steam_id_invited = value ? this.steam_id_invited : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_invited() { return steam_id_invitedSpecified; }
+    private void Resetsteam_id_invited() { steam_id_invitedSpecified = false; }
+    
 
-    private ulong _steam_id_chat = default(ulong);
+    private ulong? _steam_id_chat;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_chat", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_chat
     {
-      get { return _steam_id_chat; }
+      get { return _steam_id_chat?? default(ulong); }
       set { _steam_id_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_chatSpecified
+    {
+      get { return _steam_id_chat != null; }
+      set { if (value == (_steam_id_chat== null)) _steam_id_chat = value ? this.steam_id_chat : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_chat() { return steam_id_chatSpecified; }
+    private void Resetsteam_id_chat() { steam_id_chatSpecified = false; }
+    
 
-    private ulong _steam_id_patron = default(ulong);
+    private ulong? _steam_id_patron;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steam_id_patron", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_patron
     {
-      get { return _steam_id_patron; }
+      get { return _steam_id_patron?? default(ulong); }
       set { _steam_id_patron = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_patronSpecified
+    {
+      get { return _steam_id_patron != null; }
+      set { if (value == (_steam_id_patron== null)) _steam_id_patron = value ? this.steam_id_patron : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_patron() { return steam_id_patronSpecified; }
+    private void Resetsteam_id_patron() { steam_id_patronSpecified = false; }
+    
 
-    private int _chatroom_type = default(int);
+    private int? _chatroom_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"chatroom_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int chatroom_type
     {
-      get { return _chatroom_type; }
+      get { return _chatroom_type?? default(int); }
       set { _chatroom_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chatroom_typeSpecified
+    {
+      get { return _chatroom_type != null; }
+      set { if (value == (_chatroom_type== null)) _chatroom_type = value ? this.chatroom_type : (int?)null; }
+    }
+    private bool ShouldSerializechatroom_type() { return chatroom_typeSpecified; }
+    private void Resetchatroom_type() { chatroom_typeSpecified = false; }
+    
 
-    private ulong _steam_id_friend_chat = default(ulong);
+    private ulong? _steam_id_friend_chat;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steam_id_friend_chat", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_friend_chat
     {
-      get { return _steam_id_friend_chat; }
+      get { return _steam_id_friend_chat?? default(ulong); }
       set { _steam_id_friend_chat = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_friend_chatSpecified
+    {
+      get { return _steam_id_friend_chat != null; }
+      set { if (value == (_steam_id_friend_chat== null)) _steam_id_friend_chat = value ? this.steam_id_friend_chat : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_friend_chat() { return steam_id_friend_chatSpecified; }
+    private void Resetsteam_id_friend_chat() { steam_id_friend_chatSpecified = false; }
+    
 
-    private string _chat_name = "";
+    private string _chat_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"chat_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string chat_name
     {
-      get { return _chat_name; }
+      get { return _chat_name?? ""; }
       set { _chat_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_nameSpecified
+    {
+      get { return _chat_name != null; }
+      set { if (value == (_chat_name== null)) _chat_name = value ? this.chat_name : (string)null; }
+    }
+    private bool ShouldSerializechat_name() { return chat_nameSpecified; }
+    private void Resetchat_name() { chat_nameSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4973,68 +8764,131 @@ namespace SteamKit2.Internal
     public Stats_Logon() {}
     
 
-    private int _connect_attempts = default(int);
+    private int? _connect_attempts;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"connect_attempts", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int connect_attempts
     {
-      get { return _connect_attempts; }
+      get { return _connect_attempts?? default(int); }
       set { _connect_attempts = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_attemptsSpecified
+    {
+      get { return _connect_attempts != null; }
+      set { if (value == (_connect_attempts== null)) _connect_attempts = value ? this.connect_attempts : (int?)null; }
+    }
+    private bool ShouldSerializeconnect_attempts() { return connect_attemptsSpecified; }
+    private void Resetconnect_attempts() { connect_attemptsSpecified = false; }
+    
 
-    private int _connect_successes = default(int);
+    private int? _connect_successes;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"connect_successes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int connect_successes
     {
-      get { return _connect_successes; }
+      get { return _connect_successes?? default(int); }
       set { _connect_successes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_successesSpecified
+    {
+      get { return _connect_successes != null; }
+      set { if (value == (_connect_successes== null)) _connect_successes = value ? this.connect_successes : (int?)null; }
+    }
+    private bool ShouldSerializeconnect_successes() { return connect_successesSpecified; }
+    private void Resetconnect_successes() { connect_successesSpecified = false; }
+    
 
-    private int _connect_failures = default(int);
+    private int? _connect_failures;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"connect_failures", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int connect_failures
     {
-      get { return _connect_failures; }
+      get { return _connect_failures?? default(int); }
       set { _connect_failures = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connect_failuresSpecified
+    {
+      get { return _connect_failures != null; }
+      set { if (value == (_connect_failures== null)) _connect_failures = value ? this.connect_failures : (int?)null; }
+    }
+    private bool ShouldSerializeconnect_failures() { return connect_failuresSpecified; }
+    private void Resetconnect_failures() { connect_failuresSpecified = false; }
+    
 
-    private int _connections_dropped = default(int);
+    private int? _connections_dropped;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"connections_dropped", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int connections_dropped
     {
-      get { return _connections_dropped; }
+      get { return _connections_dropped?? default(int); }
       set { _connections_dropped = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connections_droppedSpecified
+    {
+      get { return _connections_dropped != null; }
+      set { if (value == (_connections_dropped== null)) _connections_dropped = value ? this.connections_dropped : (int?)null; }
+    }
+    private bool ShouldSerializeconnections_dropped() { return connections_droppedSpecified; }
+    private void Resetconnections_dropped() { connections_droppedSpecified = false; }
+    
 
-    private uint _seconds_running = default(uint);
+    private uint? _seconds_running;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"seconds_running", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds_running
     {
-      get { return _seconds_running; }
+      get { return _seconds_running?? default(uint); }
       set { _seconds_running = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_runningSpecified
+    {
+      get { return _seconds_running != null; }
+      set { if (value == (_seconds_running== null)) _seconds_running = value ? this.seconds_running : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds_running() { return seconds_runningSpecified; }
+    private void Resetseconds_running() { seconds_runningSpecified = false; }
+    
 
-    private uint _msec_tologonthistime = default(uint);
+    private uint? _msec_tologonthistime;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"msec_tologonthistime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msec_tologonthistime
     {
-      get { return _msec_tologonthistime; }
+      get { return _msec_tologonthistime?? default(uint); }
       set { _msec_tologonthistime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msec_tologonthistimeSpecified
+    {
+      get { return _msec_tologonthistime != null; }
+      set { if (value == (_msec_tologonthistime== null)) _msec_tologonthistime = value ? this.msec_tologonthistime : (uint?)null; }
+    }
+    private bool ShouldSerializemsec_tologonthistime() { return msec_tologonthistimeSpecified; }
+    private void Resetmsec_tologonthistime() { msec_tologonthistimeSpecified = false; }
+    
 
-    private uint _count_bad_cms = default(uint);
+    private uint? _count_bad_cms;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"count_bad_cms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count_bad_cms
     {
-      get { return _count_bad_cms; }
+      get { return _count_bad_cms?? default(uint); }
       set { _count_bad_cms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_bad_cmsSpecified
+    {
+      get { return _count_bad_cms != null; }
+      set { if (value == (_count_bad_cms== null)) _count_bad_cms = value ? this.count_bad_cms : (uint?)null; }
+    }
+    private bool ShouldSerializecount_bad_cms() { return count_bad_cmsSpecified; }
+    private void Resetcount_bad_cms() { count_bad_cmsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5046,50 +8900,95 @@ namespace SteamKit2.Internal
     public Stats_UDP() {}
     
 
-    private ulong _pkts_sent = default(ulong);
+    private ulong? _pkts_sent;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"pkts_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pkts_sent
     {
-      get { return _pkts_sent; }
+      get { return _pkts_sent?? default(ulong); }
       set { _pkts_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pkts_sentSpecified
+    {
+      get { return _pkts_sent != null; }
+      set { if (value == (_pkts_sent== null)) _pkts_sent = value ? this.pkts_sent : (ulong?)null; }
+    }
+    private bool ShouldSerializepkts_sent() { return pkts_sentSpecified; }
+    private void Resetpkts_sent() { pkts_sentSpecified = false; }
+    
 
-    private ulong _bytes_sent = default(ulong);
+    private ulong? _bytes_sent;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bytes_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_sent
     {
-      get { return _bytes_sent; }
+      get { return _bytes_sent?? default(ulong); }
       set { _bytes_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_sentSpecified
+    {
+      get { return _bytes_sent != null; }
+      set { if (value == (_bytes_sent== null)) _bytes_sent = value ? this.bytes_sent : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_sent() { return bytes_sentSpecified; }
+    private void Resetbytes_sent() { bytes_sentSpecified = false; }
+    
 
-    private ulong _pkts_recv = default(ulong);
+    private ulong? _pkts_recv;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"pkts_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pkts_recv
     {
-      get { return _pkts_recv; }
+      get { return _pkts_recv?? default(ulong); }
       set { _pkts_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pkts_recvSpecified
+    {
+      get { return _pkts_recv != null; }
+      set { if (value == (_pkts_recv== null)) _pkts_recv = value ? this.pkts_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializepkts_recv() { return pkts_recvSpecified; }
+    private void Resetpkts_recv() { pkts_recvSpecified = false; }
+    
 
-    private ulong _pkts_processed = default(ulong);
+    private ulong? _pkts_processed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"pkts_processed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pkts_processed
     {
-      get { return _pkts_processed; }
+      get { return _pkts_processed?? default(ulong); }
       set { _pkts_processed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pkts_processedSpecified
+    {
+      get { return _pkts_processed != null; }
+      set { if (value == (_pkts_processed== null)) _pkts_processed = value ? this.pkts_processed : (ulong?)null; }
+    }
+    private bool ShouldSerializepkts_processed() { return pkts_processedSpecified; }
+    private void Resetpkts_processed() { pkts_processedSpecified = false; }
+    
 
-    private ulong _bytes_recv = default(ulong);
+    private ulong? _bytes_recv;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"bytes_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_recv
     {
-      get { return _bytes_recv; }
+      get { return _bytes_recv?? default(ulong); }
       set { _bytes_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_recvSpecified
+    {
+      get { return _bytes_recv != null; }
+      set { if (value == (_bytes_recv== null)) _bytes_recv = value ? this.bytes_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_recv() { return bytes_recvSpecified; }
+    private void Resetbytes_recv() { bytes_recvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5101,23 +9000,41 @@ namespace SteamKit2.Internal
     public Stats_VConn() {}
     
 
-    private uint _connections_udp = default(uint);
+    private uint? _connections_udp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"connections_udp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint connections_udp
     {
-      get { return _connections_udp; }
+      get { return _connections_udp?? default(uint); }
       set { _connections_udp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connections_udpSpecified
+    {
+      get { return _connections_udp != null; }
+      set { if (value == (_connections_udp== null)) _connections_udp = value ? this.connections_udp : (uint?)null; }
+    }
+    private bool ShouldSerializeconnections_udp() { return connections_udpSpecified; }
+    private void Resetconnections_udp() { connections_udpSpecified = false; }
+    
 
-    private uint _connections_tcp = default(uint);
+    private uint? _connections_tcp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"connections_tcp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint connections_tcp
     {
-      get { return _connections_tcp; }
+      get { return _connections_tcp?? default(uint); }
       set { _connections_tcp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool connections_tcpSpecified
+    {
+      get { return _connections_tcp != null; }
+      set { if (value == (_connections_tcp== null)) _connections_tcp = value ? this.connections_tcp : (uint?)null; }
+    }
+    private bool ShouldSerializeconnections_tcp() { return connections_tcpSpecified; }
+    private void Resetconnections_tcp() { connections_tcpSpecified = false; }
+    
 
     private CMsgClientConnectionStats.Stats_UDP _stats_udp = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"stats_udp", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -5128,158 +9045,311 @@ namespace SteamKit2.Internal
       set { _stats_udp = value; }
     }
 
-    private ulong _pkts_abandoned = default(ulong);
+    private ulong? _pkts_abandoned;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"pkts_abandoned", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pkts_abandoned
     {
-      get { return _pkts_abandoned; }
+      get { return _pkts_abandoned?? default(ulong); }
       set { _pkts_abandoned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pkts_abandonedSpecified
+    {
+      get { return _pkts_abandoned != null; }
+      set { if (value == (_pkts_abandoned== null)) _pkts_abandoned = value ? this.pkts_abandoned : (ulong?)null; }
+    }
+    private bool ShouldSerializepkts_abandoned() { return pkts_abandonedSpecified; }
+    private void Resetpkts_abandoned() { pkts_abandonedSpecified = false; }
+    
 
-    private ulong _conn_req_received = default(ulong);
+    private ulong? _conn_req_received;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"conn_req_received", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong conn_req_received
     {
-      get { return _conn_req_received; }
+      get { return _conn_req_received?? default(ulong); }
       set { _conn_req_received = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool conn_req_receivedSpecified
+    {
+      get { return _conn_req_received != null; }
+      set { if (value == (_conn_req_received== null)) _conn_req_received = value ? this.conn_req_received : (ulong?)null; }
+    }
+    private bool ShouldSerializeconn_req_received() { return conn_req_receivedSpecified; }
+    private void Resetconn_req_received() { conn_req_receivedSpecified = false; }
+    
 
-    private ulong _pkts_resent = default(ulong);
+    private ulong? _pkts_resent;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"pkts_resent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong pkts_resent
     {
-      get { return _pkts_resent; }
+      get { return _pkts_resent?? default(ulong); }
       set { _pkts_resent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pkts_resentSpecified
+    {
+      get { return _pkts_resent != null; }
+      set { if (value == (_pkts_resent== null)) _pkts_resent = value ? this.pkts_resent : (ulong?)null; }
+    }
+    private bool ShouldSerializepkts_resent() { return pkts_resentSpecified; }
+    private void Resetpkts_resent() { pkts_resentSpecified = false; }
+    
 
-    private ulong _msgs_sent = default(ulong);
+    private ulong? _msgs_sent;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"msgs_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong msgs_sent
     {
-      get { return _msgs_sent; }
+      get { return _msgs_sent?? default(ulong); }
       set { _msgs_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgs_sentSpecified
+    {
+      get { return _msgs_sent != null; }
+      set { if (value == (_msgs_sent== null)) _msgs_sent = value ? this.msgs_sent : (ulong?)null; }
+    }
+    private bool ShouldSerializemsgs_sent() { return msgs_sentSpecified; }
+    private void Resetmsgs_sent() { msgs_sentSpecified = false; }
+    
 
-    private ulong _msgs_sent_failed = default(ulong);
+    private ulong? _msgs_sent_failed;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"msgs_sent_failed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong msgs_sent_failed
     {
-      get { return _msgs_sent_failed; }
+      get { return _msgs_sent_failed?? default(ulong); }
       set { _msgs_sent_failed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgs_sent_failedSpecified
+    {
+      get { return _msgs_sent_failed != null; }
+      set { if (value == (_msgs_sent_failed== null)) _msgs_sent_failed = value ? this.msgs_sent_failed : (ulong?)null; }
+    }
+    private bool ShouldSerializemsgs_sent_failed() { return msgs_sent_failedSpecified; }
+    private void Resetmsgs_sent_failed() { msgs_sent_failedSpecified = false; }
+    
 
-    private ulong _msgs_recv = default(ulong);
+    private ulong? _msgs_recv;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"msgs_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong msgs_recv
     {
-      get { return _msgs_recv; }
+      get { return _msgs_recv?? default(ulong); }
       set { _msgs_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgs_recvSpecified
+    {
+      get { return _msgs_recv != null; }
+      set { if (value == (_msgs_recv== null)) _msgs_recv = value ? this.msgs_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializemsgs_recv() { return msgs_recvSpecified; }
+    private void Resetmsgs_recv() { msgs_recvSpecified = false; }
+    
 
-    private ulong _datagrams_sent = default(ulong);
+    private ulong? _datagrams_sent;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"datagrams_sent", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong datagrams_sent
     {
-      get { return _datagrams_sent; }
+      get { return _datagrams_sent?? default(ulong); }
       set { _datagrams_sent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool datagrams_sentSpecified
+    {
+      get { return _datagrams_sent != null; }
+      set { if (value == (_datagrams_sent== null)) _datagrams_sent = value ? this.datagrams_sent : (ulong?)null; }
+    }
+    private bool ShouldSerializedatagrams_sent() { return datagrams_sentSpecified; }
+    private void Resetdatagrams_sent() { datagrams_sentSpecified = false; }
+    
 
-    private ulong _datagrams_recv = default(ulong);
+    private ulong? _datagrams_recv;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"datagrams_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong datagrams_recv
     {
-      get { return _datagrams_recv; }
+      get { return _datagrams_recv?? default(ulong); }
       set { _datagrams_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool datagrams_recvSpecified
+    {
+      get { return _datagrams_recv != null; }
+      set { if (value == (_datagrams_recv== null)) _datagrams_recv = value ? this.datagrams_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializedatagrams_recv() { return datagrams_recvSpecified; }
+    private void Resetdatagrams_recv() { datagrams_recvSpecified = false; }
+    
 
-    private ulong _bad_pkts_recv = default(ulong);
+    private ulong? _bad_pkts_recv;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"bad_pkts_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bad_pkts_recv
     {
-      get { return _bad_pkts_recv; }
+      get { return _bad_pkts_recv?? default(ulong); }
       set { _bad_pkts_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bad_pkts_recvSpecified
+    {
+      get { return _bad_pkts_recv != null; }
+      set { if (value == (_bad_pkts_recv== null)) _bad_pkts_recv = value ? this.bad_pkts_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializebad_pkts_recv() { return bad_pkts_recvSpecified; }
+    private void Resetbad_pkts_recv() { bad_pkts_recvSpecified = false; }
+    
 
-    private ulong _unknown_conn_pkts_recv = default(ulong);
+    private ulong? _unknown_conn_pkts_recv;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"unknown_conn_pkts_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong unknown_conn_pkts_recv
     {
-      get { return _unknown_conn_pkts_recv; }
+      get { return _unknown_conn_pkts_recv?? default(ulong); }
       set { _unknown_conn_pkts_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unknown_conn_pkts_recvSpecified
+    {
+      get { return _unknown_conn_pkts_recv != null; }
+      set { if (value == (_unknown_conn_pkts_recv== null)) _unknown_conn_pkts_recv = value ? this.unknown_conn_pkts_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializeunknown_conn_pkts_recv() { return unknown_conn_pkts_recvSpecified; }
+    private void Resetunknown_conn_pkts_recv() { unknown_conn_pkts_recvSpecified = false; }
+    
 
-    private ulong _missed_pkts_recv = default(ulong);
+    private ulong? _missed_pkts_recv;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"missed_pkts_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong missed_pkts_recv
     {
-      get { return _missed_pkts_recv; }
+      get { return _missed_pkts_recv?? default(ulong); }
       set { _missed_pkts_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool missed_pkts_recvSpecified
+    {
+      get { return _missed_pkts_recv != null; }
+      set { if (value == (_missed_pkts_recv== null)) _missed_pkts_recv = value ? this.missed_pkts_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializemissed_pkts_recv() { return missed_pkts_recvSpecified; }
+    private void Resetmissed_pkts_recv() { missed_pkts_recvSpecified = false; }
+    
 
-    private ulong _dup_pkts_recv = default(ulong);
+    private ulong? _dup_pkts_recv;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"dup_pkts_recv", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong dup_pkts_recv
     {
-      get { return _dup_pkts_recv; }
+      get { return _dup_pkts_recv?? default(ulong); }
       set { _dup_pkts_recv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dup_pkts_recvSpecified
+    {
+      get { return _dup_pkts_recv != null; }
+      set { if (value == (_dup_pkts_recv== null)) _dup_pkts_recv = value ? this.dup_pkts_recv : (ulong?)null; }
+    }
+    private bool ShouldSerializedup_pkts_recv() { return dup_pkts_recvSpecified; }
+    private void Resetdup_pkts_recv() { dup_pkts_recvSpecified = false; }
+    
 
-    private ulong _failed_connect_challenges = default(ulong);
+    private ulong? _failed_connect_challenges;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"failed_connect_challenges", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong failed_connect_challenges
     {
-      get { return _failed_connect_challenges; }
+      get { return _failed_connect_challenges?? default(ulong); }
       set { _failed_connect_challenges = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool failed_connect_challengesSpecified
+    {
+      get { return _failed_connect_challenges != null; }
+      set { if (value == (_failed_connect_challenges== null)) _failed_connect_challenges = value ? this.failed_connect_challenges : (ulong?)null; }
+    }
+    private bool ShouldSerializefailed_connect_challenges() { return failed_connect_challengesSpecified; }
+    private void Resetfailed_connect_challenges() { failed_connect_challengesSpecified = false; }
+    
 
-    private uint _micro_sec_avg_latency = default(uint);
+    private uint? _micro_sec_avg_latency;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"micro_sec_avg_latency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint micro_sec_avg_latency
     {
-      get { return _micro_sec_avg_latency; }
+      get { return _micro_sec_avg_latency?? default(uint); }
       set { _micro_sec_avg_latency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool micro_sec_avg_latencySpecified
+    {
+      get { return _micro_sec_avg_latency != null; }
+      set { if (value == (_micro_sec_avg_latency== null)) _micro_sec_avg_latency = value ? this.micro_sec_avg_latency : (uint?)null; }
+    }
+    private bool ShouldSerializemicro_sec_avg_latency() { return micro_sec_avg_latencySpecified; }
+    private void Resetmicro_sec_avg_latency() { micro_sec_avg_latencySpecified = false; }
+    
 
-    private uint _micro_sec_min_latency = default(uint);
+    private uint? _micro_sec_min_latency;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"micro_sec_min_latency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint micro_sec_min_latency
     {
-      get { return _micro_sec_min_latency; }
+      get { return _micro_sec_min_latency?? default(uint); }
       set { _micro_sec_min_latency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool micro_sec_min_latencySpecified
+    {
+      get { return _micro_sec_min_latency != null; }
+      set { if (value == (_micro_sec_min_latency== null)) _micro_sec_min_latency = value ? this.micro_sec_min_latency : (uint?)null; }
+    }
+    private bool ShouldSerializemicro_sec_min_latency() { return micro_sec_min_latencySpecified; }
+    private void Resetmicro_sec_min_latency() { micro_sec_min_latencySpecified = false; }
+    
 
-    private uint _micro_sec_max_latency = default(uint);
+    private uint? _micro_sec_max_latency;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"micro_sec_max_latency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint micro_sec_max_latency
     {
-      get { return _micro_sec_max_latency; }
+      get { return _micro_sec_max_latency?? default(uint); }
       set { _micro_sec_max_latency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool micro_sec_max_latencySpecified
+    {
+      get { return _micro_sec_max_latency != null; }
+      set { if (value == (_micro_sec_max_latency== null)) _micro_sec_max_latency = value ? this.micro_sec_max_latency : (uint?)null; }
+    }
+    private bool ShouldSerializemicro_sec_max_latency() { return micro_sec_max_latencySpecified; }
+    private void Resetmicro_sec_max_latency() { micro_sec_max_latencySpecified = false; }
+    
 
-    private uint _mem_pool_msg_in_use = default(uint);
+    private uint? _mem_pool_msg_in_use;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"mem_pool_msg_in_use", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint mem_pool_msg_in_use
     {
-      get { return _mem_pool_msg_in_use; }
+      get { return _mem_pool_msg_in_use?? default(uint); }
       set { _mem_pool_msg_in_use = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mem_pool_msg_in_useSpecified
+    {
+      get { return _mem_pool_msg_in_use != null; }
+      set { if (value == (_mem_pool_msg_in_use== null)) _mem_pool_msg_in_use = value ? this.mem_pool_msg_in_use : (uint?)null; }
+    }
+    private bool ShouldSerializemem_pool_msg_in_use() { return mem_pool_msg_in_useSpecified; }
+    private void Resetmem_pool_msg_in_use() { mem_pool_msg_in_useSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5303,37 +9373,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _server_type_for_auth_services = default(uint);
+    private uint? _server_type_for_auth_services;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_type_for_auth_services", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_type_for_auth_services
     {
-      get { return _server_type_for_auth_services; }
+      get { return _server_type_for_auth_services?? default(uint); }
       set { _server_type_for_auth_services = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_type_for_auth_servicesSpecified
+    {
+      get { return _server_type_for_auth_services != null; }
+      set { if (value == (_server_type_for_auth_services== null)) _server_type_for_auth_services = value ? this.server_type_for_auth_services : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_type_for_auth_services() { return server_type_for_auth_servicesSpecified; }
+    private void Resetserver_type_for_auth_services() { server_type_for_auth_servicesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Server_Types_Available")]
   public partial class Server_Types_Available : global::ProtoBuf.IExtensible
   {
     public Server_Types_Available() {}
     
 
-    private uint _server = default(uint);
+    private uint? _server;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server
     {
-      get { return _server; }
+      get { return _server?? default(uint); }
       set { _server = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serverSpecified
+    {
+      get { return _server != null; }
+      set { if (value == (_server== null)) _server = value ? this.server : (uint?)null; }
+    }
+    private bool ShouldSerializeserver() { return serverSpecified; }
+    private void Resetserver() { serverSpecified = false; }
+    
 
-    private bool _changed = default(bool);
+    private bool? _changed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"changed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool changed
     {
-      get { return _changed; }
+      get { return _changed?? default(bool); }
       set { _changed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool changedSpecified
+    {
+      get { return _changed != null; }
+      set { if (value == (_changed== null)) _changed = value ? this.changed : (bool?)null; }
+    }
+    private bool ShouldSerializechanged() { return changedSpecified; }
+    private void Resetchanged() { changedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5350,41 +9447,77 @@ namespace SteamKit2.Internal
     public CMsgClientGetUserStats() {}
     
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private uint _crc_stats = default(uint);
+    private uint? _crc_stats;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"crc_stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_stats
     {
-      get { return _crc_stats; }
+      get { return _crc_stats?? default(uint); }
       set { _crc_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_statsSpecified
+    {
+      get { return _crc_stats != null; }
+      set { if (value == (_crc_stats== null)) _crc_stats = value ? this.crc_stats : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_stats() { return crc_statsSpecified; }
+    private void Resetcrc_stats() { crc_statsSpecified = false; }
+    
 
-    private int _schema_local_version = default(int);
+    private int? _schema_local_version;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"schema_local_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int schema_local_version
     {
-      get { return _schema_local_version; }
+      get { return _schema_local_version?? default(int); }
       set { _schema_local_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schema_local_versionSpecified
+    {
+      get { return _schema_local_version != null; }
+      set { if (value == (_schema_local_version== null)) _schema_local_version = value ? this.schema_local_version : (int?)null; }
+    }
+    private bool ShouldSerializeschema_local_version() { return schema_local_versionSpecified; }
+    private void Resetschema_local_version() { schema_local_versionSpecified = false; }
+    
 
-    private ulong _steam_id_for_user = default(ulong);
+    private ulong? _steam_id_for_user;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steam_id_for_user", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_for_user
     {
-      get { return _steam_id_for_user; }
+      get { return _steam_id_for_user?? default(ulong); }
       set { _steam_id_for_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_for_userSpecified
+    {
+      get { return _steam_id_for_user != null; }
+      set { if (value == (_steam_id_for_user== null)) _steam_id_for_user = value ? this.steam_id_for_user : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_for_user() { return steam_id_for_userSpecified; }
+    private void Resetsteam_id_for_user() { steam_id_for_userSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5396,41 +9529,77 @@ namespace SteamKit2.Internal
     public CMsgClientGetUserStatsResponse() {}
     
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _crc_stats = default(uint);
+    private uint? _crc_stats;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"crc_stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_stats
     {
-      get { return _crc_stats; }
+      get { return _crc_stats?? default(uint); }
       set { _crc_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_statsSpecified
+    {
+      get { return _crc_stats != null; }
+      set { if (value == (_crc_stats== null)) _crc_stats = value ? this.crc_stats : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_stats() { return crc_statsSpecified; }
+    private void Resetcrc_stats() { crc_statsSpecified = false; }
+    
 
-    private byte[] _schema = null;
+    private byte[] _schema;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"schema", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] schema
     {
-      get { return _schema; }
+      get { return _schema?? null; }
       set { _schema = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool schemaSpecified
+    {
+      get { return _schema != null; }
+      set { if (value == (_schema== null)) _schema = value ? this.schema : (byte[])null; }
+    }
+    private bool ShouldSerializeschema() { return schemaSpecified; }
+    private void Resetschema() { schemaSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientGetUserStatsResponse.Stats> _stats = new global::System.Collections.Generic.List<CMsgClientGetUserStatsResponse.Stats>();
     [global::ProtoBuf.ProtoMember(5, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientGetUserStatsResponse.Stats> stats
@@ -5451,23 +9620,41 @@ namespace SteamKit2.Internal
     public Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5479,14 +9666,23 @@ namespace SteamKit2.Internal
     public Achievement_Blocks() {}
     
 
-    private uint _achievement_id = default(uint);
+    private uint? _achievement_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"achievement_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint achievement_id
     {
-      get { return _achievement_id; }
+      get { return _achievement_id?? default(uint); }
       set { _achievement_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool achievement_idSpecified
+    {
+      get { return _achievement_id != null; }
+      set { if (value == (_achievement_id== null)) _achievement_id = value ? this.achievement_id : (uint?)null; }
+    }
+    private bool ShouldSerializeachievement_id() { return achievement_idSpecified; }
+    private void Resetachievement_id() { achievement_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _unlock_time = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"unlock_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<uint> unlock_time
@@ -5510,32 +9706,59 @@ namespace SteamKit2.Internal
     public CMsgClientStoreUserStatsResponse() {}
     
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _crc_stats = default(uint);
+    private uint? _crc_stats;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"crc_stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_stats
     {
-      get { return _crc_stats; }
+      get { return _crc_stats?? default(uint); }
       set { _crc_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_statsSpecified
+    {
+      get { return _crc_stats != null; }
+      set { if (value == (_crc_stats== null)) _crc_stats = value ? this.crc_stats : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_stats() { return crc_statsSpecified; }
+    private void Resetcrc_stats() { crc_statsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientStoreUserStatsResponse.Stats_Failed_Validation> _stats_failed_validation = new global::System.Collections.Generic.List<CMsgClientStoreUserStatsResponse.Stats_Failed_Validation>();
     [global::ProtoBuf.ProtoMember(4, Name=@"stats_failed_validation", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientStoreUserStatsResponse.Stats_Failed_Validation> stats_failed_validation
@@ -5544,37 +9767,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _stats_out_of_date = default(bool);
+    private bool? _stats_out_of_date;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"stats_out_of_date", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool stats_out_of_date
     {
-      get { return _stats_out_of_date; }
+      get { return _stats_out_of_date?? default(bool); }
       set { _stats_out_of_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_out_of_dateSpecified
+    {
+      get { return _stats_out_of_date != null; }
+      set { if (value == (_stats_out_of_date== null)) _stats_out_of_date = value ? this.stats_out_of_date : (bool?)null; }
+    }
+    private bool ShouldSerializestats_out_of_date() { return stats_out_of_dateSpecified; }
+    private void Resetstats_out_of_date() { stats_out_of_dateSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Stats_Failed_Validation")]
   public partial class Stats_Failed_Validation : global::ProtoBuf.IExtensible
   {
     public Stats_Failed_Validation() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _reverted_stat_value = default(uint);
+    private uint? _reverted_stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reverted_stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint reverted_stat_value
     {
-      get { return _reverted_stat_value; }
+      get { return _reverted_stat_value?? default(uint); }
       set { _reverted_stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reverted_stat_valueSpecified
+    {
+      get { return _reverted_stat_value != null; }
+      set { if (value == (_reverted_stat_value== null)) _reverted_stat_value = value ? this.reverted_stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializereverted_stat_value() { return reverted_stat_valueSpecified; }
+    private void Resetreverted_stat_value() { reverted_stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5591,50 +9841,95 @@ namespace SteamKit2.Internal
     public CMsgClientStoreUserStats2() {}
     
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private ulong _settor_steam_id = default(ulong);
+    private ulong? _settor_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"settor_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong settor_steam_id
     {
-      get { return _settor_steam_id; }
+      get { return _settor_steam_id?? default(ulong); }
       set { _settor_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool settor_steam_idSpecified
+    {
+      get { return _settor_steam_id != null; }
+      set { if (value == (_settor_steam_id== null)) _settor_steam_id = value ? this.settor_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesettor_steam_id() { return settor_steam_idSpecified; }
+    private void Resetsettor_steam_id() { settor_steam_idSpecified = false; }
+    
 
-    private ulong _settee_steam_id = default(ulong);
+    private ulong? _settee_steam_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"settee_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong settee_steam_id
     {
-      get { return _settee_steam_id; }
+      get { return _settee_steam_id?? default(ulong); }
       set { _settee_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool settee_steam_idSpecified
+    {
+      get { return _settee_steam_id != null; }
+      set { if (value == (_settee_steam_id== null)) _settee_steam_id = value ? this.settee_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesettee_steam_id() { return settee_steam_idSpecified; }
+    private void Resetsettee_steam_id() { settee_steam_idSpecified = false; }
+    
 
-    private uint _crc_stats = default(uint);
+    private uint? _crc_stats;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"crc_stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_stats
     {
-      get { return _crc_stats; }
+      get { return _crc_stats?? default(uint); }
       set { _crc_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_statsSpecified
+    {
+      get { return _crc_stats != null; }
+      set { if (value == (_crc_stats== null)) _crc_stats = value ? this.crc_stats : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_stats() { return crc_statsSpecified; }
+    private void Resetcrc_stats() { crc_statsSpecified = false; }
+    
 
-    private bool _explicit_reset = default(bool);
+    private bool? _explicit_reset;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"explicit_reset", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool explicit_reset
     {
-      get { return _explicit_reset; }
+      get { return _explicit_reset?? default(bool); }
       set { _explicit_reset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool explicit_resetSpecified
+    {
+      get { return _explicit_reset != null; }
+      set { if (value == (_explicit_reset== null)) _explicit_reset = value ? this.explicit_reset : (bool?)null; }
+    }
+    private bool ShouldSerializeexplicit_reset() { return explicit_resetSpecified; }
+    private void Resetexplicit_reset() { explicit_resetSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientStoreUserStats2.Stats> _stats = new global::System.Collections.Generic.List<CMsgClientStoreUserStats2.Stats>();
     [global::ProtoBuf.ProtoMember(6, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientStoreUserStats2.Stats> stats
@@ -5648,23 +9943,41 @@ namespace SteamKit2.Internal
     public Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5681,32 +9994,59 @@ namespace SteamKit2.Internal
     public CMsgClientStatsUpdated() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private uint _crc_stats = default(uint);
+    private uint? _crc_stats;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"crc_stats", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint crc_stats
     {
-      get { return _crc_stats; }
+      get { return _crc_stats?? default(uint); }
       set { _crc_stats = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crc_statsSpecified
+    {
+      get { return _crc_stats != null; }
+      set { if (value == (_crc_stats== null)) _crc_stats = value ? this.crc_stats : (uint?)null; }
+    }
+    private bool ShouldSerializecrc_stats() { return crc_statsSpecified; }
+    private void Resetcrc_stats() { crc_statsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientStatsUpdated.Updated_Stats> _updated_stats = new global::System.Collections.Generic.List<CMsgClientStatsUpdated.Updated_Stats>();
     [global::ProtoBuf.ProtoMember(4, Name=@"updated_stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientStatsUpdated.Updated_Stats> updated_stats
@@ -5720,23 +10060,41 @@ namespace SteamKit2.Internal
     public Updated_Stats() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5753,23 +10111,41 @@ namespace SteamKit2.Internal
     public CMsgClientStoreUserStats() {}
     
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private bool _explicit_reset = default(bool);
+    private bool? _explicit_reset;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"explicit_reset", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool explicit_reset
     {
-      get { return _explicit_reset; }
+      get { return _explicit_reset?? default(bool); }
       set { _explicit_reset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool explicit_resetSpecified
+    {
+      get { return _explicit_reset != null; }
+      set { if (value == (_explicit_reset== null)) _explicit_reset = value ? this.explicit_reset : (bool?)null; }
+    }
+    private bool ShouldSerializeexplicit_reset() { return explicit_resetSpecified; }
+    private void Resetexplicit_reset() { explicit_resetSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientStoreUserStats.Stats_To_Store> _stats_to_store = new global::System.Collections.Generic.List<CMsgClientStoreUserStats.Stats_To_Store>();
     [global::ProtoBuf.ProtoMember(3, Name=@"stats_to_store", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientStoreUserStats.Stats_To_Store> stats_to_store
@@ -5783,23 +10159,41 @@ namespace SteamKit2.Internal
     public Stats_To_Store() {}
     
 
-    private uint _stat_id = default(uint);
+    private uint? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(uint); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (uint?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private uint _stat_value = default(uint);
+    private uint? _stat_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"stat_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stat_value
     {
-      get { return _stat_value; }
+      get { return _stat_value?? default(uint); }
       set { _stat_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_valueSpecified
+    {
+      get { return _stat_value != null; }
+      set { if (value == (_stat_value== null)) _stat_value = value ? this.stat_value : (uint?)null; }
+    }
+    private bool ShouldSerializestat_value() { return stat_valueSpecified; }
+    private void Resetstat_value() { stat_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5843,68 +10237,131 @@ namespace SteamKit2.Internal
     public CMsgClientGetClientDetailsResponse() {}
     
 
-    private uint _package_version = default(uint);
+    private uint? _package_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_version
     {
-      get { return _package_version; }
+      get { return _package_version?? default(uint); }
       set { _package_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_versionSpecified
+    {
+      get { return _package_version != null; }
+      set { if (value == (_package_version== null)) _package_version = value ? this.package_version : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_version() { return package_versionSpecified; }
+    private void Resetpackage_version() { package_versionSpecified = false; }
+    
 
-    private uint _protocol_version = default(uint);
+    private uint? _protocol_version;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"protocol_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protocol_version
     {
-      get { return _protocol_version; }
+      get { return _protocol_version?? default(uint); }
       set { _protocol_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protocol_versionSpecified
+    {
+      get { return _protocol_version != null; }
+      set { if (value == (_protocol_version== null)) _protocol_version = value ? this.protocol_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprotocol_version() { return protocol_versionSpecified; }
+    private void Resetprotocol_version() { protocol_versionSpecified = false; }
+    
 
-    private string _os = "";
+    private string _os;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"os", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string os
     {
-      get { return _os; }
+      get { return _os?? ""; }
       set { _os = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool osSpecified
+    {
+      get { return _os != null; }
+      set { if (value == (_os== null)) _os = value ? this.os : (string)null; }
+    }
+    private bool ShouldSerializeos() { return osSpecified; }
+    private void Resetos() { osSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
 
-    private string _ip_public = "";
+    private string _ip_public;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ip_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ip_public
     {
-      get { return _ip_public; }
+      get { return _ip_public?? ""; }
       set { _ip_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_publicSpecified
+    {
+      get { return _ip_public != null; }
+      set { if (value == (_ip_public== null)) _ip_public = value ? this.ip_public : (string)null; }
+    }
+    private bool ShouldSerializeip_public() { return ip_publicSpecified; }
+    private void Resetip_public() { ip_publicSpecified = false; }
+    
 
-    private string _ip_private = "";
+    private string _ip_private;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ip_private", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ip_private
     {
-      get { return _ip_private; }
+      get { return _ip_private?? ""; }
       set { _ip_private = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ip_privateSpecified
+    {
+      get { return _ip_private != null; }
+      set { if (value == (_ip_private== null)) _ip_private = value ? this.ip_private : (string)null; }
+    }
+    private bool ShouldSerializeip_private() { return ip_privateSpecified; }
+    private void Resetip_private() { ip_privateSpecified = false; }
+    
 
-    private ulong _bytes_available = default(ulong);
+    private ulong? _bytes_available;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"bytes_available", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_available
     {
-      get { return _bytes_available; }
+      get { return _bytes_available?? default(ulong); }
       set { _bytes_available = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_availableSpecified
+    {
+      get { return _bytes_available != null; }
+      set { if (value == (_bytes_available== null)) _bytes_available = value ? this.bytes_available : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_available() { return bytes_availableSpecified; }
+    private void Resetbytes_available() { bytes_availableSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientGetClientDetailsResponse.Game> _games_running = new global::System.Collections.Generic.List<CMsgClientGetClientDetailsResponse.Game>();
     [global::ProtoBuf.ProtoMember(6, Name=@"games_running", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientGetClientDetailsResponse.Game> games_running
@@ -5918,32 +10375,59 @@ namespace SteamKit2.Internal
     public Game() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _extra_info = "";
+    private string _extra_info;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"extra_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string extra_info
     {
-      get { return _extra_info; }
+      get { return _extra_info?? ""; }
       set { _extra_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool extra_infoSpecified
+    {
+      get { return _extra_info != null; }
+      set { if (value == (_extra_info== null)) _extra_info = value ? this.extra_info : (string)null; }
+    }
+    private bool ShouldSerializeextra_info() { return extra_infoSpecified; }
+    private void Resetextra_info() { extra_infoSpecified = false; }
+    
 
-    private uint _time_running_sec = default(uint);
+    private uint? _time_running_sec;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_running_sec", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_running_sec
     {
-      get { return _time_running_sec; }
+      get { return _time_running_sec?? default(uint); }
       set { _time_running_sec = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_running_secSpecified
+    {
+      get { return _time_running_sec != null; }
+      set { if (value == (_time_running_sec== null)) _time_running_sec = value ? this.time_running_sec : (uint?)null; }
+    }
+    private bool ShouldSerializetime_running_sec() { return time_running_secSpecified; }
+    private void Resettime_running_sec() { time_running_secSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5960,50 +10444,95 @@ namespace SteamKit2.Internal
     public CMsgClientGetClientAppList() {}
     
 
-    private bool _media = default(bool);
+    private bool? _media;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"media", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool media
     {
-      get { return _media; }
+      get { return _media?? default(bool); }
       set { _media = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mediaSpecified
+    {
+      get { return _media != null; }
+      set { if (value == (_media== null)) _media = value ? this.media : (bool?)null; }
+    }
+    private bool ShouldSerializemedia() { return mediaSpecified; }
+    private void Resetmedia() { mediaSpecified = false; }
+    
 
-    private bool _tools = default(bool);
+    private bool? _tools;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tools", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool tools
     {
-      get { return _tools; }
+      get { return _tools?? default(bool); }
       set { _tools = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool toolsSpecified
+    {
+      get { return _tools != null; }
+      set { if (value == (_tools== null)) _tools = value ? this.tools : (bool?)null; }
+    }
+    private bool ShouldSerializetools() { return toolsSpecified; }
+    private void Resettools() { toolsSpecified = false; }
+    
 
-    private bool _games = default(bool);
+    private bool? _games;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"games", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool games
     {
-      get { return _games; }
+      get { return _games?? default(bool); }
       set { _games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamesSpecified
+    {
+      get { return _games != null; }
+      set { if (value == (_games== null)) _games = value ? this.games : (bool?)null; }
+    }
+    private bool ShouldSerializegames() { return gamesSpecified; }
+    private void Resetgames() { gamesSpecified = false; }
+    
 
-    private bool _only_installed = default(bool);
+    private bool? _only_installed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"only_installed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_installed
     {
-      get { return _only_installed; }
+      get { return _only_installed?? default(bool); }
       set { _only_installed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_installedSpecified
+    {
+      get { return _only_installed != null; }
+      set { if (value == (_only_installed== null)) _only_installed = value ? this.only_installed : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_installed() { return only_installedSpecified; }
+    private void Resetonly_installed() { only_installedSpecified = false; }
+    
 
-    private bool _only_changing = default(bool);
+    private bool? _only_changing;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"only_changing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_changing
     {
-      get { return _only_changing; }
+      get { return _only_changing?? default(bool); }
       set { _only_changing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_changingSpecified
+    {
+      get { return _only_changing != null; }
+      set { if (value == (_only_changing== null)) _only_changing = value ? this.only_changing : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_changing() { return only_changingSpecified; }
+    private void Resetonly_changing() { only_changingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6022,145 +10551,280 @@ namespace SteamKit2.Internal
     }
   
 
-    private ulong _bytes_available = default(ulong);
+    private ulong? _bytes_available;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bytes_available", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_available
     {
-      get { return _bytes_available; }
+      get { return _bytes_available?? default(ulong); }
       set { _bytes_available = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_availableSpecified
+    {
+      get { return _bytes_available != null; }
+      set { if (value == (_bytes_available== null)) _bytes_available = value ? this.bytes_available : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_available() { return bytes_availableSpecified; }
+    private void Resetbytes_available() { bytes_availableSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"App")]
   public partial class App : global::ProtoBuf.IExtensible
   {
     public App() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _category = "";
+    private string _category;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"category", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string category
     {
-      get { return _category; }
+      get { return _category?? ""; }
       set { _category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool categorySpecified
+    {
+      get { return _category != null; }
+      set { if (value == (_category== null)) _category = value ? this.category : (string)null; }
+    }
+    private bool ShouldSerializecategory() { return categorySpecified; }
+    private void Resetcategory() { categorySpecified = false; }
+    
 
-    private string _app_type = "";
+    private string _app_type;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"app_type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string app_type
     {
-      get { return _app_type; }
+      get { return _app_type?? ""; }
       set { _app_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_typeSpecified
+    {
+      get { return _app_type != null; }
+      set { if (value == (_app_type== null)) _app_type = value ? this.app_type : (string)null; }
+    }
+    private bool ShouldSerializeapp_type() { return app_typeSpecified; }
+    private void Resetapp_type() { app_typeSpecified = false; }
+    
 
-    private bool _favorite = default(bool);
+    private bool? _favorite;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"favorite", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool favorite
     {
-      get { return _favorite; }
+      get { return _favorite?? default(bool); }
       set { _favorite = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favoriteSpecified
+    {
+      get { return _favorite != null; }
+      set { if (value == (_favorite== null)) _favorite = value ? this.favorite : (bool?)null; }
+    }
+    private bool ShouldSerializefavorite() { return favoriteSpecified; }
+    private void Resetfavorite() { favoriteSpecified = false; }
+    
 
-    private bool _installed = default(bool);
+    private bool? _installed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"installed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool installed
     {
-      get { return _installed; }
+      get { return _installed?? default(bool); }
       set { _installed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool installedSpecified
+    {
+      get { return _installed != null; }
+      set { if (value == (_installed== null)) _installed = value ? this.installed : (bool?)null; }
+    }
+    private bool ShouldSerializeinstalled() { return installedSpecified; }
+    private void Resetinstalled() { installedSpecified = false; }
+    
 
-    private bool _auto_update = default(bool);
+    private bool? _auto_update;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"auto_update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool auto_update
     {
-      get { return _auto_update; }
+      get { return _auto_update?? default(bool); }
       set { _auto_update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auto_updateSpecified
+    {
+      get { return _auto_update != null; }
+      set { if (value == (_auto_update== null)) _auto_update = value ? this.auto_update : (bool?)null; }
+    }
+    private bool ShouldSerializeauto_update() { return auto_updateSpecified; }
+    private void Resetauto_update() { auto_updateSpecified = false; }
+    
 
-    private ulong _bytes_downloaded = default(ulong);
+    private ulong? _bytes_downloaded;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"bytes_downloaded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_downloaded
     {
-      get { return _bytes_downloaded; }
+      get { return _bytes_downloaded?? default(ulong); }
       set { _bytes_downloaded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_downloadedSpecified
+    {
+      get { return _bytes_downloaded != null; }
+      set { if (value == (_bytes_downloaded== null)) _bytes_downloaded = value ? this.bytes_downloaded : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_downloaded() { return bytes_downloadedSpecified; }
+    private void Resetbytes_downloaded() { bytes_downloadedSpecified = false; }
+    
 
-    private ulong _bytes_needed = default(ulong);
+    private ulong? _bytes_needed;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"bytes_needed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_needed
     {
-      get { return _bytes_needed; }
+      get { return _bytes_needed?? default(ulong); }
       set { _bytes_needed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_neededSpecified
+    {
+      get { return _bytes_needed != null; }
+      set { if (value == (_bytes_needed== null)) _bytes_needed = value ? this.bytes_needed : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_needed() { return bytes_neededSpecified; }
+    private void Resetbytes_needed() { bytes_neededSpecified = false; }
+    
 
-    private uint _bytes_download_rate = default(uint);
+    private uint? _bytes_download_rate;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"bytes_download_rate", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bytes_download_rate
     {
-      get { return _bytes_download_rate; }
+      get { return _bytes_download_rate?? default(uint); }
       set { _bytes_download_rate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_download_rateSpecified
+    {
+      get { return _bytes_download_rate != null; }
+      set { if (value == (_bytes_download_rate== null)) _bytes_download_rate = value ? this.bytes_download_rate : (uint?)null; }
+    }
+    private bool ShouldSerializebytes_download_rate() { return bytes_download_rateSpecified; }
+    private void Resetbytes_download_rate() { bytes_download_rateSpecified = false; }
+    
 
-    private bool _download_paused = default(bool);
+    private bool? _download_paused;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"download_paused", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool download_paused
     {
-      get { return _download_paused; }
+      get { return _download_paused?? default(bool); }
       set { _download_paused = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_pausedSpecified
+    {
+      get { return _download_paused != null; }
+      set { if (value == (_download_paused== null)) _download_paused = value ? this.download_paused : (bool?)null; }
+    }
+    private bool ShouldSerializedownload_paused() { return download_pausedSpecified; }
+    private void Resetdownload_paused() { download_pausedSpecified = false; }
+    
 
-    private uint _num_downloading = default(uint);
+    private uint? _num_downloading;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"num_downloading", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_downloading
     {
-      get { return _num_downloading; }
+      get { return _num_downloading?? default(uint); }
       set { _num_downloading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_downloadingSpecified
+    {
+      get { return _num_downloading != null; }
+      set { if (value == (_num_downloading== null)) _num_downloading = value ? this.num_downloading : (uint?)null; }
+    }
+    private bool ShouldSerializenum_downloading() { return num_downloadingSpecified; }
+    private void Resetnum_downloading() { num_downloadingSpecified = false; }
+    
 
-    private uint _num_paused = default(uint);
+    private uint? _num_paused;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"num_paused", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_paused
     {
-      get { return _num_paused; }
+      get { return _num_paused?? default(uint); }
       set { _num_paused = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_pausedSpecified
+    {
+      get { return _num_paused != null; }
+      set { if (value == (_num_paused== null)) _num_paused = value ? this.num_paused : (uint?)null; }
+    }
+    private bool ShouldSerializenum_paused() { return num_pausedSpecified; }
+    private void Resetnum_paused() { num_pausedSpecified = false; }
+    
 
-    private bool _changing = default(bool);
+    private bool? _changing;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"changing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool changing
     {
-      get { return _changing; }
+      get { return _changing?? default(bool); }
       set { _changing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool changingSpecified
+    {
+      get { return _changing != null; }
+      set { if (value == (_changing== null)) _changing = value ? this.changing : (bool?)null; }
+    }
+    private bool ShouldSerializechanging() { return changingSpecified; }
+    private void Resetchanging() { changingSpecified = false; }
+    
 
-    private bool _available_on_platform = default(bool);
+    private bool? _available_on_platform;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"available_on_platform", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool available_on_platform
     {
-      get { return _available_on_platform; }
+      get { return _available_on_platform?? default(bool); }
       set { _available_on_platform = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool available_on_platformSpecified
+    {
+      get { return _available_on_platform != null; }
+      set { if (value == (_available_on_platform== null)) _available_on_platform = value ? this.available_on_platform : (bool?)null; }
+    }
+    private bool ShouldSerializeavailable_on_platform() { return available_on_platformSpecified; }
+    private void Resetavailable_on_platform() { available_on_platformSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientGetClientAppListResponse.App.DLC> _dlcs = new global::System.Collections.Generic.List<CMsgClientGetClientAppListResponse.App.DLC>();
     [global::ProtoBuf.ProtoMember(9, Name=@"dlcs", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientGetClientAppListResponse.App.DLC> dlcs
@@ -6174,23 +10838,41 @@ namespace SteamKit2.Internal
     public DLC() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _installed = default(bool);
+    private bool? _installed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"installed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool installed
     {
-      get { return _installed; }
+      get { return _installed?? default(bool); }
       set { _installed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool installedSpecified
+    {
+      get { return _installed != null; }
+      set { if (value == (_installed== null)) _installed = value ? this.installed : (bool?)null; }
+    }
+    private bool ShouldSerializeinstalled() { return installedSpecified; }
+    private void Resetinstalled() { installedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6212,14 +10894,23 @@ namespace SteamKit2.Internal
     public CMsgClientInstallClientApp() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6231,14 +10922,23 @@ namespace SteamKit2.Internal
     public CMsgClientInstallClientAppResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6250,14 +10950,23 @@ namespace SteamKit2.Internal
     public CMsgClientUninstallClientApp() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6269,14 +10978,23 @@ namespace SteamKit2.Internal
     public CMsgClientUninstallClientAppResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6288,23 +11006,41 @@ namespace SteamKit2.Internal
     public CMsgClientSetClientAppUpdateState() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _update = default(bool);
+    private bool? _update;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update
     {
-      get { return _update; }
+      get { return _update?? default(bool); }
       set { _update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool updateSpecified
+    {
+      get { return _update != null; }
+      set { if (value == (_update== null)) _update = value ? this.update : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate() { return updateSpecified; }
+    private void Resetupdate() { updateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6316,14 +11052,23 @@ namespace SteamKit2.Internal
     public CMsgClientSetClientAppUpdateStateResponse() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6335,95 +11080,185 @@ namespace SteamKit2.Internal
     public CMsgClientUFSUploadFileRequest() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private uint _platforms_to_sync_deprecated = default(uint);
+    private uint? _platforms_to_sync_deprecated;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"platforms_to_sync_deprecated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint platforms_to_sync_deprecated
     {
-      get { return _platforms_to_sync_deprecated; }
+      get { return _platforms_to_sync_deprecated?? default(uint); }
       set { _platforms_to_sync_deprecated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool platforms_to_sync_deprecatedSpecified
+    {
+      get { return _platforms_to_sync_deprecated != null; }
+      set { if (value == (_platforms_to_sync_deprecated== null)) _platforms_to_sync_deprecated = value ? this.platforms_to_sync_deprecated : (uint?)null; }
+    }
+    private bool ShouldSerializeplatforms_to_sync_deprecated() { return platforms_to_sync_deprecatedSpecified; }
+    private void Resetplatforms_to_sync_deprecated() { platforms_to_sync_deprecatedSpecified = false; }
+    
 
-    private uint _platforms_to_sync = (uint)4294967295;
+    private uint? _platforms_to_sync;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"platforms_to_sync", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4294967295)]
     public uint platforms_to_sync
     {
-      get { return _platforms_to_sync; }
+      get { return _platforms_to_sync?? (uint)4294967295; }
       set { _platforms_to_sync = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool platforms_to_syncSpecified
+    {
+      get { return _platforms_to_sync != null; }
+      set { if (value == (_platforms_to_sync== null)) _platforms_to_sync = value ? this.platforms_to_sync : (uint?)null; }
+    }
+    private bool ShouldSerializeplatforms_to_sync() { return platforms_to_syncSpecified; }
+    private void Resetplatforms_to_sync() { platforms_to_syncSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private bool _can_encrypt = default(bool);
+    private bool? _can_encrypt;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"can_encrypt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_encrypt
     {
-      get { return _can_encrypt; }
+      get { return _can_encrypt?? default(bool); }
       set { _can_encrypt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_encryptSpecified
+    {
+      get { return _can_encrypt != null; }
+      set { if (value == (_can_encrypt== null)) _can_encrypt = value ? this.can_encrypt : (bool?)null; }
+    }
+    private bool ShouldSerializecan_encrypt() { return can_encryptSpecified; }
+    private void Resetcan_encrypt() { can_encryptSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6435,77 +11270,149 @@ namespace SteamKit2.Internal
     public CMsgClientUFSUploadFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private bool _use_http = default(bool);
+    private bool? _use_http;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"use_http", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_http
     {
-      get { return _use_http; }
+      get { return _use_http?? default(bool); }
       set { _use_http = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpSpecified
+    {
+      get { return _use_http != null; }
+      set { if (value == (_use_http== null)) _use_http = value ? this.use_http : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_http() { return use_httpSpecified; }
+    private void Resetuse_http() { use_httpSpecified = false; }
+    
 
-    private string _http_host = "";
+    private string _http_host;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"http_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string http_host
     {
-      get { return _http_host; }
+      get { return _http_host?? ""; }
       set { _http_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_hostSpecified
+    {
+      get { return _http_host != null; }
+      set { if (value == (_http_host== null)) _http_host = value ? this.http_host : (string)null; }
+    }
+    private bool ShouldSerializehttp_host() { return http_hostSpecified; }
+    private void Resethttp_host() { http_hostSpecified = false; }
+    
 
-    private string _http_url = "";
+    private string _http_url;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"http_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string http_url
     {
-      get { return _http_url; }
+      get { return _http_url?? ""; }
       set { _http_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_urlSpecified
+    {
+      get { return _http_url != null; }
+      set { if (value == (_http_url== null)) _http_url = value ? this.http_url : (string)null; }
+    }
+    private bool ShouldSerializehttp_url() { return http_urlSpecified; }
+    private void Resethttp_url() { http_urlSpecified = false; }
+    
 
-    private byte[] _kv_headers = null;
+    private byte[] _kv_headers;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"kv_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] kv_headers
     {
-      get { return _kv_headers; }
+      get { return _kv_headers?? null; }
       set { _kv_headers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kv_headersSpecified
+    {
+      get { return _kv_headers != null; }
+      set { if (value == (_kv_headers== null)) _kv_headers = value ? this.kv_headers : (byte[])null; }
+    }
+    private bool ShouldSerializekv_headers() { return kv_headersSpecified; }
+    private void Resetkv_headers() { kv_headersSpecified = false; }
+    
 
-    private bool _use_https = default(bool);
+    private bool? _use_https;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"use_https", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_https
     {
-      get { return _use_https; }
+      get { return _use_https?? default(bool); }
       set { _use_https = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpsSpecified
+    {
+      get { return _use_https != null; }
+      set { if (value == (_use_https== null)) _use_https = value ? this.use_https : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_https() { return use_httpsSpecified; }
+    private void Resetuse_https() { use_httpsSpecified = false; }
+    
 
-    private bool _encrypt_file = default(bool);
+    private bool? _encrypt_file;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"encrypt_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool encrypt_file
     {
-      get { return _encrypt_file; }
+      get { return _encrypt_file?? default(bool); }
       set { _encrypt_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encrypt_fileSpecified
+    {
+      get { return _encrypt_file != null; }
+      set { if (value == (_encrypt_file== null)) _encrypt_file = value ? this.encrypt_file : (bool?)null; }
+    }
+    private bool ShouldSerializeencrypt_file() { return encrypt_fileSpecified; }
+    private void Resetencrypt_file() { encrypt_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6529,50 +11436,95 @@ namespace SteamKit2.Internal
     public File() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private uint _cub_file = default(uint);
+    private uint? _cub_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cub_file", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cub_file
     {
-      get { return _cub_file; }
+      get { return _cub_file?? default(uint); }
       set { _cub_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cub_fileSpecified
+    {
+      get { return _cub_file != null; }
+      set { if (value == (_cub_file== null)) _cub_file = value ? this.cub_file : (uint?)null; }
+    }
+    private bool ShouldSerializecub_file() { return cub_fileSpecified; }
+    private void Resetcub_file() { cub_fileSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6601,32 +11553,59 @@ namespace SteamKit2.Internal
     public File() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6643,32 +11622,59 @@ namespace SteamKit2.Internal
     public CMsgClientUFSFileChunk() {}
     
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private uint _file_start = default(uint);
+    private uint? _file_start;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_start
     {
-      get { return _file_start; }
+      get { return _file_start?? default(uint); }
       set { _file_start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_startSpecified
+    {
+      get { return _file_start != null; }
+      set { if (value == (_file_start== null)) _file_start = value ? this.file_start : (uint?)null; }
+    }
+    private bool ShouldSerializefile_start() { return file_startSpecified; }
+    private void Resetfile_start() { file_startSpecified = false; }
+    
 
-    private byte[] _data = null;
+    private byte[] _data;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] data
     {
-      get { return _data; }
+      get { return _data?? null; }
       set { _data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dataSpecified
+    {
+      get { return _data != null; }
+      set { if (value == (_data== null)) _data = value ? this.data : (byte[])null; }
+    }
+    private bool ShouldSerializedata() { return dataSpecified; }
+    private void Resetdata() { dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6690,23 +11696,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSUploadFileFinished() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6718,32 +11742,59 @@ namespace SteamKit2.Internal
     public CMsgClientUFSDeleteFileRequest() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6755,23 +11806,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSDeleteFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6790,14 +11859,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _send_path_prefixes = default(bool);
+    private bool? _send_path_prefixes;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"send_path_prefixes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool send_path_prefixes
     {
-      get { return _send_path_prefixes; }
+      get { return _send_path_prefixes?? default(bool); }
       set { _send_path_prefixes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_path_prefixesSpecified
+    {
+      get { return _send_path_prefixes != null; }
+      set { if (value == (_send_path_prefixes== null)) _send_path_prefixes = value ? this.send_path_prefixes : (bool?)null; }
+    }
+    private bool ShouldSerializesend_path_prefixes() { return send_path_prefixesSpecified; }
+    private void Resetsend_path_prefixes() { send_path_prefixesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6828,77 +11906,149 @@ namespace SteamKit2.Internal
     public File() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
 
-    private uint _platforms_to_sync = default(uint);
+    private uint? _platforms_to_sync;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"platforms_to_sync", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint platforms_to_sync
     {
-      get { return _platforms_to_sync; }
+      get { return _platforms_to_sync?? default(uint); }
       set { _platforms_to_sync = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool platforms_to_syncSpecified
+    {
+      get { return _platforms_to_sync != null; }
+      set { if (value == (_platforms_to_sync== null)) _platforms_to_sync = value ? this.platforms_to_sync : (uint?)null; }
+    }
+    private bool ShouldSerializeplatforms_to_sync() { return platforms_to_syncSpecified; }
+    private void Resetplatforms_to_sync() { platforms_to_syncSpecified = false; }
+    
 
-    private uint _path_prefix_index = default(uint);
+    private uint? _path_prefix_index;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"path_prefix_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint path_prefix_index
     {
-      get { return _path_prefix_index; }
+      get { return _path_prefix_index?? default(uint); }
       set { _path_prefix_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool path_prefix_indexSpecified
+    {
+      get { return _path_prefix_index != null; }
+      set { if (value == (_path_prefix_index== null)) _path_prefix_index = value ? this.path_prefix_index : (uint?)null; }
+    }
+    private bool ShouldSerializepath_prefix_index() { return path_prefix_indexSpecified; }
+    private void Resetpath_prefix_index() { path_prefix_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6915,32 +12065,59 @@ namespace SteamKit2.Internal
     public CMsgClientUFSDownloadRequest() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private bool _can_handle_http = default(bool);
+    private bool? _can_handle_http;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"can_handle_http", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_handle_http
     {
-      get { return _can_handle_http; }
+      get { return _can_handle_http?? default(bool); }
       set { _can_handle_http = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_handle_httpSpecified
+    {
+      get { return _can_handle_http != null; }
+      set { if (value == (_can_handle_http== null)) _can_handle_http = value ? this.can_handle_http : (bool?)null; }
+    }
+    private bool ShouldSerializecan_handle_http() { return can_handle_httpSpecified; }
+    private void Resetcan_handle_http() { can_handle_httpSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6952,122 +12129,239 @@ namespace SteamKit2.Internal
     public CMsgClientUFSDownloadResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
 
-    private bool _use_http = default(bool);
+    private bool? _use_http;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"use_http", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_http
     {
-      get { return _use_http; }
+      get { return _use_http?? default(bool); }
       set { _use_http = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpSpecified
+    {
+      get { return _use_http != null; }
+      set { if (value == (_use_http== null)) _use_http = value ? this.use_http : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_http() { return use_httpSpecified; }
+    private void Resetuse_http() { use_httpSpecified = false; }
+    
 
-    private string _http_host = "";
+    private string _http_host;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"http_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string http_host
     {
-      get { return _http_host; }
+      get { return _http_host?? ""; }
       set { _http_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_hostSpecified
+    {
+      get { return _http_host != null; }
+      set { if (value == (_http_host== null)) _http_host = value ? this.http_host : (string)null; }
+    }
+    private bool ShouldSerializehttp_host() { return http_hostSpecified; }
+    private void Resethttp_host() { http_hostSpecified = false; }
+    
 
-    private string _http_url = "";
+    private string _http_url;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"http_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string http_url
     {
-      get { return _http_url; }
+      get { return _http_url?? ""; }
       set { _http_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_urlSpecified
+    {
+      get { return _http_url != null; }
+      set { if (value == (_http_url== null)) _http_url = value ? this.http_url : (string)null; }
+    }
+    private bool ShouldSerializehttp_url() { return http_urlSpecified; }
+    private void Resethttp_url() { http_urlSpecified = false; }
+    
 
-    private byte[] _kv_headers = null;
+    private byte[] _kv_headers;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"kv_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] kv_headers
     {
-      get { return _kv_headers; }
+      get { return _kv_headers?? null; }
       set { _kv_headers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool kv_headersSpecified
+    {
+      get { return _kv_headers != null; }
+      set { if (value == (_kv_headers== null)) _kv_headers = value ? this.kv_headers : (byte[])null; }
+    }
+    private bool ShouldSerializekv_headers() { return kv_headersSpecified; }
+    private void Resetkv_headers() { kv_headersSpecified = false; }
+    
 
-    private bool _use_https = default(bool);
+    private bool? _use_https;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"use_https", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_https
     {
-      get { return _use_https; }
+      get { return _use_https?? default(bool); }
       set { _use_https = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpsSpecified
+    {
+      get { return _use_https != null; }
+      set { if (value == (_use_https== null)) _use_https = value ? this.use_https : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_https() { return use_httpsSpecified; }
+    private void Resetuse_https() { use_httpsSpecified = false; }
+    
 
-    private bool _encrypted = default(bool);
+    private bool? _encrypted;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"encrypted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool encrypted
     {
-      get { return _encrypted; }
+      get { return _encrypted?? default(bool); }
       set { _encrypted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryptedSpecified
+    {
+      get { return _encrypted != null; }
+      set { if (value == (_encrypted== null)) _encrypted = value ? this.encrypted : (bool?)null; }
+    }
+    private bool ShouldSerializeencrypted() { return encryptedSpecified; }
+    private void Resetencrypted() { encryptedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7079,23 +12373,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSLoginRequest() {}
     
 
-    private uint _protocol_version = default(uint);
+    private uint? _protocol_version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"protocol_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint protocol_version
     {
-      get { return _protocol_version; }
+      get { return _protocol_version?? default(uint); }
       set { _protocol_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool protocol_versionSpecified
+    {
+      get { return _protocol_version != null; }
+      set { if (value == (_protocol_version== null)) _protocol_version = value ? this.protocol_version : (uint?)null; }
+    }
+    private bool ShouldSerializeprotocol_version() { return protocol_versionSpecified; }
+    private void Resetprotocol_version() { protocol_versionSpecified = false; }
+    
 
-    private ulong _am_session_token = default(ulong);
+    private ulong? _am_session_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"am_session_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong am_session_token
     {
-      get { return _am_session_token; }
+      get { return _am_session_token?? default(ulong); }
       set { _am_session_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool am_session_tokenSpecified
+    {
+      get { return _am_session_token != null; }
+      set { if (value == (_am_session_token== null)) _am_session_token = value ? this.am_session_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeam_session_token() { return am_session_tokenSpecified; }
+    private void Resetam_session_token() { am_session_tokenSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _apps = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"apps", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> apps
@@ -7114,14 +12426,23 @@ namespace SteamKit2.Internal
     public CMsgClientUFSLoginResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7133,23 +12454,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestEncryptedAppTicket() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private byte[] _userdata = null;
+    private byte[] _userdata;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"userdata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] userdata
     {
-      get { return _userdata; }
+      get { return _userdata?? null; }
       set { _userdata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool userdataSpecified
+    {
+      get { return _userdata != null; }
+      set { if (value == (_userdata== null)) _userdata = value ? this.userdata : (byte[])null; }
+    }
+    private bool ShouldSerializeuserdata() { return userdataSpecified; }
+    private void Resetuserdata() { userdataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7161,23 +12500,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestEncryptedAppTicketResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
     private EncryptedAppTicket _encrypted_app_ticket = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"encrypted_app_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -7198,41 +12555,77 @@ namespace SteamKit2.Internal
     public CMsgClientWalletInfoUpdate() {}
     
 
-    private bool _has_wallet = default(bool);
+    private bool? _has_wallet;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"has_wallet", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool has_wallet
     {
-      get { return _has_wallet; }
+      get { return _has_wallet?? default(bool); }
       set { _has_wallet = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool has_walletSpecified
+    {
+      get { return _has_wallet != null; }
+      set { if (value == (_has_wallet== null)) _has_wallet = value ? this.has_wallet : (bool?)null; }
+    }
+    private bool ShouldSerializehas_wallet() { return has_walletSpecified; }
+    private void Resethas_wallet() { has_walletSpecified = false; }
+    
 
-    private int _balance = default(int);
+    private int? _balance;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"balance", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int balance
     {
-      get { return _balance; }
+      get { return _balance?? default(int); }
       set { _balance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool balanceSpecified
+    {
+      get { return _balance != null; }
+      set { if (value == (_balance== null)) _balance = value ? this.balance : (int?)null; }
+    }
+    private bool ShouldSerializebalance() { return balanceSpecified; }
+    private void Resetbalance() { balanceSpecified = false; }
+    
 
-    private int _currency = default(int);
+    private int? _currency;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"currency", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int currency
     {
-      get { return _currency; }
+      get { return _currency?? default(int); }
       set { _currency = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool currencySpecified
+    {
+      get { return _currency != null; }
+      set { if (value == (_currency== null)) _currency = value ? this.currency : (int?)null; }
+    }
+    private bool ShouldSerializecurrency() { return currencySpecified; }
+    private void Resetcurrency() { currencySpecified = false; }
+    
 
-    private int _balance_delayed = default(int);
+    private int? _balance_delayed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"balance_delayed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int balance_delayed
     {
-      get { return _balance_delayed; }
+      get { return _balance_delayed?? default(int); }
       set { _balance_delayed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool balance_delayedSpecified
+    {
+      get { return _balance_delayed != null; }
+      set { if (value == (_balance_delayed== null)) _balance_delayed = value ? this.balance_delayed : (int?)null; }
+    }
+    private bool ShouldSerializebalance_delayed() { return balance_delayedSpecified; }
+    private void Resetbalance_delayed() { balance_delayedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7244,23 +12637,41 @@ namespace SteamKit2.Internal
     public CMsgClientAppInfoUpdate() {}
     
 
-    private uint _last_changenumber = default(uint);
+    private uint? _last_changenumber;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"last_changenumber", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_changenumber
     {
-      get { return _last_changenumber; }
+      get { return _last_changenumber?? default(uint); }
       set { _last_changenumber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_changenumberSpecified
+    {
+      get { return _last_changenumber != null; }
+      set { if (value == (_last_changenumber== null)) _last_changenumber = value ? this.last_changenumber : (uint?)null; }
+    }
+    private bool ShouldSerializelast_changenumber() { return last_changenumberSpecified; }
+    private void Resetlast_changenumber() { last_changenumberSpecified = false; }
+    
 
-    private bool _send_changelist = default(bool);
+    private bool? _send_changelist;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"send_changelist", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool send_changelist
     {
-      get { return _send_changelist; }
+      get { return _send_changelist?? default(bool); }
       set { _send_changelist = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_changelistSpecified
+    {
+      get { return _send_changelist != null; }
+      set { if (value == (_send_changelist== null)) _send_changelist = value ? this.send_changelist : (bool?)null; }
+    }
+    private bool ShouldSerializesend_changelist() { return send_changelistSpecified; }
+    private void Resetsend_changelist() { send_changelistSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7272,23 +12683,41 @@ namespace SteamKit2.Internal
     public CMsgClientAppInfoChanges() {}
     
 
-    private uint _current_change_number = default(uint);
+    private uint? _current_change_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"current_change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_change_number
     {
-      get { return _current_change_number; }
+      get { return _current_change_number?? default(uint); }
       set { _current_change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_change_numberSpecified
+    {
+      get { return _current_change_number != null; }
+      set { if (value == (_current_change_number== null)) _current_change_number = value ? this.current_change_number : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_change_number() { return current_change_numberSpecified; }
+    private void Resetcurrent_change_number() { current_change_numberSpecified = false; }
+    
 
-    private bool _force_full_update = default(bool);
+    private bool? _force_full_update;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"force_full_update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool force_full_update
     {
-      get { return _force_full_update; }
+      get { return _force_full_update?? default(bool); }
       set { _force_full_update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool force_full_updateSpecified
+    {
+      get { return _force_full_update != null; }
+      set { if (value == (_force_full_update== null)) _force_full_update = value ? this.force_full_update : (bool?)null; }
+    }
+    private bool ShouldSerializeforce_full_update() { return force_full_updateSpecified; }
+    private void Resetforce_full_update() { force_full_updateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _appIDs = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"appIDs", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> appIDs
@@ -7314,37 +12743,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _supports_batches = (bool)false;
+    private bool? _supports_batches;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"supports_batches", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool supports_batches
     {
-      get { return _supports_batches; }
+      get { return _supports_batches?? (bool)false; }
       set { _supports_batches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supports_batchesSpecified
+    {
+      get { return _supports_batches != null; }
+      set { if (value == (_supports_batches== null)) _supports_batches = value ? this.supports_batches : (bool?)null; }
+    }
+    private bool ShouldSerializesupports_batches() { return supports_batchesSpecified; }
+    private void Resetsupports_batches() { supports_batchesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"App")]
   public partial class App : global::ProtoBuf.IExtensible
   {
     public App() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _section_flags = default(uint);
+    private uint? _section_flags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"section_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint section_flags
     {
-      get { return _section_flags; }
+      get { return _section_flags?? default(uint); }
       set { _section_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool section_flagsSpecified
+    {
+      get { return _section_flags != null; }
+      set { if (value == (_section_flags== null)) _section_flags = value ? this.section_flags : (uint?)null; }
+    }
+    private bool ShouldSerializesection_flags() { return section_flagsSpecified; }
+    private void Resetsection_flags() { section_flagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _section_CRC = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(3, Name=@"section_CRC", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> section_CRC
@@ -7382,37 +12838,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _apps_pending = default(uint);
+    private uint? _apps_pending;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"apps_pending", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint apps_pending
     {
-      get { return _apps_pending; }
+      get { return _apps_pending?? default(uint); }
       set { _apps_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool apps_pendingSpecified
+    {
+      get { return _apps_pending != null; }
+      set { if (value == (_apps_pending== null)) _apps_pending = value ? this.apps_pending : (uint?)null; }
+    }
+    private bool ShouldSerializeapps_pending() { return apps_pendingSpecified; }
+    private void Resetapps_pending() { apps_pendingSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"App")]
   public partial class App : global::ProtoBuf.IExtensible
   {
     public App() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientAppInfoResponse.App.Section> _sections = new global::System.Collections.Generic.List<CMsgClientAppInfoResponse.App.Section>();
     [global::ProtoBuf.ProtoMember(3, Name=@"sections", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientAppInfoResponse.App.Section> sections
@@ -7426,23 +12909,41 @@ namespace SteamKit2.Internal
     public Section() {}
     
 
-    private uint _section_id = default(uint);
+    private uint? _section_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"section_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint section_id
     {
-      get { return _section_id; }
+      get { return _section_id?? default(uint); }
       set { _section_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool section_idSpecified
+    {
+      get { return _section_id != null; }
+      set { if (value == (_section_id== null)) _section_id = value ? this.section_id : (uint?)null; }
+    }
+    private bool ShouldSerializesection_id() { return section_idSpecified; }
+    private void Resetsection_id() { section_idSpecified = false; }
+    
 
-    private byte[] _section_kv = null;
+    private byte[] _section_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"section_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] section_kv
     {
-      get { return _section_kv; }
+      get { return _section_kv?? null; }
       set { _section_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool section_kvSpecified
+    {
+      get { return _section_kv != null; }
+      set { if (value == (_section_kv== null)) _section_kv = value ? this.section_kv : (byte[])null; }
+    }
+    private bool ShouldSerializesection_kv() { return section_kvSpecified; }
+    private void Resetsection_kv() { section_kvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7471,14 +12972,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _meta_data_only = default(bool);
+    private bool? _meta_data_only;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"meta_data_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool meta_data_only
     {
-      get { return _meta_data_only; }
+      get { return _meta_data_only?? default(bool); }
       set { _meta_data_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_data_onlySpecified
+    {
+      get { return _meta_data_only != null; }
+      set { if (value == (_meta_data_only== null)) _meta_data_only = value ? this.meta_data_only : (bool?)null; }
+    }
+    private bool ShouldSerializemeta_data_only() { return meta_data_onlySpecified; }
+    private void Resetmeta_data_only() { meta_data_onlySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7504,55 +13014,100 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _packages_pending = default(uint);
+    private uint? _packages_pending;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"packages_pending", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packages_pending
     {
-      get { return _packages_pending; }
+      get { return _packages_pending?? default(uint); }
       set { _packages_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packages_pendingSpecified
+    {
+      get { return _packages_pending != null; }
+      set { if (value == (_packages_pending== null)) _packages_pending = value ? this.packages_pending : (uint?)null; }
+    }
+    private bool ShouldSerializepackages_pending() { return packages_pendingSpecified; }
+    private void Resetpackages_pending() { packages_pendingSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Package")]
   public partial class Package : global::ProtoBuf.IExtensible
   {
     public Package() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private byte[] _sha = null;
+    private byte[] _sha;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha
     {
-      get { return _sha; }
+      get { return _sha?? null; }
       set { _sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shaSpecified
+    {
+      get { return _sha != null; }
+      set { if (value == (_sha== null)) _sha = value ? this.sha : (byte[])null; }
+    }
+    private bool ShouldSerializesha() { return shaSpecified; }
+    private void Resetsha() { shaSpecified = false; }
+    
 
-    private byte[] _buffer = null;
+    private byte[] _buffer;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"buffer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] buffer
     {
-      get { return _buffer; }
+      get { return _buffer?? null; }
       set { _buffer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bufferSpecified
+    {
+      get { return _buffer != null; }
+      set { if (value == (_buffer== null)) _buffer = value ? this.buffer : (byte[])null; }
+    }
+    private bool ShouldSerializebuffer() { return bufferSpecified; }
+    private void Resetbuffer() { bufferSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7569,50 +13124,95 @@ namespace SteamKit2.Internal
     public CMsgClientPICSChangesSinceRequest() {}
     
 
-    private uint _since_change_number = default(uint);
+    private uint? _since_change_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"since_change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint since_change_number
     {
-      get { return _since_change_number; }
+      get { return _since_change_number?? default(uint); }
       set { _since_change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool since_change_numberSpecified
+    {
+      get { return _since_change_number != null; }
+      set { if (value == (_since_change_number== null)) _since_change_number = value ? this.since_change_number : (uint?)null; }
+    }
+    private bool ShouldSerializesince_change_number() { return since_change_numberSpecified; }
+    private void Resetsince_change_number() { since_change_numberSpecified = false; }
+    
 
-    private bool _send_app_info_changes = default(bool);
+    private bool? _send_app_info_changes;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"send_app_info_changes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool send_app_info_changes
     {
-      get { return _send_app_info_changes; }
+      get { return _send_app_info_changes?? default(bool); }
       set { _send_app_info_changes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_app_info_changesSpecified
+    {
+      get { return _send_app_info_changes != null; }
+      set { if (value == (_send_app_info_changes== null)) _send_app_info_changes = value ? this.send_app_info_changes : (bool?)null; }
+    }
+    private bool ShouldSerializesend_app_info_changes() { return send_app_info_changesSpecified; }
+    private void Resetsend_app_info_changes() { send_app_info_changesSpecified = false; }
+    
 
-    private bool _send_package_info_changes = default(bool);
+    private bool? _send_package_info_changes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"send_package_info_changes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool send_package_info_changes
     {
-      get { return _send_package_info_changes; }
+      get { return _send_package_info_changes?? default(bool); }
       set { _send_package_info_changes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_package_info_changesSpecified
+    {
+      get { return _send_package_info_changes != null; }
+      set { if (value == (_send_package_info_changes== null)) _send_package_info_changes = value ? this.send_package_info_changes : (bool?)null; }
+    }
+    private bool ShouldSerializesend_package_info_changes() { return send_package_info_changesSpecified; }
+    private void Resetsend_package_info_changes() { send_package_info_changesSpecified = false; }
+    
 
-    private uint _num_app_info_cached = default(uint);
+    private uint? _num_app_info_cached;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_app_info_cached", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_app_info_cached
     {
-      get { return _num_app_info_cached; }
+      get { return _num_app_info_cached?? default(uint); }
       set { _num_app_info_cached = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_app_info_cachedSpecified
+    {
+      get { return _num_app_info_cached != null; }
+      set { if (value == (_num_app_info_cached== null)) _num_app_info_cached = value ? this.num_app_info_cached : (uint?)null; }
+    }
+    private bool ShouldSerializenum_app_info_cached() { return num_app_info_cachedSpecified; }
+    private void Resetnum_app_info_cached() { num_app_info_cachedSpecified = false; }
+    
 
-    private uint _num_package_info_cached = default(uint);
+    private uint? _num_package_info_cached;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"num_package_info_cached", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_package_info_cached
     {
-      get { return _num_package_info_cached; }
+      get { return _num_package_info_cached?? default(uint); }
       set { _num_package_info_cached = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_package_info_cachedSpecified
+    {
+      get { return _num_package_info_cached != null; }
+      set { if (value == (_num_package_info_cached== null)) _num_package_info_cached = value ? this.num_package_info_cached : (uint?)null; }
+    }
+    private bool ShouldSerializenum_package_info_cached() { return num_package_info_cachedSpecified; }
+    private void Resetnum_package_info_cached() { num_package_info_cachedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7624,32 +13224,59 @@ namespace SteamKit2.Internal
     public CMsgClientPICSChangesSinceResponse() {}
     
 
-    private uint _current_change_number = default(uint);
+    private uint? _current_change_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"current_change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_change_number
     {
-      get { return _current_change_number; }
+      get { return _current_change_number?? default(uint); }
       set { _current_change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_change_numberSpecified
+    {
+      get { return _current_change_number != null; }
+      set { if (value == (_current_change_number== null)) _current_change_number = value ? this.current_change_number : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_change_number() { return current_change_numberSpecified; }
+    private void Resetcurrent_change_number() { current_change_numberSpecified = false; }
+    
 
-    private uint _since_change_number = default(uint);
+    private uint? _since_change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"since_change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint since_change_number
     {
-      get { return _since_change_number; }
+      get { return _since_change_number?? default(uint); }
       set { _since_change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool since_change_numberSpecified
+    {
+      get { return _since_change_number != null; }
+      set { if (value == (_since_change_number== null)) _since_change_number = value ? this.since_change_number : (uint?)null; }
+    }
+    private bool ShouldSerializesince_change_number() { return since_change_numberSpecified; }
+    private void Resetsince_change_number() { since_change_numberSpecified = false; }
+    
 
-    private bool _force_full_update = default(bool);
+    private bool? _force_full_update;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"force_full_update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool force_full_update
     {
-      get { return _force_full_update; }
+      get { return _force_full_update?? default(bool); }
       set { _force_full_update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool force_full_updateSpecified
+    {
+      get { return _force_full_update != null; }
+      set { if (value == (_force_full_update== null)) _force_full_update = value ? this.force_full_update : (bool?)null; }
+    }
+    private bool ShouldSerializeforce_full_update() { return force_full_updateSpecified; }
+    private void Resetforce_full_update() { force_full_updateSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientPICSChangesSinceResponse.PackageChange> _package_changes = new global::System.Collections.Generic.List<CMsgClientPICSChangesSinceResponse.PackageChange>();
     [global::ProtoBuf.ProtoMember(4, Name=@"package_changes", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientPICSChangesSinceResponse.PackageChange> package_changes
@@ -7665,55 +13292,100 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _force_full_app_update = default(bool);
+    private bool? _force_full_app_update;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"force_full_app_update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool force_full_app_update
     {
-      get { return _force_full_app_update; }
+      get { return _force_full_app_update?? default(bool); }
       set { _force_full_app_update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool force_full_app_updateSpecified
+    {
+      get { return _force_full_app_update != null; }
+      set { if (value == (_force_full_app_update== null)) _force_full_app_update = value ? this.force_full_app_update : (bool?)null; }
+    }
+    private bool ShouldSerializeforce_full_app_update() { return force_full_app_updateSpecified; }
+    private void Resetforce_full_app_update() { force_full_app_updateSpecified = false; }
+    
 
-    private bool _force_full_package_update = default(bool);
+    private bool? _force_full_package_update;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"force_full_package_update", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool force_full_package_update
     {
-      get { return _force_full_package_update; }
+      get { return _force_full_package_update?? default(bool); }
       set { _force_full_package_update = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool force_full_package_updateSpecified
+    {
+      get { return _force_full_package_update != null; }
+      set { if (value == (_force_full_package_update== null)) _force_full_package_update = value ? this.force_full_package_update : (bool?)null; }
+    }
+    private bool ShouldSerializeforce_full_package_update() { return force_full_package_updateSpecified; }
+    private void Resetforce_full_package_update() { force_full_package_updateSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PackageChange")]
   public partial class PackageChange : global::ProtoBuf.IExtensible
   {
     public PackageChange() {}
     
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private bool _needs_token = default(bool);
+    private bool? _needs_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"needs_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool needs_token
     {
-      get { return _needs_token; }
+      get { return _needs_token?? default(bool); }
       set { _needs_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool needs_tokenSpecified
+    {
+      get { return _needs_token != null; }
+      set { if (value == (_needs_token== null)) _needs_token = value ? this.needs_token : (bool?)null; }
+    }
+    private bool ShouldSerializeneeds_token() { return needs_tokenSpecified; }
+    private void Resetneeds_token() { needs_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7725,32 +13397,59 @@ namespace SteamKit2.Internal
     public AppChange() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private bool _needs_token = default(bool);
+    private bool? _needs_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"needs_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool needs_token
     {
-      get { return _needs_token; }
+      get { return _needs_token?? default(bool); }
       set { _needs_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool needs_tokenSpecified
+    {
+      get { return _needs_token != null; }
+      set { if (value == (_needs_token== null)) _needs_token = value ? this.needs_token : (bool?)null; }
+    }
+    private bool ShouldSerializeneeds_token() { return needs_tokenSpecified; }
+    private void Resetneeds_token() { needs_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7781,55 +13480,100 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _meta_data_only = default(bool);
+    private bool? _meta_data_only;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"meta_data_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool meta_data_only
     {
-      get { return _meta_data_only; }
+      get { return _meta_data_only?? default(bool); }
       set { _meta_data_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_data_onlySpecified
+    {
+      get { return _meta_data_only != null; }
+      set { if (value == (_meta_data_only== null)) _meta_data_only = value ? this.meta_data_only : (bool?)null; }
+    }
+    private bool ShouldSerializemeta_data_only() { return meta_data_onlySpecified; }
+    private void Resetmeta_data_only() { meta_data_onlySpecified = false; }
+    
 
-    private uint _num_prev_failed = default(uint);
+    private uint? _num_prev_failed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"num_prev_failed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_prev_failed
     {
-      get { return _num_prev_failed; }
+      get { return _num_prev_failed?? default(uint); }
       set { _num_prev_failed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_prev_failedSpecified
+    {
+      get { return _num_prev_failed != null; }
+      set { if (value == (_num_prev_failed== null)) _num_prev_failed = value ? this.num_prev_failed : (uint?)null; }
+    }
+    private bool ShouldSerializenum_prev_failed() { return num_prev_failedSpecified; }
+    private void Resetnum_prev_failed() { num_prev_failedSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"AppInfo")]
   public partial class AppInfo : global::ProtoBuf.IExtensible
   {
     public AppInfo() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _access_token = default(ulong);
+    private ulong? _access_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"access_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong access_token
     {
-      get { return _access_token; }
+      get { return _access_token?? default(ulong); }
       set { _access_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_tokenSpecified
+    {
+      get { return _access_token != null; }
+      set { if (value == (_access_token== null)) _access_token = value ? this.access_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeaccess_token() { return access_tokenSpecified; }
+    private void Resetaccess_token() { access_tokenSpecified = false; }
+    
 
-    private bool _only_public = default(bool);
+    private bool? _only_public;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"only_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_public
     {
-      get { return _only_public; }
+      get { return _only_public?? default(bool); }
       set { _only_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_publicSpecified
+    {
+      get { return _only_public != null; }
+      set { if (value == (_only_public== null)) _only_public = value ? this.only_public : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_public() { return only_publicSpecified; }
+    private void Resetonly_public() { only_publicSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7841,23 +13585,41 @@ namespace SteamKit2.Internal
     public PackageInfo() {}
     
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private ulong _access_token = default(ulong);
+    private ulong? _access_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"access_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong access_token
     {
-      get { return _access_token; }
+      get { return _access_token?? default(ulong); }
       set { _access_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_tokenSpecified
+    {
+      get { return _access_token != null; }
+      set { if (value == (_access_token== null)) _access_token = value ? this.access_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeaccess_token() { return access_tokenSpecified; }
+    private void Resetaccess_token() { access_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7902,109 +13664,208 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _meta_data_only = default(bool);
+    private bool? _meta_data_only;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"meta_data_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool meta_data_only
     {
-      get { return _meta_data_only; }
+      get { return _meta_data_only?? default(bool); }
       set { _meta_data_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool meta_data_onlySpecified
+    {
+      get { return _meta_data_only != null; }
+      set { if (value == (_meta_data_only== null)) _meta_data_only = value ? this.meta_data_only : (bool?)null; }
+    }
+    private bool ShouldSerializemeta_data_only() { return meta_data_onlySpecified; }
+    private void Resetmeta_data_only() { meta_data_onlySpecified = false; }
+    
 
-    private bool _response_pending = default(bool);
+    private bool? _response_pending;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"response_pending", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool response_pending
     {
-      get { return _response_pending; }
+      get { return _response_pending?? default(bool); }
       set { _response_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool response_pendingSpecified
+    {
+      get { return _response_pending != null; }
+      set { if (value == (_response_pending== null)) _response_pending = value ? this.response_pending : (bool?)null; }
+    }
+    private bool ShouldSerializeresponse_pending() { return response_pendingSpecified; }
+    private void Resetresponse_pending() { response_pendingSpecified = false; }
+    
 
-    private uint _http_min_size = default(uint);
+    private uint? _http_min_size;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"http_min_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint http_min_size
     {
-      get { return _http_min_size; }
+      get { return _http_min_size?? default(uint); }
       set { _http_min_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_min_sizeSpecified
+    {
+      get { return _http_min_size != null; }
+      set { if (value == (_http_min_size== null)) _http_min_size = value ? this.http_min_size : (uint?)null; }
+    }
+    private bool ShouldSerializehttp_min_size() { return http_min_sizeSpecified; }
+    private void Resethttp_min_size() { http_min_sizeSpecified = false; }
+    
 
-    private string _http_host = "";
+    private string _http_host;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"http_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string http_host
     {
-      get { return _http_host; }
+      get { return _http_host?? ""; }
       set { _http_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_hostSpecified
+    {
+      get { return _http_host != null; }
+      set { if (value == (_http_host== null)) _http_host = value ? this.http_host : (string)null; }
+    }
+    private bool ShouldSerializehttp_host() { return http_hostSpecified; }
+    private void Resethttp_host() { http_hostSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"AppInfo")]
   public partial class AppInfo : global::ProtoBuf.IExtensible
   {
     public AppInfo() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private bool _missing_token = default(bool);
+    private bool? _missing_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"missing_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool missing_token
     {
-      get { return _missing_token; }
+      get { return _missing_token?? default(bool); }
       set { _missing_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool missing_tokenSpecified
+    {
+      get { return _missing_token != null; }
+      set { if (value == (_missing_token== null)) _missing_token = value ? this.missing_token : (bool?)null; }
+    }
+    private bool ShouldSerializemissing_token() { return missing_tokenSpecified; }
+    private void Resetmissing_token() { missing_tokenSpecified = false; }
+    
 
-    private byte[] _sha = null;
+    private byte[] _sha;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha
     {
-      get { return _sha; }
+      get { return _sha?? null; }
       set { _sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shaSpecified
+    {
+      get { return _sha != null; }
+      set { if (value == (_sha== null)) _sha = value ? this.sha : (byte[])null; }
+    }
+    private bool ShouldSerializesha() { return shaSpecified; }
+    private void Resetsha() { shaSpecified = false; }
+    
 
-    private byte[] _buffer = null;
+    private byte[] _buffer;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"buffer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] buffer
     {
-      get { return _buffer; }
+      get { return _buffer?? null; }
       set { _buffer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bufferSpecified
+    {
+      get { return _buffer != null; }
+      set { if (value == (_buffer== null)) _buffer = value ? this.buffer : (byte[])null; }
+    }
+    private bool ShouldSerializebuffer() { return bufferSpecified; }
+    private void Resetbuffer() { bufferSpecified = false; }
+    
 
-    private bool _only_public = default(bool);
+    private bool? _only_public;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"only_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_public
     {
-      get { return _only_public; }
+      get { return _only_public?? default(bool); }
       set { _only_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_publicSpecified
+    {
+      get { return _only_public != null; }
+      set { if (value == (_only_public== null)) _only_public = value ? this.only_public : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_public() { return only_publicSpecified; }
+    private void Resetonly_public() { only_publicSpecified = false; }
+    
 
-    private uint _size = default(uint);
+    private uint? _size;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint size
     {
-      get { return _size; }
+      get { return _size?? default(uint); }
       set { _size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sizeSpecified
+    {
+      get { return _size != null; }
+      set { if (value == (_size== null)) _size = value ? this.size : (uint?)null; }
+    }
+    private bool ShouldSerializesize() { return sizeSpecified; }
+    private void Resetsize() { sizeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8016,59 +13877,113 @@ namespace SteamKit2.Internal
     public PackageInfo() {}
     
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private uint _change_number = default(uint);
+    private uint? _change_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_number", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint change_number
     {
-      get { return _change_number; }
+      get { return _change_number?? default(uint); }
       set { _change_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_numberSpecified
+    {
+      get { return _change_number != null; }
+      set { if (value == (_change_number== null)) _change_number = value ? this.change_number : (uint?)null; }
+    }
+    private bool ShouldSerializechange_number() { return change_numberSpecified; }
+    private void Resetchange_number() { change_numberSpecified = false; }
+    
 
-    private bool _missing_token = default(bool);
+    private bool? _missing_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"missing_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool missing_token
     {
-      get { return _missing_token; }
+      get { return _missing_token?? default(bool); }
       set { _missing_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool missing_tokenSpecified
+    {
+      get { return _missing_token != null; }
+      set { if (value == (_missing_token== null)) _missing_token = value ? this.missing_token : (bool?)null; }
+    }
+    private bool ShouldSerializemissing_token() { return missing_tokenSpecified; }
+    private void Resetmissing_token() { missing_tokenSpecified = false; }
+    
 
-    private byte[] _sha = null;
+    private byte[] _sha;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha
     {
-      get { return _sha; }
+      get { return _sha?? null; }
       set { _sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shaSpecified
+    {
+      get { return _sha != null; }
+      set { if (value == (_sha== null)) _sha = value ? this.sha : (byte[])null; }
+    }
+    private bool ShouldSerializesha() { return shaSpecified; }
+    private void Resetsha() { shaSpecified = false; }
+    
 
-    private byte[] _buffer = null;
+    private byte[] _buffer;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"buffer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] buffer
     {
-      get { return _buffer; }
+      get { return _buffer?? null; }
       set { _buffer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bufferSpecified
+    {
+      get { return _buffer != null; }
+      set { if (value == (_buffer== null)) _buffer = value ? this.buffer : (byte[])null; }
+    }
+    private bool ShouldSerializebuffer() { return bufferSpecified; }
+    private void Resetbuffer() { bufferSpecified = false; }
+    
 
-    private uint _size = default(uint);
+    private uint? _size;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint size
     {
-      get { return _size; }
+      get { return _size?? default(uint); }
       set { _size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sizeSpecified
+    {
+      get { return _size != null; }
+      set { if (value == (_size== null)) _size = value ? this.size : (uint?)null; }
+    }
+    private bool ShouldSerializesize() { return sizeSpecified; }
+    private void Resetsize() { sizeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8142,23 +14057,41 @@ namespace SteamKit2.Internal
     public PackageToken() {}
     
 
-    private uint _packageid = default(uint);
+    private uint? _packageid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"packageid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint packageid
     {
-      get { return _packageid; }
+      get { return _packageid?? default(uint); }
       set { _packageid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool packageidSpecified
+    {
+      get { return _packageid != null; }
+      set { if (value == (_packageid== null)) _packageid = value ? this.packageid : (uint?)null; }
+    }
+    private bool ShouldSerializepackageid() { return packageidSpecified; }
+    private void Resetpackageid() { packageidSpecified = false; }
+    
 
-    private ulong _access_token = default(ulong);
+    private ulong? _access_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"access_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong access_token
     {
-      get { return _access_token; }
+      get { return _access_token?? default(ulong); }
       set { _access_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_tokenSpecified
+    {
+      get { return _access_token != null; }
+      set { if (value == (_access_token== null)) _access_token = value ? this.access_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeaccess_token() { return access_tokenSpecified; }
+    private void Resetaccess_token() { access_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8170,23 +14103,41 @@ namespace SteamKit2.Internal
     public AppToken() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _access_token = default(ulong);
+    private ulong? _access_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"access_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong access_token
     {
-      get { return _access_token; }
+      get { return _access_token?? default(ulong); }
       set { _access_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_tokenSpecified
+    {
+      get { return _access_token != null; }
+      set { if (value == (_access_token== null)) _access_token = value ? this.access_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeaccess_token() { return access_tokenSpecified; }
+    private void Resetaccess_token() { access_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8203,14 +14154,23 @@ namespace SteamKit2.Internal
     public CMsgClientUFSGetUGCDetails() {}
     
 
-    private ulong _hcontent = (ulong)18446744073709551615;
+    private ulong? _hcontent;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hcontent", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong hcontent
     {
-      get { return _hcontent; }
+      get { return _hcontent?? (ulong)18446744073709551615; }
       set { _hcontent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hcontentSpecified
+    {
+      get { return _hcontent != null; }
+      set { if (value == (_hcontent== null)) _hcontent = value ? this.hcontent : (ulong?)null; }
+    }
+    private bool ShouldSerializehcontent() { return hcontentSpecified; }
+    private void Resethcontent() { hcontentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8222,86 +14182,167 @@ namespace SteamKit2.Internal
     public CMsgClientUFSGetUGCDetailsResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private ulong _steamid_creator = default(ulong);
+    private ulong? _steamid_creator;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steamid_creator", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_creator
     {
-      get { return _steamid_creator; }
+      get { return _steamid_creator?? default(ulong); }
       set { _steamid_creator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_creatorSpecified
+    {
+      get { return _steamid_creator != null; }
+      set { if (value == (_steamid_creator== null)) _steamid_creator = value ? this.steamid_creator : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_creator() { return steamid_creatorSpecified; }
+    private void Resetsteamid_creator() { steamid_creatorSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _compressed_file_size = default(uint);
+    private uint? _compressed_file_size;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"compressed_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint compressed_file_size
     {
-      get { return _compressed_file_size; }
+      get { return _compressed_file_size?? default(uint); }
       set { _compressed_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool compressed_file_sizeSpecified
+    {
+      get { return _compressed_file_size != null; }
+      set { if (value == (_compressed_file_size== null)) _compressed_file_size = value ? this.compressed_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializecompressed_file_size() { return compressed_file_sizeSpecified; }
+    private void Resetcompressed_file_size() { compressed_file_sizeSpecified = false; }
+    
 
-    private string _rangecheck_host = "";
+    private string _rangecheck_host;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"rangecheck_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rangecheck_host
     {
-      get { return _rangecheck_host; }
+      get { return _rangecheck_host?? ""; }
       set { _rangecheck_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rangecheck_hostSpecified
+    {
+      get { return _rangecheck_host != null; }
+      set { if (value == (_rangecheck_host== null)) _rangecheck_host = value ? this.rangecheck_host : (string)null; }
+    }
+    private bool ShouldSerializerangecheck_host() { return rangecheck_hostSpecified; }
+    private void Resetrangecheck_host() { rangecheck_hostSpecified = false; }
+    
 
-    private string _file_encoded_sha1 = "";
+    private string _file_encoded_sha1;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"file_encoded_sha1", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_encoded_sha1
     {
-      get { return _file_encoded_sha1; }
+      get { return _file_encoded_sha1?? ""; }
       set { _file_encoded_sha1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_encoded_sha1Specified
+    {
+      get { return _file_encoded_sha1 != null; }
+      set { if (value == (_file_encoded_sha1== null)) _file_encoded_sha1 = value ? this.file_encoded_sha1 : (string)null; }
+    }
+    private bool ShouldSerializefile_encoded_sha1() { return file_encoded_sha1Specified; }
+    private void Resetfile_encoded_sha1() { file_encoded_sha1Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8313,23 +14354,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSGetSingleFileInfo() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8341,68 +14400,131 @@ namespace SteamKit2.Internal
     public CMsgClientUFSGetSingleFileInfoResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8414,23 +14536,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSShareFile() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8442,23 +14582,41 @@ namespace SteamKit2.Internal
     public CMsgClientUFSShareFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _hcontent = (ulong)18446744073709551615;
+    private ulong? _hcontent;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hcontent", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong hcontent
     {
-      get { return _hcontent; }
+      get { return _hcontent?? (ulong)18446744073709551615; }
       set { _hcontent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hcontentSpecified
+    {
+      get { return _hcontent != null; }
+      set { if (value == (_hcontent== null)) _hcontent = value ? this.hcontent : (ulong?)null; }
+    }
+    private bool ShouldSerializehcontent() { return hcontentSpecified; }
+    private void Resethcontent() { hcontentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8470,23 +14628,41 @@ namespace SteamKit2.Internal
     public CMsgClientNewLoginKey() {}
     
 
-    private uint _unique_id = default(uint);
+    private uint? _unique_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"unique_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unique_id
     {
-      get { return _unique_id; }
+      get { return _unique_id?? default(uint); }
       set { _unique_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unique_idSpecified
+    {
+      get { return _unique_id != null; }
+      set { if (value == (_unique_id== null)) _unique_id = value ? this.unique_id : (uint?)null; }
+    }
+    private bool ShouldSerializeunique_id() { return unique_idSpecified; }
+    private void Resetunique_id() { unique_idSpecified = false; }
+    
 
-    private string _login_key = "";
+    private string _login_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"login_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string login_key
     {
-      get { return _login_key; }
+      get { return _login_key?? ""; }
       set { _login_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool login_keySpecified
+    {
+      get { return _login_key != null; }
+      set { if (value == (_login_key== null)) _login_key = value ? this.login_key : (string)null; }
+    }
+    private bool ShouldSerializelogin_key() { return login_keySpecified; }
+    private void Resetlogin_key() { login_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8498,14 +14674,23 @@ namespace SteamKit2.Internal
     public CMsgClientNewLoginKeyAccepted() {}
     
 
-    private uint _unique_id = default(uint);
+    private uint? _unique_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"unique_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint unique_id
     {
-      get { return _unique_id; }
+      get { return _unique_id?? default(uint); }
       set { _unique_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unique_idSpecified
+    {
+      get { return _unique_id != null; }
+      set { if (value == (_unique_id== null)) _unique_id = value ? this.unique_id : (uint?)null; }
+    }
+    private bool ShouldSerializeunique_id() { return unique_idSpecified; }
+    private void Resetunique_id() { unique_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8517,14 +14702,23 @@ namespace SteamKit2.Internal
     public CMsgClientAMGetClanOfficers() {}
     
 
-    private ulong _steamid_clan = default(ulong);
+    private ulong? _steamid_clan;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_clan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_clan
     {
-      get { return _steamid_clan; }
+      get { return _steamid_clan?? default(ulong); }
       set { _steamid_clan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_clanSpecified
+    {
+      get { return _steamid_clan != null; }
+      set { if (value == (_steamid_clan== null)) _steamid_clan = value ? this.steamid_clan : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_clan() { return steamid_clanSpecified; }
+    private void Resetsteamid_clan() { steamid_clanSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8536,32 +14730,59 @@ namespace SteamKit2.Internal
     public CMsgClientAMGetClanOfficersResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steamid_clan = default(ulong);
+    private ulong? _steamid_clan;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid_clan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_clan
     {
-      get { return _steamid_clan; }
+      get { return _steamid_clan?? default(ulong); }
       set { _steamid_clan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_clanSpecified
+    {
+      get { return _steamid_clan != null; }
+      set { if (value == (_steamid_clan== null)) _steamid_clan = value ? this.steamid_clan : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_clan() { return steamid_clanSpecified; }
+    private void Resetsteamid_clan() { steamid_clanSpecified = false; }
+    
 
-    private int _officer_count = default(int);
+    private int? _officer_count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"officer_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int officer_count
     {
-      get { return _officer_count; }
+      get { return _officer_count?? default(int); }
       set { _officer_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool officer_countSpecified
+    {
+      get { return _officer_count != null; }
+      set { if (value == (_officer_count== null)) _officer_count = value ? this.officer_count : (int?)null; }
+    }
+    private bool ShouldSerializeofficer_count() { return officer_countSpecified; }
+    private void Resetofficer_count() { officer_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8573,14 +14794,23 @@ namespace SteamKit2.Internal
     public CMsgClientAMGetPersonaNameHistory() {}
     
 
-    private int _id_count = default(int);
+    private int? _id_count;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"id_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int id_count
     {
-      get { return _id_count; }
+      get { return _id_count?? default(int); }
       set { _id_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool id_countSpecified
+    {
+      get { return _id_count != null; }
+      set { if (value == (_id_count== null)) _id_count = value ? this.id_count : (int?)null; }
+    }
+    private bool ShouldSerializeid_count() { return id_countSpecified; }
+    private void Resetid_count() { id_countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistory.IdInstance> _Ids = new global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistory.IdInstance>();
     [global::ProtoBuf.ProtoMember(2, Name=@"Ids", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistory.IdInstance> Ids
@@ -8594,14 +14824,23 @@ namespace SteamKit2.Internal
     public IdInstance() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8630,23 +14869,41 @@ namespace SteamKit2.Internal
     public NameTableInstance() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistoryResponse.NameTableInstance.NameInstance> _names = new global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistoryResponse.NameTableInstance.NameInstance>();
     [global::ProtoBuf.ProtoMember(3, Name=@"names", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientAMGetPersonaNameHistoryResponse.NameTableInstance.NameInstance> names
@@ -8660,23 +14917,41 @@ namespace SteamKit2.Internal
     public NameInstance() {}
     
 
-    private uint _name_since = default(uint);
+    private uint? _name_since;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name_since", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint name_since
     {
-      get { return _name_since; }
+      get { return _name_since?? default(uint); }
       set { _name_since = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool name_sinceSpecified
+    {
+      get { return _name_since != null; }
+      set { if (value == (_name_since== null)) _name_since = value ? this.name_since : (uint?)null; }
+    }
+    private bool ShouldSerializename_since() { return name_sinceSpecified; }
+    private void Resetname_since() { name_sinceSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8698,23 +14973,41 @@ namespace SteamKit2.Internal
     public CMsgClientDeregisterWithServer() {}
     
 
-    private uint _eservertype = default(uint);
+    private uint? _eservertype;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eservertype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eservertype
     {
-      get { return _eservertype; }
+      get { return _eservertype?? default(uint); }
       set { _eservertype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eservertypeSpecified
+    {
+      get { return _eservertype != null; }
+      set { if (value == (_eservertype== null)) _eservertype = value ? this.eservertype : (uint?)null; }
+    }
+    private bool ShouldSerializeeservertype() { return eservertypeSpecified; }
+    private void Reseteservertype() { eservertypeSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8726,32 +15019,59 @@ namespace SteamKit2.Internal
     public CMsgClientClanState() {}
     
 
-    private ulong _steamid_clan = default(ulong);
+    private ulong? _steamid_clan;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_clan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_clan
     {
-      get { return _steamid_clan; }
+      get { return _steamid_clan?? default(ulong); }
       set { _steamid_clan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_clanSpecified
+    {
+      get { return _steamid_clan != null; }
+      set { if (value == (_steamid_clan== null)) _steamid_clan = value ? this.steamid_clan : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_clan() { return steamid_clanSpecified; }
+    private void Resetsteamid_clan() { steamid_clanSpecified = false; }
+    
 
-    private uint _m_unStatusFlags = default(uint);
+    private uint? _m_unStatusFlags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"m_unStatusFlags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint m_unStatusFlags
     {
-      get { return _m_unStatusFlags; }
+      get { return _m_unStatusFlags?? default(uint); }
       set { _m_unStatusFlags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool m_unStatusFlagsSpecified
+    {
+      get { return _m_unStatusFlags != null; }
+      set { if (value == (_m_unStatusFlags== null)) _m_unStatusFlags = value ? this.m_unStatusFlags : (uint?)null; }
+    }
+    private bool ShouldSerializem_unStatusFlags() { return m_unStatusFlagsSpecified; }
+    private void Resetm_unStatusFlags() { m_unStatusFlagsSpecified = false; }
+    
 
-    private uint _clan_account_flags = default(uint);
+    private uint? _clan_account_flags;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"clan_account_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint clan_account_flags
     {
-      get { return _clan_account_flags; }
+      get { return _clan_account_flags?? default(uint); }
       set { _clan_account_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clan_account_flagsSpecified
+    {
+      get { return _clan_account_flags != null; }
+      set { if (value == (_clan_account_flags== null)) _clan_account_flags = value ? this.clan_account_flags : (uint?)null; }
+    }
+    private bool ShouldSerializeclan_account_flags() { return clan_account_flagsSpecified; }
+    private void Resetclan_account_flags() { clan_account_flagsSpecified = false; }
+    
 
     private CMsgClientClanState.NameInfo _name_info = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"name_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -8790,23 +15110,41 @@ namespace SteamKit2.Internal
     public NameInfo() {}
     
 
-    private string _clan_name = "";
+    private string _clan_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"clan_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string clan_name
     {
-      get { return _clan_name; }
+      get { return _clan_name?? ""; }
       set { _clan_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clan_nameSpecified
+    {
+      get { return _clan_name != null; }
+      set { if (value == (_clan_name== null)) _clan_name = value ? this.clan_name : (string)null; }
+    }
+    private bool ShouldSerializeclan_name() { return clan_nameSpecified; }
+    private void Resetclan_name() { clan_nameSpecified = false; }
+    
 
-    private byte[] _sha_avatar = null;
+    private byte[] _sha_avatar;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sha_avatar", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_avatar
     {
-      get { return _sha_avatar; }
+      get { return _sha_avatar?? null; }
       set { _sha_avatar = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_avatarSpecified
+    {
+      get { return _sha_avatar != null; }
+      set { if (value == (_sha_avatar== null)) _sha_avatar = value ? this.sha_avatar : (byte[])null; }
+    }
+    private bool ShouldSerializesha_avatar() { return sha_avatarSpecified; }
+    private void Resetsha_avatar() { sha_avatarSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8818,41 +15156,77 @@ namespace SteamKit2.Internal
     public UserCounts() {}
     
 
-    private uint _members = default(uint);
+    private uint? _members;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"members", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint members
     {
-      get { return _members; }
+      get { return _members?? default(uint); }
       set { _members = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool membersSpecified
+    {
+      get { return _members != null; }
+      set { if (value == (_members== null)) _members = value ? this.members : (uint?)null; }
+    }
+    private bool ShouldSerializemembers() { return membersSpecified; }
+    private void Resetmembers() { membersSpecified = false; }
+    
 
-    private uint _online = default(uint);
+    private uint? _online;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"online", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint online
     {
-      get { return _online; }
+      get { return _online?? default(uint); }
       set { _online = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool onlineSpecified
+    {
+      get { return _online != null; }
+      set { if (value == (_online== null)) _online = value ? this.online : (uint?)null; }
+    }
+    private bool ShouldSerializeonline() { return onlineSpecified; }
+    private void Resetonline() { onlineSpecified = false; }
+    
 
-    private uint _chatting = default(uint);
+    private uint? _chatting;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"chatting", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint chatting
     {
-      get { return _chatting; }
+      get { return _chatting?? default(uint); }
       set { _chatting = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chattingSpecified
+    {
+      get { return _chatting != null; }
+      set { if (value == (_chatting== null)) _chatting = value ? this.chatting : (uint?)null; }
+    }
+    private bool ShouldSerializechatting() { return chattingSpecified; }
+    private void Resetchatting() { chattingSpecified = false; }
+    
 
-    private uint _in_game = default(uint);
+    private uint? _in_game;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"in_game", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint in_game
     {
-      get { return _in_game; }
+      get { return _in_game?? default(uint); }
       set { _in_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_gameSpecified
+    {
+      get { return _in_game != null; }
+      set { if (value == (_in_game== null)) _in_game = value ? this.in_game : (uint?)null; }
+    }
+    private bool ShouldSerializein_game() { return in_gameSpecified; }
+    private void Resetin_game() { in_gameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8864,50 +15238,95 @@ namespace SteamKit2.Internal
     public Event() {}
     
 
-    private ulong _gid = default(ulong);
+    private ulong? _gid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gid
     {
-      get { return _gid; }
+      get { return _gid?? default(ulong); }
       set { _gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gidSpecified
+    {
+      get { return _gid != null; }
+      set { if (value == (_gid== null)) _gid = value ? this.gid : (ulong?)null; }
+    }
+    private bool ShouldSerializegid() { return gidSpecified; }
+    private void Resetgid() { gidSpecified = false; }
+    
 
-    private uint _event_time = default(uint);
+    private uint? _event_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"event_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint event_time
     {
-      get { return _event_time; }
+      get { return _event_time?? default(uint); }
       set { _event_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool event_timeSpecified
+    {
+      get { return _event_time != null; }
+      set { if (value == (_event_time== null)) _event_time = value ? this.event_time : (uint?)null; }
+    }
+    private bool ShouldSerializeevent_time() { return event_timeSpecified; }
+    private void Resetevent_time() { event_timeSpecified = false; }
+    
 
-    private string _headline = "";
+    private string _headline;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"headline", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string headline
     {
-      get { return _headline; }
+      get { return _headline?? ""; }
       set { _headline = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool headlineSpecified
+    {
+      get { return _headline != null; }
+      set { if (value == (_headline== null)) _headline = value ? this.headline : (string)null; }
+    }
+    private bool ShouldSerializeheadline() { return headlineSpecified; }
+    private void Resetheadline() { headlineSpecified = false; }
+    
 
-    private ulong _game_id = default(ulong);
+    private ulong? _game_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong game_id
     {
-      get { return _game_id; }
+      get { return _game_id?? default(ulong); }
       set { _game_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_idSpecified
+    {
+      get { return _game_id != null; }
+      set { if (value == (_game_id== null)) _game_id = value ? this.game_id : (ulong?)null; }
+    }
+    private bool ShouldSerializegame_id() { return game_idSpecified; }
+    private void Resetgame_id() { game_idSpecified = false; }
+    
 
-    private bool _just_posted = default(bool);
+    private bool? _just_posted;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"just_posted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool just_posted
     {
-      get { return _just_posted; }
+      get { return _just_posted?? default(bool); }
       set { _just_posted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool just_postedSpecified
+    {
+      get { return _just_posted != null; }
+      set { if (value == (_just_posted== null)) _just_posted = value ? this.just_posted : (bool?)null; }
+    }
+    private bool ShouldSerializejust_posted() { return just_postedSpecified; }
+    private void Resetjust_posted() { just_postedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8924,41 +15343,77 @@ namespace SteamKit2.Internal
     public CMsgClientFriendMsg() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private int _chat_entry_type = default(int);
+    private int? _chat_entry_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"chat_entry_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int chat_entry_type
     {
-      get { return _chat_entry_type; }
+      get { return _chat_entry_type?? default(int); }
       set { _chat_entry_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_entry_typeSpecified
+    {
+      get { return _chat_entry_type != null; }
+      set { if (value == (_chat_entry_type== null)) _chat_entry_type = value ? this.chat_entry_type : (int?)null; }
+    }
+    private bool ShouldSerializechat_entry_type() { return chat_entry_typeSpecified; }
+    private void Resetchat_entry_type() { chat_entry_typeSpecified = false; }
+    
 
-    private byte[] _message = null;
+    private byte[] _message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] message
     {
-      get { return _message; }
+      get { return _message?? null; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (byte[])null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _rtime32_server_timestamp = default(uint);
+    private uint? _rtime32_server_timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rtime32_server_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_server_timestamp
     {
-      get { return _rtime32_server_timestamp; }
+      get { return _rtime32_server_timestamp?? default(uint); }
       set { _rtime32_server_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_server_timestampSpecified
+    {
+      get { return _rtime32_server_timestamp != null; }
+      set { if (value == (_rtime32_server_timestamp== null)) _rtime32_server_timestamp = value ? this.rtime32_server_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_server_timestamp() { return rtime32_server_timestampSpecified; }
+    private void Resetrtime32_server_timestamp() { rtime32_server_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -8970,50 +15425,95 @@ namespace SteamKit2.Internal
     public CMsgClientFriendMsgIncoming() {}
     
 
-    private ulong _steamid_from = default(ulong);
+    private ulong? _steamid_from;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_from", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_from
     {
-      get { return _steamid_from; }
+      get { return _steamid_from?? default(ulong); }
       set { _steamid_from = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_fromSpecified
+    {
+      get { return _steamid_from != null; }
+      set { if (value == (_steamid_from== null)) _steamid_from = value ? this.steamid_from : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_from() { return steamid_fromSpecified; }
+    private void Resetsteamid_from() { steamid_fromSpecified = false; }
+    
 
-    private int _chat_entry_type = default(int);
+    private int? _chat_entry_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"chat_entry_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int chat_entry_type
     {
-      get { return _chat_entry_type; }
+      get { return _chat_entry_type?? default(int); }
       set { _chat_entry_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_entry_typeSpecified
+    {
+      get { return _chat_entry_type != null; }
+      set { if (value == (_chat_entry_type== null)) _chat_entry_type = value ? this.chat_entry_type : (int?)null; }
+    }
+    private bool ShouldSerializechat_entry_type() { return chat_entry_typeSpecified; }
+    private void Resetchat_entry_type() { chat_entry_typeSpecified = false; }
+    
 
-    private bool _from_limited_account = default(bool);
+    private bool? _from_limited_account;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"from_limited_account", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool from_limited_account
     {
-      get { return _from_limited_account; }
+      get { return _from_limited_account?? default(bool); }
       set { _from_limited_account = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool from_limited_accountSpecified
+    {
+      get { return _from_limited_account != null; }
+      set { if (value == (_from_limited_account== null)) _from_limited_account = value ? this.from_limited_account : (bool?)null; }
+    }
+    private bool ShouldSerializefrom_limited_account() { return from_limited_accountSpecified; }
+    private void Resetfrom_limited_account() { from_limited_accountSpecified = false; }
+    
 
-    private byte[] _message = null;
+    private byte[] _message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] message
     {
-      get { return _message; }
+      get { return _message?? null; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (byte[])null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _rtime32_server_timestamp = default(uint);
+    private uint? _rtime32_server_timestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rtime32_server_timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_server_timestamp
     {
-      get { return _rtime32_server_timestamp; }
+      get { return _rtime32_server_timestamp?? default(uint); }
       set { _rtime32_server_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_server_timestampSpecified
+    {
+      get { return _rtime32_server_timestamp != null; }
+      set { if (value == (_rtime32_server_timestamp== null)) _rtime32_server_timestamp = value ? this.rtime32_server_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_server_timestamp() { return rtime32_server_timestampSpecified; }
+    private void Resetrtime32_server_timestamp() { rtime32_server_timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9025,23 +15525,41 @@ namespace SteamKit2.Internal
     public CMsgClientAddFriend() {}
     
 
-    private ulong _steamid_to_add = default(ulong);
+    private ulong? _steamid_to_add;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_to_add", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_to_add
     {
-      get { return _steamid_to_add; }
+      get { return _steamid_to_add?? default(ulong); }
       set { _steamid_to_add = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_to_addSpecified
+    {
+      get { return _steamid_to_add != null; }
+      set { if (value == (_steamid_to_add== null)) _steamid_to_add = value ? this.steamid_to_add : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_to_add() { return steamid_to_addSpecified; }
+    private void Resetsteamid_to_add() { steamid_to_addSpecified = false; }
+    
 
-    private string _accountname_or_email_to_add = "";
+    private string _accountname_or_email_to_add;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accountname_or_email_to_add", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string accountname_or_email_to_add
     {
-      get { return _accountname_or_email_to_add; }
+      get { return _accountname_or_email_to_add?? ""; }
       set { _accountname_or_email_to_add = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountname_or_email_to_addSpecified
+    {
+      get { return _accountname_or_email_to_add != null; }
+      set { if (value == (_accountname_or_email_to_add== null)) _accountname_or_email_to_add = value ? this.accountname_or_email_to_add : (string)null; }
+    }
+    private bool ShouldSerializeaccountname_or_email_to_add() { return accountname_or_email_to_addSpecified; }
+    private void Resetaccountname_or_email_to_add() { accountname_or_email_to_addSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9053,32 +15571,59 @@ namespace SteamKit2.Internal
     public CMsgClientAddFriendResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steam_id_added = default(ulong);
+    private ulong? _steam_id_added;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steam_id_added", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_added
     {
-      get { return _steam_id_added; }
+      get { return _steam_id_added?? default(ulong); }
       set { _steam_id_added = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_addedSpecified
+    {
+      get { return _steam_id_added != null; }
+      set { if (value == (_steam_id_added== null)) _steam_id_added = value ? this.steam_id_added : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_added() { return steam_id_addedSpecified; }
+    private void Resetsteam_id_added() { steam_id_addedSpecified = false; }
+    
 
-    private string _persona_name_added = "";
+    private string _persona_name_added;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"persona_name_added", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name_added
     {
-      get { return _persona_name_added; }
+      get { return _persona_name_added?? ""; }
       set { _persona_name_added = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_name_addedSpecified
+    {
+      get { return _persona_name_added != null; }
+      set { if (value == (_persona_name_added== null)) _persona_name_added = value ? this.persona_name_added : (string)null; }
+    }
+    private bool ShouldSerializepersona_name_added() { return persona_name_addedSpecified; }
+    private void Resetpersona_name_added() { persona_name_addedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9090,14 +15635,23 @@ namespace SteamKit2.Internal
     public CMsgClientRemoveFriend() {}
     
 
-    private ulong _friendid = default(ulong);
+    private ulong? _friendid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"friendid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong friendid
     {
-      get { return _friendid; }
+      get { return _friendid?? default(ulong); }
       set { _friendid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendidSpecified
+    {
+      get { return _friendid != null; }
+      set { if (value == (_friendid== null)) _friendid = value ? this.friendid : (ulong?)null; }
+    }
+    private bool ShouldSerializefriendid() { return friendidSpecified; }
+    private void Resetfriendid() { friendidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -9109,23 +15663,41 @@ namespace SteamKit2.Internal
     public CMsgClientHideFriend() {}
     
 
-    private ulong _friendid = default(ulong);
+    private ulong? _friendid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"friendid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong friendid
     {
-      get { return _friendid; }
+      get { return _friendid?? default(ulong); }
       set { _friendid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friendidSpecified
+    {
+      get { return _friendid != null; }
+      set { if (value == (_friendid== null)) _friendid = value ? this.friendid : (ulong?)null; }
+    }
+    private bool ShouldSerializefriendid() { return friendidSpecified; }
+    private void Resetfriendid() { friendidSpecified = false; }
+    
 
-    private bool _hide = default(bool);
+    private bool? _hide;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"hide", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool hide
     {
-      get { return _hide; }
+      get { return _hide?? default(bool); }
       set { _hide = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hideSpecified
+    {
+      get { return _hide != null; }
+      set { if (value == (_hide== null)) _hide = value ? this.hide : (bool?)null; }
+    }
+    private bool ShouldSerializehide() { return hideSpecified; }
+    private void Resethide() { hideSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer2.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer2.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_clientserver_2.proto
 // Note: requires additional types generated from: steammessages_base.proto
 namespace SteamKit2.Internal
@@ -18,95 +20,185 @@ namespace SteamKit2.Internal
     public CMsgClientUCMAddScreenshot() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private string _thumbname = "";
+    private string _thumbname;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"thumbname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string thumbname
     {
-      get { return _thumbname; }
+      get { return _thumbname?? ""; }
       set { _thumbname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool thumbnameSpecified
+    {
+      get { return _thumbname != null; }
+      set { if (value == (_thumbname== null)) _thumbname = value ? this.thumbname : (string)null; }
+    }
+    private bool ShouldSerializethumbname() { return thumbnameSpecified; }
+    private void Resetthumbname() { thumbnameSpecified = false; }
+    
 
-    private string _vr_filename = "";
+    private string _vr_filename;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"vr_filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vr_filename
     {
-      get { return _vr_filename; }
+      get { return _vr_filename?? ""; }
       set { _vr_filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vr_filenameSpecified
+    {
+      get { return _vr_filename != null; }
+      set { if (value == (_vr_filename== null)) _vr_filename = value ? this.vr_filename : (string)null; }
+    }
+    private bool ShouldSerializevr_filename() { return vr_filenameSpecified; }
+    private void Resetvr_filename() { vr_filenameSpecified = false; }
+    
 
-    private uint _rtime32_created = default(uint);
+    private uint? _rtime32_created;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rtime32_created", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_created
     {
-      get { return _rtime32_created; }
+      get { return _rtime32_created?? default(uint); }
       set { _rtime32_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_createdSpecified
+    {
+      get { return _rtime32_created != null; }
+      set { if (value == (_rtime32_created== null)) _rtime32_created = value ? this.rtime32_created : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_created() { return rtime32_createdSpecified; }
+    private void Resetrtime32_created() { rtime32_createdSpecified = false; }
+    
 
-    private uint _width = default(uint);
+    private uint? _width;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"width", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint width
     {
-      get { return _width; }
+      get { return _width?? default(uint); }
       set { _width = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool widthSpecified
+    {
+      get { return _width != null; }
+      set { if (value == (_width== null)) _width = value ? this.width : (uint?)null; }
+    }
+    private bool ShouldSerializewidth() { return widthSpecified; }
+    private void Resetwidth() { widthSpecified = false; }
+    
 
-    private uint _height = default(uint);
+    private uint? _height;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"height", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint height
     {
-      get { return _height; }
+      get { return _height?? default(uint); }
       set { _height = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool heightSpecified
+    {
+      get { return _height != null; }
+      set { if (value == (_height== null)) _height = value ? this.height : (uint?)null; }
+    }
+    private bool ShouldSerializeheight() { return heightSpecified; }
+    private void Resetheight() { heightSpecified = false; }
+    
 
-    private uint _permissions = default(uint);
+    private uint? _permissions;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"permissions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint permissions
     {
-      get { return _permissions; }
+      get { return _permissions?? default(uint); }
       set { _permissions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionsSpecified
+    {
+      get { return _permissions != null; }
+      set { if (value == (_permissions== null)) _permissions = value ? this.permissions : (uint?)null; }
+    }
+    private bool ShouldSerializepermissions() { return permissionsSpecified; }
+    private void Resetpermissions() { permissionsSpecified = false; }
+    
 
-    private string _caption = "";
+    private string _caption;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"caption", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string caption
     {
-      get { return _caption; }
+      get { return _caption?? ""; }
       set { _caption = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool captionSpecified
+    {
+      get { return _caption != null; }
+      set { if (value == (_caption== null)) _caption = value ? this.caption : (string)null; }
+    }
+    private bool ShouldSerializecaption() { return captionSpecified; }
+    private void Resetcaption() { captionSpecified = false; }
+    
 
-    private string _shortcut_name = "";
+    private string _shortcut_name;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"shortcut_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string shortcut_name
     {
-      get { return _shortcut_name; }
+      get { return _shortcut_name?? ""; }
       set { _shortcut_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shortcut_nameSpecified
+    {
+      get { return _shortcut_name != null; }
+      set { if (value == (_shortcut_name== null)) _shortcut_name = value ? this.shortcut_name : (string)null; }
+    }
+    private bool ShouldSerializeshortcut_name() { return shortcut_nameSpecified; }
+    private void Resetshortcut_name() { shortcut_nameSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMAddScreenshot.Tag> _tag = new global::System.Collections.Generic.List<CMsgClientUCMAddScreenshot.Tag>();
     [global::ProtoBuf.ProtoMember(10, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMAddScreenshot.Tag> tag
@@ -122,14 +214,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _spoiler_tag = default(bool);
+    private bool? _spoiler_tag;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"spoiler_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool spoiler_tag
     {
-      get { return _spoiler_tag; }
+      get { return _spoiler_tag?? default(bool); }
       set { _spoiler_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spoiler_tagSpecified
+    {
+      get { return _spoiler_tag != null; }
+      set { if (value == (_spoiler_tag== null)) _spoiler_tag = value ? this.spoiler_tag : (bool?)null; }
+    }
+    private bool ShouldSerializespoiler_tag() { return spoiler_tagSpecified; }
+    private void Resetspoiler_tag() { spoiler_tagSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _tagged_publishedfileid = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(13, Name=@"tagged_publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> tagged_publishedfileid
@@ -143,23 +244,41 @@ namespace SteamKit2.Internal
     public Tag() {}
     
 
-    private string _tag_name = "";
+    private string _tag_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tag_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag_name
     {
-      get { return _tag_name; }
+      get { return _tag_name?? ""; }
       set { _tag_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tag_nameSpecified
+    {
+      get { return _tag_name != null; }
+      set { if (value == (_tag_name== null)) _tag_name = value ? this.tag_name : (string)null; }
+    }
+    private bool ShouldSerializetag_name() { return tag_nameSpecified; }
+    private void Resettag_name() { tag_nameSpecified = false; }
+    
 
-    private string _tag_value = "";
+    private string _tag_value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"tag_value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag_value
     {
-      get { return _tag_value; }
+      get { return _tag_value?? ""; }
       set { _tag_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tag_valueSpecified
+    {
+      get { return _tag_value != null; }
+      set { if (value == (_tag_value== null)) _tag_value = value ? this.tag_value : (string)null; }
+    }
+    private bool ShouldSerializetag_value() { return tag_valueSpecified; }
+    private void Resettag_value() { tag_valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -176,23 +295,41 @@ namespace SteamKit2.Internal
     public CMsgClientUCMAddScreenshotResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _screenshotid = (ulong)18446744073709551615;
+    private ulong? _screenshotid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"screenshotid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong screenshotid
     {
-      get { return _screenshotid; }
+      get { return _screenshotid?? (ulong)18446744073709551615; }
       set { _screenshotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool screenshotidSpecified
+    {
+      get { return _screenshotid != null; }
+      set { if (value == (_screenshotid== null)) _screenshotid = value ? this.screenshotid : (ulong?)null; }
+    }
+    private bool ShouldSerializescreenshotid() { return screenshotidSpecified; }
+    private void Resetscreenshotid() { screenshotidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -204,14 +341,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMDeleteScreenshot() {}
     
 
-    private ulong _screenshotid = (ulong)18446744073709551615;
+    private ulong? _screenshotid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"screenshotid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong screenshotid
     {
-      get { return _screenshotid; }
+      get { return _screenshotid?? (ulong)18446744073709551615; }
       set { _screenshotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool screenshotidSpecified
+    {
+      get { return _screenshotid != null; }
+      set { if (value == (_screenshotid== null)) _screenshotid = value ? this.screenshotid : (ulong?)null; }
+    }
+    private bool ShouldSerializescreenshotid() { return screenshotidSpecified; }
+    private void Resetscreenshotid() { screenshotidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -223,14 +369,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMDeleteScreenshotResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -242,59 +397,113 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishFile() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private string _preview_file_name = "";
+    private string _preview_file_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"preview_file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preview_file_name
     {
-      get { return _preview_file_name; }
+      get { return _preview_file_name?? ""; }
       set { _preview_file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_file_nameSpecified
+    {
+      get { return _preview_file_name != null; }
+      set { if (value == (_preview_file_name== null)) _preview_file_name = value ? this.preview_file_name : (string)null; }
+    }
+    private bool ShouldSerializepreview_file_name() { return preview_file_nameSpecified; }
+    private void Resetpreview_file_name() { preview_file_nameSpecified = false; }
+    
 
-    private uint _consumer_app_id = default(uint);
+    private uint? _consumer_app_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"consumer_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint consumer_app_id
     {
-      get { return _consumer_app_id; }
+      get { return _consumer_app_id?? default(uint); }
       set { _consumer_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool consumer_app_idSpecified
+    {
+      get { return _consumer_app_id != null; }
+      set { if (value == (_consumer_app_id== null)) _consumer_app_id = value ? this.consumer_app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeconsumer_app_id() { return consumer_app_idSpecified; }
+    private void Resetconsumer_app_id() { consumer_app_idSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(8, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -303,77 +512,149 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _workshop_file = default(bool);
+    private bool? _workshop_file;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"workshop_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool workshop_file
     {
-      get { return _workshop_file; }
+      get { return _workshop_file?? default(bool); }
       set { _workshop_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_fileSpecified
+    {
+      get { return _workshop_file != null; }
+      set { if (value == (_workshop_file== null)) _workshop_file = value ? this.workshop_file : (bool?)null; }
+    }
+    private bool ShouldSerializeworkshop_file() { return workshop_fileSpecified; }
+    private void Resetworkshop_file() { workshop_fileSpecified = false; }
+    
 
-    private int _visibility = default(int);
+    private int? _visibility;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? default(int); }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (int?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private uint _file_type = default(uint);
+    private uint? _file_type;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_type
     {
-      get { return _file_type; }
+      get { return _file_type?? default(uint); }
       set { _file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_typeSpecified
+    {
+      get { return _file_type != null; }
+      set { if (value == (_file_type== null)) _file_type = value ? this.file_type : (uint?)null; }
+    }
+    private bool ShouldSerializefile_type() { return file_typeSpecified; }
+    private void Resetfile_type() { file_typeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _video_provider = default(uint);
+    private uint? _video_provider;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"video_provider", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint video_provider
     {
-      get { return _video_provider; }
+      get { return _video_provider?? default(uint); }
       set { _video_provider = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_providerSpecified
+    {
+      get { return _video_provider != null; }
+      set { if (value == (_video_provider== null)) _video_provider = value ? this.video_provider : (uint?)null; }
+    }
+    private bool ShouldSerializevideo_provider() { return video_providerSpecified; }
+    private void Resetvideo_provider() { video_providerSpecified = false; }
+    
 
-    private string _video_account_name = "";
+    private string _video_account_name;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"video_account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string video_account_name
     {
-      get { return _video_account_name; }
+      get { return _video_account_name?? ""; }
       set { _video_account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_account_nameSpecified
+    {
+      get { return _video_account_name != null; }
+      set { if (value == (_video_account_name== null)) _video_account_name = value ? this.video_account_name : (string)null; }
+    }
+    private bool ShouldSerializevideo_account_name() { return video_account_nameSpecified; }
+    private void Resetvideo_account_name() { video_account_nameSpecified = false; }
+    
 
-    private string _video_identifier = "";
+    private string _video_identifier;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"video_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string video_identifier
     {
-      get { return _video_identifier; }
+      get { return _video_identifier?? ""; }
       set { _video_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_identifierSpecified
+    {
+      get { return _video_identifier != null; }
+      set { if (value == (_video_identifier== null)) _video_identifier = value ? this.video_identifier : (string)null; }
+    }
+    private bool ShouldSerializevideo_identifier() { return video_identifierSpecified; }
+    private void Resetvideo_identifier() { video_identifierSpecified = false; }
+    
 
-    private bool _in_progress = default(bool);
+    private bool? _in_progress;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"in_progress", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_progress
     {
-      get { return _in_progress; }
+      get { return _in_progress?? default(bool); }
       set { _in_progress = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_progressSpecified
+    {
+      get { return _in_progress != null; }
+      set { if (value == (_in_progress== null)) _in_progress = value ? this.in_progress : (bool?)null; }
+    }
+    private bool ShouldSerializein_progress() { return in_progressSpecified; }
+    private void Resetin_progress() { in_progressSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -385,32 +666,59 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _published_file_id = (ulong)18446744073709551615;
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(@"18446744073709551615")]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? (ulong)18446744073709551615; }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private bool _needs_workshop_legal_agreement_acceptance = (bool)false;
+    private bool? _needs_workshop_legal_agreement_acceptance;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"needs_workshop_legal_agreement_acceptance", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool needs_workshop_legal_agreement_acceptance
     {
-      get { return _needs_workshop_legal_agreement_acceptance; }
+      get { return _needs_workshop_legal_agreement_acceptance?? (bool)false; }
       set { _needs_workshop_legal_agreement_acceptance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool needs_workshop_legal_agreement_acceptanceSpecified
+    {
+      get { return _needs_workshop_legal_agreement_acceptance != null; }
+      set { if (value == (_needs_workshop_legal_agreement_acceptance== null)) _needs_workshop_legal_agreement_acceptance = value ? this.needs_workshop_legal_agreement_acceptance : (bool?)null; }
+    }
+    private bool ShouldSerializeneeds_workshop_legal_agreement_acceptance() { return needs_workshop_legal_agreement_acceptanceSpecified; }
+    private void Resetneeds_workshop_legal_agreement_acceptance() { needs_workshop_legal_agreement_acceptanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -422,59 +730,113 @@ namespace SteamKit2.Internal
     public CMsgClientUCMUpdatePublishedFile() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private string _file_name = "";
+    private string _file_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_name
     {
-      get { return _file_name; }
+      get { return _file_name?? ""; }
       set { _file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_nameSpecified
+    {
+      get { return _file_name != null; }
+      set { if (value == (_file_name== null)) _file_name = value ? this.file_name : (string)null; }
+    }
+    private bool ShouldSerializefile_name() { return file_nameSpecified; }
+    private void Resetfile_name() { file_nameSpecified = false; }
+    
 
-    private string _preview_file_name = "";
+    private string _preview_file_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"preview_file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preview_file_name
     {
-      get { return _preview_file_name; }
+      get { return _preview_file_name?? ""; }
       set { _preview_file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_file_nameSpecified
+    {
+      get { return _preview_file_name != null; }
+      set { if (value == (_preview_file_name== null)) _preview_file_name = value ? this.preview_file_name : (string)null; }
+    }
+    private bool ShouldSerializepreview_file_name() { return preview_file_nameSpecified; }
+    private void Resetpreview_file_name() { preview_file_nameSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _description = "";
+    private string _description;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string description
     {
-      get { return _description; }
+      get { return _description?? ""; }
       set { _description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool descriptionSpecified
+    {
+      get { return _description != null; }
+      set { if (value == (_description== null)) _description = value ? this.description : (string)null; }
+    }
+    private bool ShouldSerializedescription() { return descriptionSpecified; }
+    private void Resetdescription() { descriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(7, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -483,140 +845,275 @@ namespace SteamKit2.Internal
     }
   
 
-    private int _visibility = default(int);
+    private int? _visibility;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? default(int); }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (int?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private bool _update_file = default(bool);
+    private bool? _update_file;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"update_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_file
     {
-      get { return _update_file; }
+      get { return _update_file?? default(bool); }
       set { _update_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_fileSpecified
+    {
+      get { return _update_file != null; }
+      set { if (value == (_update_file== null)) _update_file = value ? this.update_file : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_file() { return update_fileSpecified; }
+    private void Resetupdate_file() { update_fileSpecified = false; }
+    
 
-    private bool _update_preview_file = default(bool);
+    private bool? _update_preview_file;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"update_preview_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_preview_file
     {
-      get { return _update_preview_file; }
+      get { return _update_preview_file?? default(bool); }
       set { _update_preview_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_preview_fileSpecified
+    {
+      get { return _update_preview_file != null; }
+      set { if (value == (_update_preview_file== null)) _update_preview_file = value ? this.update_preview_file : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_preview_file() { return update_preview_fileSpecified; }
+    private void Resetupdate_preview_file() { update_preview_fileSpecified = false; }
+    
 
-    private bool _update_title = default(bool);
+    private bool? _update_title;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"update_title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_title
     {
-      get { return _update_title; }
+      get { return _update_title?? default(bool); }
       set { _update_title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_titleSpecified
+    {
+      get { return _update_title != null; }
+      set { if (value == (_update_title== null)) _update_title = value ? this.update_title : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_title() { return update_titleSpecified; }
+    private void Resetupdate_title() { update_titleSpecified = false; }
+    
 
-    private bool _update_description = default(bool);
+    private bool? _update_description;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"update_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_description
     {
-      get { return _update_description; }
+      get { return _update_description?? default(bool); }
       set { _update_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_descriptionSpecified
+    {
+      get { return _update_description != null; }
+      set { if (value == (_update_description== null)) _update_description = value ? this.update_description : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_description() { return update_descriptionSpecified; }
+    private void Resetupdate_description() { update_descriptionSpecified = false; }
+    
 
-    private bool _update_tags = default(bool);
+    private bool? _update_tags;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"update_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_tags
     {
-      get { return _update_tags; }
+      get { return _update_tags?? default(bool); }
       set { _update_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_tagsSpecified
+    {
+      get { return _update_tags != null; }
+      set { if (value == (_update_tags== null)) _update_tags = value ? this.update_tags : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_tags() { return update_tagsSpecified; }
+    private void Resetupdate_tags() { update_tagsSpecified = false; }
+    
 
-    private bool _update_visibility = default(bool);
+    private bool? _update_visibility;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"update_visibility", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_visibility
     {
-      get { return _update_visibility; }
+      get { return _update_visibility?? default(bool); }
       set { _update_visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_visibilitySpecified
+    {
+      get { return _update_visibility != null; }
+      set { if (value == (_update_visibility== null)) _update_visibility = value ? this.update_visibility : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_visibility() { return update_visibilitySpecified; }
+    private void Resetupdate_visibility() { update_visibilitySpecified = false; }
+    
 
-    private string _change_description = "";
+    private string _change_description;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"change_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string change_description
     {
-      get { return _change_description; }
+      get { return _change_description?? ""; }
       set { _change_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_descriptionSpecified
+    {
+      get { return _change_description != null; }
+      set { if (value == (_change_description== null)) _change_description = value ? this.change_description : (string)null; }
+    }
+    private bool ShouldSerializechange_description() { return change_descriptionSpecified; }
+    private void Resetchange_description() { change_descriptionSpecified = false; }
+    
 
-    private bool _update_url = default(bool);
+    private bool? _update_url;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"update_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_url
     {
-      get { return _update_url; }
+      get { return _update_url?? default(bool); }
       set { _update_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_urlSpecified
+    {
+      get { return _update_url != null; }
+      set { if (value == (_update_url== null)) _update_url = value ? this.update_url : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_url() { return update_urlSpecified; }
+    private void Resetupdate_url() { update_urlSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private bool _update_content_manifest = default(bool);
+    private bool? _update_content_manifest;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"update_content_manifest", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_content_manifest
     {
-      get { return _update_content_manifest; }
+      get { return _update_content_manifest?? default(bool); }
       set { _update_content_manifest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_content_manifestSpecified
+    {
+      get { return _update_content_manifest != null; }
+      set { if (value == (_update_content_manifest== null)) _update_content_manifest = value ? this.update_content_manifest : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_content_manifest() { return update_content_manifestSpecified; }
+    private void Resetupdate_content_manifest() { update_content_manifestSpecified = false; }
+    
 
-    private ulong _content_manifest = default(ulong);
+    private ulong? _content_manifest;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"content_manifest", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong content_manifest
     {
-      get { return _content_manifest; }
+      get { return _content_manifest?? default(ulong); }
       set { _content_manifest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool content_manifestSpecified
+    {
+      get { return _content_manifest != null; }
+      set { if (value == (_content_manifest== null)) _content_manifest = value ? this.content_manifest : (ulong?)null; }
+    }
+    private bool ShouldSerializecontent_manifest() { return content_manifestSpecified; }
+    private void Resetcontent_manifest() { content_manifestSpecified = false; }
+    
 
-    private string _metadata = "";
+    private string _metadata;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? ""; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (string)null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
 
-    private bool _update_metadata = default(bool);
+    private bool? _update_metadata;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"update_metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool update_metadata
     {
-      get { return _update_metadata; }
+      get { return _update_metadata?? default(bool); }
       set { _update_metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_metadataSpecified
+    {
+      get { return _update_metadata != null; }
+      set { if (value == (_update_metadata== null)) _update_metadata = value ? this.update_metadata : (bool?)null; }
+    }
+    private bool ShouldSerializeupdate_metadata() { return update_metadataSpecified; }
+    private void Resetupdate_metadata() { update_metadataSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _removed_kvtags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(23, Name=@"removed_kvtags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> removed_kvtags
@@ -646,37 +1143,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private bool _clear_in_progress = default(bool);
+    private bool? _clear_in_progress;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"clear_in_progress", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool clear_in_progress
     {
-      get { return _clear_in_progress; }
+      get { return _clear_in_progress?? default(bool); }
       set { _clear_in_progress = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clear_in_progressSpecified
+    {
+      get { return _clear_in_progress != null; }
+      set { if (value == (_clear_in_progress== null)) _clear_in_progress = value ? this.clear_in_progress : (bool?)null; }
+    }
+    private bool ShouldSerializeclear_in_progress() { return clear_in_progressSpecified; }
+    private void Resetclear_in_progress() { clear_in_progressSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"KeyValueTag")]
   public partial class KeyValueTag : global::ProtoBuf.IExtensible
   {
     public KeyValueTag() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -688,50 +1212,95 @@ namespace SteamKit2.Internal
     public AdditionalPreview() {}
     
 
-    private string _original_file_name = "";
+    private string _original_file_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"original_file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string original_file_name
     {
-      get { return _original_file_name; }
+      get { return _original_file_name?? ""; }
       set { _original_file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool original_file_nameSpecified
+    {
+      get { return _original_file_name != null; }
+      set { if (value == (_original_file_name== null)) _original_file_name = value ? this.original_file_name : (string)null; }
+    }
+    private bool ShouldSerializeoriginal_file_name() { return original_file_nameSpecified; }
+    private void Resetoriginal_file_name() { original_file_nameSpecified = false; }
+    
 
-    private string _internal_file_name = "";
+    private string _internal_file_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"internal_file_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string internal_file_name
     {
-      get { return _internal_file_name; }
+      get { return _internal_file_name?? ""; }
       set { _internal_file_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool internal_file_nameSpecified
+    {
+      get { return _internal_file_name != null; }
+      set { if (value == (_internal_file_name== null)) _internal_file_name = value ? this.internal_file_name : (string)null; }
+    }
+    private bool ShouldSerializeinternal_file_name() { return internal_file_nameSpecified; }
+    private void Resetinternal_file_name() { internal_file_nameSpecified = false; }
+    
 
-    private string _videoid = "";
+    private string _videoid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"videoid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string videoid
     {
-      get { return _videoid; }
+      get { return _videoid?? ""; }
       set { _videoid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool videoidSpecified
+    {
+      get { return _videoid != null; }
+      set { if (value == (_videoid== null)) _videoid = value ? this.videoid : (string)null; }
+    }
+    private bool ShouldSerializevideoid() { return videoidSpecified; }
+    private void Resetvideoid() { videoidSpecified = false; }
+    
 
-    private uint _preview_type = default(uint);
+    private uint? _preview_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"preview_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint preview_type
     {
-      get { return _preview_type; }
+      get { return _preview_type?? default(uint); }
       set { _preview_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_typeSpecified
+    {
+      get { return _preview_type != null; }
+      set { if (value == (_preview_type== null)) _preview_type = value ? this.preview_type : (uint?)null; }
+    }
+    private bool ShouldSerializepreview_type() { return preview_typeSpecified; }
+    private void Resetpreview_type() { preview_typeSpecified = false; }
+    
 
-    private int _update_index = (int)-1;
+    private int? _update_index;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"update_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)-1)]
     public int update_index
     {
-      get { return _update_index; }
+      get { return _update_index?? (int)-1; }
       set { _update_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_indexSpecified
+    {
+      get { return _update_index != null; }
+      set { if (value == (_update_index== null)) _update_index = value ? this.update_index : (int?)null; }
+    }
+    private bool ShouldSerializeupdate_index() { return update_indexSpecified; }
+    private void Resetupdate_index() { update_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -748,23 +1317,41 @@ namespace SteamKit2.Internal
     public CMsgClientUCMUpdatePublishedFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _needs_workshop_legal_agreement_acceptance = (bool)false;
+    private bool? _needs_workshop_legal_agreement_acceptance;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"needs_workshop_legal_agreement_acceptance", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool needs_workshop_legal_agreement_acceptance
     {
-      get { return _needs_workshop_legal_agreement_acceptance; }
+      get { return _needs_workshop_legal_agreement_acceptance?? (bool)false; }
       set { _needs_workshop_legal_agreement_acceptance = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool needs_workshop_legal_agreement_acceptanceSpecified
+    {
+      get { return _needs_workshop_legal_agreement_acceptance != null; }
+      set { if (value == (_needs_workshop_legal_agreement_acceptance== null)) _needs_workshop_legal_agreement_acceptance = value ? this.needs_workshop_legal_agreement_acceptance : (bool?)null; }
+    }
+    private bool ShouldSerializeneeds_workshop_legal_agreement_acceptance() { return needs_workshop_legal_agreement_acceptanceSpecified; }
+    private void Resetneeds_workshop_legal_agreement_acceptance() { needs_workshop_legal_agreement_acceptanceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -776,14 +1363,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMDeletePublishedFile() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -795,14 +1391,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMDeletePublishedFileResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -814,32 +1419,59 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserPublishedFiles() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
 
-    private uint _sort_order = default(uint);
+    private uint? _sort_order;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sort_order", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sort_order
     {
-      get { return _sort_order; }
+      get { return _sort_order?? default(uint); }
       set { _sort_order = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sort_orderSpecified
+    {
+      get { return _sort_order != null; }
+      set { if (value == (_sort_order== null)) _sort_order = value ? this.sort_order : (uint?)null; }
+    }
+    private bool ShouldSerializesort_order() { return sort_orderSpecified; }
+    private void Resetsort_order() { sort_orderSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -851,14 +1483,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserPublishedFilesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserPublishedFilesResponse.PublishedFileId> _published_files = new global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserPublishedFilesResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"published_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserPublishedFilesResponse.PublishedFileId> published_files
@@ -867,28 +1508,46 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -905,50 +1564,95 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserSubscribedFiles() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
 
-    private uint _list_type = (uint)1;
+    private uint? _list_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"list_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint list_type
     {
-      get { return _list_type; }
+      get { return _list_type?? (uint)1; }
       set { _list_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool list_typeSpecified
+    {
+      get { return _list_type != null; }
+      set { if (value == (_list_type== null)) _list_type = value ? this.list_type : (uint?)null; }
+    }
+    private bool ShouldSerializelist_type() { return list_typeSpecified; }
+    private void Resetlist_type() { list_typeSpecified = false; }
+    
 
-    private uint _matching_file_type = (uint)0;
+    private uint? _matching_file_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"matching_file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint matching_file_type
     {
-      get { return _matching_file_type; }
+      get { return _matching_file_type?? (uint)0; }
       set { _matching_file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_file_typeSpecified
+    {
+      get { return _matching_file_type != null; }
+      set { if (value == (_matching_file_type== null)) _matching_file_type = value ? this.matching_file_type : (uint?)null; }
+    }
+    private bool ShouldSerializematching_file_type() { return matching_file_typeSpecified; }
+    private void Resetmatching_file_type() { matching_file_typeSpecified = false; }
+    
 
-    private uint _count = (uint)50;
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)50)]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? (uint)50; }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -960,14 +1664,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserSubscribedFilesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesResponse.PublishedFileId> _subscribed_files = new global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"subscribed_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesResponse.PublishedFileId> subscribed_files
@@ -976,37 +1689,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _rtime32_subscribed = (uint)0;
+    private uint? _rtime32_subscribed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rtime32_subscribed", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint rtime32_subscribed
     {
-      get { return _rtime32_subscribed; }
+      get { return _rtime32_subscribed?? (uint)0; }
       set { _rtime32_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_subscribedSpecified
+    {
+      get { return _rtime32_subscribed != null; }
+      set { if (value == (_rtime32_subscribed== null)) _rtime32_subscribed = value ? this.rtime32_subscribed : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_subscribed() { return rtime32_subscribedSpecified; }
+    private void Resetrtime32_subscribed() { rtime32_subscribedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1023,32 +1763,59 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserSubscribedFilesWithUpdates() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
 
-    private uint _start_time = default(uint);
+    private uint? _start_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"start_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_time
     {
-      get { return _start_time; }
+      get { return _start_time?? default(uint); }
       set { _start_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_timeSpecified
+    {
+      get { return _start_time != null; }
+      set { if (value == (_start_time== null)) _start_time = value ? this.start_time : (uint?)null; }
+    }
+    private bool ShouldSerializestart_time() { return start_timeSpecified; }
+    private void Resetstart_time() { start_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1060,14 +1827,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumerateUserSubscribedFilesWithUpdatesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesWithUpdatesResponse.PublishedFileId> _subscribed_files = new global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesWithUpdatesResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"subscribed_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMEnumerateUserSubscribedFilesWithUpdatesResponse.PublishedFileId> subscribed_files
@@ -1076,82 +1852,154 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _rtime32_subscribed = (uint)0;
+    private uint? _rtime32_subscribed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rtime32_subscribed", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint rtime32_subscribed
     {
-      get { return _rtime32_subscribed; }
+      get { return _rtime32_subscribed?? (uint)0; }
       set { _rtime32_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_subscribedSpecified
+    {
+      get { return _rtime32_subscribed != null; }
+      set { if (value == (_rtime32_subscribed== null)) _rtime32_subscribed = value ? this.rtime32_subscribed : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_subscribed() { return rtime32_subscribedSpecified; }
+    private void Resetrtime32_subscribed() { rtime32_subscribedSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _file_hcontent = default(ulong);
+    private ulong? _file_hcontent;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"file_hcontent", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong file_hcontent
     {
-      get { return _file_hcontent; }
+      get { return _file_hcontent?? default(ulong); }
       set { _file_hcontent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_hcontentSpecified
+    {
+      get { return _file_hcontent != null; }
+      set { if (value == (_file_hcontent== null)) _file_hcontent = value ? this.file_hcontent : (ulong?)null; }
+    }
+    private bool ShouldSerializefile_hcontent() { return file_hcontentSpecified; }
+    private void Resetfile_hcontent() { file_hcontentSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _rtime32_last_updated = default(uint);
+    private uint? _rtime32_last_updated;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rtime32_last_updated", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_last_updated
     {
-      get { return _rtime32_last_updated; }
+      get { return _rtime32_last_updated?? default(uint); }
       set { _rtime32_last_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_last_updatedSpecified
+    {
+      get { return _rtime32_last_updated != null; }
+      set { if (value == (_rtime32_last_updated== null)) _rtime32_last_updated = value ? this.rtime32_last_updated : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_last_updated() { return rtime32_last_updatedSpecified; }
+    private void Resetrtime32_last_updated() { rtime32_last_updatedSpecified = false; }
+    
 
-    private bool _is_depot_content = default(bool);
+    private bool? _is_depot_content;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_depot_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_depot_content
     {
-      get { return _is_depot_content; }
+      get { return _is_depot_content?? default(bool); }
       set { _is_depot_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_depot_contentSpecified
+    {
+      get { return _is_depot_content != null; }
+      set { if (value == (_is_depot_content== null)) _is_depot_content = value ? this.is_depot_content : (bool?)null; }
+    }
+    private bool ShouldSerializeis_depot_content() { return is_depot_contentSpecified; }
+    private void Resetis_depot_content() { is_depot_contentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1168,68 +2016,131 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishedFileSubscribed() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _file_hcontent = default(ulong);
+    private ulong? _file_hcontent;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_hcontent", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong file_hcontent
     {
-      get { return _file_hcontent; }
+      get { return _file_hcontent?? default(ulong); }
       set { _file_hcontent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_hcontentSpecified
+    {
+      get { return _file_hcontent != null; }
+      set { if (value == (_file_hcontent== null)) _file_hcontent = value ? this.file_hcontent : (ulong?)null; }
+    }
+    private bool ShouldSerializefile_hcontent() { return file_hcontentSpecified; }
+    private void Resetfile_hcontent() { file_hcontentSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _rtime_subscribed = default(uint);
+    private uint? _rtime_subscribed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"rtime_subscribed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime_subscribed
     {
-      get { return _rtime_subscribed; }
+      get { return _rtime_subscribed?? default(uint); }
       set { _rtime_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_subscribedSpecified
+    {
+      get { return _rtime_subscribed != null; }
+      set { if (value == (_rtime_subscribed== null)) _rtime_subscribed = value ? this.rtime_subscribed : (uint?)null; }
+    }
+    private bool ShouldSerializertime_subscribed() { return rtime_subscribedSpecified; }
+    private void Resetrtime_subscribed() { rtime_subscribedSpecified = false; }
+    
 
-    private bool _is_depot_content = default(bool);
+    private bool? _is_depot_content;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"is_depot_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_depot_content
     {
-      get { return _is_depot_content; }
+      get { return _is_depot_content?? default(bool); }
       set { _is_depot_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_depot_contentSpecified
+    {
+      get { return _is_depot_content != null; }
+      set { if (value == (_is_depot_content== null)) _is_depot_content = value ? this.is_depot_content : (bool?)null; }
+    }
+    private bool ShouldSerializeis_depot_content() { return is_depot_contentSpecified; }
+    private void Resetis_depot_content() { is_depot_contentSpecified = false; }
+    
 
-    private uint _rtime_updated = default(uint);
+    private uint? _rtime_updated;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"rtime_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime_updated
     {
-      get { return _rtime_updated; }
+      get { return _rtime_updated?? default(uint); }
       set { _rtime_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_updatedSpecified
+    {
+      get { return _rtime_updated != null; }
+      set { if (value == (_rtime_updated== null)) _rtime_updated = value ? this.rtime_updated : (uint?)null; }
+    }
+    private bool ShouldSerializertime_updated() { return rtime_updatedSpecified; }
+    private void Resetrtime_updated() { rtime_updatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1241,23 +2152,41 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishedFileUnsubscribed() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1269,23 +2198,41 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishedFileDeleted() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1297,59 +2244,113 @@ namespace SteamKit2.Internal
     public CMsgClientUCMPublishedFileUpdated() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
 
-    private ulong _hcontent = default(ulong);
+    private ulong? _hcontent;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hcontent", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong hcontent
     {
-      get { return _hcontent; }
+      get { return _hcontent?? default(ulong); }
       set { _hcontent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hcontentSpecified
+    {
+      get { return _hcontent != null; }
+      set { if (value == (_hcontent== null)) _hcontent = value ? this.hcontent : (ulong?)null; }
+    }
+    private bool ShouldSerializehcontent() { return hcontentSpecified; }
+    private void Resethcontent() { hcontentSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private bool _is_depot_content = default(bool);
+    private bool? _is_depot_content;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"is_depot_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_depot_content
     {
-      get { return _is_depot_content; }
+      get { return _is_depot_content?? default(bool); }
       set { _is_depot_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_depot_contentSpecified
+    {
+      get { return _is_depot_content != null; }
+      set { if (value == (_is_depot_content== null)) _is_depot_content = value ? this.is_depot_content : (bool?)null; }
+    }
+    private bool ShouldSerializeis_depot_content() { return is_depot_contentSpecified; }
+    private void Resetis_depot_content() { is_depot_contentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1361,32 +2362,59 @@ namespace SteamKit2.Internal
     public CMsgClientWorkshopItemChangesRequest() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _last_time_updated = default(uint);
+    private uint? _last_time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_updated
     {
-      get { return _last_time_updated; }
+      get { return _last_time_updated?? default(uint); }
       set { _last_time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_updatedSpecified
+    {
+      get { return _last_time_updated != null; }
+      set { if (value == (_last_time_updated== null)) _last_time_updated = value ? this.last_time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_updated() { return last_time_updatedSpecified; }
+    private void Resetlast_time_updated() { last_time_updatedSpecified = false; }
+    
 
-    private uint _num_items_needed = default(uint);
+    private uint? _num_items_needed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_items_needed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_items_needed
     {
-      get { return _num_items_needed; }
+      get { return _num_items_needed?? default(uint); }
       set { _num_items_needed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_items_neededSpecified
+    {
+      get { return _num_items_needed != null; }
+      set { if (value == (_num_items_needed== null)) _num_items_needed = value ? this.num_items_needed : (uint?)null; }
+    }
+    private bool ShouldSerializenum_items_needed() { return num_items_neededSpecified; }
+    private void Resetnum_items_needed() { num_items_neededSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1398,23 +2426,41 @@ namespace SteamKit2.Internal
     public CMsgClientWorkshopItemChangesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _update_time = default(uint);
+    private uint? _update_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"update_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint update_time
     {
-      get { return _update_time; }
+      get { return _update_time?? default(uint); }
       set { _update_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_timeSpecified
+    {
+      get { return _update_time != null; }
+      set { if (value == (_update_time== null)) _update_time = value ? this.update_time : (uint?)null; }
+    }
+    private bool ShouldSerializeupdate_time() { return update_timeSpecified; }
+    private void Resetupdate_time() { update_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientWorkshopItemChangesResponse.WorkshopItemInfo> _workshop_items = new global::System.Collections.Generic.List<CMsgClientWorkshopItemChangesResponse.WorkshopItemInfo>();
     [global::ProtoBuf.ProtoMember(5, Name=@"workshop_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientWorkshopItemChangesResponse.WorkshopItemInfo> workshop_items
@@ -1428,32 +2474,59 @@ namespace SteamKit2.Internal
     public WorkshopItemInfo() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
 
-    private ulong _manifest_id = default(ulong);
+    private ulong? _manifest_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"manifest_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong manifest_id
     {
-      get { return _manifest_id; }
+      get { return _manifest_id?? default(ulong); }
       set { _manifest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifest_idSpecified
+    {
+      get { return _manifest_id != null; }
+      set { if (value == (_manifest_id== null)) _manifest_id = value ? this.manifest_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemanifest_id() { return manifest_idSpecified; }
+    private void Resetmanifest_id() { manifest_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1470,23 +2543,41 @@ namespace SteamKit2.Internal
     public CMsgClientWorkshopItemInfoRequest() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _last_time_updated = default(uint);
+    private uint? _last_time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_updated
     {
-      get { return _last_time_updated; }
+      get { return _last_time_updated?? default(uint); }
       set { _last_time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_updatedSpecified
+    {
+      get { return _last_time_updated != null; }
+      set { if (value == (_last_time_updated== null)) _last_time_updated = value ? this.last_time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_updated() { return last_time_updatedSpecified; }
+    private void Resetlast_time_updated() { last_time_updatedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoRequest.WorkshopItem> _workshop_items = new global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoRequest.WorkshopItem>();
     [global::ProtoBuf.ProtoMember(3, Name=@"workshop_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoRequest.WorkshopItem> workshop_items
@@ -1500,23 +2591,41 @@ namespace SteamKit2.Internal
     public WorkshopItem() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1533,23 +2642,41 @@ namespace SteamKit2.Internal
     public CMsgClientWorkshopItemInfoResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _update_time = default(uint);
+    private uint? _update_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"update_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint update_time
     {
-      get { return _update_time; }
+      get { return _update_time?? default(uint); }
       set { _update_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_timeSpecified
+    {
+      get { return _update_time != null; }
+      set { if (value == (_update_time== null)) _update_time = value ? this.update_time : (uint?)null; }
+    }
+    private bool ShouldSerializeupdate_time() { return update_timeSpecified; }
+    private void Resetupdate_time() { update_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoResponse.WorkshopItemInfo> _workshop_items = new global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoResponse.WorkshopItemInfo>();
     [global::ProtoBuf.ProtoMember(3, Name=@"workshop_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientWorkshopItemInfoResponse.WorkshopItemInfo> workshop_items
@@ -1570,41 +2697,77 @@ namespace SteamKit2.Internal
     public WorkshopItemInfo() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
 
-    private ulong _manifest_id = default(ulong);
+    private ulong? _manifest_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"manifest_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong manifest_id
     {
-      get { return _manifest_id; }
+      get { return _manifest_id?? default(ulong); }
       set { _manifest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifest_idSpecified
+    {
+      get { return _manifest_id != null; }
+      set { if (value == (_manifest_id== null)) _manifest_id = value ? this.manifest_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemanifest_id() { return manifest_idSpecified; }
+    private void Resetmanifest_id() { manifest_idSpecified = false; }
+    
 
-    private bool _is_legacy = default(bool);
+    private bool? _is_legacy;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_legacy", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_legacy
     {
-      get { return _is_legacy; }
+      get { return _is_legacy?? default(bool); }
       set { _is_legacy = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_legacySpecified
+    {
+      get { return _is_legacy != null; }
+      set { if (value == (_is_legacy== null)) _is_legacy = value ? this.is_legacy : (bool?)null; }
+    }
+    private bool ShouldSerializeis_legacy() { return is_legacySpecified; }
+    private void Resetis_legacy() { is_legacySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1621,23 +2784,41 @@ namespace SteamKit2.Internal
     public CMsgClientUCMGetPublishedFilesForUser() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private ulong _creator_steam_id = default(ulong);
+    private ulong? _creator_steam_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"creator_steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong creator_steam_id
     {
-      get { return _creator_steam_id; }
+      get { return _creator_steam_id?? default(ulong); }
       set { _creator_steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creator_steam_idSpecified
+    {
+      get { return _creator_steam_id != null; }
+      set { if (value == (_creator_steam_id== null)) _creator_steam_id = value ? this.creator_steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializecreator_steam_id() { return creator_steam_idSpecified; }
+    private void Resetcreator_steam_id() { creator_steam_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _required_tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"required_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> required_tags
@@ -1653,14 +2834,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1672,14 +2862,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMGetPublishedFilesForUserResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMGetPublishedFilesForUserResponse.PublishedFileId> _published_files = new global::System.Collections.Generic.List<CMsgClientUCMGetPublishedFilesForUserResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"published_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMGetPublishedFilesForUserResponse.PublishedFileId> published_files
@@ -1688,28 +2887,46 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1726,32 +2943,59 @@ namespace SteamKit2.Internal
     public CMsgClientUCMSetUserPublishedFileAction() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _action = default(int);
+    private int? _action;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int action
     {
-      get { return _action; }
+      get { return _action?? default(int); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (int?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1763,14 +3007,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMSetUserPublishedFileActionResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1782,32 +3035,59 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumeratePublishedFilesByUserAction() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
 
-    private int _action = default(int);
+    private int? _action;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int action
     {
-      get { return _action; }
+      get { return _action?? default(int); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (int?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1819,14 +3099,23 @@ namespace SteamKit2.Internal
     public CMsgClientUCMEnumeratePublishedFilesByUserActionResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUCMEnumeratePublishedFilesByUserActionResponse.PublishedFileId> _published_files = new global::System.Collections.Generic.List<CMsgClientUCMEnumeratePublishedFilesByUserActionResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"published_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUCMEnumeratePublishedFilesByUserActionResponse.PublishedFileId> published_files
@@ -1835,37 +3124,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _rtime_time_stamp = (uint)0;
+    private uint? _rtime_time_stamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rtime_time_stamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint rtime_time_stamp
     {
-      get { return _rtime_time_stamp; }
+      get { return _rtime_time_stamp?? (uint)0; }
       set { _rtime_time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime_time_stampSpecified
+    {
+      get { return _rtime_time_stamp != null; }
+      set { if (value == (_rtime_time_stamp== null)) _rtime_time_stamp = value ? this.rtime_time_stamp : (uint?)null; }
+    }
+    private bool ShouldSerializertime_time_stamp() { return rtime_time_stampSpecified; }
+    private void Resetrtime_time_stamp() { rtime_time_stampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1892,50 +3208,95 @@ namespace SteamKit2.Internal
     public CMsgClientUpdateUserGameInfo() {}
     
 
-    private ulong _steamid_idgs = default(ulong);
+    private ulong? _steamid_idgs;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_idgs", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_idgs
     {
-      get { return _steamid_idgs; }
+      get { return _steamid_idgs?? default(ulong); }
       set { _steamid_idgs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_idgsSpecified
+    {
+      get { return _steamid_idgs != null; }
+      set { if (value == (_steamid_idgs== null)) _steamid_idgs = value ? this.steamid_idgs : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_idgs() { return steamid_idgsSpecified; }
+    private void Resetsteamid_idgs() { steamid_idgsSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private uint _game_ip = default(uint);
+    private uint? _game_ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"game_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_ip
     {
-      get { return _game_ip; }
+      get { return _game_ip?? default(uint); }
       set { _game_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_ipSpecified
+    {
+      get { return _game_ip != null; }
+      set { if (value == (_game_ip== null)) _game_ip = value ? this.game_ip : (uint?)null; }
+    }
+    private bool ShouldSerializegame_ip() { return game_ipSpecified; }
+    private void Resetgame_ip() { game_ipSpecified = false; }
+    
 
-    private uint _game_port = default(uint);
+    private uint? _game_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_port
     {
-      get { return _game_port; }
+      get { return _game_port?? default(uint); }
       set { _game_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_portSpecified
+    {
+      get { return _game_port != null; }
+      set { if (value == (_game_port== null)) _game_port = value ? this.game_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_port() { return game_portSpecified; }
+    private void Resetgame_port() { game_portSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1947,14 +3308,23 @@ namespace SteamKit2.Internal
     public CMsgClientRichPresenceUpload() {}
     
 
-    private byte[] _rich_presence_kv = null;
+    private byte[] _rich_presence_kv;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"rich_presence_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] rich_presence_kv
     {
-      get { return _rich_presence_kv; }
+      get { return _rich_presence_kv?? null; }
       set { _rich_presence_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rich_presence_kvSpecified
+    {
+      get { return _rich_presence_kv != null; }
+      set { if (value == (_rich_presence_kv== null)) _rich_presence_kv = value ? this.rich_presence_kv : (byte[])null; }
+    }
+    private bool ShouldSerializerich_presence_kv() { return rich_presence_kvSpecified; }
+    private void Resetrich_presence_kv() { rich_presence_kvSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamid_broadcast = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"steamid_broadcast", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamid_broadcast
@@ -2002,23 +3372,41 @@ namespace SteamKit2.Internal
     public RichPresence() {}
     
 
-    private ulong _steamid_user = default(ulong);
+    private ulong? _steamid_user;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid_user", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_user
     {
-      get { return _steamid_user; }
+      get { return _steamid_user?? default(ulong); }
       set { _steamid_user = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_userSpecified
+    {
+      get { return _steamid_user != null; }
+      set { if (value == (_steamid_user== null)) _steamid_user = value ? this.steamid_user : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_user() { return steamid_userSpecified; }
+    private void Resetsteamid_user() { steamid_userSpecified = false; }
+    
 
-    private byte[] _rich_presence_kv = null;
+    private byte[] _rich_presence_kv;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rich_presence_kv", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] rich_presence_kv
     {
-      get { return _rich_presence_kv; }
+      get { return _rich_presence_kv?? null; }
       set { _rich_presence_kv = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rich_presence_kvSpecified
+    {
+      get { return _rich_presence_kv != null; }
+      set { if (value == (_rich_presence_kv== null)) _rich_presence_kv = value ? this.rich_presence_kv : (byte[])null; }
+    }
+    private bool ShouldSerializerich_presence_kv() { return rich_presence_kvSpecified; }
+    private void Resetrich_presence_kv() { rich_presence_kvSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2035,14 +3423,23 @@ namespace SteamKit2.Internal
     public CMsgClientCheckFileSignature() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2054,95 +3451,185 @@ namespace SteamKit2.Internal
     public CMsgClientCheckFileSignatureResponse() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _pid = default(uint);
+    private uint? _pid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"pid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint pid
     {
-      get { return _pid; }
+      get { return _pid?? default(uint); }
       set { _pid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pidSpecified
+    {
+      get { return _pid != null; }
+      set { if (value == (_pid== null)) _pid = value ? this.pid : (uint?)null; }
+    }
+    private bool ShouldSerializepid() { return pidSpecified; }
+    private void Resetpid() { pidSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _esignatureresult = default(uint);
+    private uint? _esignatureresult;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"esignatureresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint esignatureresult
     {
-      get { return _esignatureresult; }
+      get { return _esignatureresult?? default(uint); }
       set { _esignatureresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool esignatureresultSpecified
+    {
+      get { return _esignatureresult != null; }
+      set { if (value == (_esignatureresult== null)) _esignatureresult = value ? this.esignatureresult : (uint?)null; }
+    }
+    private bool ShouldSerializeesignatureresult() { return esignatureresultSpecified; }
+    private void Resetesignatureresult() { esignatureresultSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private byte[] _signatureheader = null;
+    private byte[] _signatureheader;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"signatureheader", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signatureheader
     {
-      get { return _signatureheader; }
+      get { return _signatureheader?? null; }
       set { _signatureheader = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureheaderSpecified
+    {
+      get { return _signatureheader != null; }
+      set { if (value == (_signatureheader== null)) _signatureheader = value ? this.signatureheader : (byte[])null; }
+    }
+    private bool ShouldSerializesignatureheader() { return signatureheaderSpecified; }
+    private void Resetsignatureheader() { signatureheaderSpecified = false; }
+    
 
-    private uint _filesize = default(uint);
+    private uint? _filesize;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"filesize", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filesize
     {
-      get { return _filesize; }
+      get { return _filesize?? default(uint); }
       set { _filesize = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filesizeSpecified
+    {
+      get { return _filesize != null; }
+      set { if (value == (_filesize== null)) _filesize = value ? this.filesize : (uint?)null; }
+    }
+    private bool ShouldSerializefilesize() { return filesizeSpecified; }
+    private void Resetfilesize() { filesizeSpecified = false; }
+    
 
-    private uint _getlasterror = default(uint);
+    private uint? _getlasterror;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"getlasterror", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint getlasterror
     {
-      get { return _getlasterror; }
+      get { return _getlasterror?? default(uint); }
       set { _getlasterror = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool getlasterrorSpecified
+    {
+      get { return _getlasterror != null; }
+      set { if (value == (_getlasterror== null)) _getlasterror = value ? this.getlasterror : (uint?)null; }
+    }
+    private bool ShouldSerializegetlasterror() { return getlasterrorSpecified; }
+    private void Resetgetlasterror() { getlasterrorSpecified = false; }
+    
 
-    private uint _evalvesignaturecheckdetail = default(uint);
+    private uint? _evalvesignaturecheckdetail;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"evalvesignaturecheckdetail", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint evalvesignaturecheckdetail
     {
-      get { return _evalvesignaturecheckdetail; }
+      get { return _evalvesignaturecheckdetail?? default(uint); }
       set { _evalvesignaturecheckdetail = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool evalvesignaturecheckdetailSpecified
+    {
+      get { return _evalvesignaturecheckdetail != null; }
+      set { if (value == (_evalvesignaturecheckdetail== null)) _evalvesignaturecheckdetail = value ? this.evalvesignaturecheckdetail : (uint?)null; }
+    }
+    private bool ShouldSerializeevalvesignaturecheckdetail() { return evalvesignaturecheckdetailSpecified; }
+    private void Resetevalvesignaturecheckdetail() { evalvesignaturecheckdetailSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2154,32 +3641,59 @@ namespace SteamKit2.Internal
     public CMsgClientReadMachineAuth() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _offset = default(uint);
+    private uint? _offset;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint offset
     {
-      get { return _offset; }
+      get { return _offset?? default(uint); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (uint?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
 
-    private uint _cubtoread = default(uint);
+    private uint? _cubtoread;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cubtoread", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cubtoread
     {
-      get { return _cubtoread; }
+      get { return _cubtoread?? default(uint); }
       set { _cubtoread = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cubtoreadSpecified
+    {
+      get { return _cubtoread != null; }
+      set { if (value == (_cubtoread== null)) _cubtoread = value ? this.cubtoread : (uint?)null; }
+    }
+    private bool ShouldSerializecubtoread() { return cubtoreadSpecified; }
+    private void Resetcubtoread() { cubtoreadSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2191,86 +3705,167 @@ namespace SteamKit2.Internal
     public CMsgClientReadMachineAuthResponse() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _filesize = default(uint);
+    private uint? _filesize;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filesize", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filesize
     {
-      get { return _filesize; }
+      get { return _filesize?? default(uint); }
       set { _filesize = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filesizeSpecified
+    {
+      get { return _filesize != null; }
+      set { if (value == (_filesize== null)) _filesize = value ? this.filesize : (uint?)null; }
+    }
+    private bool ShouldSerializefilesize() { return filesizeSpecified; }
+    private void Resetfilesize() { filesizeSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private uint _getlasterror = default(uint);
+    private uint? _getlasterror;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"getlasterror", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint getlasterror
     {
-      get { return _getlasterror; }
+      get { return _getlasterror?? default(uint); }
       set { _getlasterror = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool getlasterrorSpecified
+    {
+      get { return _getlasterror != null; }
+      set { if (value == (_getlasterror== null)) _getlasterror = value ? this.getlasterror : (uint?)null; }
+    }
+    private bool ShouldSerializegetlasterror() { return getlasterrorSpecified; }
+    private void Resetgetlasterror() { getlasterrorSpecified = false; }
+    
 
-    private uint _offset = default(uint);
+    private uint? _offset;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint offset
     {
-      get { return _offset; }
+      get { return _offset?? default(uint); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (uint?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
 
-    private uint _cubread = default(uint);
+    private uint? _cubread;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cubread", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cubread
     {
-      get { return _cubread; }
+      get { return _cubread?? default(uint); }
       set { _cubread = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cubreadSpecified
+    {
+      get { return _cubread != null; }
+      set { if (value == (_cubread== null)) _cubread = value ? this.cubread : (uint?)null; }
+    }
+    private bool ShouldSerializecubread() { return cubreadSpecified; }
+    private void Resetcubread() { cubreadSpecified = false; }
+    
 
-    private byte[] _bytes_read = null;
+    private byte[] _bytes_read;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"bytes_read", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] bytes_read
     {
-      get { return _bytes_read; }
+      get { return _bytes_read?? null; }
       set { _bytes_read = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_readSpecified
+    {
+      get { return _bytes_read != null; }
+      set { if (value == (_bytes_read== null)) _bytes_read = value ? this.bytes_read : (byte[])null; }
+    }
+    private bool ShouldSerializebytes_read() { return bytes_readSpecified; }
+    private void Resetbytes_read() { bytes_readSpecified = false; }
+    
 
-    private string _filename_sentry = "";
+    private string _filename_sentry;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"filename_sentry", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename_sentry
     {
-      get { return _filename_sentry; }
+      get { return _filename_sentry?? ""; }
       set { _filename_sentry = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filename_sentrySpecified
+    {
+      get { return _filename_sentry != null; }
+      set { if (value == (_filename_sentry== null)) _filename_sentry = value ? this.filename_sentry : (string)null; }
+    }
+    private bool ShouldSerializefilename_sentry() { return filename_sentrySpecified; }
+    private void Resetfilename_sentry() { filename_sentrySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2282,77 +3877,149 @@ namespace SteamKit2.Internal
     public CMsgClientUpdateMachineAuth() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _offset = default(uint);
+    private uint? _offset;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint offset
     {
-      get { return _offset; }
+      get { return _offset?? default(uint); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (uint?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
 
-    private uint _cubtowrite = default(uint);
+    private uint? _cubtowrite;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cubtowrite", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cubtowrite
     {
-      get { return _cubtowrite; }
+      get { return _cubtowrite?? default(uint); }
       set { _cubtowrite = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cubtowriteSpecified
+    {
+      get { return _cubtowrite != null; }
+      set { if (value == (_cubtowrite== null)) _cubtowrite = value ? this.cubtowrite : (uint?)null; }
+    }
+    private bool ShouldSerializecubtowrite() { return cubtowriteSpecified; }
+    private void Resetcubtowrite() { cubtowriteSpecified = false; }
+    
 
-    private byte[] _bytes = null;
+    private byte[] _bytes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bytes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] bytes
     {
-      get { return _bytes; }
+      get { return _bytes?? null; }
       set { _bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytesSpecified
+    {
+      get { return _bytes != null; }
+      set { if (value == (_bytes== null)) _bytes = value ? this.bytes : (byte[])null; }
+    }
+    private bool ShouldSerializebytes() { return bytesSpecified; }
+    private void Resetbytes() { bytesSpecified = false; }
+    
 
-    private uint _otp_type = default(uint);
+    private uint? _otp_type;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"otp_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_type
     {
-      get { return _otp_type; }
+      get { return _otp_type?? default(uint); }
       set { _otp_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_typeSpecified
+    {
+      get { return _otp_type != null; }
+      set { if (value == (_otp_type== null)) _otp_type = value ? this.otp_type : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_type() { return otp_typeSpecified; }
+    private void Resetotp_type() { otp_typeSpecified = false; }
+    
 
-    private string _otp_identifier = "";
+    private string _otp_identifier;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"otp_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string otp_identifier
     {
-      get { return _otp_identifier; }
+      get { return _otp_identifier?? ""; }
       set { _otp_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_identifierSpecified
+    {
+      get { return _otp_identifier != null; }
+      set { if (value == (_otp_identifier== null)) _otp_identifier = value ? this.otp_identifier : (string)null; }
+    }
+    private bool ShouldSerializeotp_identifier() { return otp_identifierSpecified; }
+    private void Resetotp_identifier() { otp_identifierSpecified = false; }
+    
 
-    private byte[] _otp_sharedsecret = null;
+    private byte[] _otp_sharedsecret;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"otp_sharedsecret", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] otp_sharedsecret
     {
-      get { return _otp_sharedsecret; }
+      get { return _otp_sharedsecret?? null; }
       set { _otp_sharedsecret = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_sharedsecretSpecified
+    {
+      get { return _otp_sharedsecret != null; }
+      set { if (value == (_otp_sharedsecret== null)) _otp_sharedsecret = value ? this.otp_sharedsecret : (byte[])null; }
+    }
+    private bool ShouldSerializeotp_sharedsecret() { return otp_sharedsecretSpecified; }
+    private void Resetotp_sharedsecret() { otp_sharedsecretSpecified = false; }
+    
 
-    private uint _otp_timedrift = default(uint);
+    private uint? _otp_timedrift;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"otp_timedrift", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_timedrift
     {
-      get { return _otp_timedrift; }
+      get { return _otp_timedrift?? default(uint); }
       set { _otp_timedrift = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_timedriftSpecified
+    {
+      get { return _otp_timedrift != null; }
+      set { if (value == (_otp_timedrift== null)) _otp_timedrift = value ? this.otp_timedrift : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_timedrift() { return otp_timedriftSpecified; }
+    private void Resetotp_timedrift() { otp_timedriftSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2364,95 +4031,185 @@ namespace SteamKit2.Internal
     public CMsgClientUpdateMachineAuthResponse() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _filesize = default(uint);
+    private uint? _filesize;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filesize", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filesize
     {
-      get { return _filesize; }
+      get { return _filesize?? default(uint); }
       set { _filesize = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filesizeSpecified
+    {
+      get { return _filesize != null; }
+      set { if (value == (_filesize== null)) _filesize = value ? this.filesize : (uint?)null; }
+    }
+    private bool ShouldSerializefilesize() { return filesizeSpecified; }
+    private void Resetfilesize() { filesizeSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private uint _getlasterror = default(uint);
+    private uint? _getlasterror;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"getlasterror", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint getlasterror
     {
-      get { return _getlasterror; }
+      get { return _getlasterror?? default(uint); }
       set { _getlasterror = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool getlasterrorSpecified
+    {
+      get { return _getlasterror != null; }
+      set { if (value == (_getlasterror== null)) _getlasterror = value ? this.getlasterror : (uint?)null; }
+    }
+    private bool ShouldSerializegetlasterror() { return getlasterrorSpecified; }
+    private void Resetgetlasterror() { getlasterrorSpecified = false; }
+    
 
-    private uint _offset = default(uint);
+    private uint? _offset;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint offset
     {
-      get { return _offset; }
+      get { return _offset?? default(uint); }
       set { _offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offsetSpecified
+    {
+      get { return _offset != null; }
+      set { if (value == (_offset== null)) _offset = value ? this.offset : (uint?)null; }
+    }
+    private bool ShouldSerializeoffset() { return offsetSpecified; }
+    private void Resetoffset() { offsetSpecified = false; }
+    
 
-    private uint _cubwrote = default(uint);
+    private uint? _cubwrote;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cubwrote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cubwrote
     {
-      get { return _cubwrote; }
+      get { return _cubwrote?? default(uint); }
       set { _cubwrote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cubwroteSpecified
+    {
+      get { return _cubwrote != null; }
+      set { if (value == (_cubwrote== null)) _cubwrote = value ? this.cubwrote : (uint?)null; }
+    }
+    private bool ShouldSerializecubwrote() { return cubwroteSpecified; }
+    private void Resetcubwrote() { cubwroteSpecified = false; }
+    
 
-    private int _otp_type = default(int);
+    private int? _otp_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"otp_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int otp_type
     {
-      get { return _otp_type; }
+      get { return _otp_type?? default(int); }
       set { _otp_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_typeSpecified
+    {
+      get { return _otp_type != null; }
+      set { if (value == (_otp_type== null)) _otp_type = value ? this.otp_type : (int?)null; }
+    }
+    private bool ShouldSerializeotp_type() { return otp_typeSpecified; }
+    private void Resetotp_type() { otp_typeSpecified = false; }
+    
 
-    private uint _otp_value = default(uint);
+    private uint? _otp_value;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"otp_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_value
     {
-      get { return _otp_value; }
+      get { return _otp_value?? default(uint); }
       set { _otp_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_valueSpecified
+    {
+      get { return _otp_value != null; }
+      set { if (value == (_otp_value== null)) _otp_value = value ? this.otp_value : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_value() { return otp_valueSpecified; }
+    private void Resetotp_value() { otp_valueSpecified = false; }
+    
 
-    private string _otp_identifier = "";
+    private string _otp_identifier;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"otp_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string otp_identifier
     {
-      get { return _otp_identifier; }
+      get { return _otp_identifier?? ""; }
       set { _otp_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_identifierSpecified
+    {
+      get { return _otp_identifier != null; }
+      set { if (value == (_otp_identifier== null)) _otp_identifier = value ? this.otp_identifier : (string)null; }
+    }
+    private bool ShouldSerializeotp_identifier() { return otp_identifierSpecified; }
+    private void Resetotp_identifier() { otp_identifierSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2464,104 +4221,203 @@ namespace SteamKit2.Internal
     public CMsgClientRequestMachineAuth() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _eresult_sentryfile = default(uint);
+    private uint? _eresult_sentryfile;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult_sentryfile", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult_sentryfile
     {
-      get { return _eresult_sentryfile; }
+      get { return _eresult_sentryfile?? default(uint); }
       set { _eresult_sentryfile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresult_sentryfileSpecified
+    {
+      get { return _eresult_sentryfile != null; }
+      set { if (value == (_eresult_sentryfile== null)) _eresult_sentryfile = value ? this.eresult_sentryfile : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult_sentryfile() { return eresult_sentryfileSpecified; }
+    private void Reseteresult_sentryfile() { eresult_sentryfileSpecified = false; }
+    
 
-    private uint _filesize = default(uint);
+    private uint? _filesize;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filesize", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filesize
     {
-      get { return _filesize; }
+      get { return _filesize?? default(uint); }
       set { _filesize = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filesizeSpecified
+    {
+      get { return _filesize != null; }
+      set { if (value == (_filesize== null)) _filesize = value ? this.filesize : (uint?)null; }
+    }
+    private bool ShouldSerializefilesize() { return filesizeSpecified; }
+    private void Resetfilesize() { filesizeSpecified = false; }
+    
 
-    private byte[] _sha_sentryfile = null;
+    private byte[] _sha_sentryfile;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_sentryfile", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_sentryfile
     {
-      get { return _sha_sentryfile; }
+      get { return _sha_sentryfile?? null; }
       set { _sha_sentryfile = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_sentryfileSpecified
+    {
+      get { return _sha_sentryfile != null; }
+      set { if (value == (_sha_sentryfile== null)) _sha_sentryfile = value ? this.sha_sentryfile : (byte[])null; }
+    }
+    private bool ShouldSerializesha_sentryfile() { return sha_sentryfileSpecified; }
+    private void Resetsha_sentryfile() { sha_sentryfileSpecified = false; }
+    
 
-    private int _lock_account_action = default(int);
+    private int? _lock_account_action;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"lock_account_action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int lock_account_action
     {
-      get { return _lock_account_action; }
+      get { return _lock_account_action?? default(int); }
       set { _lock_account_action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lock_account_actionSpecified
+    {
+      get { return _lock_account_action != null; }
+      set { if (value == (_lock_account_action== null)) _lock_account_action = value ? this.lock_account_action : (int?)null; }
+    }
+    private bool ShouldSerializelock_account_action() { return lock_account_actionSpecified; }
+    private void Resetlock_account_action() { lock_account_actionSpecified = false; }
+    
 
-    private uint _otp_type = default(uint);
+    private uint? _otp_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"otp_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_type
     {
-      get { return _otp_type; }
+      get { return _otp_type?? default(uint); }
       set { _otp_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_typeSpecified
+    {
+      get { return _otp_type != null; }
+      set { if (value == (_otp_type== null)) _otp_type = value ? this.otp_type : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_type() { return otp_typeSpecified; }
+    private void Resetotp_type() { otp_typeSpecified = false; }
+    
 
-    private string _otp_identifier = "";
+    private string _otp_identifier;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"otp_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string otp_identifier
     {
-      get { return _otp_identifier; }
+      get { return _otp_identifier?? ""; }
       set { _otp_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_identifierSpecified
+    {
+      get { return _otp_identifier != null; }
+      set { if (value == (_otp_identifier== null)) _otp_identifier = value ? this.otp_identifier : (string)null; }
+    }
+    private bool ShouldSerializeotp_identifier() { return otp_identifierSpecified; }
+    private void Resetotp_identifier() { otp_identifierSpecified = false; }
+    
 
-    private byte[] _otp_sharedsecret = null;
+    private byte[] _otp_sharedsecret;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"otp_sharedsecret", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] otp_sharedsecret
     {
-      get { return _otp_sharedsecret; }
+      get { return _otp_sharedsecret?? null; }
       set { _otp_sharedsecret = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_sharedsecretSpecified
+    {
+      get { return _otp_sharedsecret != null; }
+      set { if (value == (_otp_sharedsecret== null)) _otp_sharedsecret = value ? this.otp_sharedsecret : (byte[])null; }
+    }
+    private bool ShouldSerializeotp_sharedsecret() { return otp_sharedsecretSpecified; }
+    private void Resetotp_sharedsecret() { otp_sharedsecretSpecified = false; }
+    
 
-    private uint _otp_value = default(uint);
+    private uint? _otp_value;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"otp_value", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint otp_value
     {
-      get { return _otp_value; }
+      get { return _otp_value?? default(uint); }
       set { _otp_value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool otp_valueSpecified
+    {
+      get { return _otp_value != null; }
+      set { if (value == (_otp_value== null)) _otp_value = value ? this.otp_value : (uint?)null; }
+    }
+    private bool ShouldSerializeotp_value() { return otp_valueSpecified; }
+    private void Resetotp_value() { otp_valueSpecified = false; }
+    
 
-    private string _machine_name = "";
+    private string _machine_name;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"machine_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name
     {
-      get { return _machine_name; }
+      get { return _machine_name?? ""; }
       set { _machine_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_nameSpecified
+    {
+      get { return _machine_name != null; }
+      set { if (value == (_machine_name== null)) _machine_name = value ? this.machine_name : (string)null; }
+    }
+    private bool ShouldSerializemachine_name() { return machine_nameSpecified; }
+    private void Resetmachine_name() { machine_nameSpecified = false; }
+    
 
-    private string _machine_name_userchosen = "";
+    private string _machine_name_userchosen;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"machine_name_userchosen", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name_userchosen
     {
-      get { return _machine_name_userchosen; }
+      get { return _machine_name_userchosen?? ""; }
       set { _machine_name_userchosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_name_userchosenSpecified
+    {
+      get { return _machine_name_userchosen != null; }
+      set { if (value == (_machine_name_userchosen== null)) _machine_name_userchosen = value ? this.machine_name_userchosen : (string)null; }
+    }
+    private bool ShouldSerializemachine_name_userchosen() { return machine_name_userchosenSpecified; }
+    private void Resetmachine_name_userchosen() { machine_name_userchosenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2573,14 +4429,23 @@ namespace SteamKit2.Internal
     public CMsgClientRequestMachineAuthResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2592,23 +4457,41 @@ namespace SteamKit2.Internal
     public CMsgClientCreateFriendsGroup() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _groupname = "";
+    private string _groupname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"groupname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string groupname
     {
-      get { return _groupname; }
+      get { return _groupname?? ""; }
       set { _groupname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupnameSpecified
+    {
+      get { return _groupname != null; }
+      set { if (value == (_groupname== null)) _groupname = value ? this.groupname : (string)null; }
+    }
+    private bool ShouldSerializegroupname() { return groupnameSpecified; }
+    private void Resetgroupname() { groupnameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2620,23 +4503,41 @@ namespace SteamKit2.Internal
     public CMsgClientCreateFriendsGroupResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2648,23 +4549,41 @@ namespace SteamKit2.Internal
     public CMsgClientDeleteFriendsGroup() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2676,14 +4595,23 @@ namespace SteamKit2.Internal
     public CMsgClientDeleteFriendsGroupResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2695,23 +4623,41 @@ namespace SteamKit2.Internal
     public CMsgClientRenameFriendsGroup() {}
     
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
 
-    private string _groupname = "";
+    private string _groupname;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"groupname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string groupname
     {
-      get { return _groupname; }
+      get { return _groupname?? ""; }
       set { _groupname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupnameSpecified
+    {
+      get { return _groupname != null; }
+      set { if (value == (_groupname== null)) _groupname = value ? this.groupname : (string)null; }
+    }
+    private bool ShouldSerializegroupname() { return groupnameSpecified; }
+    private void Resetgroupname() { groupnameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2723,14 +4669,23 @@ namespace SteamKit2.Internal
     public CMsgClientRenameFriendsGroupResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2742,23 +4697,41 @@ namespace SteamKit2.Internal
     public CMsgClientAddFriendToGroup() {}
     
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
 
-    private ulong _steamiduser = default(ulong);
+    private ulong? _steamiduser;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamiduser", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamiduser
     {
-      get { return _steamiduser; }
+      get { return _steamiduser?? default(ulong); }
       set { _steamiduser = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamiduserSpecified
+    {
+      get { return _steamiduser != null; }
+      set { if (value == (_steamiduser== null)) _steamiduser = value ? this.steamiduser : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamiduser() { return steamiduserSpecified; }
+    private void Resetsteamiduser() { steamiduserSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2770,14 +4743,23 @@ namespace SteamKit2.Internal
     public CMsgClientAddFriendToGroupResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2789,23 +4771,41 @@ namespace SteamKit2.Internal
     public CMsgClientRemoveFriendFromGroup() {}
     
 
-    private int _groupid = default(int);
+    private int? _groupid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"groupid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int groupid
     {
-      get { return _groupid; }
+      get { return _groupid?? default(int); }
       set { _groupid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool groupidSpecified
+    {
+      get { return _groupid != null; }
+      set { if (value == (_groupid== null)) _groupid = value ? this.groupid : (int?)null; }
+    }
+    private bool ShouldSerializegroupid() { return groupidSpecified; }
+    private void Resetgroupid() { groupidSpecified = false; }
+    
 
-    private ulong _steamiduser = default(ulong);
+    private ulong? _steamiduser;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamiduser", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamiduser
     {
-      get { return _steamiduser; }
+      get { return _steamiduser?? default(ulong); }
       set { _steamiduser = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamiduserSpecified
+    {
+      get { return _steamiduser != null; }
+      set { if (value == (_steamiduser== null)) _steamiduser = value ? this.steamiduser : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamiduser() { return steamiduserSpecified; }
+    private void Resetsteamiduser() { steamiduserSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2817,14 +4817,23 @@ namespace SteamKit2.Internal
     public CMsgClientRemoveFriendFromGroupResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2836,14 +4845,23 @@ namespace SteamKit2.Internal
     public CMsgClientRegisterKey() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2855,32 +4873,59 @@ namespace SteamKit2.Internal
     public CMsgClientPurchaseResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _purchase_result_details = default(int);
+    private int? _purchase_result_details;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"purchase_result_details", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int purchase_result_details
     {
-      get { return _purchase_result_details; }
+      get { return _purchase_result_details?? default(int); }
       set { _purchase_result_details = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_result_detailsSpecified
+    {
+      get { return _purchase_result_details != null; }
+      set { if (value == (_purchase_result_details== null)) _purchase_result_details = value ? this.purchase_result_details : (int?)null; }
+    }
+    private bool ShouldSerializepurchase_result_details() { return purchase_result_detailsSpecified; }
+    private void Resetpurchase_result_details() { purchase_result_detailsSpecified = false; }
+    
 
-    private byte[] _purchase_receipt_info = null;
+    private byte[] _purchase_receipt_info;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"purchase_receipt_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] purchase_receipt_info
     {
-      get { return _purchase_receipt_info; }
+      get { return _purchase_receipt_info?? null; }
       set { _purchase_receipt_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool purchase_receipt_infoSpecified
+    {
+      get { return _purchase_receipt_info != null; }
+      set { if (value == (_purchase_receipt_info== null)) _purchase_receipt_info = value ? this.purchase_receipt_info : (byte[])null; }
+    }
+    private bool ShouldSerializepurchase_receipt_info() { return purchase_receipt_infoSpecified; }
+    private void Resetpurchase_receipt_info() { purchase_receipt_infoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2892,59 +4937,113 @@ namespace SteamKit2.Internal
     public CMsgClientActivateOEMLicense() {}
     
 
-    private string _bios_manufacturer = "";
+    private string _bios_manufacturer;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"bios_manufacturer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string bios_manufacturer
     {
-      get { return _bios_manufacturer; }
+      get { return _bios_manufacturer?? ""; }
       set { _bios_manufacturer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bios_manufacturerSpecified
+    {
+      get { return _bios_manufacturer != null; }
+      set { if (value == (_bios_manufacturer== null)) _bios_manufacturer = value ? this.bios_manufacturer : (string)null; }
+    }
+    private bool ShouldSerializebios_manufacturer() { return bios_manufacturerSpecified; }
+    private void Resetbios_manufacturer() { bios_manufacturerSpecified = false; }
+    
 
-    private string _bios_serialnumber = "";
+    private string _bios_serialnumber;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bios_serialnumber", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string bios_serialnumber
     {
-      get { return _bios_serialnumber; }
+      get { return _bios_serialnumber?? ""; }
       set { _bios_serialnumber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bios_serialnumberSpecified
+    {
+      get { return _bios_serialnumber != null; }
+      set { if (value == (_bios_serialnumber== null)) _bios_serialnumber = value ? this.bios_serialnumber : (string)null; }
+    }
+    private bool ShouldSerializebios_serialnumber() { return bios_serialnumberSpecified; }
+    private void Resetbios_serialnumber() { bios_serialnumberSpecified = false; }
+    
 
-    private byte[] _license_file = null;
+    private byte[] _license_file;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"license_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] license_file
     {
-      get { return _license_file; }
+      get { return _license_file?? null; }
       set { _license_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool license_fileSpecified
+    {
+      get { return _license_file != null; }
+      set { if (value == (_license_file== null)) _license_file = value ? this.license_file : (byte[])null; }
+    }
+    private bool ShouldSerializelicense_file() { return license_fileSpecified; }
+    private void Resetlicense_file() { license_fileSpecified = false; }
+    
 
-    private string _mainboard_manufacturer = "";
+    private string _mainboard_manufacturer;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"mainboard_manufacturer", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mainboard_manufacturer
     {
-      get { return _mainboard_manufacturer; }
+      get { return _mainboard_manufacturer?? ""; }
       set { _mainboard_manufacturer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mainboard_manufacturerSpecified
+    {
+      get { return _mainboard_manufacturer != null; }
+      set { if (value == (_mainboard_manufacturer== null)) _mainboard_manufacturer = value ? this.mainboard_manufacturer : (string)null; }
+    }
+    private bool ShouldSerializemainboard_manufacturer() { return mainboard_manufacturerSpecified; }
+    private void Resetmainboard_manufacturer() { mainboard_manufacturerSpecified = false; }
+    
 
-    private string _mainboard_product = "";
+    private string _mainboard_product;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"mainboard_product", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mainboard_product
     {
-      get { return _mainboard_product; }
+      get { return _mainboard_product?? ""; }
       set { _mainboard_product = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mainboard_productSpecified
+    {
+      get { return _mainboard_product != null; }
+      set { if (value == (_mainboard_product== null)) _mainboard_product = value ? this.mainboard_product : (string)null; }
+    }
+    private bool ShouldSerializemainboard_product() { return mainboard_productSpecified; }
+    private void Resetmainboard_product() { mainboard_productSpecified = false; }
+    
 
-    private string _mainboard_serialnumber = "";
+    private string _mainboard_serialnumber;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"mainboard_serialnumber", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mainboard_serialnumber
     {
-      get { return _mainboard_serialnumber; }
+      get { return _mainboard_serialnumber?? ""; }
       set { _mainboard_serialnumber = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mainboard_serialnumberSpecified
+    {
+      get { return _mainboard_serialnumber != null; }
+      set { if (value == (_mainboard_serialnumber== null)) _mainboard_serialnumber = value ? this.mainboard_serialnumber : (string)null; }
+    }
+    private bool ShouldSerializemainboard_serialnumber() { return mainboard_serialnumberSpecified; }
+    private void Resetmainboard_serialnumber() { mainboard_serialnumberSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2956,14 +5055,23 @@ namespace SteamKit2.Internal
     public CMsgClientRegisterOEMMachine() {}
     
 
-    private byte[] _oem_register_file = null;
+    private byte[] _oem_register_file;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"oem_register_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] oem_register_file
     {
-      get { return _oem_register_file; }
+      get { return _oem_register_file?? null; }
       set { _oem_register_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool oem_register_fileSpecified
+    {
+      get { return _oem_register_file != null; }
+      set { if (value == (_oem_register_file== null)) _oem_register_file = value ? this.oem_register_file : (byte[])null; }
+    }
+    private bool ShouldSerializeoem_register_file() { return oem_register_fileSpecified; }
+    private void Resetoem_register_file() { oem_register_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2975,14 +5083,23 @@ namespace SteamKit2.Internal
     public CMsgClientRegisterOEMMachineResponse() {}
     
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2994,23 +5111,41 @@ namespace SteamKit2.Internal
     public CMsgClientPurchaseWithMachineID() {}
     
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private byte[] _machine_info = null;
+    private byte[] _machine_info;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"machine_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] machine_info
     {
-      get { return _machine_info; }
+      get { return _machine_info?? null; }
       set { _machine_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_infoSpecified
+    {
+      get { return _machine_info != null; }
+      set { if (value == (_machine_info== null)) _machine_info = value ? this.machine_info : (byte[])null; }
+    }
+    private bool ShouldSerializemachine_info() { return machine_infoSpecified; }
+    private void Resetmachine_info() { machine_infoSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3022,32 +5157,59 @@ namespace SteamKit2.Internal
     public CMsgTrading_InitiateTradeRequest() {}
     
 
-    private uint _trade_request_id = default(uint);
+    private uint? _trade_request_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"trade_request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_request_id
     {
-      get { return _trade_request_id; }
+      get { return _trade_request_id?? default(uint); }
       set { _trade_request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_request_idSpecified
+    {
+      get { return _trade_request_id != null; }
+      set { if (value == (_trade_request_id== null)) _trade_request_id = value ? this.trade_request_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_request_id() { return trade_request_idSpecified; }
+    private void Resettrade_request_id() { trade_request_idSpecified = false; }
+    
 
-    private ulong _other_steamid = default(ulong);
+    private ulong? _other_steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"other_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong other_steamid
     {
-      get { return _other_steamid; }
+      get { return _other_steamid?? default(ulong); }
       set { _other_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_steamidSpecified
+    {
+      get { return _other_steamid != null; }
+      set { if (value == (_other_steamid== null)) _other_steamid = value ? this.other_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeother_steamid() { return other_steamidSpecified; }
+    private void Resetother_steamid() { other_steamidSpecified = false; }
+    
 
-    private string _other_name = "";
+    private string _other_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"other_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string other_name
     {
-      get { return _other_name; }
+      get { return _other_name?? ""; }
       set { _other_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_nameSpecified
+    {
+      get { return _other_name != null; }
+      set { if (value == (_other_name== null)) _other_name = value ? this.other_name : (string)null; }
+    }
+    private bool ShouldSerializeother_name() { return other_nameSpecified; }
+    private void Resetother_name() { other_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3059,86 +5221,167 @@ namespace SteamKit2.Internal
     public CMsgTrading_InitiateTradeResponse() {}
     
 
-    private uint _response = default(uint);
+    private uint? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint response
     {
-      get { return _response; }
+      get { return _response?? default(uint); }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (uint?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private uint _trade_request_id = default(uint);
+    private uint? _trade_request_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"trade_request_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint trade_request_id
     {
-      get { return _trade_request_id; }
+      get { return _trade_request_id?? default(uint); }
       set { _trade_request_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool trade_request_idSpecified
+    {
+      get { return _trade_request_id != null; }
+      set { if (value == (_trade_request_id== null)) _trade_request_id = value ? this.trade_request_id : (uint?)null; }
+    }
+    private bool ShouldSerializetrade_request_id() { return trade_request_idSpecified; }
+    private void Resettrade_request_id() { trade_request_idSpecified = false; }
+    
 
-    private ulong _other_steamid = default(ulong);
+    private ulong? _other_steamid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"other_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong other_steamid
     {
-      get { return _other_steamid; }
+      get { return _other_steamid?? default(ulong); }
       set { _other_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_steamidSpecified
+    {
+      get { return _other_steamid != null; }
+      set { if (value == (_other_steamid== null)) _other_steamid = value ? this.other_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeother_steamid() { return other_steamidSpecified; }
+    private void Resetother_steamid() { other_steamidSpecified = false; }
+    
 
-    private uint _steamguard_required_days = default(uint);
+    private uint? _steamguard_required_days;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steamguard_required_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamguard_required_days
     {
-      get { return _steamguard_required_days; }
+      get { return _steamguard_required_days?? default(uint); }
       set { _steamguard_required_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_required_daysSpecified
+    {
+      get { return _steamguard_required_days != null; }
+      set { if (value == (_steamguard_required_days== null)) _steamguard_required_days = value ? this.steamguard_required_days : (uint?)null; }
+    }
+    private bool ShouldSerializesteamguard_required_days() { return steamguard_required_daysSpecified; }
+    private void Resetsteamguard_required_days() { steamguard_required_daysSpecified = false; }
+    
 
-    private uint _new_device_cooldown_days = default(uint);
+    private uint? _new_device_cooldown_days;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"new_device_cooldown_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint new_device_cooldown_days
     {
-      get { return _new_device_cooldown_days; }
+      get { return _new_device_cooldown_days?? default(uint); }
       set { _new_device_cooldown_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_device_cooldown_daysSpecified
+    {
+      get { return _new_device_cooldown_days != null; }
+      set { if (value == (_new_device_cooldown_days== null)) _new_device_cooldown_days = value ? this.new_device_cooldown_days : (uint?)null; }
+    }
+    private bool ShouldSerializenew_device_cooldown_days() { return new_device_cooldown_daysSpecified; }
+    private void Resetnew_device_cooldown_days() { new_device_cooldown_daysSpecified = false; }
+    
 
-    private uint _default_password_reset_probation_days = default(uint);
+    private uint? _default_password_reset_probation_days;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"default_password_reset_probation_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint default_password_reset_probation_days
     {
-      get { return _default_password_reset_probation_days; }
+      get { return _default_password_reset_probation_days?? default(uint); }
       set { _default_password_reset_probation_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool default_password_reset_probation_daysSpecified
+    {
+      get { return _default_password_reset_probation_days != null; }
+      set { if (value == (_default_password_reset_probation_days== null)) _default_password_reset_probation_days = value ? this.default_password_reset_probation_days : (uint?)null; }
+    }
+    private bool ShouldSerializedefault_password_reset_probation_days() { return default_password_reset_probation_daysSpecified; }
+    private void Resetdefault_password_reset_probation_days() { default_password_reset_probation_daysSpecified = false; }
+    
 
-    private uint _password_reset_probation_days = default(uint);
+    private uint? _password_reset_probation_days;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"password_reset_probation_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint password_reset_probation_days
     {
-      get { return _password_reset_probation_days; }
+      get { return _password_reset_probation_days?? default(uint); }
       set { _password_reset_probation_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool password_reset_probation_daysSpecified
+    {
+      get { return _password_reset_probation_days != null; }
+      set { if (value == (_password_reset_probation_days== null)) _password_reset_probation_days = value ? this.password_reset_probation_days : (uint?)null; }
+    }
+    private bool ShouldSerializepassword_reset_probation_days() { return password_reset_probation_daysSpecified; }
+    private void Resetpassword_reset_probation_days() { password_reset_probation_daysSpecified = false; }
+    
 
-    private uint _default_email_change_probation_days = default(uint);
+    private uint? _default_email_change_probation_days;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"default_email_change_probation_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint default_email_change_probation_days
     {
-      get { return _default_email_change_probation_days; }
+      get { return _default_email_change_probation_days?? default(uint); }
       set { _default_email_change_probation_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool default_email_change_probation_daysSpecified
+    {
+      get { return _default_email_change_probation_days != null; }
+      set { if (value == (_default_email_change_probation_days== null)) _default_email_change_probation_days = value ? this.default_email_change_probation_days : (uint?)null; }
+    }
+    private bool ShouldSerializedefault_email_change_probation_days() { return default_email_change_probation_daysSpecified; }
+    private void Resetdefault_email_change_probation_days() { default_email_change_probation_daysSpecified = false; }
+    
 
-    private uint _email_change_probation_days = default(uint);
+    private uint? _email_change_probation_days;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"email_change_probation_days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_change_probation_days
     {
-      get { return _email_change_probation_days; }
+      get { return _email_change_probation_days?? default(uint); }
       set { _email_change_probation_days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_change_probation_daysSpecified
+    {
+      get { return _email_change_probation_days != null; }
+      set { if (value == (_email_change_probation_days== null)) _email_change_probation_days = value ? this.email_change_probation_days : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_change_probation_days() { return email_change_probation_daysSpecified; }
+    private void Resetemail_change_probation_days() { email_change_probation_daysSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3150,14 +5393,23 @@ namespace SteamKit2.Internal
     public CMsgTrading_CancelTradeRequest() {}
     
 
-    private ulong _other_steamid = default(ulong);
+    private ulong? _other_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"other_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong other_steamid
     {
-      get { return _other_steamid; }
+      get { return _other_steamid?? default(ulong); }
       set { _other_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_steamidSpecified
+    {
+      get { return _other_steamid != null; }
+      set { if (value == (_other_steamid== null)) _other_steamid = value ? this.other_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeother_steamid() { return other_steamidSpecified; }
+    private void Resetother_steamid() { other_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3169,14 +5421,23 @@ namespace SteamKit2.Internal
     public CMsgTrading_StartSession() {}
     
 
-    private ulong _other_steamid = default(ulong);
+    private ulong? _other_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"other_steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong other_steamid
     {
-      get { return _other_steamid; }
+      get { return _other_steamid?? default(ulong); }
       set { _other_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool other_steamidSpecified
+    {
+      get { return _other_steamid != null; }
+      set { if (value == (_other_steamid== null)) _other_steamid = value ? this.other_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeother_steamid() { return other_steamidSpecified; }
+    private void Resetother_steamid() { other_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3188,77 +5449,149 @@ namespace SteamKit2.Internal
     public CMsgClientEmailChange() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _email = "";
+    private string _email;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string email
     {
-      get { return _email; }
+      get { return _email?? ""; }
       set { _email = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool emailSpecified
+    {
+      get { return _email != null; }
+      set { if (value == (_email== null)) _email = value ? this.email : (string)null; }
+    }
+    private bool ShouldSerializeemail() { return emailSpecified; }
+    private void Resetemail() { emailSpecified = false; }
+    
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
 
-    private bool _final = default(bool);
+    private bool? _final;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"final", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool final
     {
-      get { return _final; }
+      get { return _final?? default(bool); }
       set { _final = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool finalSpecified
+    {
+      get { return _final != null; }
+      set { if (value == (_final== null)) _final = value ? this.final : (bool?)null; }
+    }
+    private bool ShouldSerializefinal() { return finalSpecified; }
+    private void Resetfinal() { finalSpecified = false; }
+    
 
-    private bool _newmethod = default(bool);
+    private bool? _newmethod;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"newmethod", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool newmethod
     {
-      get { return _newmethod; }
+      get { return _newmethod?? default(bool); }
       set { _newmethod = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool newmethodSpecified
+    {
+      get { return _newmethod != null; }
+      set { if (value == (_newmethod== null)) _newmethod = value ? this.newmethod : (bool?)null; }
+    }
+    private bool ShouldSerializenewmethod() { return newmethodSpecified; }
+    private void Resetnewmethod() { newmethodSpecified = false; }
+    
 
-    private string _twofactor_code = "";
+    private string _twofactor_code;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"twofactor_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string twofactor_code
     {
-      get { return _twofactor_code; }
+      get { return _twofactor_code?? ""; }
       set { _twofactor_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool twofactor_codeSpecified
+    {
+      get { return _twofactor_code != null; }
+      set { if (value == (_twofactor_code== null)) _twofactor_code = value ? this.twofactor_code : (string)null; }
+    }
+    private bool ShouldSerializetwofactor_code() { return twofactor_codeSpecified; }
+    private void Resettwofactor_code() { twofactor_codeSpecified = false; }
+    
 
-    private string _sms_code = "";
+    private string _sms_code;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sms_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sms_code
     {
-      get { return _sms_code; }
+      get { return _sms_code?? ""; }
       set { _sms_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sms_codeSpecified
+    {
+      get { return _sms_code != null; }
+      set { if (value == (_sms_code== null)) _sms_code = value ? this.sms_code : (string)null; }
+    }
+    private bool ShouldSerializesms_code() { return sms_codeSpecified; }
+    private void Resetsms_code() { sms_codeSpecified = false; }
+    
 
-    private bool _client_supports_sms = default(bool);
+    private bool? _client_supports_sms;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"client_supports_sms", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool client_supports_sms
     {
-      get { return _client_supports_sms; }
+      get { return _client_supports_sms?? default(bool); }
       set { _client_supports_sms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_supports_smsSpecified
+    {
+      get { return _client_supports_sms != null; }
+      set { if (value == (_client_supports_sms== null)) _client_supports_sms = value ? this.client_supports_sms : (bool?)null; }
+    }
+    private bool ShouldSerializeclient_supports_sms() { return client_supports_smsSpecified; }
+    private void Resetclient_supports_sms() { client_supports_smsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3270,23 +5603,41 @@ namespace SteamKit2.Internal
     public CMsgClientEmailChangeResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _requires_sms_code = default(bool);
+    private bool? _requires_sms_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"requires_sms_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool requires_sms_code
     {
-      get { return _requires_sms_code; }
+      get { return _requires_sms_code?? default(bool); }
       set { _requires_sms_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool requires_sms_codeSpecified
+    {
+      get { return _requires_sms_code != null; }
+      set { if (value == (_requires_sms_code== null)) _requires_sms_code = value ? this.requires_sms_code : (bool?)null; }
+    }
+    private bool ShouldSerializerequires_sms_code() { return requires_sms_codeSpecified; }
+    private void Resetrequires_sms_code() { requires_sms_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3298,32 +5649,59 @@ namespace SteamKit2.Internal
     public CMsgClientGetCDNAuthToken() {}
     
 
-    private uint _depot_id = default(uint);
+    private uint? _depot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"depot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depot_id
     {
-      get { return _depot_id; }
+      get { return _depot_id?? default(uint); }
       set { _depot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_idSpecified
+    {
+      get { return _depot_id != null; }
+      set { if (value == (_depot_id== null)) _depot_id = value ? this.depot_id : (uint?)null; }
+    }
+    private bool ShouldSerializedepot_id() { return depot_idSpecified; }
+    private void Resetdepot_id() { depot_idSpecified = false; }
+    
 
-    private string _host_name = "";
+    private string _host_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"host_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string host_name
     {
-      get { return _host_name; }
+      get { return _host_name?? ""; }
       set { _host_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool host_nameSpecified
+    {
+      get { return _host_name != null; }
+      set { if (value == (_host_name== null)) _host_name = value ? this.host_name : (string)null; }
+    }
+    private bool ShouldSerializehost_name() { return host_nameSpecified; }
+    private void Resethost_name() { host_nameSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3335,23 +5713,41 @@ namespace SteamKit2.Internal
     public CMsgClientGetDepotDecryptionKey() {}
     
 
-    private uint _depot_id = default(uint);
+    private uint? _depot_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"depot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depot_id
     {
-      get { return _depot_id; }
+      get { return _depot_id?? default(uint); }
       set { _depot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_idSpecified
+    {
+      get { return _depot_id != null; }
+      set { if (value == (_depot_id== null)) _depot_id = value ? this.depot_id : (uint?)null; }
+    }
+    private bool ShouldSerializedepot_id() { return depot_idSpecified; }
+    private void Resetdepot_id() { depot_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3363,32 +5759,59 @@ namespace SteamKit2.Internal
     public CMsgClientGetDepotDecryptionKeyResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _depot_id = default(uint);
+    private uint? _depot_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depot_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depot_id
     {
-      get { return _depot_id; }
+      get { return _depot_id?? default(uint); }
       set { _depot_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_idSpecified
+    {
+      get { return _depot_id != null; }
+      set { if (value == (_depot_id== null)) _depot_id = value ? this.depot_id : (uint?)null; }
+    }
+    private bool ShouldSerializedepot_id() { return depot_idSpecified; }
+    private void Resetdepot_id() { depot_idSpecified = false; }
+    
 
-    private byte[] _depot_encryption_key = null;
+    private byte[] _depot_encryption_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"depot_encryption_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] depot_encryption_key
     {
-      get { return _depot_encryption_key; }
+      get { return _depot_encryption_key?? null; }
       set { _depot_encryption_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_encryption_keySpecified
+    {
+      get { return _depot_encryption_key != null; }
+      set { if (value == (_depot_encryption_key== null)) _depot_encryption_key = value ? this.depot_encryption_key : (byte[])null; }
+    }
+    private bool ShouldSerializedepot_encryption_key() { return depot_encryption_keySpecified; }
+    private void Resetdepot_encryption_key() { depot_encryption_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3400,23 +5823,41 @@ namespace SteamKit2.Internal
     public CMsgClientCheckAppBetaPassword() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _betapassword = "";
+    private string _betapassword;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"betapassword", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string betapassword
     {
-      get { return _betapassword; }
+      get { return _betapassword?? ""; }
       set { _betapassword = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool betapasswordSpecified
+    {
+      get { return _betapassword != null; }
+      set { if (value == (_betapassword== null)) _betapassword = value ? this.betapassword : (string)null; }
+    }
+    private bool ShouldSerializebetapassword() { return betapasswordSpecified; }
+    private void Resetbetapassword() { betapasswordSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3428,14 +5869,23 @@ namespace SteamKit2.Internal
     public CMsgClientCheckAppBetaPasswordResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientCheckAppBetaPasswordResponse.BetaPassword> _betapasswords = new global::System.Collections.Generic.List<CMsgClientCheckAppBetaPasswordResponse.BetaPassword>();
     [global::ProtoBuf.ProtoMember(4, Name=@"betapasswords", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientCheckAppBetaPasswordResponse.BetaPassword> betapasswords
@@ -3449,23 +5899,41 @@ namespace SteamKit2.Internal
     public BetaPassword() {}
     
 
-    private string _betaname = "";
+    private string _betaname;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"betaname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string betaname
     {
-      get { return _betaname; }
+      get { return _betaname?? ""; }
       set { _betaname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool betanameSpecified
+    {
+      get { return _betaname != null; }
+      set { if (value == (_betaname== null)) _betaname = value ? this.betaname : (string)null; }
+    }
+    private bool ShouldSerializebetaname() { return betanameSpecified; }
+    private void Resetbetaname() { betanameSpecified = false; }
+    
 
-    private string _betapassword = "";
+    private string _betapassword;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"betapassword", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string betapassword
     {
-      get { return _betapassword; }
+      get { return _betapassword?? ""; }
       set { _betapassword = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool betapasswordSpecified
+    {
+      get { return _betapassword != null; }
+      set { if (value == (_betapassword== null)) _betapassword = value ? this.betapassword : (string)null; }
+    }
+    private bool ShouldSerializebetapassword() { return betapasswordSpecified; }
+    private void Resetbetapassword() { betapasswordSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3482,14 +5950,23 @@ namespace SteamKit2.Internal
     public CMsgClientUpdateAppJobReport() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _depot_ids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"depot_ids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> depot_ids
@@ -3498,122 +5975,239 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _app_state = default(uint);
+    private uint? _app_state;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_state
     {
-      get { return _app_state; }
+      get { return _app_state?? default(uint); }
       set { _app_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_stateSpecified
+    {
+      get { return _app_state != null; }
+      set { if (value == (_app_state== null)) _app_state = value ? this.app_state : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_state() { return app_stateSpecified; }
+    private void Resetapp_state() { app_stateSpecified = false; }
+    
 
-    private uint _job_app_error = default(uint);
+    private uint? _job_app_error;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"job_app_error", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint job_app_error
     {
-      get { return _job_app_error; }
+      get { return _job_app_error?? default(uint); }
       set { _job_app_error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_app_errorSpecified
+    {
+      get { return _job_app_error != null; }
+      set { if (value == (_job_app_error== null)) _job_app_error = value ? this.job_app_error : (uint?)null; }
+    }
+    private bool ShouldSerializejob_app_error() { return job_app_errorSpecified; }
+    private void Resetjob_app_error() { job_app_errorSpecified = false; }
+    
 
-    private string _error_details = "";
+    private string _error_details;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"error_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error_details
     {
-      get { return _error_details; }
+      get { return _error_details?? ""; }
       set { _error_details = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_detailsSpecified
+    {
+      get { return _error_details != null; }
+      set { if (value == (_error_details== null)) _error_details = value ? this.error_details : (string)null; }
+    }
+    private bool ShouldSerializeerror_details() { return error_detailsSpecified; }
+    private void Reseterror_details() { error_detailsSpecified = false; }
+    
 
-    private uint _job_duration = default(uint);
+    private uint? _job_duration;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"job_duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint job_duration
     {
-      get { return _job_duration; }
+      get { return _job_duration?? default(uint); }
       set { _job_duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_durationSpecified
+    {
+      get { return _job_duration != null; }
+      set { if (value == (_job_duration== null)) _job_duration = value ? this.job_duration : (uint?)null; }
+    }
+    private bool ShouldSerializejob_duration() { return job_durationSpecified; }
+    private void Resetjob_duration() { job_durationSpecified = false; }
+    
 
-    private uint _files_validation_failed = default(uint);
+    private uint? _files_validation_failed;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"files_validation_failed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint files_validation_failed
     {
-      get { return _files_validation_failed; }
+      get { return _files_validation_failed?? default(uint); }
       set { _files_validation_failed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool files_validation_failedSpecified
+    {
+      get { return _files_validation_failed != null; }
+      set { if (value == (_files_validation_failed== null)) _files_validation_failed = value ? this.files_validation_failed : (uint?)null; }
+    }
+    private bool ShouldSerializefiles_validation_failed() { return files_validation_failedSpecified; }
+    private void Resetfiles_validation_failed() { files_validation_failedSpecified = false; }
+    
 
-    private ulong _job_bytes_downloaded = default(ulong);
+    private ulong? _job_bytes_downloaded;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"job_bytes_downloaded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong job_bytes_downloaded
     {
-      get { return _job_bytes_downloaded; }
+      get { return _job_bytes_downloaded?? default(ulong); }
       set { _job_bytes_downloaded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_bytes_downloadedSpecified
+    {
+      get { return _job_bytes_downloaded != null; }
+      set { if (value == (_job_bytes_downloaded== null)) _job_bytes_downloaded = value ? this.job_bytes_downloaded : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_bytes_downloaded() { return job_bytes_downloadedSpecified; }
+    private void Resetjob_bytes_downloaded() { job_bytes_downloadedSpecified = false; }
+    
 
-    private ulong _job_bytes_staged = default(ulong);
+    private ulong? _job_bytes_staged;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"job_bytes_staged", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong job_bytes_staged
     {
-      get { return _job_bytes_staged; }
+      get { return _job_bytes_staged?? default(ulong); }
       set { _job_bytes_staged = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool job_bytes_stagedSpecified
+    {
+      get { return _job_bytes_staged != null; }
+      set { if (value == (_job_bytes_staged== null)) _job_bytes_staged = value ? this.job_bytes_staged : (ulong?)null; }
+    }
+    private bool ShouldSerializejob_bytes_staged() { return job_bytes_stagedSpecified; }
+    private void Resetjob_bytes_staged() { job_bytes_stagedSpecified = false; }
+    
 
-    private ulong _bytes_comitted = default(ulong);
+    private ulong? _bytes_comitted;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"bytes_comitted", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_comitted
     {
-      get { return _bytes_comitted; }
+      get { return _bytes_comitted?? default(ulong); }
       set { _bytes_comitted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_comittedSpecified
+    {
+      get { return _bytes_comitted != null; }
+      set { if (value == (_bytes_comitted== null)) _bytes_comitted = value ? this.bytes_comitted : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_comitted() { return bytes_comittedSpecified; }
+    private void Resetbytes_comitted() { bytes_comittedSpecified = false; }
+    
 
-    private uint _start_app_state = default(uint);
+    private uint? _start_app_state;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"start_app_state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_app_state
     {
-      get { return _start_app_state; }
+      get { return _start_app_state?? default(uint); }
       set { _start_app_state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_app_stateSpecified
+    {
+      get { return _start_app_state != null; }
+      set { if (value == (_start_app_state== null)) _start_app_state = value ? this.start_app_state : (uint?)null; }
+    }
+    private bool ShouldSerializestart_app_state() { return start_app_stateSpecified; }
+    private void Resetstart_app_state() { start_app_stateSpecified = false; }
+    
 
-    private ulong _stats_machine_id = default(ulong);
+    private ulong? _stats_machine_id;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"stats_machine_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong stats_machine_id
     {
-      get { return _stats_machine_id; }
+      get { return _stats_machine_id?? default(ulong); }
       set { _stats_machine_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_machine_idSpecified
+    {
+      get { return _stats_machine_id != null; }
+      set { if (value == (_stats_machine_id== null)) _stats_machine_id = value ? this.stats_machine_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestats_machine_id() { return stats_machine_idSpecified; }
+    private void Resetstats_machine_id() { stats_machine_idSpecified = false; }
+    
 
-    private string _branch_name = "";
+    private string _branch_name;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"branch_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string branch_name
     {
-      get { return _branch_name; }
+      get { return _branch_name?? ""; }
       set { _branch_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool branch_nameSpecified
+    {
+      get { return _branch_name != null; }
+      set { if (value == (_branch_name== null)) _branch_name = value ? this.branch_name : (string)null; }
+    }
+    private bool ShouldSerializebranch_name() { return branch_nameSpecified; }
+    private void Resetbranch_name() { branch_nameSpecified = false; }
+    
 
-    private ulong _total_bytes_downloaded = default(ulong);
+    private ulong? _total_bytes_downloaded;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"total_bytes_downloaded", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong total_bytes_downloaded
     {
-      get { return _total_bytes_downloaded; }
+      get { return _total_bytes_downloaded?? default(ulong); }
       set { _total_bytes_downloaded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_bytes_downloadedSpecified
+    {
+      get { return _total_bytes_downloaded != null; }
+      set { if (value == (_total_bytes_downloaded== null)) _total_bytes_downloaded = value ? this.total_bytes_downloaded : (ulong?)null; }
+    }
+    private bool ShouldSerializetotal_bytes_downloaded() { return total_bytes_downloadedSpecified; }
+    private void Resettotal_bytes_downloaded() { total_bytes_downloadedSpecified = false; }
+    
 
-    private ulong _total_bytes_staged = default(ulong);
+    private ulong? _total_bytes_staged;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"total_bytes_staged", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong total_bytes_staged
     {
-      get { return _total_bytes_staged; }
+      get { return _total_bytes_staged?? default(ulong); }
       set { _total_bytes_staged = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_bytes_stagedSpecified
+    {
+      get { return _total_bytes_staged != null; }
+      set { if (value == (_total_bytes_staged== null)) _total_bytes_staged = value ? this.total_bytes_staged : (ulong?)null; }
+    }
+    private bool ShouldSerializetotal_bytes_staged() { return total_bytes_stagedSpecified; }
+    private void Resettotal_bytes_staged() { total_bytes_stagedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3625,68 +6219,131 @@ namespace SteamKit2.Internal
     public CMsgClientDPContentStatsReport() {}
     
 
-    private ulong _stats_machine_id = default(ulong);
+    private ulong? _stats_machine_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stats_machine_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong stats_machine_id
     {
-      get { return _stats_machine_id; }
+      get { return _stats_machine_id?? default(ulong); }
       set { _stats_machine_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stats_machine_idSpecified
+    {
+      get { return _stats_machine_id != null; }
+      set { if (value == (_stats_machine_id== null)) _stats_machine_id = value ? this.stats_machine_id : (ulong?)null; }
+    }
+    private bool ShouldSerializestats_machine_id() { return stats_machine_idSpecified; }
+    private void Resetstats_machine_id() { stats_machine_idSpecified = false; }
+    
 
-    private string _country_code = "";
+    private string _country_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"country_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string country_code
     {
-      get { return _country_code; }
+      get { return _country_code?? ""; }
       set { _country_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool country_codeSpecified
+    {
+      get { return _country_code != null; }
+      set { if (value == (_country_code== null)) _country_code = value ? this.country_code : (string)null; }
+    }
+    private bool ShouldSerializecountry_code() { return country_codeSpecified; }
+    private void Resetcountry_code() { country_codeSpecified = false; }
+    
 
-    private int _os_type = default(int);
+    private int? _os_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"os_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int os_type
     {
-      get { return _os_type; }
+      get { return _os_type?? default(int); }
       set { _os_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_typeSpecified
+    {
+      get { return _os_type != null; }
+      set { if (value == (_os_type== null)) _os_type = value ? this.os_type : (int?)null; }
+    }
+    private bool ShouldSerializeos_type() { return os_typeSpecified; }
+    private void Resetos_type() { os_typeSpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private uint _num_install_folders = default(uint);
+    private uint? _num_install_folders;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"num_install_folders", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_install_folders
     {
-      get { return _num_install_folders; }
+      get { return _num_install_folders?? default(uint); }
       set { _num_install_folders = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_install_foldersSpecified
+    {
+      get { return _num_install_folders != null; }
+      set { if (value == (_num_install_folders== null)) _num_install_folders = value ? this.num_install_folders : (uint?)null; }
+    }
+    private bool ShouldSerializenum_install_folders() { return num_install_foldersSpecified; }
+    private void Resetnum_install_folders() { num_install_foldersSpecified = false; }
+    
 
-    private uint _num_installed_games = default(uint);
+    private uint? _num_installed_games;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_installed_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_installed_games
     {
-      get { return _num_installed_games; }
+      get { return _num_installed_games?? default(uint); }
       set { _num_installed_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_installed_gamesSpecified
+    {
+      get { return _num_installed_games != null; }
+      set { if (value == (_num_installed_games== null)) _num_installed_games = value ? this.num_installed_games : (uint?)null; }
+    }
+    private bool ShouldSerializenum_installed_games() { return num_installed_gamesSpecified; }
+    private void Resetnum_installed_games() { num_installed_gamesSpecified = false; }
+    
 
-    private ulong _size_installed_games = default(ulong);
+    private ulong? _size_installed_games;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"size_installed_games", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong size_installed_games
     {
-      get { return _size_installed_games; }
+      get { return _size_installed_games?? default(ulong); }
       set { _size_installed_games = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool size_installed_gamesSpecified
+    {
+      get { return _size_installed_games != null; }
+      set { if (value == (_size_installed_games== null)) _size_installed_games = value ? this.size_installed_games : (ulong?)null; }
+    }
+    private bool ShouldSerializesize_installed_games() { return size_installed_gamesSpecified; }
+    private void Resetsize_installed_games() { size_installed_gamesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3698,32 +6355,59 @@ namespace SteamKit2.Internal
     public CMsgClientGetCDNAuthTokenResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _token = "";
+    private string _token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token
     {
-      get { return _token; }
+      get { return _token?? ""; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (string)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
 
-    private uint _expiration_time = default(uint);
+    private uint? _expiration_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"expiration_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint expiration_time
     {
-      get { return _expiration_time; }
+      get { return _expiration_time?? default(uint); }
       set { _expiration_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expiration_timeSpecified
+    {
+      get { return _expiration_time != null; }
+      set { if (value == (_expiration_time== null)) _expiration_time = value ? this.expiration_time : (uint?)null; }
+    }
+    private bool ShouldSerializeexpiration_time() { return expiration_timeSpecified; }
+    private void Resetexpiration_time() { expiration_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3735,14 +6419,23 @@ namespace SteamKit2.Internal
     public CMsgDownloadRateStatistics() {}
     
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgDownloadRateStatistics.StatsInfo> _stats = new global::System.Collections.Generic.List<CMsgDownloadRateStatistics.StatsInfo>();
     [global::ProtoBuf.ProtoMember(2, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgDownloadRateStatistics.StatsInfo> stats
@@ -3756,41 +6449,77 @@ namespace SteamKit2.Internal
     public StatsInfo() {}
     
 
-    private uint _source_type = default(uint);
+    private uint? _source_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"source_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_type
     {
-      get { return _source_type; }
+      get { return _source_type?? default(uint); }
       set { _source_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_typeSpecified
+    {
+      get { return _source_type != null; }
+      set { if (value == (_source_type== null)) _source_type = value ? this.source_type : (uint?)null; }
+    }
+    private bool ShouldSerializesource_type() { return source_typeSpecified; }
+    private void Resetsource_type() { source_typeSpecified = false; }
+    
 
-    private uint _source_id = default(uint);
+    private uint? _source_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"source_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint source_id
     {
-      get { return _source_id; }
+      get { return _source_id?? default(uint); }
       set { _source_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool source_idSpecified
+    {
+      get { return _source_id != null; }
+      set { if (value == (_source_id== null)) _source_id = value ? this.source_id : (uint?)null; }
+    }
+    private bool ShouldSerializesource_id() { return source_idSpecified; }
+    private void Resetsource_id() { source_idSpecified = false; }
+    
 
-    private uint _seconds = default(uint);
+    private uint? _seconds;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint seconds
     {
-      get { return _seconds; }
+      get { return _seconds?? default(uint); }
       set { _seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secondsSpecified
+    {
+      get { return _seconds != null; }
+      set { if (value == (_seconds== null)) _seconds = value ? this.seconds : (uint?)null; }
+    }
+    private bool ShouldSerializeseconds() { return secondsSpecified; }
+    private void Resetseconds() { secondsSpecified = false; }
+    
 
-    private ulong _bytes = default(ulong);
+    private ulong? _bytes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes
     {
-      get { return _bytes; }
+      get { return _bytes?? default(ulong); }
       set { _bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytesSpecified
+    {
+      get { return _bytes != null; }
+      set { if (value == (_bytes== null)) _bytes = value ? this.bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes() { return bytesSpecified; }
+    private void Resetbytes() { bytesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3807,23 +6536,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestAccountData() {}
     
 
-    private string _account_or_email = "";
+    private string _account_or_email;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_or_email", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_or_email
     {
-      get { return _account_or_email; }
+      get { return _account_or_email?? ""; }
       set { _account_or_email = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_or_emailSpecified
+    {
+      get { return _account_or_email != null; }
+      set { if (value == (_account_or_email== null)) _account_or_email = value ? this.account_or_email : (string)null; }
+    }
+    private bool ShouldSerializeaccount_or_email() { return account_or_emailSpecified; }
+    private void Resetaccount_or_email() { account_or_emailSpecified = false; }
+    
 
-    private uint _action = default(uint);
+    private uint? _action;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action
     {
-      get { return _action; }
+      get { return _action?? default(uint); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (uint?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3835,68 +6582,131 @@ namespace SteamKit2.Internal
     public CMsgClientRequestAccountDataResponse() {}
     
 
-    private uint _action = default(uint);
+    private uint? _action;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"action", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint action
     {
-      get { return _action; }
+      get { return _action?? default(uint); }
       set { _action = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actionSpecified
+    {
+      get { return _action != null; }
+      set { if (value == (_action== null)) _action = value ? this.action : (uint?)null; }
+    }
+    private bool ShouldSerializeaction() { return actionSpecified; }
+    private void Resetaction() { actionSpecified = false; }
+    
 
-    private uint _eresult = default(uint);
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? default(uint); }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private uint _ct_matches = default(uint);
+    private uint? _ct_matches;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ct_matches", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ct_matches
     {
-      get { return _ct_matches; }
+      get { return _ct_matches?? default(uint); }
       set { _ct_matches = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ct_matchesSpecified
+    {
+      get { return _ct_matches != null; }
+      set { if (value == (_ct_matches== null)) _ct_matches = value ? this.ct_matches : (uint?)null; }
+    }
+    private bool ShouldSerializect_matches() { return ct_matchesSpecified; }
+    private void Resetct_matches() { ct_matchesSpecified = false; }
+    
 
-    private string _account_name_suggestion1 = "";
+    private string _account_name_suggestion1;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"account_name_suggestion1", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name_suggestion1
     {
-      get { return _account_name_suggestion1; }
+      get { return _account_name_suggestion1?? ""; }
       set { _account_name_suggestion1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_name_suggestion1Specified
+    {
+      get { return _account_name_suggestion1 != null; }
+      set { if (value == (_account_name_suggestion1== null)) _account_name_suggestion1 = value ? this.account_name_suggestion1 : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name_suggestion1() { return account_name_suggestion1Specified; }
+    private void Resetaccount_name_suggestion1() { account_name_suggestion1Specified = false; }
+    
 
-    private string _account_name_suggestion2 = "";
+    private string _account_name_suggestion2;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"account_name_suggestion2", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name_suggestion2
     {
-      get { return _account_name_suggestion2; }
+      get { return _account_name_suggestion2?? ""; }
       set { _account_name_suggestion2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_name_suggestion2Specified
+    {
+      get { return _account_name_suggestion2 != null; }
+      set { if (value == (_account_name_suggestion2== null)) _account_name_suggestion2 = value ? this.account_name_suggestion2 : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name_suggestion2() { return account_name_suggestion2Specified; }
+    private void Resetaccount_name_suggestion2() { account_name_suggestion2Specified = false; }
+    
 
-    private string _account_name_suggestion3 = "";
+    private string _account_name_suggestion3;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"account_name_suggestion3", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name_suggestion3
     {
-      get { return _account_name_suggestion3; }
+      get { return _account_name_suggestion3?? ""; }
       set { _account_name_suggestion3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_name_suggestion3Specified
+    {
+      get { return _account_name_suggestion3 != null; }
+      set { if (value == (_account_name_suggestion3== null)) _account_name_suggestion3 = value ? this.account_name_suggestion3 : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name_suggestion3() { return account_name_suggestion3Specified; }
+    private void Resetaccount_name_suggestion3() { account_name_suggestion3Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3908,50 +6718,95 @@ namespace SteamKit2.Internal
     public CMsgClientUGSGetGlobalStats() {}
     
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private uint _history_days_requested = default(uint);
+    private uint? _history_days_requested;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"history_days_requested", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint history_days_requested
     {
-      get { return _history_days_requested; }
+      get { return _history_days_requested?? default(uint); }
       set { _history_days_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool history_days_requestedSpecified
+    {
+      get { return _history_days_requested != null; }
+      set { if (value == (_history_days_requested== null)) _history_days_requested = value ? this.history_days_requested : (uint?)null; }
+    }
+    private bool ShouldSerializehistory_days_requested() { return history_days_requestedSpecified; }
+    private void Resethistory_days_requested() { history_days_requestedSpecified = false; }
+    
 
-    private uint _time_last_requested = default(uint);
+    private uint? _time_last_requested;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"time_last_requested", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_last_requested
     {
-      get { return _time_last_requested; }
+      get { return _time_last_requested?? default(uint); }
       set { _time_last_requested = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_last_requestedSpecified
+    {
+      get { return _time_last_requested != null; }
+      set { if (value == (_time_last_requested== null)) _time_last_requested = value ? this.time_last_requested : (uint?)null; }
+    }
+    private bool ShouldSerializetime_last_requested() { return time_last_requestedSpecified; }
+    private void Resettime_last_requested() { time_last_requestedSpecified = false; }
+    
 
-    private uint _first_day_cached = default(uint);
+    private uint? _first_day_cached;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"first_day_cached", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint first_day_cached
     {
-      get { return _first_day_cached; }
+      get { return _first_day_cached?? default(uint); }
       set { _first_day_cached = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool first_day_cachedSpecified
+    {
+      get { return _first_day_cached != null; }
+      set { if (value == (_first_day_cached== null)) _first_day_cached = value ? this.first_day_cached : (uint?)null; }
+    }
+    private bool ShouldSerializefirst_day_cached() { return first_day_cachedSpecified; }
+    private void Resetfirst_day_cached() { first_day_cachedSpecified = false; }
+    
 
-    private uint _days_cached = default(uint);
+    private uint? _days_cached;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"days_cached", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint days_cached
     {
-      get { return _days_cached; }
+      get { return _days_cached?? default(uint); }
       set { _days_cached = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool days_cachedSpecified
+    {
+      get { return _days_cached != null; }
+      set { if (value == (_days_cached== null)) _days_cached = value ? this.days_cached : (uint?)null; }
+    }
+    private bool ShouldSerializedays_cached() { return days_cachedSpecified; }
+    private void Resetdays_cached() { days_cachedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -3963,32 +6818,59 @@ namespace SteamKit2.Internal
     public CMsgClientUGSGetGlobalStatsResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private int _day_current = default(int);
+    private int? _day_current;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"day_current", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int day_current
     {
-      get { return _day_current; }
+      get { return _day_current?? default(int); }
       set { _day_current = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool day_currentSpecified
+    {
+      get { return _day_current != null; }
+      set { if (value == (_day_current== null)) _day_current = value ? this.day_current : (int?)null; }
+    }
+    private bool ShouldSerializeday_current() { return day_currentSpecified; }
+    private void Resetday_current() { day_currentSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day> _days = new global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day>();
     [global::ProtoBuf.ProtoMember(4, Name=@"days", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day> days
@@ -4002,14 +6884,23 @@ namespace SteamKit2.Internal
     public Day() {}
     
 
-    private uint _day_id = default(uint);
+    private uint? _day_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"day_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint day_id
     {
-      get { return _day_id; }
+      get { return _day_id?? default(uint); }
       set { _day_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool day_idSpecified
+    {
+      get { return _day_id != null; }
+      set { if (value == (_day_id== null)) _day_id = value ? this.day_id : (uint?)null; }
+    }
+    private bool ShouldSerializeday_id() { return day_idSpecified; }
+    private void Resetday_id() { day_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day.Stat> _stats = new global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day.Stat>();
     [global::ProtoBuf.ProtoMember(2, Name=@"stats", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientUGSGetGlobalStatsResponse.Day.Stat> stats
@@ -4023,23 +6914,41 @@ namespace SteamKit2.Internal
     public Stat() {}
     
 
-    private int _stat_id = default(int);
+    private int? _stat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stat_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int stat_id
     {
-      get { return _stat_id; }
+      get { return _stat_id?? default(int); }
       set { _stat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stat_idSpecified
+    {
+      get { return _stat_id != null; }
+      set { if (value == (_stat_id== null)) _stat_id = value ? this.stat_id : (int?)null; }
+    }
+    private bool ShouldSerializestat_id() { return stat_idSpecified; }
+    private void Resetstat_id() { stat_idSpecified = false; }
+    
 
-    private long _data = default(long);
+    private long? _data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"data", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(long))]
     public long data
     {
-      get { return _data; }
+      get { return _data?? default(long); }
       set { _data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dataSpecified
+    {
+      get { return _data != null; }
+      set { if (value == (_data== null)) _data = value ? this.data : (long?)null; }
+    }
+    private bool ShouldSerializedata() { return dataSpecified; }
+    private void Resetdata() { dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4061,104 +6970,203 @@ namespace SteamKit2.Internal
     public CMsgGameServerData() {}
     
 
-    private ulong _steam_id_gs = default(ulong);
+    private ulong? _steam_id_gs;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_gs", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_gs
     {
-      get { return _steam_id_gs; }
+      get { return _steam_id_gs?? default(ulong); }
       set { _steam_id_gs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_gsSpecified
+    {
+      get { return _steam_id_gs != null; }
+      set { if (value == (_steam_id_gs== null)) _steam_id_gs = value ? this.steam_id_gs : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_gs() { return steam_id_gsSpecified; }
+    private void Resetsteam_id_gs() { steam_id_gsSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _query_port = default(uint);
+    private uint? _query_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"query_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint query_port
     {
-      get { return _query_port; }
+      get { return _query_port?? default(uint); }
       set { _query_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_portSpecified
+    {
+      get { return _query_port != null; }
+      set { if (value == (_query_port== null)) _query_port = value ? this.query_port : (uint?)null; }
+    }
+    private bool ShouldSerializequery_port() { return query_portSpecified; }
+    private void Resetquery_port() { query_portSpecified = false; }
+    
 
-    private uint _game_port = default(uint);
+    private uint? _game_port;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_port
     {
-      get { return _game_port; }
+      get { return _game_port?? default(uint); }
       set { _game_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_portSpecified
+    {
+      get { return _game_port != null; }
+      set { if (value == (_game_port== null)) _game_port = value ? this.game_port : (uint?)null; }
+    }
+    private bool ShouldSerializegame_port() { return game_portSpecified; }
+    private void Resetgame_port() { game_portSpecified = false; }
+    
 
-    private uint _sourcetv_port = default(uint);
+    private uint? _sourcetv_port;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"sourcetv_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sourcetv_port
     {
-      get { return _sourcetv_port; }
+      get { return _sourcetv_port?? default(uint); }
       set { _sourcetv_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sourcetv_portSpecified
+    {
+      get { return _sourcetv_port != null; }
+      set { if (value == (_sourcetv_port== null)) _sourcetv_port = value ? this.sourcetv_port : (uint?)null; }
+    }
+    private bool ShouldSerializesourcetv_port() { return sourcetv_portSpecified; }
+    private void Resetsourcetv_port() { sourcetv_portSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private string _gamedir = "";
+    private string _gamedir;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"gamedir", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gamedir
     {
-      get { return _gamedir; }
+      get { return _gamedir?? ""; }
       set { _gamedir = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamedirSpecified
+    {
+      get { return _gamedir != null; }
+      set { if (value == (_gamedir== null)) _gamedir = value ? this.gamedir : (string)null; }
+    }
+    private bool ShouldSerializegamedir() { return gamedirSpecified; }
+    private void Resetgamedir() { gamedirSpecified = false; }
+    
 
-    private string _version = "";
+    private string _version;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string version
     {
-      get { return _version; }
+      get { return _version?? ""; }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (string)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private string _product = "";
+    private string _product;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"product", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string product
     {
-      get { return _product; }
+      get { return _product?? ""; }
       set { _product = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool productSpecified
+    {
+      get { return _product != null; }
+      set { if (value == (_product== null)) _product = value ? this.product : (string)null; }
+    }
+    private bool ShouldSerializeproduct() { return productSpecified; }
+    private void Resetproduct() { productSpecified = false; }
+    
 
-    private string _region = "";
+    private string _region;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"region", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string region
     {
-      get { return _region; }
+      get { return _region?? ""; }
       set { _region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool regionSpecified
+    {
+      get { return _region != null; }
+      set { if (value == (_region== null)) _region = value ? this.region : (string)null; }
+    }
+    private bool ShouldSerializeregion() { return regionSpecified; }
+    private void Resetregion() { regionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGameServerData.Player> _players = new global::System.Collections.Generic.List<CMsgGameServerData.Player>();
     [global::ProtoBuf.ProtoMember(11, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGameServerData.Player> players
@@ -4167,109 +7175,208 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _max_players = default(uint);
+    private uint? _max_players;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"max_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_players
     {
-      get { return _max_players; }
+      get { return _max_players?? default(uint); }
       set { _max_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_playersSpecified
+    {
+      get { return _max_players != null; }
+      set { if (value == (_max_players== null)) _max_players = value ? this.max_players : (uint?)null; }
+    }
+    private bool ShouldSerializemax_players() { return max_playersSpecified; }
+    private void Resetmax_players() { max_playersSpecified = false; }
+    
 
-    private uint _bot_count = default(uint);
+    private uint? _bot_count;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"bot_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint bot_count
     {
-      get { return _bot_count; }
+      get { return _bot_count?? default(uint); }
       set { _bot_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bot_countSpecified
+    {
+      get { return _bot_count != null; }
+      set { if (value == (_bot_count== null)) _bot_count = value ? this.bot_count : (uint?)null; }
+    }
+    private bool ShouldSerializebot_count() { return bot_countSpecified; }
+    private void Resetbot_count() { bot_countSpecified = false; }
+    
 
-    private bool _password = default(bool);
+    private bool? _password;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool password
     {
-      get { return _password; }
+      get { return _password?? default(bool); }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (bool?)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private bool _secure = default(bool);
+    private bool? _secure;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"secure", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool secure
     {
-      get { return _secure; }
+      get { return _secure?? default(bool); }
       set { _secure = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secureSpecified
+    {
+      get { return _secure != null; }
+      set { if (value == (_secure== null)) _secure = value ? this.secure : (bool?)null; }
+    }
+    private bool ShouldSerializesecure() { return secureSpecified; }
+    private void Resetsecure() { secureSpecified = false; }
+    
 
-    private bool _dedicated = default(bool);
+    private bool? _dedicated;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"dedicated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool dedicated
     {
-      get { return _dedicated; }
+      get { return _dedicated?? default(bool); }
       set { _dedicated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dedicatedSpecified
+    {
+      get { return _dedicated != null; }
+      set { if (value == (_dedicated== null)) _dedicated = value ? this.dedicated : (bool?)null; }
+    }
+    private bool ShouldSerializededicated() { return dedicatedSpecified; }
+    private void Resetdedicated() { dedicatedSpecified = false; }
+    
 
-    private string _os = "";
+    private string _os;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"os", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string os
     {
-      get { return _os; }
+      get { return _os?? ""; }
       set { _os = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool osSpecified
+    {
+      get { return _os != null; }
+      set { if (value == (_os== null)) _os = value ? this.os : (string)null; }
+    }
+    private bool ShouldSerializeos() { return osSpecified; }
+    private void Resetos() { osSpecified = false; }
+    
 
-    private string _game_data = "";
+    private string _game_data;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"game_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_data
     {
-      get { return _game_data; }
+      get { return _game_data?? ""; }
       set { _game_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_dataSpecified
+    {
+      get { return _game_data != null; }
+      set { if (value == (_game_data== null)) _game_data = value ? this.game_data : (string)null; }
+    }
+    private bool ShouldSerializegame_data() { return game_dataSpecified; }
+    private void Resetgame_data() { game_dataSpecified = false; }
+    
 
-    private uint _game_data_version = default(uint);
+    private uint? _game_data_version;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"game_data_version", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint game_data_version
     {
-      get { return _game_data_version; }
+      get { return _game_data_version?? default(uint); }
       set { _game_data_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_data_versionSpecified
+    {
+      get { return _game_data_version != null; }
+      set { if (value == (_game_data_version== null)) _game_data_version = value ? this.game_data_version : (uint?)null; }
+    }
+    private bool ShouldSerializegame_data_version() { return game_data_versionSpecified; }
+    private void Resetgame_data_version() { game_data_versionSpecified = false; }
+    
 
-    private string _game_type = "";
+    private string _game_type;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? ""; }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (string)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Player")]
   public partial class Player : global::ProtoBuf.IExtensible
   {
     public Player() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4286,32 +7393,59 @@ namespace SteamKit2.Internal
     public CMsgGameServerRemove() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _query_port = default(uint);
+    private uint? _query_port;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"query_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint query_port
     {
-      get { return _query_port; }
+      get { return _query_port?? default(uint); }
       set { _query_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_portSpecified
+    {
+      get { return _query_port != null; }
+      set { if (value == (_query_port== null)) _query_port = value ? this.query_port : (uint?)null; }
+    }
+    private bool ShouldSerializequery_port() { return query_portSpecified; }
+    private void Resetquery_port() { query_portSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4323,50 +7457,95 @@ namespace SteamKit2.Internal
     public CMsgClientGMSServerQuery() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _geo_location_ip = default(uint);
+    private uint? _geo_location_ip;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"geo_location_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint geo_location_ip
     {
-      get { return _geo_location_ip; }
+      get { return _geo_location_ip?? default(uint); }
       set { _geo_location_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool geo_location_ipSpecified
+    {
+      get { return _geo_location_ip != null; }
+      set { if (value == (_geo_location_ip== null)) _geo_location_ip = value ? this.geo_location_ip : (uint?)null; }
+    }
+    private bool ShouldSerializegeo_location_ip() { return geo_location_ipSpecified; }
+    private void Resetgeo_location_ip() { geo_location_ipSpecified = false; }
+    
 
-    private uint _region_code = default(uint);
+    private uint? _region_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"region_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint region_code
     {
-      get { return _region_code; }
+      get { return _region_code?? default(uint); }
       set { _region_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool region_codeSpecified
+    {
+      get { return _region_code != null; }
+      set { if (value == (_region_code== null)) _region_code = value ? this.region_code : (uint?)null; }
+    }
+    private bool ShouldSerializeregion_code() { return region_codeSpecified; }
+    private void Resetregion_code() { region_codeSpecified = false; }
+    
 
-    private string _filter_text = "";
+    private string _filter_text;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filter_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filter_text
     {
-      get { return _filter_text; }
+      get { return _filter_text?? ""; }
       set { _filter_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filter_textSpecified
+    {
+      get { return _filter_text != null; }
+      set { if (value == (_filter_text== null)) _filter_text = value ? this.filter_text : (string)null; }
+    }
+    private bool ShouldSerializefilter_text() { return filter_textSpecified; }
+    private void Resetfilter_text() { filter_textSpecified = false; }
+    
 
-    private uint _max_servers = default(uint);
+    private uint? _max_servers;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"max_servers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_servers
     {
-      get { return _max_servers; }
+      get { return _max_servers?? default(uint); }
       set { _max_servers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_serversSpecified
+    {
+      get { return _max_servers != null; }
+      set { if (value == (_max_servers== null)) _max_servers = value ? this.max_servers : (uint?)null; }
+    }
+    private bool ShouldSerializemax_servers() { return max_serversSpecified; }
+    private void Resetmax_servers() { max_serversSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4385,46 +7564,82 @@ namespace SteamKit2.Internal
     }
   
 
-    private string _error = "";
+    private string _error;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string error
     {
-      get { return _error; }
+      get { return _error?? ""; }
       set { _error = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool errorSpecified
+    {
+      get { return _error != null; }
+      set { if (value == (_error== null)) _error = value ? this.error : (string)null; }
+    }
+    private bool ShouldSerializeerror() { return errorSpecified; }
+    private void Reseterror() { errorSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Server")]
   public partial class Server : global::ProtoBuf.IExtensible
   {
     public Server() {}
     
 
-    private uint _server_ip = default(uint);
+    private uint? _server_ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_ip
     {
-      get { return _server_ip; }
+      get { return _server_ip?? default(uint); }
       set { _server_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_ipSpecified
+    {
+      get { return _server_ip != null; }
+      set { if (value == (_server_ip== null)) _server_ip = value ? this.server_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_ip() { return server_ipSpecified; }
+    private void Resetserver_ip() { server_ipSpecified = false; }
+    
 
-    private uint _server_port = default(uint);
+    private uint? _server_port;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"server_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint server_port
     {
-      get { return _server_port; }
+      get { return _server_port?? default(uint); }
       set { _server_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_portSpecified
+    {
+      get { return _server_port != null; }
+      set { if (value == (_server_port== null)) _server_port = value ? this.server_port : (uint?)null; }
+    }
+    private bool ShouldSerializeserver_port() { return server_portSpecified; }
+    private void Resetserver_port() { server_portSpecified = false; }
+    
 
-    private uint _auth_players = default(uint);
+    private uint? _auth_players;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"auth_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint auth_players
     {
-      get { return _auth_players; }
+      get { return _auth_players?? default(uint); }
       set { _auth_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_playersSpecified
+    {
+      get { return _auth_players != null; }
+      set { if (value == (_auth_players== null)) _auth_players = value ? this.auth_players : (uint?)null; }
+    }
+    private bool ShouldSerializeauth_players() { return auth_playersSpecified; }
+    private void Resetauth_players() { auth_playersSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4441,32 +7656,59 @@ namespace SteamKit2.Internal
     public CMsgGameServerOutOfDate() {}
     
 
-    private ulong _steam_id_gs = default(ulong);
+    private ulong? _steam_id_gs;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_gs", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_gs
     {
-      get { return _steam_id_gs; }
+      get { return _steam_id_gs?? default(ulong); }
       set { _steam_id_gs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_gsSpecified
+    {
+      get { return _steam_id_gs != null; }
+      set { if (value == (_steam_id_gs== null)) _steam_id_gs = value ? this.steam_id_gs : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_gs() { return steam_id_gsSpecified; }
+    private void Resetsteam_id_gs() { steam_id_gsSpecified = false; }
+    
 
-    private bool _reject = default(bool);
+    private bool? _reject;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"reject", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool reject
     {
-      get { return _reject; }
+      get { return _reject?? default(bool); }
       set { _reject = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rejectSpecified
+    {
+      get { return _reject != null; }
+      set { if (value == (_reject== null)) _reject = value ? this.reject : (bool?)null; }
+    }
+    private bool ShouldSerializereject() { return rejectSpecified; }
+    private void Resetreject() { rejectSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4478,14 +7720,23 @@ namespace SteamKit2.Internal
     public CMsgClientRedeemGuestPass() {}
     
 
-    private ulong _guest_pass_id = default(ulong);
+    private ulong? _guest_pass_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"guest_pass_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong guest_pass_id
     {
-      get { return _guest_pass_id; }
+      get { return _guest_pass_id?? default(ulong); }
       set { _guest_pass_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guest_pass_idSpecified
+    {
+      get { return _guest_pass_id != null; }
+      set { if (value == (_guest_pass_id== null)) _guest_pass_id = value ? this.guest_pass_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeguest_pass_id() { return guest_pass_idSpecified; }
+    private void Resetguest_pass_id() { guest_pass_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4497,32 +7748,59 @@ namespace SteamKit2.Internal
     public CMsgClientRedeemGuestPassResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _package_id = default(uint);
+    private uint? _package_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"package_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint package_id
     {
-      get { return _package_id; }
+      get { return _package_id?? default(uint); }
       set { _package_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool package_idSpecified
+    {
+      get { return _package_id != null; }
+      set { if (value == (_package_id== null)) _package_id = value ? this.package_id : (uint?)null; }
+    }
+    private bool ShouldSerializepackage_id() { return package_idSpecified; }
+    private void Resetpackage_id() { package_idSpecified = false; }
+    
 
-    private uint _must_own_appid = default(uint);
+    private uint? _must_own_appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"must_own_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint must_own_appid
     {
-      get { return _must_own_appid; }
+      get { return _must_own_appid?? default(uint); }
       set { _must_own_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool must_own_appidSpecified
+    {
+      get { return _must_own_appid != null; }
+      set { if (value == (_must_own_appid== null)) _must_own_appid = value ? this.must_own_appid : (uint?)null; }
+    }
+    private bool ShouldSerializemust_own_appid() { return must_own_appidSpecified; }
+    private void Resetmust_own_appid() { must_own_appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4551,14 +7829,23 @@ namespace SteamKit2.Internal
     public CMsgClientGetClanActivityCountsResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4570,50 +7857,95 @@ namespace SteamKit2.Internal
     public CMsgClientOGSReportString() {}
     
 
-    private bool _accumulated = default(bool);
+    private bool? _accumulated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accumulated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool accumulated
     {
-      get { return _accumulated; }
+      get { return _accumulated?? default(bool); }
       set { _accumulated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accumulatedSpecified
+    {
+      get { return _accumulated != null; }
+      set { if (value == (_accumulated== null)) _accumulated = value ? this.accumulated : (bool?)null; }
+    }
+    private bool ShouldSerializeaccumulated() { return accumulatedSpecified; }
+    private void Resetaccumulated() { accumulatedSpecified = false; }
+    
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private int _severity = default(int);
+    private int? _severity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"severity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int severity
     {
-      get { return _severity; }
+      get { return _severity?? default(int); }
       set { _severity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool severitySpecified
+    {
+      get { return _severity != null; }
+      set { if (value == (_severity== null)) _severity = value ? this.severity : (int?)null; }
+    }
+    private bool ShouldSerializeseverity() { return severitySpecified; }
+    private void Resetseverity() { severitySpecified = false; }
+    
 
-    private string _formatter = "";
+    private string _formatter;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"formatter", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string formatter
     {
-      get { return _formatter; }
+      get { return _formatter?? ""; }
       set { _formatter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool formatterSpecified
+    {
+      get { return _formatter != null; }
+      set { if (value == (_formatter== null)) _formatter = value ? this.formatter : (string)null; }
+    }
+    private bool ShouldSerializeformatter() { return formatterSpecified; }
+    private void Resetformatter() { formatterSpecified = false; }
+    
 
-    private byte[] _varargs = null;
+    private byte[] _varargs;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"varargs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] varargs
     {
-      get { return _varargs; }
+      get { return _varargs?? null; }
       set { _varargs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool varargsSpecified
+    {
+      get { return _varargs != null; }
+      set { if (value == (_varargs== null)) _varargs = value ? this.varargs : (byte[])null; }
+    }
+    private bool ShouldSerializevarargs() { return varargsSpecified; }
+    private void Resetvarargs() { varargsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4625,32 +7957,59 @@ namespace SteamKit2.Internal
     public CMsgClientOGSReportBug() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private string _bugtext = "";
+    private string _bugtext;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"bugtext", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string bugtext
     {
-      get { return _bugtext; }
+      get { return _bugtext?? ""; }
       set { _bugtext = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bugtextSpecified
+    {
+      get { return _bugtext != null; }
+      set { if (value == (_bugtext== null)) _bugtext = value ? this.bugtext : (string)null; }
+    }
+    private bool ShouldSerializebugtext() { return bugtextSpecified; }
+    private void Resetbugtext() { bugtextSpecified = false; }
+    
 
-    private byte[] _screenshot = null;
+    private byte[] _screenshot;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"screenshot", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] screenshot
     {
-      get { return _screenshot; }
+      get { return _screenshot?? null; }
       set { _screenshot = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool screenshotSpecified
+    {
+      get { return _screenshot != null; }
+      set { if (value == (_screenshot== null)) _screenshot = value ? this.screenshot : (byte[])null; }
+    }
+    private bool ShouldSerializescreenshot() { return screenshotSpecified; }
+    private void Resetscreenshot() { screenshotSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4662,14 +8021,23 @@ namespace SteamKit2.Internal
     public CMsgGSAssociateWithClan() {}
     
 
-    private ulong _steam_id_clan = default(ulong);
+    private ulong? _steam_id_clan;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_clan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_clan
     {
-      get { return _steam_id_clan; }
+      get { return _steam_id_clan?? default(ulong); }
       set { _steam_id_clan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_clanSpecified
+    {
+      get { return _steam_id_clan != null; }
+      set { if (value == (_steam_id_clan== null)) _steam_id_clan = value ? this.steam_id_clan : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_clan() { return steam_id_clanSpecified; }
+    private void Resetsteam_id_clan() { steam_id_clanSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4681,23 +8049,41 @@ namespace SteamKit2.Internal
     public CMsgGSAssociateWithClanResponse() {}
     
 
-    private ulong _steam_id_clan = default(ulong);
+    private ulong? _steam_id_clan;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_clan", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_clan
     {
-      get { return _steam_id_clan; }
+      get { return _steam_id_clan?? default(ulong); }
       set { _steam_id_clan = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_clanSpecified
+    {
+      get { return _steam_id_clan != null; }
+      set { if (value == (_steam_id_clan== null)) _steam_id_clan = value ? this.steam_id_clan : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_clan() { return steam_id_clanSpecified; }
+    private void Resetsteam_id_clan() { steam_id_clanSpecified = false; }
+    
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4709,14 +8095,23 @@ namespace SteamKit2.Internal
     public CMsgGSComputeNewPlayerCompatibility() {}
     
 
-    private ulong _steam_id_candidate = default(ulong);
+    private ulong? _steam_id_candidate;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_candidate", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_candidate
     {
-      get { return _steam_id_candidate; }
+      get { return _steam_id_candidate?? default(ulong); }
       set { _steam_id_candidate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_candidateSpecified
+    {
+      get { return _steam_id_candidate != null; }
+      set { if (value == (_steam_id_candidate== null)) _steam_id_candidate = value ? this.steam_id_candidate : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_candidate() { return steam_id_candidateSpecified; }
+    private void Resetsteam_id_candidate() { steam_id_candidateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4728,59 +8123,113 @@ namespace SteamKit2.Internal
     public CMsgGSComputeNewPlayerCompatibilityResponse() {}
     
 
-    private ulong _steam_id_candidate = default(ulong);
+    private ulong? _steam_id_candidate;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id_candidate", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id_candidate
     {
-      get { return _steam_id_candidate; }
+      get { return _steam_id_candidate?? default(ulong); }
       set { _steam_id_candidate = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_id_candidateSpecified
+    {
+      get { return _steam_id_candidate != null; }
+      set { if (value == (_steam_id_candidate== null)) _steam_id_candidate = value ? this.steam_id_candidate : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id_candidate() { return steam_id_candidateSpecified; }
+    private void Resetsteam_id_candidate() { steam_id_candidateSpecified = false; }
+    
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _is_clan_member = default(bool);
+    private bool? _is_clan_member;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_clan_member", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_clan_member
     {
-      get { return _is_clan_member; }
+      get { return _is_clan_member?? default(bool); }
       set { _is_clan_member = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_clan_memberSpecified
+    {
+      get { return _is_clan_member != null; }
+      set { if (value == (_is_clan_member== null)) _is_clan_member = value ? this.is_clan_member : (bool?)null; }
+    }
+    private bool ShouldSerializeis_clan_member() { return is_clan_memberSpecified; }
+    private void Resetis_clan_member() { is_clan_memberSpecified = false; }
+    
 
-    private int _ct_dont_like_you = default(int);
+    private int? _ct_dont_like_you;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ct_dont_like_you", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ct_dont_like_you
     {
-      get { return _ct_dont_like_you; }
+      get { return _ct_dont_like_you?? default(int); }
       set { _ct_dont_like_you = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ct_dont_like_youSpecified
+    {
+      get { return _ct_dont_like_you != null; }
+      set { if (value == (_ct_dont_like_you== null)) _ct_dont_like_you = value ? this.ct_dont_like_you : (int?)null; }
+    }
+    private bool ShouldSerializect_dont_like_you() { return ct_dont_like_youSpecified; }
+    private void Resetct_dont_like_you() { ct_dont_like_youSpecified = false; }
+    
 
-    private int _ct_you_dont_like = default(int);
+    private int? _ct_you_dont_like;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ct_you_dont_like", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ct_you_dont_like
     {
-      get { return _ct_you_dont_like; }
+      get { return _ct_you_dont_like?? default(int); }
       set { _ct_you_dont_like = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ct_you_dont_likeSpecified
+    {
+      get { return _ct_you_dont_like != null; }
+      set { if (value == (_ct_you_dont_like== null)) _ct_you_dont_like = value ? this.ct_you_dont_like : (int?)null; }
+    }
+    private bool ShouldSerializect_you_dont_like() { return ct_you_dont_likeSpecified; }
+    private void Resetct_you_dont_like() { ct_you_dont_likeSpecified = false; }
+    
 
-    private int _ct_clanmembers_dont_like_you = default(int);
+    private int? _ct_clanmembers_dont_like_you;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"ct_clanmembers_dont_like_you", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ct_clanmembers_dont_like_you
     {
-      get { return _ct_clanmembers_dont_like_you; }
+      get { return _ct_clanmembers_dont_like_you?? default(int); }
       set { _ct_clanmembers_dont_like_you = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ct_clanmembers_dont_like_youSpecified
+    {
+      get { return _ct_clanmembers_dont_like_you != null; }
+      set { if (value == (_ct_clanmembers_dont_like_you== null)) _ct_clanmembers_dont_like_you = value ? this.ct_clanmembers_dont_like_you : (int?)null; }
+    }
+    private bool ShouldSerializect_clanmembers_dont_like_you() { return ct_clanmembers_dont_like_youSpecified; }
+    private void Resetct_clanmembers_dont_like_you() { ct_clanmembers_dont_like_youSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4802,50 +8251,95 @@ namespace SteamKit2.Internal
     public CMsgGCClient() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _msgtype = default(uint);
+    private uint? _msgtype;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"msgtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint msgtype
     {
-      get { return _msgtype; }
+      get { return _msgtype?? default(uint); }
       set { _msgtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool msgtypeSpecified
+    {
+      get { return _msgtype != null; }
+      set { if (value == (_msgtype== null)) _msgtype = value ? this.msgtype : (uint?)null; }
+    }
+    private bool ShouldSerializemsgtype() { return msgtypeSpecified; }
+    private void Resetmsgtype() { msgtypeSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _gcname = "";
+    private string _gcname;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"gcname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gcname
     {
-      get { return _gcname; }
+      get { return _gcname?? ""; }
       set { _gcname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gcnameSpecified
+    {
+      get { return _gcname != null; }
+      set { if (value == (_gcname== null)) _gcname = value ? this.gcname : (string)null; }
+    }
+    private bool ShouldSerializegcname() { return gcnameSpecified; }
+    private void Resetgcname() { gcnameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4874,14 +8368,23 @@ namespace SteamKit2.Internal
     public CMsgClientRequestFreeLicenseResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _granted_packageids = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"granted_packageids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> granted_packageids
@@ -4907,77 +8410,149 @@ namespace SteamKit2.Internal
     public CMsgDRMDownloadRequestWithCrashData() {}
     
 
-    private uint _download_flags = default(uint);
+    private uint? _download_flags;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"download_flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_flags
     {
-      get { return _download_flags; }
+      get { return _download_flags?? default(uint); }
       set { _download_flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_flagsSpecified
+    {
+      get { return _download_flags != null; }
+      set { if (value == (_download_flags== null)) _download_flags = value ? this.download_flags : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_flags() { return download_flagsSpecified; }
+    private void Resetdownload_flags() { download_flagsSpecified = false; }
+    
 
-    private uint _download_types_known = default(uint);
+    private uint? _download_types_known;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"download_types_known", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_types_known
     {
-      get { return _download_types_known; }
+      get { return _download_types_known?? default(uint); }
       set { _download_types_known = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_types_knownSpecified
+    {
+      get { return _download_types_known != null; }
+      set { if (value == (_download_types_known== null)) _download_types_known = value ? this.download_types_known : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_types_known() { return download_types_knownSpecified; }
+    private void Resetdownload_types_known() { download_types_knownSpecified = false; }
+    
 
-    private byte[] _guid_drm = null;
+    private byte[] _guid_drm;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"guid_drm", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] guid_drm
     {
-      get { return _guid_drm; }
+      get { return _guid_drm?? null; }
       set { _guid_drm = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guid_drmSpecified
+    {
+      get { return _guid_drm != null; }
+      set { if (value == (_guid_drm== null)) _guid_drm = value ? this.guid_drm : (byte[])null; }
+    }
+    private bool ShouldSerializeguid_drm() { return guid_drmSpecified; }
+    private void Resetguid_drm() { guid_drmSpecified = false; }
+    
 
-    private byte[] _guid_split = null;
+    private byte[] _guid_split;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"guid_split", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] guid_split
     {
-      get { return _guid_split; }
+      get { return _guid_split?? null; }
       set { _guid_split = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guid_splitSpecified
+    {
+      get { return _guid_split != null; }
+      set { if (value == (_guid_split== null)) _guid_split = value ? this.guid_split : (byte[])null; }
+    }
+    private bool ShouldSerializeguid_split() { return guid_splitSpecified; }
+    private void Resetguid_split() { guid_splitSpecified = false; }
+    
 
-    private byte[] _guid_merge = null;
+    private byte[] _guid_merge;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"guid_merge", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] guid_merge
     {
-      get { return _guid_merge; }
+      get { return _guid_merge?? null; }
       set { _guid_merge = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool guid_mergeSpecified
+    {
+      get { return _guid_merge != null; }
+      set { if (value == (_guid_merge== null)) _guid_merge = value ? this.guid_merge : (byte[])null; }
+    }
+    private bool ShouldSerializeguid_merge() { return guid_mergeSpecified; }
+    private void Resetguid_merge() { guid_mergeSpecified = false; }
+    
 
-    private string _module_name = "";
+    private string _module_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"module_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string module_name
     {
-      get { return _module_name; }
+      get { return _module_name?? ""; }
       set { _module_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_nameSpecified
+    {
+      get { return _module_name != null; }
+      set { if (value == (_module_name== null)) _module_name = value ? this.module_name : (string)null; }
+    }
+    private bool ShouldSerializemodule_name() { return module_nameSpecified; }
+    private void Resetmodule_name() { module_nameSpecified = false; }
+    
 
-    private string _module_path = "";
+    private string _module_path;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"module_path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string module_path
     {
-      get { return _module_path; }
+      get { return _module_path?? ""; }
       set { _module_path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_pathSpecified
+    {
+      get { return _module_path != null; }
+      set { if (value == (_module_path== null)) _module_path = value ? this.module_path : (string)null; }
+    }
+    private bool ShouldSerializemodule_path() { return module_pathSpecified; }
+    private void Resetmodule_path() { module_pathSpecified = false; }
+    
 
-    private byte[] _crash_data = null;
+    private byte[] _crash_data;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"crash_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] crash_data
     {
-      get { return _crash_data; }
+      get { return _crash_data?? null; }
       set { _crash_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crash_dataSpecified
+    {
+      get { return _crash_data != null; }
+      set { if (value == (_crash_data== null)) _crash_data = value ? this.crash_data : (byte[])null; }
+    }
+    private bool ShouldSerializecrash_data() { return crash_dataSpecified; }
+    private void Resetcrash_data() { crash_dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -4989,77 +8564,149 @@ namespace SteamKit2.Internal
     public CMsgDRMDownloadResponse() {}
     
 
-    private uint _eresult = (uint)2;
+    private uint? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (uint)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (uint?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _blob_download_type = default(uint);
+    private uint? _blob_download_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"blob_download_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint blob_download_type
     {
-      get { return _blob_download_type; }
+      get { return _blob_download_type?? default(uint); }
       set { _blob_download_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool blob_download_typeSpecified
+    {
+      get { return _blob_download_type != null; }
+      set { if (value == (_blob_download_type== null)) _blob_download_type = value ? this.blob_download_type : (uint?)null; }
+    }
+    private bool ShouldSerializeblob_download_type() { return blob_download_typeSpecified; }
+    private void Resetblob_download_type() { blob_download_typeSpecified = false; }
+    
 
-    private byte[] _merge_guid = null;
+    private byte[] _merge_guid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"merge_guid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] merge_guid
     {
-      get { return _merge_guid; }
+      get { return _merge_guid?? null; }
       set { _merge_guid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool merge_guidSpecified
+    {
+      get { return _merge_guid != null; }
+      set { if (value == (_merge_guid== null)) _merge_guid = value ? this.merge_guid : (byte[])null; }
+    }
+    private bool ShouldSerializemerge_guid() { return merge_guidSpecified; }
+    private void Resetmerge_guid() { merge_guidSpecified = false; }
+    
 
-    private uint _download_file_dfs_ip = default(uint);
+    private uint? _download_file_dfs_ip;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"download_file_dfs_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_file_dfs_ip
     {
-      get { return _download_file_dfs_ip; }
+      get { return _download_file_dfs_ip?? default(uint); }
       set { _download_file_dfs_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_dfs_ipSpecified
+    {
+      get { return _download_file_dfs_ip != null; }
+      set { if (value == (_download_file_dfs_ip== null)) _download_file_dfs_ip = value ? this.download_file_dfs_ip : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_file_dfs_ip() { return download_file_dfs_ipSpecified; }
+    private void Resetdownload_file_dfs_ip() { download_file_dfs_ipSpecified = false; }
+    
 
-    private uint _download_file_dfs_port = default(uint);
+    private uint? _download_file_dfs_port;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"download_file_dfs_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_file_dfs_port
     {
-      get { return _download_file_dfs_port; }
+      get { return _download_file_dfs_port?? default(uint); }
       set { _download_file_dfs_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_dfs_portSpecified
+    {
+      get { return _download_file_dfs_port != null; }
+      set { if (value == (_download_file_dfs_port== null)) _download_file_dfs_port = value ? this.download_file_dfs_port : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_file_dfs_port() { return download_file_dfs_portSpecified; }
+    private void Resetdownload_file_dfs_port() { download_file_dfs_portSpecified = false; }
+    
 
-    private string _download_file_url = "";
+    private string _download_file_url;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"download_file_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string download_file_url
     {
-      get { return _download_file_url; }
+      get { return _download_file_url?? ""; }
       set { _download_file_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_urlSpecified
+    {
+      get { return _download_file_url != null; }
+      set { if (value == (_download_file_url== null)) _download_file_url = value ? this.download_file_url : (string)null; }
+    }
+    private bool ShouldSerializedownload_file_url() { return download_file_urlSpecified; }
+    private void Resetdownload_file_url() { download_file_urlSpecified = false; }
+    
 
-    private string _module_path = "";
+    private string _module_path;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"module_path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string module_path
     {
-      get { return _module_path; }
+      get { return _module_path?? ""; }
       set { _module_path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_pathSpecified
+    {
+      get { return _module_path != null; }
+      set { if (value == (_module_path== null)) _module_path = value ? this.module_path : (string)null; }
+    }
+    private bool ShouldSerializemodule_path() { return module_pathSpecified; }
+    private void Resetmodule_path() { module_pathSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5071,77 +8718,149 @@ namespace SteamKit2.Internal
     public CMsgDRMFinalResult() {}
     
 
-    private uint _eResult = (uint)2;
+    private uint? _eResult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eResult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eResult
     {
-      get { return _eResult; }
+      get { return _eResult?? (uint)2; }
       set { _eResult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eResultSpecified
+    {
+      get { return _eResult != null; }
+      set { if (value == (_eResult== null)) _eResult = value ? this.eResult : (uint?)null; }
+    }
+    private bool ShouldSerializeeResult() { return eResultSpecified; }
+    private void ReseteResult() { eResultSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _blob_download_type = default(uint);
+    private uint? _blob_download_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"blob_download_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint blob_download_type
     {
-      get { return _blob_download_type; }
+      get { return _blob_download_type?? default(uint); }
       set { _blob_download_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool blob_download_typeSpecified
+    {
+      get { return _blob_download_type != null; }
+      set { if (value == (_blob_download_type== null)) _blob_download_type = value ? this.blob_download_type : (uint?)null; }
+    }
+    private bool ShouldSerializeblob_download_type() { return blob_download_typeSpecified; }
+    private void Resetblob_download_type() { blob_download_typeSpecified = false; }
+    
 
-    private uint _error_detail = default(uint);
+    private uint? _error_detail;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"error_detail", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint error_detail
     {
-      get { return _error_detail; }
+      get { return _error_detail?? default(uint); }
       set { _error_detail = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool error_detailSpecified
+    {
+      get { return _error_detail != null; }
+      set { if (value == (_error_detail== null)) _error_detail = value ? this.error_detail : (uint?)null; }
+    }
+    private bool ShouldSerializeerror_detail() { return error_detailSpecified; }
+    private void Reseterror_detail() { error_detailSpecified = false; }
+    
 
-    private byte[] _merge_guid = null;
+    private byte[] _merge_guid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"merge_guid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] merge_guid
     {
-      get { return _merge_guid; }
+      get { return _merge_guid?? null; }
       set { _merge_guid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool merge_guidSpecified
+    {
+      get { return _merge_guid != null; }
+      set { if (value == (_merge_guid== null)) _merge_guid = value ? this.merge_guid : (byte[])null; }
+    }
+    private bool ShouldSerializemerge_guid() { return merge_guidSpecified; }
+    private void Resetmerge_guid() { merge_guidSpecified = false; }
+    
 
-    private uint _download_file_dfs_ip = default(uint);
+    private uint? _download_file_dfs_ip;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"download_file_dfs_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_file_dfs_ip
     {
-      get { return _download_file_dfs_ip; }
+      get { return _download_file_dfs_ip?? default(uint); }
       set { _download_file_dfs_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_dfs_ipSpecified
+    {
+      get { return _download_file_dfs_ip != null; }
+      set { if (value == (_download_file_dfs_ip== null)) _download_file_dfs_ip = value ? this.download_file_dfs_ip : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_file_dfs_ip() { return download_file_dfs_ipSpecified; }
+    private void Resetdownload_file_dfs_ip() { download_file_dfs_ipSpecified = false; }
+    
 
-    private uint _download_file_dfs_port = default(uint);
+    private uint? _download_file_dfs_port;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"download_file_dfs_port", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint download_file_dfs_port
     {
-      get { return _download_file_dfs_port; }
+      get { return _download_file_dfs_port?? default(uint); }
       set { _download_file_dfs_port = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_dfs_portSpecified
+    {
+      get { return _download_file_dfs_port != null; }
+      set { if (value == (_download_file_dfs_port== null)) _download_file_dfs_port = value ? this.download_file_dfs_port : (uint?)null; }
+    }
+    private bool ShouldSerializedownload_file_dfs_port() { return download_file_dfs_portSpecified; }
+    private void Resetdownload_file_dfs_port() { download_file_dfs_portSpecified = false; }
+    
 
-    private string _download_file_url = "";
+    private string _download_file_url;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"download_file_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string download_file_url
     {
-      get { return _download_file_url; }
+      get { return _download_file_url?? ""; }
       set { _download_file_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_file_urlSpecified
+    {
+      get { return _download_file_url != null; }
+      set { if (value == (_download_file_url== null)) _download_file_url = value ? this.download_file_url : (string)null; }
+    }
+    private bool ShouldSerializedownload_file_url() { return download_file_urlSpecified; }
+    private void Resetdownload_file_url() { download_file_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5153,14 +8872,23 @@ namespace SteamKit2.Internal
     public CMsgClientDPCheckSpecialSurvey() {}
     
 
-    private uint _survey_id = default(uint);
+    private uint? _survey_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"survey_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint survey_id
     {
-      get { return _survey_id; }
+      get { return _survey_id?? default(uint); }
       set { _survey_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_idSpecified
+    {
+      get { return _survey_id != null; }
+      set { if (value == (_survey_id== null)) _survey_id = value ? this.survey_id : (uint?)null; }
+    }
+    private bool ShouldSerializesurvey_id() { return survey_idSpecified; }
+    private void Resetsurvey_id() { survey_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5172,59 +8900,113 @@ namespace SteamKit2.Internal
     public CMsgClientDPCheckSpecialSurveyResponse() {}
     
 
-    private uint _eResult = (uint)2;
+    private uint? _eResult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eResult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eResult
     {
-      get { return _eResult; }
+      get { return _eResult?? (uint)2; }
       set { _eResult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eResultSpecified
+    {
+      get { return _eResult != null; }
+      set { if (value == (_eResult== null)) _eResult = value ? this.eResult : (uint?)null; }
+    }
+    private bool ShouldSerializeeResult() { return eResultSpecified; }
+    private void ReseteResult() { eResultSpecified = false; }
+    
 
-    private uint _state = default(uint);
+    private uint? _state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint state
     {
-      get { return _state; }
+      get { return _state?? default(uint); }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (uint?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _custom_url = "";
+    private string _custom_url;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"custom_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string custom_url
     {
-      get { return _custom_url; }
+      get { return _custom_url?? ""; }
       set { _custom_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool custom_urlSpecified
+    {
+      get { return _custom_url != null; }
+      set { if (value == (_custom_url== null)) _custom_url = value ? this.custom_url : (string)null; }
+    }
+    private bool ShouldSerializecustom_url() { return custom_urlSpecified; }
+    private void Resetcustom_url() { custom_urlSpecified = false; }
+    
 
-    private bool _include_software = default(bool);
+    private bool? _include_software;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"include_software", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_software
     {
-      get { return _include_software; }
+      get { return _include_software?? default(bool); }
       set { _include_software = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_softwareSpecified
+    {
+      get { return _include_software != null; }
+      set { if (value == (_include_software== null)) _include_software = value ? this.include_software : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_software() { return include_softwareSpecified; }
+    private void Resetinclude_software() { include_softwareSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5236,23 +9018,41 @@ namespace SteamKit2.Internal
     public CMsgClientDPSendSpecialSurveyResponse() {}
     
 
-    private uint _survey_id = default(uint);
+    private uint? _survey_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"survey_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint survey_id
     {
-      get { return _survey_id; }
+      get { return _survey_id?? default(uint); }
       set { _survey_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool survey_idSpecified
+    {
+      get { return _survey_id != null; }
+      set { if (value == (_survey_id== null)) _survey_id = value ? this.survey_id : (uint?)null; }
+    }
+    private bool ShouldSerializesurvey_id() { return survey_idSpecified; }
+    private void Resetsurvey_id() { survey_idSpecified = false; }
+    
 
-    private byte[] _data = null;
+    private byte[] _data;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] data
     {
-      get { return _data; }
+      get { return _data?? null; }
       set { _data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dataSpecified
+    {
+      get { return _data != null; }
+      set { if (value == (_data== null)) _data = value ? this.data : (byte[])null; }
+    }
+    private bool ShouldSerializedata() { return dataSpecified; }
+    private void Resetdata() { dataSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5264,23 +9064,41 @@ namespace SteamKit2.Internal
     public CMsgClientDPSendSpecialSurveyResponseReply() {}
     
 
-    private uint _eResult = (uint)2;
+    private uint? _eResult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eResult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)2)]
     public uint eResult
     {
-      get { return _eResult; }
+      get { return _eResult?? (uint)2; }
       set { _eResult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eResultSpecified
+    {
+      get { return _eResult != null; }
+      set { if (value == (_eResult== null)) _eResult = value ? this.eResult : (uint?)null; }
+    }
+    private bool ShouldSerializeeResult() { return eResultSpecified; }
+    private void ReseteResult() { eResultSpecified = false; }
+    
 
-    private byte[] _token = null;
+    private byte[] _token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] token
     {
-      get { return _token; }
+      get { return _token?? null; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (byte[])null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5292,23 +9110,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestForgottenPasswordEmail() {}
     
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _password_tried = "";
+    private string _password_tried;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password_tried", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password_tried
     {
-      get { return _password_tried; }
+      get { return _password_tried?? ""; }
       set { _password_tried = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool password_triedSpecified
+    {
+      get { return _password_tried != null; }
+      set { if (value == (_password_tried== null)) _password_tried = value ? this.password_tried : (string)null; }
+    }
+    private bool ShouldSerializepassword_tried() { return password_triedSpecified; }
+    private void Resetpassword_tried() { password_triedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5320,23 +9156,41 @@ namespace SteamKit2.Internal
     public CMsgClientRequestForgottenPasswordEmailResponse() {}
     
 
-    private uint _eResult = default(uint);
+    private uint? _eResult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eResult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint eResult
     {
-      get { return _eResult; }
+      get { return _eResult?? default(uint); }
       set { _eResult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eResultSpecified
+    {
+      get { return _eResult != null; }
+      set { if (value == (_eResult== null)) _eResult = value ? this.eResult : (uint?)null; }
+    }
+    private bool ShouldSerializeeResult() { return eResultSpecified; }
+    private void ReseteResult() { eResultSpecified = false; }
+    
 
-    private bool _use_secret_question = default(bool);
+    private bool? _use_secret_question;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"use_secret_question", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_secret_question
     {
-      get { return _use_secret_question; }
+      get { return _use_secret_question?? default(bool); }
       set { _use_secret_question = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_secret_questionSpecified
+    {
+      get { return _use_secret_question != null; }
+      set { if (value == (_use_secret_question== null)) _use_secret_question = value ? this.use_secret_question : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_secret_question() { return use_secret_questionSpecified; }
+    private void Resetuse_secret_question() { use_secret_questionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5348,14 +9202,23 @@ namespace SteamKit2.Internal
     public CMsgClientItemAnnouncements() {}
     
 
-    private uint _count_new_items = default(uint);
+    private uint? _count_new_items;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"count_new_items", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count_new_items
     {
-      get { return _count_new_items; }
+      get { return _count_new_items?? default(uint); }
       set { _count_new_items = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_new_itemsSpecified
+    {
+      get { return _count_new_items != null; }
+      set { if (value == (_count_new_items== null)) _count_new_items = value ? this.count_new_items : (uint?)null; }
+    }
+    private bool ShouldSerializecount_new_items() { return count_new_itemsSpecified; }
+    private void Resetcount_new_items() { count_new_itemsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5389,23 +9252,41 @@ namespace SteamKit2.Internal
     public Notification() {}
     
 
-    private uint _user_notification_type = default(uint);
+    private uint? _user_notification_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"user_notification_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint user_notification_type
     {
-      get { return _user_notification_type; }
+      get { return _user_notification_type?? default(uint); }
       set { _user_notification_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_notification_typeSpecified
+    {
+      get { return _user_notification_type != null; }
+      set { if (value == (_user_notification_type== null)) _user_notification_type = value ? this.user_notification_type : (uint?)null; }
+    }
+    private bool ShouldSerializeuser_notification_type() { return user_notification_typeSpecified; }
+    private void Resetuser_notification_type() { user_notification_typeSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5422,32 +9303,59 @@ namespace SteamKit2.Internal
     public CMsgClientCommentNotifications() {}
     
 
-    private uint _count_new_comments = default(uint);
+    private uint? _count_new_comments;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"count_new_comments", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count_new_comments
     {
-      get { return _count_new_comments; }
+      get { return _count_new_comments?? default(uint); }
       set { _count_new_comments = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_new_commentsSpecified
+    {
+      get { return _count_new_comments != null; }
+      set { if (value == (_count_new_comments== null)) _count_new_comments = value ? this.count_new_comments : (uint?)null; }
+    }
+    private bool ShouldSerializecount_new_comments() { return count_new_commentsSpecified; }
+    private void Resetcount_new_comments() { count_new_commentsSpecified = false; }
+    
 
-    private uint _count_new_comments_owner = default(uint);
+    private uint? _count_new_comments_owner;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count_new_comments_owner", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count_new_comments_owner
     {
-      get { return _count_new_comments_owner; }
+      get { return _count_new_comments_owner?? default(uint); }
       set { _count_new_comments_owner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_new_comments_ownerSpecified
+    {
+      get { return _count_new_comments_owner != null; }
+      set { if (value == (_count_new_comments_owner== null)) _count_new_comments_owner = value ? this.count_new_comments_owner : (uint?)null; }
+    }
+    private bool ShouldSerializecount_new_comments_owner() { return count_new_comments_ownerSpecified; }
+    private void Resetcount_new_comments_owner() { count_new_comments_ownerSpecified = false; }
+    
 
-    private uint _count_new_comments_subscriptions = default(uint);
+    private uint? _count_new_comments_subscriptions;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"count_new_comments_subscriptions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count_new_comments_subscriptions
     {
-      get { return _count_new_comments_subscriptions; }
+      get { return _count_new_comments_subscriptions?? default(uint); }
       set { _count_new_comments_subscriptions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool count_new_comments_subscriptionsSpecified
+    {
+      get { return _count_new_comments_subscriptions != null; }
+      set { if (value == (_count_new_comments_subscriptions== null)) _count_new_comments_subscriptions = value ? this.count_new_comments_subscriptions : (uint?)null; }
+    }
+    private bool ShouldSerializecount_new_comments_subscriptions() { return count_new_comments_subscriptionsSpecified; }
+    private void Resetcount_new_comments_subscriptions() { count_new_comments_subscriptionsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5469,14 +9377,23 @@ namespace SteamKit2.Internal
     public CMsgClientOfflineMessageNotification() {}
     
 
-    private uint _offline_messages = default(uint);
+    private uint? _offline_messages;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"offline_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint offline_messages
     {
-      get { return _offline_messages; }
+      get { return _offline_messages?? default(uint); }
       set { _offline_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool offline_messagesSpecified
+    {
+      get { return _offline_messages != null; }
+      set { if (value == (_offline_messages== null)) _offline_messages = value ? this.offline_messages : (uint?)null; }
+    }
+    private bool ShouldSerializeoffline_messages() { return offline_messagesSpecified; }
+    private void Resetoffline_messages() { offline_messagesSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<uint> _friends_with_offline_messages = new global::System.Collections.Generic.List<uint>();
     [global::ProtoBuf.ProtoMember(2, Name=@"friends_with_offline_messages", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<uint> friends_with_offline_messages
@@ -5505,14 +9422,23 @@ namespace SteamKit2.Internal
     public CMsgClientFSGetFriendMessageHistory() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5524,23 +9450,41 @@ namespace SteamKit2.Internal
     public CMsgClientFSGetFriendMessageHistoryResponse() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _success = default(uint);
+    private uint? _success;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint success
     {
-      get { return _success; }
+      get { return _success?? default(uint); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (uint?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientFSGetFriendMessageHistoryResponse.FriendMessage> _messages = new global::System.Collections.Generic.List<CMsgClientFSGetFriendMessageHistoryResponse.FriendMessage>();
     [global::ProtoBuf.ProtoMember(3, Name=@"messages", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientFSGetFriendMessageHistoryResponse.FriendMessage> messages
@@ -5554,41 +9498,77 @@ namespace SteamKit2.Internal
     public FriendMessage() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private bool _unread = default(bool);
+    private bool? _unread;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"unread", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool unread
     {
-      get { return _unread; }
+      get { return _unread?? default(bool); }
       set { _unread = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unreadSpecified
+    {
+      get { return _unread != null; }
+      set { if (value == (_unread== null)) _unread = value ? this.unread : (bool?)null; }
+    }
+    private bool ShouldSerializeunread() { return unreadSpecified; }
+    private void Resetunread() { unreadSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5644,23 +9624,41 @@ namespace SteamKit2.Internal
     public Friend() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _level = default(uint);
+    private uint? _level;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint level
     {
-      get { return _level; }
+      get { return _level?? default(uint); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (uint?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5677,59 +9675,113 @@ namespace SteamKit2.Internal
     public CMsgClientEmailAddrInfo() {}
     
 
-    private string _email_address = "";
+    private string _email_address;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"email_address", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string email_address
     {
-      get { return _email_address; }
+      get { return _email_address?? ""; }
       set { _email_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_addressSpecified
+    {
+      get { return _email_address != null; }
+      set { if (value == (_email_address== null)) _email_address = value ? this.email_address : (string)null; }
+    }
+    private bool ShouldSerializeemail_address() { return email_addressSpecified; }
+    private void Resetemail_address() { email_addressSpecified = false; }
+    
 
-    private bool _email_is_validated = default(bool);
+    private bool? _email_is_validated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_is_validated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool email_is_validated
     {
-      get { return _email_is_validated; }
+      get { return _email_is_validated?? default(bool); }
       set { _email_is_validated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_is_validatedSpecified
+    {
+      get { return _email_is_validated != null; }
+      set { if (value == (_email_is_validated== null)) _email_is_validated = value ? this.email_is_validated : (bool?)null; }
+    }
+    private bool ShouldSerializeemail_is_validated() { return email_is_validatedSpecified; }
+    private void Resetemail_is_validated() { email_is_validatedSpecified = false; }
+    
 
-    private bool _email_validation_changed = default(bool);
+    private bool? _email_validation_changed;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email_validation_changed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool email_validation_changed
     {
-      get { return _email_validation_changed; }
+      get { return _email_validation_changed?? default(bool); }
       set { _email_validation_changed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_validation_changedSpecified
+    {
+      get { return _email_validation_changed != null; }
+      set { if (value == (_email_validation_changed== null)) _email_validation_changed = value ? this.email_validation_changed : (bool?)null; }
+    }
+    private bool ShouldSerializeemail_validation_changed() { return email_validation_changedSpecified; }
+    private void Resetemail_validation_changed() { email_validation_changedSpecified = false; }
+    
 
-    private bool _credential_change_requires_code = default(bool);
+    private bool? _credential_change_requires_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"credential_change_requires_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool credential_change_requires_code
     {
-      get { return _credential_change_requires_code; }
+      get { return _credential_change_requires_code?? default(bool); }
       set { _credential_change_requires_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool credential_change_requires_codeSpecified
+    {
+      get { return _credential_change_requires_code != null; }
+      set { if (value == (_credential_change_requires_code== null)) _credential_change_requires_code = value ? this.credential_change_requires_code : (bool?)null; }
+    }
+    private bool ShouldSerializecredential_change_requires_code() { return credential_change_requires_codeSpecified; }
+    private void Resetcredential_change_requires_code() { credential_change_requires_codeSpecified = false; }
+    
 
-    private bool _password_or_secretqa_change_requires_code = default(bool);
+    private bool? _password_or_secretqa_change_requires_code;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"password_or_secretqa_change_requires_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool password_or_secretqa_change_requires_code
     {
-      get { return _password_or_secretqa_change_requires_code; }
+      get { return _password_or_secretqa_change_requires_code?? default(bool); }
       set { _password_or_secretqa_change_requires_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool password_or_secretqa_change_requires_codeSpecified
+    {
+      get { return _password_or_secretqa_change_requires_code != null; }
+      set { if (value == (_password_or_secretqa_change_requires_code== null)) _password_or_secretqa_change_requires_code = value ? this.password_or_secretqa_change_requires_code : (bool?)null; }
+    }
+    private bool ShouldSerializepassword_or_secretqa_change_requires_code() { return password_or_secretqa_change_requires_codeSpecified; }
+    private void Resetpassword_or_secretqa_change_requires_code() { password_or_secretqa_change_requires_codeSpecified = false; }
+    
 
-    private bool _remind_user_about_email = default(bool);
+    private bool? _remind_user_about_email;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"remind_user_about_email", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool remind_user_about_email
     {
-      get { return _remind_user_about_email; }
+      get { return _remind_user_about_email?? default(bool); }
       set { _remind_user_about_email = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool remind_user_about_emailSpecified
+    {
+      get { return _remind_user_about_email != null; }
+      set { if (value == (_remind_user_about_email== null)) _remind_user_about_email = value ? this.remind_user_about_email : (bool?)null; }
+    }
+    private bool ShouldSerializeremind_user_about_email() { return remind_user_about_emailSpecified; }
+    private void Resetremind_user_about_email() { remind_user_about_emailSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5741,50 +9793,95 @@ namespace SteamKit2.Internal
     public CMsgCREEnumeratePublishedFiles() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _query_type = default(int);
+    private int? _query_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"query_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int query_type
     {
-      get { return _query_type; }
+      get { return _query_type?? default(int); }
       set { _query_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_typeSpecified
+    {
+      get { return _query_type != null; }
+      set { if (value == (_query_type== null)) _query_type = value ? this.query_type : (int?)null; }
+    }
+    private bool ShouldSerializequery_type() { return query_typeSpecified; }
+    private void Resetquery_type() { query_typeSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
 
-    private uint _days = default(uint);
+    private uint? _days;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint days
     {
-      get { return _days; }
+      get { return _days?? default(uint); }
       set { _days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool daysSpecified
+    {
+      get { return _days != null; }
+      set { if (value == (_days== null)) _days = value ? this.days : (uint?)null; }
+    }
+    private bool ShouldSerializedays() { return daysSpecified; }
+    private void Resetdays() { daysSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(6, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -5800,14 +9897,23 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _matching_file_type = (uint)13;
+    private uint? _matching_file_type;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"matching_file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)13)]
     public uint matching_file_type
     {
-      get { return _matching_file_type; }
+      get { return _matching_file_type?? (uint)13; }
       set { _matching_file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_file_typeSpecified
+    {
+      get { return _matching_file_type != null; }
+      set { if (value == (_matching_file_type== null)) _matching_file_type = value ? this.matching_file_type : (uint?)null; }
+    }
+    private bool ShouldSerializematching_file_type() { return matching_file_typeSpecified; }
+    private void Resetmatching_file_type() { matching_file_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5819,14 +9925,23 @@ namespace SteamKit2.Internal
     public CMsgCREEnumeratePublishedFilesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgCREEnumeratePublishedFilesResponse.PublishedFileId> _published_files = new global::System.Collections.Generic.List<CMsgCREEnumeratePublishedFilesResponse.PublishedFileId>();
     [global::ProtoBuf.ProtoMember(2, Name=@"published_files", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgCREEnumeratePublishedFilesResponse.PublishedFileId> published_files
@@ -5835,64 +9950,118 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _total_results = default(uint);
+    private uint? _total_results;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(uint); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PublishedFileId")]
   public partial class PublishedFileId : global::ProtoBuf.IExtensible
   {
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private int _votes_for = default(int);
+    private int? _votes_for;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"votes_for", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int votes_for
     {
-      get { return _votes_for; }
+      get { return _votes_for?? default(int); }
       set { _votes_for = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_forSpecified
+    {
+      get { return _votes_for != null; }
+      set { if (value == (_votes_for== null)) _votes_for = value ? this.votes_for : (int?)null; }
+    }
+    private bool ShouldSerializevotes_for() { return votes_forSpecified; }
+    private void Resetvotes_for() { votes_forSpecified = false; }
+    
 
-    private int _votes_against = default(int);
+    private int? _votes_against;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"votes_against", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int votes_against
     {
-      get { return _votes_against; }
+      get { return _votes_against?? default(int); }
       set { _votes_against = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_againstSpecified
+    {
+      get { return _votes_against != null; }
+      set { if (value == (_votes_against== null)) _votes_against = value ? this.votes_against : (int?)null; }
+    }
+    private bool ShouldSerializevotes_against() { return votes_againstSpecified; }
+    private void Resetvotes_against() { votes_againstSpecified = false; }
+    
 
-    private int _reports = default(int);
+    private int? _reports;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reports", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int reports
     {
-      get { return _reports; }
+      get { return _reports?? default(int); }
       set { _reports = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reportsSpecified
+    {
+      get { return _reports != null; }
+      set { if (value == (_reports== null)) _reports = value ? this.reports : (int?)null; }
+    }
+    private bool ShouldSerializereports() { return reportsSpecified; }
+    private void Resetreports() { reportsSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5921,14 +10090,23 @@ namespace SteamKit2.Internal
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -5945,14 +10123,23 @@ namespace SteamKit2.Internal
     public CMsgCREItemVoteSummaryResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgCREItemVoteSummaryResponse.ItemVoteSummary> _item_vote_summaries = new global::System.Collections.Generic.List<CMsgCREItemVoteSummaryResponse.ItemVoteSummary>();
     [global::ProtoBuf.ProtoMember(2, Name=@"item_vote_summaries", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgCREItemVoteSummaryResponse.ItemVoteSummary> item_vote_summaries
@@ -5966,50 +10153,95 @@ namespace SteamKit2.Internal
     public ItemVoteSummary() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private int _votes_for = default(int);
+    private int? _votes_for;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"votes_for", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int votes_for
     {
-      get { return _votes_for; }
+      get { return _votes_for?? default(int); }
       set { _votes_for = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_forSpecified
+    {
+      get { return _votes_for != null; }
+      set { if (value == (_votes_for== null)) _votes_for = value ? this.votes_for : (int?)null; }
+    }
+    private bool ShouldSerializevotes_for() { return votes_forSpecified; }
+    private void Resetvotes_for() { votes_forSpecified = false; }
+    
 
-    private int _votes_against = default(int);
+    private int? _votes_against;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"votes_against", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int votes_against
     {
-      get { return _votes_against; }
+      get { return _votes_against?? default(int); }
       set { _votes_against = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_againstSpecified
+    {
+      get { return _votes_against != null; }
+      set { if (value == (_votes_against== null)) _votes_against = value ? this.votes_against : (int?)null; }
+    }
+    private bool ShouldSerializevotes_against() { return votes_againstSpecified; }
+    private void Resetvotes_against() { votes_againstSpecified = false; }
+    
 
-    private int _reports = default(int);
+    private int? _reports;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"reports", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int reports
     {
-      get { return _reports; }
+      get { return _reports?? default(int); }
       set { _reports = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool reportsSpecified
+    {
+      get { return _reports != null; }
+      set { if (value == (_reports== null)) _reports = value ? this.reports : (int?)null; }
+    }
+    private bool ShouldSerializereports() { return reportsSpecified; }
+    private void Resetreports() { reportsSpecified = false; }
+    
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6026,23 +10258,41 @@ namespace SteamKit2.Internal
     public CMsgCREUpdateUserPublishedItemVote() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private bool _vote_up = default(bool);
+    private bool? _vote_up;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote_up", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool vote_up
     {
-      get { return _vote_up; }
+      get { return _vote_up?? default(bool); }
       set { _vote_up = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vote_upSpecified
+    {
+      get { return _vote_up != null; }
+      set { if (value == (_vote_up== null)) _vote_up = value ? this.vote_up : (bool?)null; }
+    }
+    private bool ShouldSerializevote_up() { return vote_upSpecified; }
+    private void Resetvote_up() { vote_upSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6054,14 +10304,23 @@ namespace SteamKit2.Internal
     public CMsgCREUpdateUserPublishedItemVoteResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6085,14 +10344,23 @@ namespace SteamKit2.Internal
     public PublishedFileId() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6109,14 +10377,23 @@ namespace SteamKit2.Internal
     public CMsgCREGetUserPublishedItemVoteDetailsResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgCREGetUserPublishedItemVoteDetailsResponse.UserItemVoteDetail> _user_item_vote_details = new global::System.Collections.Generic.List<CMsgCREGetUserPublishedItemVoteDetailsResponse.UserItemVoteDetail>();
     [global::ProtoBuf.ProtoMember(2, Name=@"user_item_vote_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgCREGetUserPublishedItemVoteDetailsResponse.UserItemVoteDetail> user_item_vote_details
@@ -6130,23 +10407,41 @@ namespace SteamKit2.Internal
     public UserItemVoteDetail() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private int _vote = (int)0;
+    private int? _vote;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vote", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int vote
     {
-      get { return _vote; }
+      get { return _vote?? (int)0; }
       set { _vote = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool voteSpecified
+    {
+      get { return _vote != null; }
+      set { if (value == (_vote== null)) _vote = value ? this.vote : (int?)null; }
+    }
+    private bool ShouldSerializevote() { return voteSpecified; }
+    private void Resetvote() { voteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6163,23 +10458,41 @@ namespace SteamKit2.Internal
     public CMsgGameServerPingSample() {}
     
 
-    private uint _my_ip = default(uint);
+    private uint? _my_ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"my_ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint my_ip
     {
-      get { return _my_ip; }
+      get { return _my_ip?? default(uint); }
       set { _my_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool my_ipSpecified
+    {
+      get { return _my_ip != null; }
+      set { if (value == (_my_ip== null)) _my_ip = value ? this.my_ip : (uint?)null; }
+    }
+    private bool ShouldSerializemy_ip() { return my_ipSpecified; }
+    private void Resetmy_ip() { my_ipSpecified = false; }
+    
 
-    private int _gs_app_id = default(int);
+    private int? _gs_app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gs_app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int gs_app_id
     {
-      get { return _gs_app_id; }
+      get { return _gs_app_id?? default(int); }
       set { _gs_app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gs_app_idSpecified
+    {
+      get { return _gs_app_id != null; }
+      set { if (value == (_gs_app_id== null)) _gs_app_id = value ? this.gs_app_id : (int?)null; }
+    }
+    private bool ShouldSerializegs_app_id() { return gs_app_idSpecified; }
+    private void Resetgs_app_id() { gs_app_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgGameServerPingSample.Sample> _gs_samples = new global::System.Collections.Generic.List<CMsgGameServerPingSample.Sample>();
     [global::ProtoBuf.ProtoMember(3, Name=@"gs_samples", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgGameServerPingSample.Sample> gs_samples
@@ -6193,32 +10506,59 @@ namespace SteamKit2.Internal
     public Sample() {}
     
 
-    private uint _ip = default(uint);
+    private uint? _ip;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ip", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ip
     {
-      get { return _ip; }
+      get { return _ip?? default(uint); }
       set { _ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipSpecified
+    {
+      get { return _ip != null; }
+      set { if (value == (_ip== null)) _ip = value ? this.ip : (uint?)null; }
+    }
+    private bool ShouldSerializeip() { return ipSpecified; }
+    private void Resetip() { ipSpecified = false; }
+    
 
-    private uint _avg_ping_ms = default(uint);
+    private uint? _avg_ping_ms;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"avg_ping_ms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint avg_ping_ms
     {
-      get { return _avg_ping_ms; }
+      get { return _avg_ping_ms?? default(uint); }
       set { _avg_ping_ms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool avg_ping_msSpecified
+    {
+      get { return _avg_ping_ms != null; }
+      set { if (value == (_avg_ping_ms== null)) _avg_ping_ms = value ? this.avg_ping_ms : (uint?)null; }
+    }
+    private bool ShouldSerializeavg_ping_ms() { return avg_ping_msSpecified; }
+    private void Resetavg_ping_ms() { avg_ping_msSpecified = false; }
+    
 
-    private uint _stddev_ping_ms_x10 = default(uint);
+    private uint? _stddev_ping_ms_x10;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"stddev_ping_ms_x10", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint stddev_ping_ms_x10
     {
-      get { return _stddev_ping_ms_x10; }
+      get { return _stddev_ping_ms_x10?? default(uint); }
       set { _stddev_ping_ms_x10 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stddev_ping_ms_x10Specified
+    {
+      get { return _stddev_ping_ms_x10 != null; }
+      set { if (value == (_stddev_ping_ms_x10== null)) _stddev_ping_ms_x10 = value ? this.stddev_ping_ms_x10 : (uint?)null; }
+    }
+    private bool ShouldSerializestddev_ping_ms_x10() { return stddev_ping_ms_x10Specified; }
+    private void Resetstddev_ping_ms_x10() { stddev_ping_ms_x10Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6235,14 +10575,23 @@ namespace SteamKit2.Internal
     public CMsgFSGetFollowerCount() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6254,23 +10603,41 @@ namespace SteamKit2.Internal
     public CMsgFSGetFollowerCountResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _count = (int)0;
+    private int? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int count
     {
-      get { return _count; }
+      get { return _count?? (int)0; }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (int?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6282,14 +10649,23 @@ namespace SteamKit2.Internal
     public CMsgFSGetIsFollowing() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6301,23 +10677,41 @@ namespace SteamKit2.Internal
     public CMsgFSGetIsFollowingResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private bool _is_following = (bool)false;
+    private bool? _is_following;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_following", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool is_following
     {
-      get { return _is_following; }
+      get { return _is_following?? (bool)false; }
       set { _is_following = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_followingSpecified
+    {
+      get { return _is_following != null; }
+      set { if (value == (_is_following== null)) _is_following = value ? this.is_following : (bool?)null; }
+    }
+    private bool ShouldSerializeis_following() { return is_followingSpecified; }
+    private void Resetis_following() { is_followingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6329,14 +10723,23 @@ namespace SteamKit2.Internal
     public CMsgFSEnumerateFollowingList() {}
     
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6348,23 +10751,41 @@ namespace SteamKit2.Internal
     public CMsgFSEnumerateFollowingListResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _total_results = default(int);
+    private int? _total_results;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_results", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int total_results
     {
-      get { return _total_results; }
+      get { return _total_results?? default(int); }
       set { _total_results = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_resultsSpecified
+    {
+      get { return _total_results != null; }
+      set { if (value == (_total_results== null)) _total_results = value ? this.total_results : (int?)null; }
+    }
+    private bool ShouldSerializetotal_results() { return total_resultsSpecified; }
+    private void Resettotal_results() { total_resultsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steam_ids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"steam_ids", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steam_ids
@@ -6383,14 +10804,23 @@ namespace SteamKit2.Internal
     public CMsgDPGetNumberOfCurrentPlayers() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6402,23 +10832,41 @@ namespace SteamKit2.Internal
     public CMsgDPGetNumberOfCurrentPlayersResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _player_count = default(int);
+    private int? _player_count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"player_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int player_count
     {
-      get { return _player_count; }
+      get { return _player_count?? default(int); }
       set { _player_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_countSpecified
+    {
+      get { return _player_count != null; }
+      set { if (value == (_player_count== null)) _player_count = value ? this.player_count : (int?)null; }
+    }
+    private bool ShouldSerializeplayer_count() { return player_countSpecified; }
+    private void Resetplayer_count() { player_countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6430,32 +10878,59 @@ namespace SteamKit2.Internal
     public CMsgClientFriendUserStatusPublished() {}
     
 
-    private ulong _friend_steamid = default(ulong);
+    private ulong? _friend_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"friend_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong friend_steamid
     {
-      get { return _friend_steamid; }
+      get { return _friend_steamid?? default(ulong); }
       set { _friend_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool friend_steamidSpecified
+    {
+      get { return _friend_steamid != null; }
+      set { if (value == (_friend_steamid== null)) _friend_steamid = value ? this.friend_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializefriend_steamid() { return friend_steamidSpecified; }
+    private void Resetfriend_steamid() { friend_steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _status_text = "";
+    private string _status_text;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"status_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string status_text
     {
-      get { return _status_text; }
+      get { return _status_text?? ""; }
       set { _status_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool status_textSpecified
+    {
+      get { return _status_text != null; }
+      set { if (value == (_status_text== null)) _status_text = value ? this.status_text : (string)null; }
+    }
+    private bool ShouldSerializestatus_text() { return status_textSpecified; }
+    private void Resetstatus_text() { status_textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6467,32 +10942,59 @@ namespace SteamKit2.Internal
     public CMsgClientServiceMethod() {}
     
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
-    private byte[] _serialized_method = null;
+    private byte[] _serialized_method;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"serialized_method", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_method
     {
-      get { return _serialized_method; }
+      get { return _serialized_method?? null; }
       set { _serialized_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_methodSpecified
+    {
+      get { return _serialized_method != null; }
+      set { if (value == (_serialized_method== null)) _serialized_method = value ? this.serialized_method : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_method() { return serialized_methodSpecified; }
+    private void Resetserialized_method() { serialized_methodSpecified = false; }
+    
 
-    private bool _is_notification = default(bool);
+    private bool? _is_notification;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_notification", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_notification
     {
-      get { return _is_notification; }
+      get { return _is_notification?? default(bool); }
       set { _is_notification = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_notificationSpecified
+    {
+      get { return _is_notification != null; }
+      set { if (value == (_is_notification== null)) _is_notification = value ? this.is_notification : (bool?)null; }
+    }
+    private bool ShouldSerializeis_notification() { return is_notificationSpecified; }
+    private void Resetis_notification() { is_notificationSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6504,23 +11006,41 @@ namespace SteamKit2.Internal
     public CMsgClientServiceMethodResponse() {}
     
 
-    private string _method_name = "";
+    private string _method_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"method_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string method_name
     {
-      get { return _method_name; }
+      get { return _method_name?? ""; }
       set { _method_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool method_nameSpecified
+    {
+      get { return _method_name != null; }
+      set { if (value == (_method_name== null)) _method_name = value ? this.method_name : (string)null; }
+    }
+    private bool ShouldSerializemethod_name() { return method_nameSpecified; }
+    private void Resetmethod_name() { method_nameSpecified = false; }
+    
 
-    private byte[] _serialized_method_response = null;
+    private byte[] _serialized_method_response;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"serialized_method_response", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_method_response
     {
-      get { return _serialized_method_response; }
+      get { return _serialized_method_response?? null; }
       set { _serialized_method_response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_method_responseSpecified
+    {
+      get { return _serialized_method_response != null; }
+      set { if (value == (_serialized_method_response== null)) _serialized_method_response = value ? this.serialized_method_response : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_method_response() { return serialized_method_responseSpecified; }
+    private void Resetserialized_method_response() { serialized_method_responseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6532,14 +11052,23 @@ namespace SteamKit2.Internal
     public CMsgClientUIMode() {}
     
 
-    private uint _uimode = default(uint);
+    private uint? _uimode;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"uimode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint uimode
     {
-      get { return _uimode; }
+      get { return _uimode?? default(uint); }
       set { _uimode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool uimodeSpecified
+    {
+      get { return _uimode != null; }
+      set { if (value == (_uimode== null)) _uimode = value ? this.uimode : (uint?)null; }
+    }
+    private bool ShouldSerializeuimode() { return uimodeSpecified; }
+    private void Resetuimode() { uimodeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6551,14 +11080,23 @@ namespace SteamKit2.Internal
     public CMsgClientVanityURLChangedNotification() {}
     
 
-    private string _vanity_url = "";
+    private string _vanity_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"vanity_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vanity_url
     {
-      get { return _vanity_url; }
+      get { return _vanity_url?? ""; }
       set { _vanity_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vanity_urlSpecified
+    {
+      get { return _vanity_url != null; }
+      set { if (value == (_vanity_url== null)) _vanity_url = value ? this.vanity_url : (string)null; }
+    }
+    private bool ShouldSerializevanity_url() { return vanity_urlSpecified; }
+    private void Resetvanity_url() { vanity_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6570,23 +11108,41 @@ namespace SteamKit2.Internal
     public CMsgClientAuthorizeLocalDeviceRequest() {}
     
 
-    private string _device_description = "";
+    private string _device_description;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"device_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_description
     {
-      get { return _device_description; }
+      get { return _device_description?? ""; }
       set { _device_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_descriptionSpecified
+    {
+      get { return _device_description != null; }
+      set { if (value == (_device_description== null)) _device_description = value ? this.device_description : (string)null; }
+    }
+    private bool ShouldSerializedevice_description() { return device_descriptionSpecified; }
+    private void Resetdevice_description() { device_descriptionSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6598,32 +11154,59 @@ namespace SteamKit2.Internal
     public CMsgClientAuthorizeLocalDevice() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private ulong _authed_device_token = default(ulong);
+    private ulong? _authed_device_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"authed_device_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong authed_device_token
     {
-      get { return _authed_device_token; }
+      get { return _authed_device_token?? default(ulong); }
       set { _authed_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authed_device_tokenSpecified
+    {
+      get { return _authed_device_token != null; }
+      set { if (value == (_authed_device_token== null)) _authed_device_token = value ? this.authed_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauthed_device_token() { return authed_device_tokenSpecified; }
+    private void Resetauthed_device_token() { authed_device_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6635,23 +11218,41 @@ namespace SteamKit2.Internal
     public CMsgClientDeauthorizeDeviceRequest() {}
     
 
-    private uint _deauthorization_account_id = default(uint);
+    private uint? _deauthorization_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"deauthorization_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deauthorization_account_id
     {
-      get { return _deauthorization_account_id; }
+      get { return _deauthorization_account_id?? default(uint); }
       set { _deauthorization_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deauthorization_account_idSpecified
+    {
+      get { return _deauthorization_account_id != null; }
+      set { if (value == (_deauthorization_account_id== null)) _deauthorization_account_id = value ? this.deauthorization_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializedeauthorization_account_id() { return deauthorization_account_idSpecified; }
+    private void Resetdeauthorization_account_id() { deauthorization_account_idSpecified = false; }
+    
 
-    private ulong _deauthorization_device_token = default(ulong);
+    private ulong? _deauthorization_device_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"deauthorization_device_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong deauthorization_device_token
     {
-      get { return _deauthorization_device_token; }
+      get { return _deauthorization_device_token?? default(ulong); }
       set { _deauthorization_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deauthorization_device_tokenSpecified
+    {
+      get { return _deauthorization_device_token != null; }
+      set { if (value == (_deauthorization_device_token== null)) _deauthorization_device_token = value ? this.deauthorization_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializedeauthorization_device_token() { return deauthorization_device_tokenSpecified; }
+    private void Resetdeauthorization_device_token() { deauthorization_device_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6663,23 +11264,41 @@ namespace SteamKit2.Internal
     public CMsgClientDeauthorizeDevice() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private uint _deauthorization_account_id = default(uint);
+    private uint? _deauthorization_account_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"deauthorization_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deauthorization_account_id
     {
-      get { return _deauthorization_account_id; }
+      get { return _deauthorization_account_id?? default(uint); }
       set { _deauthorization_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deauthorization_account_idSpecified
+    {
+      get { return _deauthorization_account_id != null; }
+      set { if (value == (_deauthorization_account_id== null)) _deauthorization_account_id = value ? this.deauthorization_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializedeauthorization_account_id() { return deauthorization_account_idSpecified; }
+    private void Resetdeauthorization_account_id() { deauthorization_account_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6710,23 +11329,41 @@ namespace SteamKit2.Internal
     public DeviceToken() {}
     
 
-    private uint _owner_account_id = default(uint);
+    private uint? _owner_account_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_account_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_account_id
     {
-      get { return _owner_account_id; }
+      get { return _owner_account_id?? default(uint); }
       set { _owner_account_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_account_idSpecified
+    {
+      get { return _owner_account_id != null; }
+      set { if (value == (_owner_account_id== null)) _owner_account_id = value ? this.owner_account_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_account_id() { return owner_account_idSpecified; }
+    private void Resetowner_account_id() { owner_account_idSpecified = false; }
+    
 
-    private ulong _token_id = default(ulong);
+    private ulong? _token_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"token_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong token_id
     {
-      get { return _token_id; }
+      get { return _token_id?? default(ulong); }
       set { _token_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_idSpecified
+    {
+      get { return _token_id != null; }
+      set { if (value == (_token_id== null)) _token_id = value ? this.token_id : (ulong?)null; }
+    }
+    private bool ShouldSerializetoken_id() { return token_idSpecified; }
+    private void Resettoken_id() { token_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6753,14 +11390,23 @@ namespace SteamKit2.Internal
     public CMsgClientGetAuthorizedDevicesResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientGetAuthorizedDevicesResponse.AuthorizedDevice> _authorized_device = new global::System.Collections.Generic.List<CMsgClientGetAuthorizedDevicesResponse.AuthorizedDevice>();
     [global::ProtoBuf.ProtoMember(2, Name=@"authorized_device", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientGetAuthorizedDevicesResponse.AuthorizedDevice> authorized_device
@@ -6774,59 +11420,113 @@ namespace SteamKit2.Internal
     public AuthorizedDevice() {}
     
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
 
-    private string _device_name = "";
+    private string _device_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"device_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_name
     {
-      get { return _device_name; }
+      get { return _device_name?? ""; }
       set { _device_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_nameSpecified
+    {
+      get { return _device_name != null; }
+      set { if (value == (_device_name== null)) _device_name = value ? this.device_name : (string)null; }
+    }
+    private bool ShouldSerializedevice_name() { return device_nameSpecified; }
+    private void Resetdevice_name() { device_nameSpecified = false; }
+    
 
-    private uint _last_access_time = default(uint);
+    private uint? _last_access_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"last_access_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_access_time
     {
-      get { return _last_access_time; }
+      get { return _last_access_time?? default(uint); }
       set { _last_access_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_access_timeSpecified
+    {
+      get { return _last_access_time != null; }
+      set { if (value == (_last_access_time== null)) _last_access_time = value ? this.last_access_time : (uint?)null; }
+    }
+    private bool ShouldSerializelast_access_time() { return last_access_timeSpecified; }
+    private void Resetlast_access_time() { last_access_timeSpecified = false; }
+    
 
-    private uint _borrower_id = default(uint);
+    private uint? _borrower_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"borrower_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint borrower_id
     {
-      get { return _borrower_id; }
+      get { return _borrower_id?? default(uint); }
       set { _borrower_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool borrower_idSpecified
+    {
+      get { return _borrower_id != null; }
+      set { if (value == (_borrower_id== null)) _borrower_id = value ? this.borrower_id : (uint?)null; }
+    }
+    private bool ShouldSerializeborrower_id() { return borrower_idSpecified; }
+    private void Resetborrower_id() { borrower_idSpecified = false; }
+    
 
-    private bool _is_pending = default(bool);
+    private bool? _is_pending;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_pending", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pending
     {
-      get { return _is_pending; }
+      get { return _is_pending?? default(bool); }
       set { _is_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_pendingSpecified
+    {
+      get { return _is_pending != null; }
+      set { if (value == (_is_pending== null)) _is_pending = value ? this.is_pending : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pending() { return is_pendingSpecified; }
+    private void Resetis_pending() { is_pendingSpecified = false; }
+    
 
-    private uint _app_played = default(uint);
+    private uint? _app_played;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"app_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_played
     {
-      get { return _app_played; }
+      get { return _app_played?? default(uint); }
       set { _app_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_playedSpecified
+    {
+      get { return _app_played != null; }
+      set { if (value == (_app_played== null)) _app_played = value ? this.app_played : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_played() { return app_playedSpecified; }
+    private void Resetapp_played() { app_playedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6865,23 +11565,41 @@ namespace SteamKit2.Internal
     public Emoticon() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private int _count = default(int);
+    private int? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int count
     {
-      get { return _count; }
+      get { return _count?? default(int); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (int?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6905,37 +11623,64 @@ namespace SteamKit2.Internal
     }
   
 
-    private uint _own_library_locked_by = default(uint);
+    private uint? _own_library_locked_by;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"own_library_locked_by", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint own_library_locked_by
     {
-      get { return _own_library_locked_by; }
+      get { return _own_library_locked_by?? default(uint); }
       set { _own_library_locked_by = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool own_library_locked_bySpecified
+    {
+      get { return _own_library_locked_by != null; }
+      set { if (value == (_own_library_locked_by== null)) _own_library_locked_by = value ? this.own_library_locked_by : (uint?)null; }
+    }
+    private bool ShouldSerializeown_library_locked_by() { return own_library_locked_bySpecified; }
+    private void Resetown_library_locked_by() { own_library_locked_bySpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"LockedLibrary")]
   public partial class LockedLibrary : global::ProtoBuf.IExtensible
   {
     public LockedLibrary() {}
     
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
 
-    private uint _locked_by = default(uint);
+    private uint? _locked_by;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"locked_by", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint locked_by
     {
-      get { return _locked_by; }
+      get { return _locked_by?? default(uint); }
       set { _locked_by = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool locked_bySpecified
+    {
+      get { return _locked_by != null; }
+      set { if (value == (_locked_by== null)) _locked_by = value ? this.locked_by : (uint?)null; }
+    }
+    private bool ShouldSerializelocked_by() { return locked_bySpecified; }
+    private void Resetlocked_by() { locked_bySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -6952,14 +11697,23 @@ namespace SteamKit2.Internal
     public CMsgClientSharedLibraryStopPlaying() {}
     
 
-    private int _seconds_left = default(int);
+    private int? _seconds_left;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"seconds_left", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int seconds_left
     {
-      get { return _seconds_left; }
+      get { return _seconds_left?? default(int); }
       set { _seconds_left = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_leftSpecified
+    {
+      get { return _seconds_left != null; }
+      set { if (value == (_seconds_left== null)) _seconds_left = value ? this.seconds_left : (int?)null; }
+    }
+    private bool ShouldSerializeseconds_left() { return seconds_leftSpecified; }
+    private void Resetseconds_left() { seconds_leftSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CMsgClientSharedLibraryStopPlaying.StopApp> _stop_apps = new global::System.Collections.Generic.List<CMsgClientSharedLibraryStopPlaying.StopApp>();
     [global::ProtoBuf.ProtoMember(2, Name=@"stop_apps", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CMsgClientSharedLibraryStopPlaying.StopApp> stop_apps
@@ -6973,23 +11727,41 @@ namespace SteamKit2.Internal
     public StopApp() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _owner_id = default(uint);
+    private uint? _owner_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"owner_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint owner_id
     {
-      get { return _owner_id; }
+      get { return _owner_id?? default(uint); }
       set { _owner_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_idSpecified
+    {
+      get { return _owner_id != null; }
+      set { if (value == (_owner_id== null)) _owner_id = value ? this.owner_id : (uint?)null; }
+    }
+    private bool ShouldSerializeowner_id() { return owner_idSpecified; }
+    private void Resetowner_id() { owner_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7006,95 +11778,185 @@ namespace SteamKit2.Internal
     public CMsgClientServiceCall() {}
     
 
-    private byte[] _sysid_routing = null;
+    private byte[] _sysid_routing;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sysid_routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sysid_routing
     {
-      get { return _sysid_routing; }
+      get { return _sysid_routing?? null; }
       set { _sysid_routing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sysid_routingSpecified
+    {
+      get { return _sysid_routing != null; }
+      set { if (value == (_sysid_routing== null)) _sysid_routing = value ? this.sysid_routing : (byte[])null; }
+    }
+    private bool ShouldSerializesysid_routing() { return sysid_routingSpecified; }
+    private void Resetsysid_routing() { sysid_routingSpecified = false; }
+    
 
-    private uint _call_handle = default(uint);
+    private uint? _call_handle;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"call_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint call_handle
     {
-      get { return _call_handle; }
+      get { return _call_handle?? default(uint); }
       set { _call_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool call_handleSpecified
+    {
+      get { return _call_handle != null; }
+      set { if (value == (_call_handle== null)) _call_handle = value ? this.call_handle : (uint?)null; }
+    }
+    private bool ShouldSerializecall_handle() { return call_handleSpecified; }
+    private void Resetcall_handle() { call_handleSpecified = false; }
+    
 
-    private uint _module_crc = default(uint);
+    private uint? _module_crc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"module_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint module_crc
     {
-      get { return _module_crc; }
+      get { return _module_crc?? default(uint); }
       set { _module_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_crcSpecified
+    {
+      get { return _module_crc != null; }
+      set { if (value == (_module_crc== null)) _module_crc = value ? this.module_crc : (uint?)null; }
+    }
+    private bool ShouldSerializemodule_crc() { return module_crcSpecified; }
+    private void Resetmodule_crc() { module_crcSpecified = false; }
+    
 
-    private byte[] _module_hash = null;
+    private byte[] _module_hash;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"module_hash", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] module_hash
     {
-      get { return _module_hash; }
+      get { return _module_hash?? null; }
       set { _module_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_hashSpecified
+    {
+      get { return _module_hash != null; }
+      set { if (value == (_module_hash== null)) _module_hash = value ? this.module_hash : (byte[])null; }
+    }
+    private bool ShouldSerializemodule_hash() { return module_hashSpecified; }
+    private void Resetmodule_hash() { module_hashSpecified = false; }
+    
 
-    private uint _function_id = default(uint);
+    private uint? _function_id;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"function_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint function_id
     {
-      get { return _function_id; }
+      get { return _function_id?? default(uint); }
       set { _function_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool function_idSpecified
+    {
+      get { return _function_id != null; }
+      set { if (value == (_function_id== null)) _function_id = value ? this.function_id : (uint?)null; }
+    }
+    private bool ShouldSerializefunction_id() { return function_idSpecified; }
+    private void Resetfunction_id() { function_idSpecified = false; }
+    
 
-    private uint _cub_output_max = default(uint);
+    private uint? _cub_output_max;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"cub_output_max", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cub_output_max
     {
-      get { return _cub_output_max; }
+      get { return _cub_output_max?? default(uint); }
       set { _cub_output_max = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cub_output_maxSpecified
+    {
+      get { return _cub_output_max != null; }
+      set { if (value == (_cub_output_max== null)) _cub_output_max = value ? this.cub_output_max : (uint?)null; }
+    }
+    private bool ShouldSerializecub_output_max() { return cub_output_maxSpecified; }
+    private void Resetcub_output_max() { cub_output_maxSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private byte[] _callparameter = null;
+    private byte[] _callparameter;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"callparameter", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] callparameter
     {
-      get { return _callparameter; }
+      get { return _callparameter?? null; }
       set { _callparameter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool callparameterSpecified
+    {
+      get { return _callparameter != null; }
+      set { if (value == (_callparameter== null)) _callparameter = value ? this.callparameter : (byte[])null; }
+    }
+    private bool ShouldSerializecallparameter() { return callparameterSpecified; }
+    private void Resetcallparameter() { callparameterSpecified = false; }
+    
 
-    private bool _ping_only = default(bool);
+    private bool? _ping_only;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"ping_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ping_only
     {
-      get { return _ping_only; }
+      get { return _ping_only?? default(bool); }
       set { _ping_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ping_onlySpecified
+    {
+      get { return _ping_only != null; }
+      set { if (value == (_ping_only== null)) _ping_only = value ? this.ping_only : (bool?)null; }
+    }
+    private bool ShouldSerializeping_only() { return ping_onlySpecified; }
+    private void Resetping_only() { ping_onlySpecified = false; }
+    
 
-    private uint _max_outstanding_calls = default(uint);
+    private uint? _max_outstanding_calls;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"max_outstanding_calls", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint max_outstanding_calls
     {
-      get { return _max_outstanding_calls; }
+      get { return _max_outstanding_calls?? default(uint); }
       set { _max_outstanding_calls = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_outstanding_callsSpecified
+    {
+      get { return _max_outstanding_calls != null; }
+      set { if (value == (_max_outstanding_calls== null)) _max_outstanding_calls = value ? this.max_outstanding_calls : (uint?)null; }
+    }
+    private bool ShouldSerializemax_outstanding_calls() { return max_outstanding_callsSpecified; }
+    private void Resetmax_outstanding_calls() { max_outstanding_callsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7106,32 +11968,59 @@ namespace SteamKit2.Internal
     public CMsgClientServiceModule() {}
     
 
-    private uint _module_crc = default(uint);
+    private uint? _module_crc;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"module_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint module_crc
     {
-      get { return _module_crc; }
+      get { return _module_crc?? default(uint); }
       set { _module_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_crcSpecified
+    {
+      get { return _module_crc != null; }
+      set { if (value == (_module_crc== null)) _module_crc = value ? this.module_crc : (uint?)null; }
+    }
+    private bool ShouldSerializemodule_crc() { return module_crcSpecified; }
+    private void Resetmodule_crc() { module_crcSpecified = false; }
+    
 
-    private byte[] _module_hash = null;
+    private byte[] _module_hash;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"module_hash", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] module_hash
     {
-      get { return _module_hash; }
+      get { return _module_hash?? null; }
       set { _module_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_hashSpecified
+    {
+      get { return _module_hash != null; }
+      set { if (value == (_module_hash== null)) _module_hash = value ? this.module_hash : (byte[])null; }
+    }
+    private bool ShouldSerializemodule_hash() { return module_hashSpecified; }
+    private void Resetmodule_hash() { module_hashSpecified = false; }
+    
 
-    private byte[] _module_content = null;
+    private byte[] _module_content;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"module_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] module_content
     {
-      get { return _module_content; }
+      get { return _module_content?? null; }
       set { _module_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_contentSpecified
+    {
+      get { return _module_content != null; }
+      set { if (value == (_module_content== null)) _module_content = value ? this.module_content : (byte[])null; }
+    }
+    private bool ShouldSerializemodule_content() { return module_contentSpecified; }
+    private void Resetmodule_content() { module_contentSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7143,194 +12032,383 @@ namespace SteamKit2.Internal
     public CMsgClientServiceCallResponse() {}
     
 
-    private byte[] _sysid_routing = null;
+    private byte[] _sysid_routing;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sysid_routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sysid_routing
     {
-      get { return _sysid_routing; }
+      get { return _sysid_routing?? null; }
       set { _sysid_routing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sysid_routingSpecified
+    {
+      get { return _sysid_routing != null; }
+      set { if (value == (_sysid_routing== null)) _sysid_routing = value ? this.sysid_routing : (byte[])null; }
+    }
+    private bool ShouldSerializesysid_routing() { return sysid_routingSpecified; }
+    private void Resetsysid_routing() { sysid_routingSpecified = false; }
+    
 
-    private uint _call_handle = default(uint);
+    private uint? _call_handle;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"call_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint call_handle
     {
-      get { return _call_handle; }
+      get { return _call_handle?? default(uint); }
       set { _call_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool call_handleSpecified
+    {
+      get { return _call_handle != null; }
+      set { if (value == (_call_handle== null)) _call_handle = value ? this.call_handle : (uint?)null; }
+    }
+    private bool ShouldSerializecall_handle() { return call_handleSpecified; }
+    private void Resetcall_handle() { call_handleSpecified = false; }
+    
 
-    private uint _module_crc = default(uint);
+    private uint? _module_crc;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"module_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint module_crc
     {
-      get { return _module_crc; }
+      get { return _module_crc?? default(uint); }
       set { _module_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_crcSpecified
+    {
+      get { return _module_crc != null; }
+      set { if (value == (_module_crc== null)) _module_crc = value ? this.module_crc : (uint?)null; }
+    }
+    private bool ShouldSerializemodule_crc() { return module_crcSpecified; }
+    private void Resetmodule_crc() { module_crcSpecified = false; }
+    
 
-    private byte[] _module_hash = null;
+    private byte[] _module_hash;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"module_hash", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] module_hash
     {
-      get { return _module_hash; }
+      get { return _module_hash?? null; }
       set { _module_hash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool module_hashSpecified
+    {
+      get { return _module_hash != null; }
+      set { if (value == (_module_hash== null)) _module_hash = value ? this.module_hash : (byte[])null; }
+    }
+    private bool ShouldSerializemodule_hash() { return module_hashSpecified; }
+    private void Resetmodule_hash() { module_hashSpecified = false; }
+    
 
-    private uint _ecallresult = default(uint);
+    private uint? _ecallresult;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ecallresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ecallresult
     {
-      get { return _ecallresult; }
+      get { return _ecallresult?? default(uint); }
       set { _ecallresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ecallresultSpecified
+    {
+      get { return _ecallresult != null; }
+      set { if (value == (_ecallresult== null)) _ecallresult = value ? this.ecallresult : (uint?)null; }
+    }
+    private bool ShouldSerializeecallresult() { return ecallresultSpecified; }
+    private void Resetecallresult() { ecallresultSpecified = false; }
+    
 
-    private byte[] _result_content = null;
+    private byte[] _result_content;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"result_content", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] result_content
     {
-      get { return _result_content; }
+      get { return _result_content?? null; }
       set { _result_content = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool result_contentSpecified
+    {
+      get { return _result_content != null; }
+      set { if (value == (_result_content== null)) _result_content = value ? this.result_content : (byte[])null; }
+    }
+    private bool ShouldSerializeresult_content() { return result_contentSpecified; }
+    private void Resetresult_content() { result_contentSpecified = false; }
+    
 
-    private byte[] _os_version_info = null;
+    private byte[] _os_version_info;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"os_version_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] os_version_info
     {
-      get { return _os_version_info; }
+      get { return _os_version_info?? null; }
       set { _os_version_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_version_infoSpecified
+    {
+      get { return _os_version_info != null; }
+      set { if (value == (_os_version_info== null)) _os_version_info = value ? this.os_version_info : (byte[])null; }
+    }
+    private bool ShouldSerializeos_version_info() { return os_version_infoSpecified; }
+    private void Resetos_version_info() { os_version_infoSpecified = false; }
+    
 
-    private byte[] _system_info = null;
+    private byte[] _system_info;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"system_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] system_info
     {
-      get { return _system_info; }
+      get { return _system_info?? null; }
       set { _system_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool system_infoSpecified
+    {
+      get { return _system_info != null; }
+      set { if (value == (_system_info== null)) _system_info = value ? this.system_info : (byte[])null; }
+    }
+    private bool ShouldSerializesystem_info() { return system_infoSpecified; }
+    private void Resetsystem_info() { system_infoSpecified = false; }
+    
 
-    private ulong _load_address = default(ulong);
+    private ulong? _load_address;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"load_address", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong load_address
     {
-      get { return _load_address; }
+      get { return _load_address?? default(ulong); }
       set { _load_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool load_addressSpecified
+    {
+      get { return _load_address != null; }
+      set { if (value == (_load_address== null)) _load_address = value ? this.load_address : (ulong?)null; }
+    }
+    private bool ShouldSerializeload_address() { return load_addressSpecified; }
+    private void Resetload_address() { load_addressSpecified = false; }
+    
 
-    private byte[] _exception_record = null;
+    private byte[] _exception_record;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"exception_record", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] exception_record
     {
-      get { return _exception_record; }
+      get { return _exception_record?? null; }
       set { _exception_record = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool exception_recordSpecified
+    {
+      get { return _exception_record != null; }
+      set { if (value == (_exception_record== null)) _exception_record = value ? this.exception_record : (byte[])null; }
+    }
+    private bool ShouldSerializeexception_record() { return exception_recordSpecified; }
+    private void Resetexception_record() { exception_recordSpecified = false; }
+    
 
-    private byte[] _portable_os_version_info = null;
+    private byte[] _portable_os_version_info;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"portable_os_version_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] portable_os_version_info
     {
-      get { return _portable_os_version_info; }
+      get { return _portable_os_version_info?? null; }
       set { _portable_os_version_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool portable_os_version_infoSpecified
+    {
+      get { return _portable_os_version_info != null; }
+      set { if (value == (_portable_os_version_info== null)) _portable_os_version_info = value ? this.portable_os_version_info : (byte[])null; }
+    }
+    private bool ShouldSerializeportable_os_version_info() { return portable_os_version_infoSpecified; }
+    private void Resetportable_os_version_info() { portable_os_version_infoSpecified = false; }
+    
 
-    private byte[] _portable_system_info = null;
+    private byte[] _portable_system_info;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"portable_system_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] portable_system_info
     {
-      get { return _portable_system_info; }
+      get { return _portable_system_info?? null; }
       set { _portable_system_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool portable_system_infoSpecified
+    {
+      get { return _portable_system_info != null; }
+      set { if (value == (_portable_system_info== null)) _portable_system_info = value ? this.portable_system_info : (byte[])null; }
+    }
+    private bool ShouldSerializeportable_system_info() { return portable_system_infoSpecified; }
+    private void Resetportable_system_info() { portable_system_infoSpecified = false; }
+    
 
-    private bool _was_converted = default(bool);
+    private bool? _was_converted;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"was_converted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_converted
     {
-      get { return _was_converted; }
+      get { return _was_converted?? default(bool); }
       set { _was_converted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_convertedSpecified
+    {
+      get { return _was_converted != null; }
+      set { if (value == (_was_converted== null)) _was_converted = value ? this.was_converted : (bool?)null; }
+    }
+    private bool ShouldSerializewas_converted() { return was_convertedSpecified; }
+    private void Resetwas_converted() { was_convertedSpecified = false; }
+    
 
-    private uint _internal_result = default(uint);
+    private uint? _internal_result;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"internal_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint internal_result
     {
-      get { return _internal_result; }
+      get { return _internal_result?? default(uint); }
       set { _internal_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool internal_resultSpecified
+    {
+      get { return _internal_result != null; }
+      set { if (value == (_internal_result== null)) _internal_result = value ? this.internal_result : (uint?)null; }
+    }
+    private bool ShouldSerializeinternal_result() { return internal_resultSpecified; }
+    private void Resetinternal_result() { internal_resultSpecified = false; }
+    
 
-    private uint _current_count = default(uint);
+    private uint? _current_count;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"current_count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint current_count
     {
-      get { return _current_count; }
+      get { return _current_count?? default(uint); }
       set { _current_count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool current_countSpecified
+    {
+      get { return _current_count != null; }
+      set { if (value == (_current_count== null)) _current_count = value ? this.current_count : (uint?)null; }
+    }
+    private bool ShouldSerializecurrent_count() { return current_countSpecified; }
+    private void Resetcurrent_count() { current_countSpecified = false; }
+    
 
-    private uint _last_call_handle = default(uint);
+    private uint? _last_call_handle;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"last_call_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_call_handle
     {
-      get { return _last_call_handle; }
+      get { return _last_call_handle?? default(uint); }
       set { _last_call_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_call_handleSpecified
+    {
+      get { return _last_call_handle != null; }
+      set { if (value == (_last_call_handle== null)) _last_call_handle = value ? this.last_call_handle : (uint?)null; }
+    }
+    private bool ShouldSerializelast_call_handle() { return last_call_handleSpecified; }
+    private void Resetlast_call_handle() { last_call_handleSpecified = false; }
+    
 
-    private uint _last_call_module_crc = default(uint);
+    private uint? _last_call_module_crc;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"last_call_module_crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_call_module_crc
     {
-      get { return _last_call_module_crc; }
+      get { return _last_call_module_crc?? default(uint); }
       set { _last_call_module_crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_call_module_crcSpecified
+    {
+      get { return _last_call_module_crc != null; }
+      set { if (value == (_last_call_module_crc== null)) _last_call_module_crc = value ? this.last_call_module_crc : (uint?)null; }
+    }
+    private bool ShouldSerializelast_call_module_crc() { return last_call_module_crcSpecified; }
+    private void Resetlast_call_module_crc() { last_call_module_crcSpecified = false; }
+    
 
-    private byte[] _last_call_sysid_routing = null;
+    private byte[] _last_call_sysid_routing;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"last_call_sysid_routing", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] last_call_sysid_routing
     {
-      get { return _last_call_sysid_routing; }
+      get { return _last_call_sysid_routing?? null; }
       set { _last_call_sysid_routing = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_call_sysid_routingSpecified
+    {
+      get { return _last_call_sysid_routing != null; }
+      set { if (value == (_last_call_sysid_routing== null)) _last_call_sysid_routing = value ? this.last_call_sysid_routing : (byte[])null; }
+    }
+    private bool ShouldSerializelast_call_sysid_routing() { return last_call_sysid_routingSpecified; }
+    private void Resetlast_call_sysid_routing() { last_call_sysid_routingSpecified = false; }
+    
 
-    private uint _last_ecallresult = default(uint);
+    private uint? _last_ecallresult;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"last_ecallresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_ecallresult
     {
-      get { return _last_ecallresult; }
+      get { return _last_ecallresult?? default(uint); }
       set { _last_ecallresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_ecallresultSpecified
+    {
+      get { return _last_ecallresult != null; }
+      set { if (value == (_last_ecallresult== null)) _last_ecallresult = value ? this.last_ecallresult : (uint?)null; }
+    }
+    private bool ShouldSerializelast_ecallresult() { return last_ecallresultSpecified; }
+    private void Resetlast_ecallresult() { last_ecallresultSpecified = false; }
+    
 
-    private uint _last_callissue_delta = default(uint);
+    private uint? _last_callissue_delta;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"last_callissue_delta", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_callissue_delta
     {
-      get { return _last_callissue_delta; }
+      get { return _last_callissue_delta?? default(uint); }
       set { _last_callissue_delta = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_callissue_deltaSpecified
+    {
+      get { return _last_callissue_delta != null; }
+      set { if (value == (_last_callissue_delta== null)) _last_callissue_delta = value ? this.last_callissue_delta : (uint?)null; }
+    }
+    private bool ShouldSerializelast_callissue_delta() { return last_callissue_deltaSpecified; }
+    private void Resetlast_callissue_delta() { last_callissue_deltaSpecified = false; }
+    
 
-    private uint _last_callcomplete_delta = default(uint);
+    private uint? _last_callcomplete_delta;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"last_callcomplete_delta", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_callcomplete_delta
     {
-      get { return _last_callcomplete_delta; }
+      get { return _last_callcomplete_delta?? default(uint); }
       set { _last_callcomplete_delta = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_callcomplete_deltaSpecified
+    {
+      get { return _last_callcomplete_delta != null; }
+      set { if (value == (_last_callcomplete_delta== null)) _last_callcomplete_delta = value ? this.last_callcomplete_delta : (uint?)null; }
+    }
+    private bool ShouldSerializelast_callcomplete_delta() { return last_callcomplete_deltaSpecified; }
+    private void Resetlast_callcomplete_delta() { last_callcomplete_deltaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7352,23 +12430,41 @@ namespace SteamKit2.Internal
     public CMsgAMUnlockStreamingResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private byte[] _encryption_key = null;
+    private byte[] _encryption_key;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"encryption_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] encryption_key
     {
-      get { return _encryption_key; }
+      get { return _encryption_key?? null; }
       set { _encryption_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryption_keySpecified
+    {
+      get { return _encryption_key != null; }
+      set { if (value == (_encryption_key== null)) _encryption_key = value ? this.encryption_key : (byte[])null; }
+    }
+    private bool ShouldSerializeencryption_key() { return encryption_keySpecified; }
+    private void Resetencryption_key() { encryption_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7380,23 +12476,41 @@ namespace SteamKit2.Internal
     public CMsgClientPlayingSessionState() {}
     
 
-    private bool _playing_blocked = default(bool);
+    private bool? _playing_blocked;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"playing_blocked", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool playing_blocked
     {
-      get { return _playing_blocked; }
+      get { return _playing_blocked?? default(bool); }
       set { _playing_blocked = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playing_blockedSpecified
+    {
+      get { return _playing_blocked != null; }
+      set { if (value == (_playing_blocked== null)) _playing_blocked = value ? this.playing_blocked : (bool?)null; }
+    }
+    private bool ShouldSerializeplaying_blocked() { return playing_blockedSpecified; }
+    private void Resetplaying_blocked() { playing_blockedSpecified = false; }
+    
 
-    private uint _playing_app = default(uint);
+    private uint? _playing_app;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"playing_app", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint playing_app
     {
-      get { return _playing_app; }
+      get { return _playing_app?? default(uint); }
       set { _playing_app = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playing_appSpecified
+    {
+      get { return _playing_app != null; }
+      set { if (value == (_playing_app== null)) _playing_app = value ? this.playing_app : (uint?)null; }
+    }
+    private bool ShouldSerializeplaying_app() { return playing_appSpecified; }
+    private void Resetplaying_app() { playing_appSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7408,14 +12522,23 @@ namespace SteamKit2.Internal
     public CMsgClientKickPlayingSession() {}
     
 
-    private bool _only_stop_game = default(bool);
+    private bool? _only_stop_game;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"only_stop_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool only_stop_game
     {
-      get { return _only_stop_game; }
+      get { return _only_stop_game?? default(bool); }
       set { _only_stop_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool only_stop_gameSpecified
+    {
+      get { return _only_stop_game != null; }
+      set { if (value == (_only_stop_game== null)) _only_stop_game = value ? this.only_stop_game : (bool?)null; }
+    }
+    private bool ShouldSerializeonly_stop_game() { return only_stop_gameSpecified; }
+    private void Resetonly_stop_game() { only_stop_gameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7427,41 +12550,77 @@ namespace SteamKit2.Internal
     public CMsgClientCreateAccount() {}
     
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _email = "";
+    private string _email;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"email", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string email
     {
-      get { return _email; }
+      get { return _email?? ""; }
       set { _email = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool emailSpecified
+    {
+      get { return _email != null; }
+      set { if (value == (_email== null)) _email = value ? this.email : (string)null; }
+    }
+    private bool ShouldSerializeemail() { return emailSpecified; }
+    private void Resetemail() { emailSpecified = false; }
+    
 
-    private uint _launcher = default(uint);
+    private uint? _launcher;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"launcher", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint launcher
     {
-      get { return _launcher; }
+      get { return _launcher?? default(uint); }
       set { _launcher = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool launcherSpecified
+    {
+      get { return _launcher != null; }
+      set { if (value == (_launcher== null)) _launcher = value ? this.launcher : (uint?)null; }
+    }
+    private bool ShouldSerializelauncher() { return launcherSpecified; }
+    private void Resetlauncher() { launcherSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7473,23 +12632,41 @@ namespace SteamKit2.Internal
     public CMsgClientCreateAccountResponse() {}
     
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7501,41 +12678,77 @@ namespace SteamKit2.Internal
     public CMsgClientVoiceCallPreAuthorize() {}
     
 
-    private ulong _caller_steamid = default(ulong);
+    private ulong? _caller_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"caller_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caller_steamid
     {
-      get { return _caller_steamid; }
+      get { return _caller_steamid?? default(ulong); }
       set { _caller_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caller_steamidSpecified
+    {
+      get { return _caller_steamid != null; }
+      set { if (value == (_caller_steamid== null)) _caller_steamid = value ? this.caller_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaller_steamid() { return caller_steamidSpecified; }
+    private void Resetcaller_steamid() { caller_steamidSpecified = false; }
+    
 
-    private ulong _receiver_steamid = default(ulong);
+    private ulong? _receiver_steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"receiver_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong receiver_steamid
     {
-      get { return _receiver_steamid; }
+      get { return _receiver_steamid?? default(ulong); }
       set { _receiver_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiver_steamidSpecified
+    {
+      get { return _receiver_steamid != null; }
+      set { if (value == (_receiver_steamid== null)) _receiver_steamid = value ? this.receiver_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializereceiver_steamid() { return receiver_steamidSpecified; }
+    private void Resetreceiver_steamid() { receiver_steamidSpecified = false; }
+    
 
-    private int _caller_id = default(int);
+    private int? _caller_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"caller_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int caller_id
     {
-      get { return _caller_id; }
+      get { return _caller_id?? default(int); }
       set { _caller_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caller_idSpecified
+    {
+      get { return _caller_id != null; }
+      set { if (value == (_caller_id== null)) _caller_id = value ? this.caller_id : (int?)null; }
+    }
+    private bool ShouldSerializecaller_id() { return caller_idSpecified; }
+    private void Resetcaller_id() { caller_idSpecified = false; }
+    
 
-    private bool _hangup = default(bool);
+    private bool? _hangup;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"hangup", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool hangup
     {
-      get { return _hangup; }
+      get { return _hangup?? default(bool); }
       set { _hangup = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hangupSpecified
+    {
+      get { return _hangup != null; }
+      set { if (value == (_hangup== null)) _hangup = value ? this.hangup : (bool?)null; }
+    }
+    private bool ShouldSerializehangup() { return hangupSpecified; }
+    private void Resethangup() { hangupSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -7547,41 +12760,77 @@ namespace SteamKit2.Internal
     public CMsgClientVoiceCallPreAuthorizeResponse() {}
     
 
-    private ulong _caller_steamid = default(ulong);
+    private ulong? _caller_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"caller_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong caller_steamid
     {
-      get { return _caller_steamid; }
+      get { return _caller_steamid?? default(ulong); }
       set { _caller_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caller_steamidSpecified
+    {
+      get { return _caller_steamid != null; }
+      set { if (value == (_caller_steamid== null)) _caller_steamid = value ? this.caller_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializecaller_steamid() { return caller_steamidSpecified; }
+    private void Resetcaller_steamid() { caller_steamidSpecified = false; }
+    
 
-    private ulong _receiver_steamid = default(ulong);
+    private ulong? _receiver_steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"receiver_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong receiver_steamid
     {
-      get { return _receiver_steamid; }
+      get { return _receiver_steamid?? default(ulong); }
       set { _receiver_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool receiver_steamidSpecified
+    {
+      get { return _receiver_steamid != null; }
+      set { if (value == (_receiver_steamid== null)) _receiver_steamid = value ? this.receiver_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializereceiver_steamid() { return receiver_steamidSpecified; }
+    private void Resetreceiver_steamid() { receiver_steamidSpecified = false; }
+    
 
-    private int _eresult = (int)2;
+    private int? _eresult;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"eresult", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)2)]
     public int eresult
     {
-      get { return _eresult; }
+      get { return _eresult?? (int)2; }
       set { _eresult = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool eresultSpecified
+    {
+      get { return _eresult != null; }
+      set { if (value == (_eresult== null)) _eresult = value ? this.eresult : (int?)null; }
+    }
+    private bool ShouldSerializeeresult() { return eresultSpecified; }
+    private void Reseteresult() { eresultSpecified = false; }
+    
 
-    private int _caller_id = default(int);
+    private int? _caller_id;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"caller_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int caller_id
     {
-      get { return _caller_id; }
+      get { return _caller_id?? default(int); }
       set { _caller_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool caller_idSpecified
+    {
+      get { return _caller_id != null; }
+      set { if (value == (_caller_id== null)) _caller_id = value ? this.caller_id : (int?)null; }
+    }
+    private bool ShouldSerializecaller_id() { return caller_idSpecified; }
+    private void Resetcaller_id() { caller_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgBroadcast.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgBroadcast.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_broadcast.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,59 +20,113 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_BeginBroadcastSession_Request() {}
     
 
-    private int _permission = default(int);
+    private int? _permission;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int permission
     {
-      get { return _permission; }
+      get { return _permission?? default(int); }
       set { _permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionSpecified
+    {
+      get { return _permission != null; }
+      set { if (value == (_permission== null)) _permission = value ? this.permission : (int?)null; }
+    }
+    private bool ShouldSerializepermission() { return permissionSpecified; }
+    private void Resetpermission() { permissionSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private ulong _client_instance_id = default(ulong);
+    private ulong? _client_instance_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong client_instance_id
     {
-      get { return _client_instance_id; }
+      get { return _client_instance_id?? default(ulong); }
       set { _client_instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_instance_idSpecified
+    {
+      get { return _client_instance_id != null; }
+      set { if (value == (_client_instance_id== null)) _client_instance_id = value ? this.client_instance_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeclient_instance_id() { return client_instance_idSpecified; }
+    private void Resetclient_instance_id() { client_instance_idSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private uint _cellid = default(uint);
+    private uint? _cellid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"cellid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cellid
     {
-      get { return _cellid; }
+      get { return _cellid?? default(uint); }
       set { _cellid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cellidSpecified
+    {
+      get { return _cellid != null; }
+      set { if (value == (_cellid== null)) _cellid = value ? this.cellid : (uint?)null; }
+    }
+    private bool ShouldSerializecellid() { return cellidSpecified; }
+    private void Resetcellid() { cellidSpecified = false; }
+    
 
-    private ulong _rtmp_token = default(ulong);
+    private ulong? _rtmp_token;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"rtmp_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong rtmp_token
     {
-      get { return _rtmp_token; }
+      get { return _rtmp_token?? default(ulong); }
       set { _rtmp_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtmp_tokenSpecified
+    {
+      get { return _rtmp_token != null; }
+      set { if (value == (_rtmp_token== null)) _rtmp_token = value ? this.rtmp_token : (ulong?)null; }
+    }
+    private bool ShouldSerializertmp_token() { return rtmp_tokenSpecified; }
+    private void Resetrtmp_token() { rtmp_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -82,14 +138,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_BeginBroadcastSession_Response() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -101,14 +166,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_EndBroadcastSession_Request() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -130,41 +204,77 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_StartBroadcastUpload_Request() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private uint _cellid = default(uint);
+    private uint? _cellid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"cellid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cellid
     {
-      get { return _cellid; }
+      get { return _cellid?? default(uint); }
       set { _cellid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cellidSpecified
+    {
+      get { return _cellid != null; }
+      set { if (value == (_cellid== null)) _cellid = value ? this.cellid : (uint?)null; }
+    }
+    private bool ShouldSerializecellid() { return cellidSpecified; }
+    private void Resetcellid() { cellidSpecified = false; }
+    
 
-    private bool _as_rtmp = default(bool);
+    private bool? _as_rtmp;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"as_rtmp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool as_rtmp
     {
-      get { return _as_rtmp; }
+      get { return _as_rtmp?? default(bool); }
       set { _as_rtmp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool as_rtmpSpecified
+    {
+      get { return _as_rtmp != null; }
+      set { if (value == (_as_rtmp== null)) _as_rtmp = value ? this.as_rtmp : (bool?)null; }
+    }
+    private bool ShouldSerializeas_rtmp() { return as_rtmpSpecified; }
+    private void Resetas_rtmp() { as_rtmpSpecified = false; }
+    
 
-    private uint _delay_seconds = default(uint);
+    private uint? _delay_seconds;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"delay_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint delay_seconds
     {
-      get { return _delay_seconds; }
+      get { return _delay_seconds?? default(uint); }
       set { _delay_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool delay_secondsSpecified
+    {
+      get { return _delay_seconds != null; }
+      set { if (value == (_delay_seconds== null)) _delay_seconds = value ? this.delay_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializedelay_seconds() { return delay_secondsSpecified; }
+    private void Resetdelay_seconds() { delay_secondsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -176,32 +286,59 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_StartBroadcastUpload_Response() {}
     
 
-    private string _upload_token = "";
+    private string _upload_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upload_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string upload_token
     {
-      get { return _upload_token; }
+      get { return _upload_token?? ""; }
       set { _upload_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_tokenSpecified
+    {
+      get { return _upload_token != null; }
+      set { if (value == (_upload_token== null)) _upload_token = value ? this.upload_token : (string)null; }
+    }
+    private bool ShouldSerializeupload_token() { return upload_tokenSpecified; }
+    private void Resetupload_token() { upload_tokenSpecified = false; }
+    
 
-    private string _upload_address = "";
+    private string _upload_address;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"upload_address", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string upload_address
     {
-      get { return _upload_address; }
+      get { return _upload_address?? ""; }
       set { _upload_address = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_addressSpecified
+    {
+      get { return _upload_address != null; }
+      set { if (value == (_upload_address== null)) _upload_address = value ? this.upload_address : (string)null; }
+    }
+    private bool ShouldSerializeupload_address() { return upload_addressSpecified; }
+    private void Resetupload_address() { upload_addressSpecified = false; }
+    
 
-    private ulong _upload_relay_id = default(ulong);
+    private ulong? _upload_relay_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"upload_relay_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upload_relay_id
     {
-      get { return _upload_relay_id; }
+      get { return _upload_relay_id?? default(ulong); }
       set { _upload_relay_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_relay_idSpecified
+    {
+      get { return _upload_relay_id != null; }
+      set { if (value == (_upload_relay_id== null)) _upload_relay_id = value ? this.upload_relay_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeupload_relay_id() { return upload_relay_idSpecified; }
+    private void Resetupload_relay_id() { upload_relay_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -213,23 +350,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_NotifyBroadcastUploadStop_Notification() {}
     
 
-    private ulong _broadcast_relay_id = default(ulong);
+    private ulong? _broadcast_relay_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_relay_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_relay_id
     {
-      get { return _broadcast_relay_id; }
+      get { return _broadcast_relay_id?? default(ulong); }
       set { _broadcast_relay_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_relay_idSpecified
+    {
+      get { return _broadcast_relay_id != null; }
+      set { if (value == (_broadcast_relay_id== null)) _broadcast_relay_id = value ? this.broadcast_relay_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_relay_id() { return broadcast_relay_idSpecified; }
+    private void Resetbroadcast_relay_id() { broadcast_relay_idSpecified = false; }
+    
 
-    private uint _upload_result = default(uint);
+    private uint? _upload_result;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"upload_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint upload_result
     {
-      get { return _upload_result; }
+      get { return _upload_result?? default(uint); }
       set { _upload_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_resultSpecified
+    {
+      get { return _upload_result != null; }
+      set { if (value == (_upload_result== null)) _upload_result = value ? this.upload_result : (uint?)null; }
+    }
+    private bool ShouldSerializeupload_result() { return upload_resultSpecified; }
+    private void Resetupload_result() { upload_resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -241,50 +396,95 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_WatchBroadcast_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _existing_broadcast_id = default(ulong);
+    private ulong? _existing_broadcast_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"existing_broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong existing_broadcast_id
     {
-      get { return _existing_broadcast_id; }
+      get { return _existing_broadcast_id?? default(ulong); }
       set { _existing_broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool existing_broadcast_idSpecified
+    {
+      get { return _existing_broadcast_id != null; }
+      set { if (value == (_existing_broadcast_id== null)) _existing_broadcast_id = value ? this.existing_broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializeexisting_broadcast_id() { return existing_broadcast_idSpecified; }
+    private void Resetexisting_broadcast_id() { existing_broadcast_idSpecified = false; }
+    
 
-    private ulong _viewer_token = default(ulong);
+    private ulong? _viewer_token;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"viewer_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong viewer_token
     {
-      get { return _viewer_token; }
+      get { return _viewer_token?? default(ulong); }
       set { _viewer_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewer_tokenSpecified
+    {
+      get { return _viewer_token != null; }
+      set { if (value == (_viewer_token== null)) _viewer_token = value ? this.viewer_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeviewer_token() { return viewer_tokenSpecified; }
+    private void Resetviewer_token() { viewer_tokenSpecified = false; }
+    
 
-    private uint _client_ip = default(uint);
+    private uint? _client_ip;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_ip
     {
-      get { return _client_ip; }
+      get { return _client_ip?? default(uint); }
       set { _client_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_ipSpecified
+    {
+      get { return _client_ip != null; }
+      set { if (value == (_client_ip== null)) _client_ip = value ? this.client_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_ip() { return client_ipSpecified; }
+    private void Resetclient_ip() { client_ipSpecified = false; }
+    
 
-    private uint _client_cell = default(uint);
+    private uint? _client_cell;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"client_cell", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_cell
     {
-      get { return _client_cell; }
+      get { return _client_cell?? default(uint); }
       set { _client_cell = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_cellSpecified
+    {
+      get { return _client_cell != null; }
+      set { if (value == (_client_cell== null)) _client_cell = value ? this.client_cell : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_cell() { return client_cellSpecified; }
+    private void Resetclient_cell() { client_cellSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -296,95 +496,185 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_WatchBroadcast_Response() {}
     
 
-    private CBroadcast_WatchBroadcast_Response.EWatchResponse _response = CBroadcast_WatchBroadcast_Response.EWatchResponse.k_EWatchResponseReady;
+    private CBroadcast_WatchBroadcast_Response.EWatchResponse? _response;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"response", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CBroadcast_WatchBroadcast_Response.EWatchResponse.k_EWatchResponseReady)]
     public CBroadcast_WatchBroadcast_Response.EWatchResponse response
     {
-      get { return _response; }
+      get { return _response?? CBroadcast_WatchBroadcast_Response.EWatchResponse.k_EWatchResponseReady; }
       set { _response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool responseSpecified
+    {
+      get { return _response != null; }
+      set { if (value == (_response== null)) _response = value ? this.response : (CBroadcast_WatchBroadcast_Response.EWatchResponse?)null; }
+    }
+    private bool ShouldSerializeresponse() { return responseSpecified; }
+    private void Resetresponse() { responseSpecified = false; }
+    
 
-    private string _mpd_url = "";
+    private string _mpd_url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"mpd_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mpd_url
     {
-      get { return _mpd_url; }
+      get { return _mpd_url?? ""; }
       set { _mpd_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mpd_urlSpecified
+    {
+      get { return _mpd_url != null; }
+      set { if (value == (_mpd_url== null)) _mpd_url = value ? this.mpd_url : (string)null; }
+    }
+    private bool ShouldSerializempd_url() { return mpd_urlSpecified; }
+    private void Resetmpd_url() { mpd_urlSpecified = false; }
+    
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private uint _num_viewers = default(uint);
+    private uint? _num_viewers;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"num_viewers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_viewers
     {
-      get { return _num_viewers; }
+      get { return _num_viewers?? default(uint); }
       set { _num_viewers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_viewersSpecified
+    {
+      get { return _num_viewers != null; }
+      set { if (value == (_num_viewers== null)) _num_viewers = value ? this.num_viewers : (uint?)null; }
+    }
+    private bool ShouldSerializenum_viewers() { return num_viewersSpecified; }
+    private void Resetnum_viewers() { num_viewersSpecified = false; }
+    
 
-    private int _permission = default(int);
+    private int? _permission;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int permission
     {
-      get { return _permission; }
+      get { return _permission?? default(int); }
       set { _permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionSpecified
+    {
+      get { return _permission != null; }
+      set { if (value == (_permission== null)) _permission = value ? this.permission : (int?)null; }
+    }
+    private bool ShouldSerializepermission() { return permissionSpecified; }
+    private void Resetpermission() { permissionSpecified = false; }
+    
 
-    private bool _is_rtmp = default(bool);
+    private bool? _is_rtmp;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_rtmp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_rtmp
     {
-      get { return _is_rtmp; }
+      get { return _is_rtmp?? default(bool); }
       set { _is_rtmp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_rtmpSpecified
+    {
+      get { return _is_rtmp != null; }
+      set { if (value == (_is_rtmp== null)) _is_rtmp = value ? this.is_rtmp : (bool?)null; }
+    }
+    private bool ShouldSerializeis_rtmp() { return is_rtmpSpecified; }
+    private void Resetis_rtmp() { is_rtmpSpecified = false; }
+    
 
-    private int _seconds_delay = default(int);
+    private int? _seconds_delay;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"seconds_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int seconds_delay
     {
-      get { return _seconds_delay; }
+      get { return _seconds_delay?? default(int); }
       set { _seconds_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_delaySpecified
+    {
+      get { return _seconds_delay != null; }
+      set { if (value == (_seconds_delay== null)) _seconds_delay = value ? this.seconds_delay : (int?)null; }
+    }
+    private bool ShouldSerializeseconds_delay() { return seconds_delaySpecified; }
+    private void Resetseconds_delay() { seconds_delaySpecified = false; }
+    
 
-    private ulong _viewer_token = default(ulong);
+    private ulong? _viewer_token;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"viewer_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong viewer_token
     {
-      get { return _viewer_token; }
+      get { return _viewer_token?? default(ulong); }
       set { _viewer_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewer_tokenSpecified
+    {
+      get { return _viewer_token != null; }
+      set { if (value == (_viewer_token== null)) _viewer_token = value ? this.viewer_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeviewer_token() { return viewer_tokenSpecified; }
+    private void Resetviewer_token() { viewer_tokenSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EWatchResponse", EnumPassthru=true)]
     public enum EWatchResponse
     {
@@ -434,23 +724,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_GetBroadcastStatus_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -462,68 +770,131 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_GetBroadcastStatus_Response() {}
     
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private uint _num_viewers = default(uint);
+    private uint? _num_viewers;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"num_viewers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_viewers
     {
-      get { return _num_viewers; }
+      get { return _num_viewers?? default(uint); }
       set { _num_viewers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_viewersSpecified
+    {
+      get { return _num_viewers != null; }
+      set { if (value == (_num_viewers== null)) _num_viewers = value ? this.num_viewers : (uint?)null; }
+    }
+    private bool ShouldSerializenum_viewers() { return num_viewersSpecified; }
+    private void Resetnum_viewers() { num_viewersSpecified = false; }
+    
 
-    private int _permission = default(int);
+    private int? _permission;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int permission
     {
-      get { return _permission; }
+      get { return _permission?? default(int); }
       set { _permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionSpecified
+    {
+      get { return _permission != null; }
+      set { if (value == (_permission== null)) _permission = value ? this.permission : (int?)null; }
+    }
+    private bool ShouldSerializepermission() { return permissionSpecified; }
+    private void Resetpermission() { permissionSpecified = false; }
+    
 
-    private bool _is_rtmp = default(bool);
+    private bool? _is_rtmp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_rtmp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_rtmp
     {
-      get { return _is_rtmp; }
+      get { return _is_rtmp?? default(bool); }
       set { _is_rtmp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_rtmpSpecified
+    {
+      get { return _is_rtmp != null; }
+      set { if (value == (_is_rtmp== null)) _is_rtmp = value ? this.is_rtmp : (bool?)null; }
+    }
+    private bool ShouldSerializeis_rtmp() { return is_rtmpSpecified; }
+    private void Resetis_rtmp() { is_rtmpSpecified = false; }
+    
 
-    private int _seconds_delay = default(int);
+    private int? _seconds_delay;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"seconds_delay", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int seconds_delay
     {
-      get { return _seconds_delay; }
+      get { return _seconds_delay?? default(int); }
       set { _seconds_delay = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_delaySpecified
+    {
+      get { return _seconds_delay != null; }
+      set { if (value == (_seconds_delay== null)) _seconds_delay = value ? this.seconds_delay : (int?)null; }
+    }
+    private bool ShouldSerializeseconds_delay() { return seconds_delaySpecified; }
+    private void Resetseconds_delay() { seconds_delaySpecified = false; }
+    
 
-    private bool _is_publisher = default(bool);
+    private bool? _is_publisher;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"is_publisher", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_publisher
     {
-      get { return _is_publisher; }
+      get { return _is_publisher?? default(bool); }
       set { _is_publisher = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_publisherSpecified
+    {
+      get { return _is_publisher != null; }
+      set { if (value == (_is_publisher== null)) _is_publisher = value ? this.is_publisher : (bool?)null; }
+    }
+    private bool ShouldSerializeis_publisher() { return is_publisherSpecified; }
+    private void Resetis_publisher() { is_publisherSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -535,23 +906,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_InviteToBroadcast_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _approval_response = default(bool);
+    private bool? _approval_response;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"approval_response", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool approval_response
     {
-      get { return _approval_response; }
+      get { return _approval_response?? default(bool); }
       set { _approval_response = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool approval_responseSpecified
+    {
+      get { return _approval_response != null; }
+      set { if (value == (_approval_response== null)) _approval_response = value ? this.approval_response : (bool?)null; }
+    }
+    private bool ShouldSerializeapproval_response() { return approval_responseSpecified; }
+    private void Resetapproval_response() { approval_responseSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -563,14 +952,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_InviteToBroadcast_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -582,41 +980,77 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_SendBroadcastStateToServer_Request() {}
     
 
-    private int _permission = default(int);
+    private int? _permission;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"permission", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int permission
     {
-      get { return _permission; }
+      get { return _permission?? default(int); }
       set { _permission = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool permissionSpecified
+    {
+      get { return _permission != null; }
+      set { if (value == (_permission== null)) _permission = value ? this.permission : (int?)null; }
+    }
+    private bool ShouldSerializepermission() { return permissionSpecified; }
+    private void Resetpermission() { permissionSpecified = false; }
+    
 
-    private ulong _gameid = default(ulong);
+    private ulong? _gameid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong gameid
     {
-      get { return _gameid; }
+      get { return _gameid?? default(ulong); }
       set { _gameid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameidSpecified
+    {
+      get { return _gameid != null; }
+      set { if (value == (_gameid== null)) _gameid = value ? this.gameid : (ulong?)null; }
+    }
+    private bool ShouldSerializegameid() { return gameidSpecified; }
+    private void Resetgameid() { gameidSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _game_data_config = "";
+    private string _game_data_config;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"game_data_config", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_data_config
     {
-      get { return _game_data_config; }
+      get { return _game_data_config?? ""; }
       set { _game_data_config = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_data_configSpecified
+    {
+      get { return _game_data_config != null; }
+      set { if (value == (_game_data_config== null)) _game_data_config = value ? this.game_data_config : (string)null; }
+    }
+    private bool ShouldSerializegame_data_config() { return game_data_configSpecified; }
+    private void Resetgame_data_config() { game_data_configSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -638,14 +1072,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_NotifyBroadcastSessionHeartbeat_Notification() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -657,41 +1100,77 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_GetBroadcastChatInfo_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private uint _client_ip = default(uint);
+    private uint? _client_ip;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"client_ip", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_ip
     {
-      get { return _client_ip; }
+      get { return _client_ip?? default(uint); }
       set { _client_ip = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_ipSpecified
+    {
+      get { return _client_ip != null; }
+      set { if (value == (_client_ip== null)) _client_ip = value ? this.client_ip : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_ip() { return client_ipSpecified; }
+    private void Resetclient_ip() { client_ipSpecified = false; }
+    
 
-    private uint _client_cell = default(uint);
+    private uint? _client_cell;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"client_cell", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_cell
     {
-      get { return _client_cell; }
+      get { return _client_cell?? default(uint); }
       set { _client_cell = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_cellSpecified
+    {
+      get { return _client_cell != null; }
+      set { if (value == (_client_cell== null)) _client_cell = value ? this.client_cell : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_cell() { return client_cellSpecified; }
+    private void Resetclient_cell() { client_cellSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -703,32 +1182,59 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_GetBroadcastChatInfo_Response() {}
     
 
-    private ulong _chat_id = default(ulong);
+    private ulong? _chat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"chat_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong chat_id
     {
-      get { return _chat_id; }
+      get { return _chat_id?? default(ulong); }
       set { _chat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_idSpecified
+    {
+      get { return _chat_id != null; }
+      set { if (value == (_chat_id== null)) _chat_id = value ? this.chat_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechat_id() { return chat_idSpecified; }
+    private void Resetchat_id() { chat_idSpecified = false; }
+    
 
-    private string _view_url = "";
+    private string _view_url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"view_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string view_url
     {
-      get { return _view_url; }
+      get { return _view_url?? ""; }
       set { _view_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool view_urlSpecified
+    {
+      get { return _view_url != null; }
+      set { if (value == (_view_url== null)) _view_url = value ? this.view_url : (string)null; }
+    }
+    private bool ShouldSerializeview_url() { return view_urlSpecified; }
+    private void Resetview_url() { view_urlSpecified = false; }
+    
 
-    private string _view_url_template = "";
+    private string _view_url_template;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"view_url_template", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string view_url_template
     {
-      get { return _view_url_template; }
+      get { return _view_url_template?? ""; }
       set { _view_url_template = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool view_url_templateSpecified
+    {
+      get { return _view_url_template != null; }
+      set { if (value == (_view_url_template== null)) _view_url_template = value ? this.view_url_template : (string)null; }
+    }
+    private bool ShouldSerializeview_url_template() { return view_url_templateSpecified; }
+    private void Resetview_url_template() { view_url_templateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -740,32 +1246,59 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_PostChatMessage_Request() {}
     
 
-    private ulong _chat_id = default(ulong);
+    private ulong? _chat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"chat_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong chat_id
     {
-      get { return _chat_id; }
+      get { return _chat_id?? default(ulong); }
       set { _chat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_idSpecified
+    {
+      get { return _chat_id != null; }
+      set { if (value == (_chat_id== null)) _chat_id = value ? this.chat_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechat_id() { return chat_idSpecified; }
+    private void Resetchat_id() { chat_idSpecified = false; }
+    
 
-    private string _message = "";
+    private string _message;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string message
     {
-      get { return _message; }
+      get { return _message?? ""; }
       set { _message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool messageSpecified
+    {
+      get { return _message != null; }
+      set { if (value == (_message== null)) _message = value ? this.message : (string)null; }
+    }
+    private bool ShouldSerializemessage() { return messageSpecified; }
+    private void Resetmessage() { messageSpecified = false; }
+    
 
-    private uint _instance_id = default(uint);
+    private uint? _instance_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"instance_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint instance_id
     {
-      get { return _instance_id; }
+      get { return _instance_id?? default(uint); }
       set { _instance_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool instance_idSpecified
+    {
+      get { return _instance_id != null; }
+      set { if (value == (_instance_id== null)) _instance_id = value ? this.instance_id : (uint?)null; }
+    }
+    private bool ShouldSerializeinstance_id() { return instance_idSpecified; }
+    private void Resetinstance_id() { instance_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -777,32 +1310,59 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_PostChatMessage_Response() {}
     
 
-    private string _persona_name = "";
+    private string _persona_name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"persona_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona_name
     {
-      get { return _persona_name; }
+      get { return _persona_name?? ""; }
       set { _persona_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool persona_nameSpecified
+    {
+      get { return _persona_name != null; }
+      set { if (value == (_persona_name== null)) _persona_name = value ? this.persona_name : (string)null; }
+    }
+    private bool ShouldSerializepersona_name() { return persona_nameSpecified; }
+    private void Resetpersona_name() { persona_nameSpecified = false; }
+    
 
-    private bool _in_game = default(bool);
+    private bool? _in_game;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"in_game", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool in_game
     {
-      get { return _in_game; }
+      get { return _in_game?? default(bool); }
       set { _in_game = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool in_gameSpecified
+    {
+      get { return _in_game != null; }
+      set { if (value == (_in_game== null)) _in_game = value ? this.in_game : (bool?)null; }
+    }
+    private bool ShouldSerializein_game() { return in_gameSpecified; }
+    private void Resetin_game() { in_gameSpecified = false; }
+    
 
-    private int _result = default(int);
+    private int? _result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int result
     {
-      get { return _result; }
+      get { return _result?? default(int); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (int?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -814,32 +1374,59 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_MuteBroadcastChatUser_Request() {}
     
 
-    private ulong _chat_id = default(ulong);
+    private ulong? _chat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"chat_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong chat_id
     {
-      get { return _chat_id; }
+      get { return _chat_id?? default(ulong); }
       set { _chat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_idSpecified
+    {
+      get { return _chat_id != null; }
+      set { if (value == (_chat_id== null)) _chat_id = value ? this.chat_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechat_id() { return chat_idSpecified; }
+    private void Resetchat_id() { chat_idSpecified = false; }
+    
 
-    private ulong _user_steamid = default(ulong);
+    private ulong? _user_steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"user_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong user_steamid
     {
-      get { return _user_steamid; }
+      get { return _user_steamid?? default(ulong); }
       set { _user_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_steamidSpecified
+    {
+      get { return _user_steamid != null; }
+      set { if (value == (_user_steamid== null)) _user_steamid = value ? this.user_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeuser_steamid() { return user_steamidSpecified; }
+    private void Resetuser_steamid() { user_steamidSpecified = false; }
+    
 
-    private bool _muted = default(bool);
+    private bool? _muted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"muted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool muted
     {
-      get { return _muted; }
+      get { return _muted?? default(bool); }
       set { _muted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mutedSpecified
+    {
+      get { return _muted != null; }
+      set { if (value == (_muted== null)) _muted = value ? this.muted : (bool?)null; }
+    }
+    private bool ShouldSerializemuted() { return mutedSpecified; }
+    private void Resetmuted() { mutedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -861,23 +1448,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_RemoveUserChatText_Request() {}
     
 
-    private ulong _chat_id = default(ulong);
+    private ulong? _chat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"chat_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong chat_id
     {
-      get { return _chat_id; }
+      get { return _chat_id?? default(ulong); }
       set { _chat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_idSpecified
+    {
+      get { return _chat_id != null; }
+      set { if (value == (_chat_id== null)) _chat_id = value ? this.chat_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechat_id() { return chat_idSpecified; }
+    private void Resetchat_id() { chat_idSpecified = false; }
+    
 
-    private ulong _user_steamid = default(ulong);
+    private ulong? _user_steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"user_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong user_steamid
     {
-      get { return _user_steamid; }
+      get { return _user_steamid?? default(ulong); }
       set { _user_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool user_steamidSpecified
+    {
+      get { return _user_steamid != null; }
+      set { if (value == (_user_steamid== null)) _user_steamid = value ? this.user_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeuser_steamid() { return user_steamidSpecified; }
+    private void Resetuser_steamid() { user_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -899,14 +1504,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_GetBroadcastChatUserNames_Request() {}
     
 
-    private ulong _chat_id = default(ulong);
+    private ulong? _chat_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"chat_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong chat_id
     {
-      get { return _chat_id; }
+      get { return _chat_id?? default(ulong); }
       set { _chat_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chat_idSpecified
+    {
+      get { return _chat_id != null; }
+      set { if (value == (_chat_id== null)) _chat_id = value ? this.chat_id : (ulong?)null; }
+    }
+    private bool ShouldSerializechat_id() { return chat_idSpecified; }
+    private void Resetchat_id() { chat_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _user_steamid = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"user_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> user_steamid
@@ -937,23 +1551,41 @@ namespace SteamKit2.Unified.Internal
     public PersonaName() {}
     
 
-    private ulong _steam_id = default(ulong);
+    private ulong? _steam_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steam_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steam_id
     {
-      get { return _steam_id; }
+      get { return _steam_id?? default(ulong); }
       set { _steam_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steam_idSpecified
+    {
+      get { return _steam_id != null; }
+      set { if (value == (_steam_id== null)) _steam_id = value ? this.steam_id : (ulong?)null; }
+    }
+    private bool ShouldSerializesteam_id() { return steam_idSpecified; }
+    private void Resetsteam_id() { steam_idSpecified = false; }
+    
 
-    private string _persona = "";
+    private string _persona;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"persona", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string persona
     {
-      get { return _persona; }
+      get { return _persona?? ""; }
       set { _persona = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool personaSpecified
+    {
+      get { return _persona != null; }
+      set { if (value == (_persona== null)) _persona = value ? this.persona : (string)null; }
+    }
+    private bool ShouldSerializepersona() { return personaSpecified; }
+    private void Resetpersona() { personaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -970,23 +1602,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_BroadcastViewerState_Notification() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private CBroadcast_BroadcastViewerState_Notification.EViewerState _state = CBroadcast_BroadcastViewerState_Notification.EViewerState.k_EViewerNeedsApproval;
+    private CBroadcast_BroadcastViewerState_Notification.EViewerState? _state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(CBroadcast_BroadcastViewerState_Notification.EViewerState.k_EViewerNeedsApproval)]
     public CBroadcast_BroadcastViewerState_Notification.EViewerState state
     {
-      get { return _state; }
+      get { return _state?? CBroadcast_BroadcastViewerState_Notification.EViewerState.k_EViewerNeedsApproval; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (CBroadcast_BroadcastViewerState_Notification.EViewerState?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
     [global::ProtoBuf.ProtoContract(Name=@"EViewerState", EnumPassthru=true)]
     public enum EViewerState
     {
@@ -1012,14 +1662,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_WaitingBroadcastViewer_Notification() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1031,41 +1690,77 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_StopBroadcastUpload_Notification() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private ulong _broadcast_relay_id = default(ulong);
+    private ulong? _broadcast_relay_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"broadcast_relay_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_relay_id
     {
-      get { return _broadcast_relay_id; }
+      get { return _broadcast_relay_id?? default(ulong); }
       set { _broadcast_relay_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_relay_idSpecified
+    {
+      get { return _broadcast_relay_id != null; }
+      set { if (value == (_broadcast_relay_id== null)) _broadcast_relay_id = value ? this.broadcast_relay_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_relay_id() { return broadcast_relay_idSpecified; }
+    private void Resetbroadcast_relay_id() { broadcast_relay_idSpecified = false; }
+    
 
-    private uint _upload_result = default(uint);
+    private uint? _upload_result;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"upload_result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint upload_result
     {
-      get { return _upload_result; }
+      get { return _upload_result?? default(uint); }
       set { _upload_result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_resultSpecified
+    {
+      get { return _upload_result != null; }
+      set { if (value == (_upload_result== null)) _upload_result = value ? this.upload_result : (uint?)null; }
+    }
+    private bool ShouldSerializeupload_result() { return upload_resultSpecified; }
+    private void Resetupload_result() { upload_resultSpecified = false; }
+    
 
-    private bool _too_many_poor_uploads = default(bool);
+    private bool? _too_many_poor_uploads;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"too_many_poor_uploads", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool too_many_poor_uploads
     {
-      get { return _too_many_poor_uploads; }
+      get { return _too_many_poor_uploads?? default(bool); }
       set { _too_many_poor_uploads = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool too_many_poor_uploadsSpecified
+    {
+      get { return _too_many_poor_uploads != null; }
+      set { if (value == (_too_many_poor_uploads== null)) _too_many_poor_uploads = value ? this.too_many_poor_uploads : (bool?)null; }
+    }
+    private bool ShouldSerializetoo_many_poor_uploads() { return too_many_poor_uploadsSpecified; }
+    private void Resettoo_many_poor_uploads() { too_many_poor_uploadsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1077,14 +1772,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_SessionClosed_Notification() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1096,14 +1800,23 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_ViewerBroadcastInvite_Notification() {}
     
 
-    private ulong _broadcaster_steamid = default(ulong);
+    private ulong? _broadcaster_steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcaster_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcaster_steamid
     {
-      get { return _broadcaster_steamid; }
+      get { return _broadcaster_steamid?? default(ulong); }
       set { _broadcaster_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcaster_steamidSpecified
+    {
+      get { return _broadcaster_steamid != null; }
+      set { if (value == (_broadcaster_steamid== null)) _broadcaster_steamid = value ? this.broadcaster_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcaster_steamid() { return broadcaster_steamidSpecified; }
+    private void Resetbroadcaster_steamid() { broadcaster_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1115,23 +1828,41 @@ namespace SteamKit2.Unified.Internal
     public CBroadcast_BroadcastStatus_Notification() {}
     
 
-    private ulong _broadcast_id = default(ulong);
+    private ulong? _broadcast_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"broadcast_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong broadcast_id
     {
-      get { return _broadcast_id; }
+      get { return _broadcast_id?? default(ulong); }
       set { _broadcast_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool broadcast_idSpecified
+    {
+      get { return _broadcast_id != null; }
+      set { if (value == (_broadcast_id== null)) _broadcast_id = value ? this.broadcast_id : (ulong?)null; }
+    }
+    private bool ShouldSerializebroadcast_id() { return broadcast_idSpecified; }
+    private void Resetbroadcast_id() { broadcast_idSpecified = false; }
+    
 
-    private int _num_viewers = default(int);
+    private int? _num_viewers;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"num_viewers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_viewers
     {
-      get { return _num_viewers; }
+      get { return _num_viewers?? default(int); }
       set { _num_viewers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_viewersSpecified
+    {
+      get { return _num_viewers != null; }
+      set { if (value == (_num_viewers== null)) _num_viewers = value ? this.num_viewers : (int?)null; }
+    }
+    private bool ShouldSerializenum_viewers() { return num_viewersSpecified; }
+    private void Resetnum_viewers() { num_viewersSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgCloud.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgCloud.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_cloud.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public CCloud_GetUploadServerInfo_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,14 +48,23 @@ namespace SteamKit2.Unified.Internal
     public CCloud_GetUploadServerInfo_Response() {}
     
 
-    private string _server_url = "";
+    private string _server_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"server_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string server_url
     {
-      get { return _server_url; }
+      get { return _server_url?? ""; }
       set { _server_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_urlSpecified
+    {
+      get { return _server_url != null; }
+      set { if (value == (_server_url== null)) _server_url = value ? this.server_url : (string)null; }
+    }
+    private bool ShouldSerializeserver_url() { return server_urlSpecified; }
+    private void Resetserver_url() { server_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -56,50 +76,95 @@ namespace SteamKit2.Unified.Internal
     public CCloud_BeginHTTPUpload_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private string _file_sha = "";
+    private string _file_sha;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"file_sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_sha
     {
-      get { return _file_sha; }
+      get { return _file_sha?? ""; }
       set { _file_sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_shaSpecified
+    {
+      get { return _file_sha != null; }
+      set { if (value == (_file_sha== null)) _file_sha = value ? this.file_sha : (string)null; }
+    }
+    private bool ShouldSerializefile_sha() { return file_shaSpecified; }
+    private void Resetfile_sha() { file_shaSpecified = false; }
+    
 
-    private bool _is_public = default(bool);
+    private bool? _is_public;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_public", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_public
     {
-      get { return _is_public; }
+      get { return _is_public?? default(bool); }
       set { _is_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_publicSpecified
+    {
+      get { return _is_public != null; }
+      set { if (value == (_is_public== null)) _is_public = value ? this.is_public : (bool?)null; }
+    }
+    private bool ShouldSerializeis_public() { return is_publicSpecified; }
+    private void Resetis_public() { is_publicSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _platforms_to_sync = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(6, Name=@"platforms_to_sync", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> platforms_to_sync
@@ -132,50 +197,95 @@ namespace SteamKit2.Unified.Internal
     public CCloud_BeginHTTPUpload_Response() {}
     
 
-    private ulong _ugcid = default(ulong);
+    private ulong? _ugcid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ugcid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugcid
     {
-      get { return _ugcid; }
+      get { return _ugcid?? default(ulong); }
       set { _ugcid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugcidSpecified
+    {
+      get { return _ugcid != null; }
+      set { if (value == (_ugcid== null)) _ugcid = value ? this.ugcid : (ulong?)null; }
+    }
+    private bool ShouldSerializeugcid() { return ugcidSpecified; }
+    private void Resetugcid() { ugcidSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _url_host = "";
+    private string _url_host;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_host
     {
-      get { return _url_host; }
+      get { return _url_host?? ""; }
       set { _url_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_hostSpecified
+    {
+      get { return _url_host != null; }
+      set { if (value == (_url_host== null)) _url_host = value ? this.url_host : (string)null; }
+    }
+    private bool ShouldSerializeurl_host() { return url_hostSpecified; }
+    private void Reseturl_host() { url_hostSpecified = false; }
+    
 
-    private string _url_path = "";
+    private string _url_path;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"url_path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_path
     {
-      get { return _url_path; }
+      get { return _url_path?? ""; }
       set { _url_path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_pathSpecified
+    {
+      get { return _url_path != null; }
+      set { if (value == (_url_path== null)) _url_path = value ? this.url_path : (string)null; }
+    }
+    private bool ShouldSerializeurl_path() { return url_pathSpecified; }
+    private void Reseturl_path() { url_pathSpecified = false; }
+    
 
-    private bool _use_https = default(bool);
+    private bool? _use_https;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"use_https", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_https
     {
-      get { return _use_https; }
+      get { return _use_https?? default(bool); }
       set { _use_https = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpsSpecified
+    {
+      get { return _use_https != null; }
+      set { if (value == (_use_https== null)) _use_https = value ? this.use_https : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_https() { return use_httpsSpecified; }
+    private void Resetuse_https() { use_httpsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CCloud_BeginHTTPUpload_Response.HTTPHeaders> _request_headers = new global::System.Collections.Generic.List<CCloud_BeginHTTPUpload_Response.HTTPHeaders>();
     [global::ProtoBuf.ProtoMember(6, Name=@"request_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CCloud_BeginHTTPUpload_Response.HTTPHeaders> request_headers
@@ -189,23 +299,41 @@ namespace SteamKit2.Unified.Internal
     public HTTPHeaders() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -222,41 +350,77 @@ namespace SteamKit2.Unified.Internal
     public CCloud_CommitHTTPUpload_Request() {}
     
 
-    private bool _transfer_succeeded = default(bool);
+    private bool? _transfer_succeeded;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"transfer_succeeded", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool transfer_succeeded
     {
-      get { return _transfer_succeeded; }
+      get { return _transfer_succeeded?? default(bool); }
       set { _transfer_succeeded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transfer_succeededSpecified
+    {
+      get { return _transfer_succeeded != null; }
+      set { if (value == (_transfer_succeeded== null)) _transfer_succeeded = value ? this.transfer_succeeded : (bool?)null; }
+    }
+    private bool ShouldSerializetransfer_succeeded() { return transfer_succeededSpecified; }
+    private void Resettransfer_succeeded() { transfer_succeededSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _file_sha = "";
+    private string _file_sha;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_sha
     {
-      get { return _file_sha; }
+      get { return _file_sha?? ""; }
       set { _file_sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_shaSpecified
+    {
+      get { return _file_sha != null; }
+      set { if (value == (_file_sha== null)) _file_sha = value ? this.file_sha : (string)null; }
+    }
+    private bool ShouldSerializefile_sha() { return file_shaSpecified; }
+    private void Resetfile_sha() { file_shaSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -268,14 +432,23 @@ namespace SteamKit2.Unified.Internal
     public CCloud_CommitHTTPUpload_Response() {}
     
 
-    private bool _file_committed = default(bool);
+    private bool? _file_committed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_committed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool file_committed
     {
-      get { return _file_committed; }
+      get { return _file_committed?? default(bool); }
       set { _file_committed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_committedSpecified
+    {
+      get { return _file_committed != null; }
+      set { if (value == (_file_committed== null)) _file_committed = value ? this.file_committed : (bool?)null; }
+    }
+    private bool ShouldSerializefile_committed() { return file_committedSpecified; }
+    private void Resetfile_committed() { file_committedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -287,23 +460,41 @@ namespace SteamKit2.Unified.Internal
     public CCloud_GetFileDetails_Request() {}
     
 
-    private ulong _ugcid = default(ulong);
+    private ulong? _ugcid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ugcid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugcid
     {
-      get { return _ugcid; }
+      get { return _ugcid?? default(ulong); }
       set { _ugcid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugcidSpecified
+    {
+      get { return _ugcid != null; }
+      set { if (value == (_ugcid== null)) _ugcid = value ? this.ugcid : (ulong?)null; }
+    }
+    private bool ShouldSerializeugcid() { return ugcidSpecified; }
+    private void Resetugcid() { ugcidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -315,68 +506,131 @@ namespace SteamKit2.Unified.Internal
     public CCloud_UserFile() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _ugcid = default(ulong);
+    private ulong? _ugcid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ugcid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong ugcid
     {
-      get { return _ugcid; }
+      get { return _ugcid?? default(ulong); }
       set { _ugcid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ugcidSpecified
+    {
+      get { return _ugcid != null; }
+      set { if (value == (_ugcid== null)) _ugcid = value ? this.ugcid : (ulong?)null; }
+    }
+    private bool ShouldSerializeugcid() { return ugcidSpecified; }
+    private void Resetugcid() { ugcidSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private ulong _timestamp = default(ulong);
+    private ulong? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(ulong); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private ulong _steamid_creator = default(ulong);
+    private ulong? _steamid_creator;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"steamid_creator", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid_creator
     {
-      get { return _steamid_creator; }
+      get { return _steamid_creator?? default(ulong); }
       set { _steamid_creator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamid_creatorSpecified
+    {
+      get { return _steamid_creator != null; }
+      set { if (value == (_steamid_creator== null)) _steamid_creator = value ? this.steamid_creator : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid_creator() { return steamid_creatorSpecified; }
+    private void Resetsteamid_creator() { steamid_creatorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -407,41 +661,77 @@ namespace SteamKit2.Unified.Internal
     public CCloud_EnumerateUserFiles_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _extended_details = default(bool);
+    private bool? _extended_details;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"extended_details", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool extended_details
     {
-      get { return _extended_details; }
+      get { return _extended_details?? default(bool); }
       set { _extended_details = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool extended_detailsSpecified
+    {
+      get { return _extended_details != null; }
+      set { if (value == (_extended_details== null)) _extended_details = value ? this.extended_details : (bool?)null; }
+    }
+    private bool ShouldSerializeextended_details() { return extended_detailsSpecified; }
+    private void Resetextended_details() { extended_detailsSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private uint _start_index = default(uint);
+    private uint? _start_index;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"start_index", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint start_index
     {
-      get { return _start_index; }
+      get { return _start_index?? default(uint); }
       set { _start_index = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool start_indexSpecified
+    {
+      get { return _start_index != null; }
+      set { if (value == (_start_index== null)) _start_index = value ? this.start_index : (uint?)null; }
+    }
+    private bool ShouldSerializestart_index() { return start_indexSpecified; }
+    private void Resetstart_index() { start_indexSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -460,14 +750,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _total_files = default(uint);
+    private uint? _total_files;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_files", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_files
     {
-      get { return _total_files; }
+      get { return _total_files?? default(uint); }
       set { _total_files = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_filesSpecified
+    {
+      get { return _total_files != null; }
+      set { if (value == (_total_files== null)) _total_files = value ? this.total_files : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_files() { return total_filesSpecified; }
+    private void Resettotal_files() { total_filesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -479,23 +778,41 @@ namespace SteamKit2.Unified.Internal
     public CCloud_Delete_Request() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -527,23 +844,41 @@ namespace SteamKit2.Unified.Internal
     public CCloud_GetClientEncryptionKey_Response() {}
     
 
-    private byte[] _key = null;
+    private byte[] _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] key
     {
-      get { return _key; }
+      get { return _key?? null; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (byte[])null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private int _crc = default(int);
+    private int? _crc;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"crc", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int crc
     {
-      get { return _crc; }
+      get { return _crc?? default(int); }
       set { _crc = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool crcSpecified
+    {
+      get { return _crc != null; }
+      set { if (value == (_crc== null)) _crc = value ? this.crc : (int?)null; }
+    }
+    private bool ShouldSerializecrc() { return crcSpecified; }
+    private void Resetcrc() { crcSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -555,68 +890,131 @@ namespace SteamKit2.Unified.Internal
     public CCloud_CDNReport_Notification() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private uint _http_status_code = default(uint);
+    private uint? _http_status_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"http_status_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint http_status_code
     {
-      get { return _http_status_code; }
+      get { return _http_status_code?? default(uint); }
       set { _http_status_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_status_codeSpecified
+    {
+      get { return _http_status_code != null; }
+      set { if (value == (_http_status_code== null)) _http_status_code = value ? this.http_status_code : (uint?)null; }
+    }
+    private bool ShouldSerializehttp_status_code() { return http_status_codeSpecified; }
+    private void Resethttp_status_code() { http_status_codeSpecified = false; }
+    
 
-    private ulong _expected_bytes = default(ulong);
+    private ulong? _expected_bytes;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"expected_bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong expected_bytes
     {
-      get { return _expected_bytes; }
+      get { return _expected_bytes?? default(ulong); }
       set { _expected_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool expected_bytesSpecified
+    {
+      get { return _expected_bytes != null; }
+      set { if (value == (_expected_bytes== null)) _expected_bytes = value ? this.expected_bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializeexpected_bytes() { return expected_bytesSpecified; }
+    private void Resetexpected_bytes() { expected_bytesSpecified = false; }
+    
 
-    private ulong _received_bytes = default(ulong);
+    private ulong? _received_bytes;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"received_bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong received_bytes
     {
-      get { return _received_bytes; }
+      get { return _received_bytes?? default(ulong); }
       set { _received_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool received_bytesSpecified
+    {
+      get { return _received_bytes != null; }
+      set { if (value == (_received_bytes== null)) _received_bytes = value ? this.received_bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializereceived_bytes() { return received_bytesSpecified; }
+    private void Resetreceived_bytes() { received_bytesSpecified = false; }
+    
 
-    private uint _duration = default(uint);
+    private uint? _duration;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"duration", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration
     {
-      get { return _duration; }
+      get { return _duration?? default(uint); }
       set { _duration = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool durationSpecified
+    {
+      get { return _duration != null; }
+      set { if (value == (_duration== null)) _duration = value ? this.duration : (uint?)null; }
+    }
+    private bool ShouldSerializeduration() { return durationSpecified; }
+    private void Resetduration() { durationSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -628,86 +1026,167 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ExternalStorageTransferReport_Notification() {}
     
 
-    private string _host = "";
+    private string _host;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string host
     {
-      get { return _host; }
+      get { return _host?? ""; }
       set { _host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hostSpecified
+    {
+      get { return _host != null; }
+      set { if (value == (_host== null)) _host = value ? this.host : (string)null; }
+    }
+    private bool ShouldSerializehost() { return hostSpecified; }
+    private void Resethost() { hostSpecified = false; }
+    
 
-    private string _path = "";
+    private string _path;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string path
     {
-      get { return _path; }
+      get { return _path?? ""; }
       set { _path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pathSpecified
+    {
+      get { return _path != null; }
+      set { if (value == (_path== null)) _path = value ? this.path : (string)null; }
+    }
+    private bool ShouldSerializepath() { return pathSpecified; }
+    private void Resetpath() { pathSpecified = false; }
+    
 
-    private bool _is_upload = default(bool);
+    private bool? _is_upload;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_upload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_upload
     {
-      get { return _is_upload; }
+      get { return _is_upload?? default(bool); }
       set { _is_upload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_uploadSpecified
+    {
+      get { return _is_upload != null; }
+      set { if (value == (_is_upload== null)) _is_upload = value ? this.is_upload : (bool?)null; }
+    }
+    private bool ShouldSerializeis_upload() { return is_uploadSpecified; }
+    private void Resetis_upload() { is_uploadSpecified = false; }
+    
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private uint _http_status_code = default(uint);
+    private uint? _http_status_code;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"http_status_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint http_status_code
     {
-      get { return _http_status_code; }
+      get { return _http_status_code?? default(uint); }
       set { _http_status_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_status_codeSpecified
+    {
+      get { return _http_status_code != null; }
+      set { if (value == (_http_status_code== null)) _http_status_code = value ? this.http_status_code : (uint?)null; }
+    }
+    private bool ShouldSerializehttp_status_code() { return http_status_codeSpecified; }
+    private void Resethttp_status_code() { http_status_codeSpecified = false; }
+    
 
-    private ulong _bytes_expected = default(ulong);
+    private ulong? _bytes_expected;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"bytes_expected", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_expected
     {
-      get { return _bytes_expected; }
+      get { return _bytes_expected?? default(ulong); }
       set { _bytes_expected = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_expectedSpecified
+    {
+      get { return _bytes_expected != null; }
+      set { if (value == (_bytes_expected== null)) _bytes_expected = value ? this.bytes_expected : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_expected() { return bytes_expectedSpecified; }
+    private void Resetbytes_expected() { bytes_expectedSpecified = false; }
+    
 
-    private ulong _bytes_actual = default(ulong);
+    private ulong? _bytes_actual;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"bytes_actual", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong bytes_actual
     {
-      get { return _bytes_actual; }
+      get { return _bytes_actual?? default(ulong); }
       set { _bytes_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bytes_actualSpecified
+    {
+      get { return _bytes_actual != null; }
+      set { if (value == (_bytes_actual== null)) _bytes_actual = value ? this.bytes_actual : (ulong?)null; }
+    }
+    private bool ShouldSerializebytes_actual() { return bytes_actualSpecified; }
+    private void Resetbytes_actual() { bytes_actualSpecified = false; }
+    
 
-    private uint _duration_ms = default(uint);
+    private uint? _duration_ms;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"duration_ms", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint duration_ms
     {
-      get { return _duration_ms; }
+      get { return _duration_ms?? default(uint); }
       set { _duration_ms = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool duration_msSpecified
+    {
+      get { return _duration_ms != null; }
+      set { if (value == (_duration_ms== null)) _duration_ms = value ? this.duration_ms : (uint?)null; }
+    }
+    private bool ShouldSerializeduration_ms() { return duration_msSpecified; }
+    private void Resetduration_ms() { duration_msSpecified = false; }
+    
 
-    private uint _cellid = default(uint);
+    private uint? _cellid;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"cellid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cellid
     {
-      get { return _cellid; }
+      get { return _cellid?? default(uint); }
       set { _cellid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cellidSpecified
+    {
+      get { return _cellid != null; }
+      set { if (value == (_cellid== null)) _cellid = value ? this.cellid : (uint?)null; }
+    }
+    private bool ShouldSerializecellid() { return cellidSpecified; }
+    private void Resetcellid() { cellidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -719,95 +1198,185 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientBeginFileUpload_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private byte[] _file_sha = null;
+    private byte[] _file_sha;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"file_sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] file_sha
     {
-      get { return _file_sha; }
+      get { return _file_sha?? null; }
       set { _file_sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_shaSpecified
+    {
+      get { return _file_sha != null; }
+      set { if (value == (_file_sha== null)) _file_sha = value ? this.file_sha : (byte[])null; }
+    }
+    private bool ShouldSerializefile_sha() { return file_shaSpecified; }
+    private void Resetfile_sha() { file_shaSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _platforms_to_sync = (uint)4294967295;
+    private uint? _platforms_to_sync;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"platforms_to_sync", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)4294967295)]
     public uint platforms_to_sync
     {
-      get { return _platforms_to_sync; }
+      get { return _platforms_to_sync?? (uint)4294967295; }
       set { _platforms_to_sync = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool platforms_to_syncSpecified
+    {
+      get { return _platforms_to_sync != null; }
+      set { if (value == (_platforms_to_sync== null)) _platforms_to_sync = value ? this.platforms_to_sync : (uint?)null; }
+    }
+    private bool ShouldSerializeplatforms_to_sync() { return platforms_to_syncSpecified; }
+    private void Resetplatforms_to_sync() { platforms_to_syncSpecified = false; }
+    
 
-    private uint _cell_id = default(uint);
+    private uint? _cell_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"cell_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint cell_id
     {
-      get { return _cell_id; }
+      get { return _cell_id?? default(uint); }
       set { _cell_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cell_idSpecified
+    {
+      get { return _cell_id != null; }
+      set { if (value == (_cell_id== null)) _cell_id = value ? this.cell_id : (uint?)null; }
+    }
+    private bool ShouldSerializecell_id() { return cell_idSpecified; }
+    private void Resetcell_id() { cell_idSpecified = false; }
+    
 
-    private bool _can_encrypt = default(bool);
+    private bool? _can_encrypt;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"can_encrypt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_encrypt
     {
-      get { return _can_encrypt; }
+      get { return _can_encrypt?? default(bool); }
       set { _can_encrypt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_encryptSpecified
+    {
+      get { return _can_encrypt != null; }
+      set { if (value == (_can_encrypt== null)) _can_encrypt = value ? this.can_encrypt : (bool?)null; }
+    }
+    private bool ShouldSerializecan_encrypt() { return can_encryptSpecified; }
+    private void Resetcan_encrypt() { can_encryptSpecified = false; }
+    
 
-    private bool _is_shared_file = default(bool);
+    private bool? _is_shared_file;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_shared_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_shared_file
     {
-      get { return _is_shared_file; }
+      get { return _is_shared_file?? default(bool); }
       set { _is_shared_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_shared_fileSpecified
+    {
+      get { return _is_shared_file != null; }
+      set { if (value == (_is_shared_file== null)) _is_shared_file = value ? this.is_shared_file : (bool?)null; }
+    }
+    private bool ShouldSerializeis_shared_file() { return is_shared_fileSpecified; }
+    private void Resetis_shared_file() { is_shared_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -819,41 +1388,77 @@ namespace SteamKit2.Unified.Internal
     public ClientCloudFileUploadBlockDetails() {}
     
 
-    private string _url_host = "";
+    private string _url_host;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"url_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_host
     {
-      get { return _url_host; }
+      get { return _url_host?? ""; }
       set { _url_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_hostSpecified
+    {
+      get { return _url_host != null; }
+      set { if (value == (_url_host== null)) _url_host = value ? this.url_host : (string)null; }
+    }
+    private bool ShouldSerializeurl_host() { return url_hostSpecified; }
+    private void Reseturl_host() { url_hostSpecified = false; }
+    
 
-    private string _url_path = "";
+    private string _url_path;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"url_path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_path
     {
-      get { return _url_path; }
+      get { return _url_path?? ""; }
       set { _url_path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_pathSpecified
+    {
+      get { return _url_path != null; }
+      set { if (value == (_url_path== null)) _url_path = value ? this.url_path : (string)null; }
+    }
+    private bool ShouldSerializeurl_path() { return url_pathSpecified; }
+    private void Reseturl_path() { url_pathSpecified = false; }
+    
 
-    private bool _use_https = default(bool);
+    private bool? _use_https;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"use_https", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_https
     {
-      get { return _use_https; }
+      get { return _use_https?? default(bool); }
       set { _use_https = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpsSpecified
+    {
+      get { return _use_https != null; }
+      set { if (value == (_use_https== null)) _use_https = value ? this.use_https : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_https() { return use_httpsSpecified; }
+    private void Resetuse_https() { use_httpsSpecified = false; }
+    
 
-    private int _http_method = default(int);
+    private int? _http_method;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"http_method", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int http_method
     {
-      get { return _http_method; }
+      get { return _http_method?? default(int); }
       set { _http_method = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool http_methodSpecified
+    {
+      get { return _http_method != null; }
+      set { if (value == (_http_method== null)) _http_method = value ? this.http_method : (int?)null; }
+    }
+    private bool ShouldSerializehttp_method() { return http_methodSpecified; }
+    private void Resethttp_method() { http_methodSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails.HTTPHeaders> _request_headers = new global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails.HTTPHeaders>();
     [global::ProtoBuf.ProtoMember(5, Name=@"request_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails.HTTPHeaders> request_headers
@@ -862,64 +1467,118 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private ulong _block_offset = default(ulong);
+    private ulong? _block_offset;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"block_offset", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong block_offset
     {
-      get { return _block_offset; }
+      get { return _block_offset?? default(ulong); }
       set { _block_offset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool block_offsetSpecified
+    {
+      get { return _block_offset != null; }
+      set { if (value == (_block_offset== null)) _block_offset = value ? this.block_offset : (ulong?)null; }
+    }
+    private bool ShouldSerializeblock_offset() { return block_offsetSpecified; }
+    private void Resetblock_offset() { block_offsetSpecified = false; }
+    
 
-    private uint _block_length = default(uint);
+    private uint? _block_length;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"block_length", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint block_length
     {
-      get { return _block_length; }
+      get { return _block_length?? default(uint); }
       set { _block_length = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool block_lengthSpecified
+    {
+      get { return _block_length != null; }
+      set { if (value == (_block_length== null)) _block_length = value ? this.block_length : (uint?)null; }
+    }
+    private bool ShouldSerializeblock_length() { return block_lengthSpecified; }
+    private void Resetblock_length() { block_lengthSpecified = false; }
+    
 
-    private byte[] _explicit_body_data = null;
+    private byte[] _explicit_body_data;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"explicit_body_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] explicit_body_data
     {
-      get { return _explicit_body_data; }
+      get { return _explicit_body_data?? null; }
       set { _explicit_body_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool explicit_body_dataSpecified
+    {
+      get { return _explicit_body_data != null; }
+      set { if (value == (_explicit_body_data== null)) _explicit_body_data = value ? this.explicit_body_data : (byte[])null; }
+    }
+    private bool ShouldSerializeexplicit_body_data() { return explicit_body_dataSpecified; }
+    private void Resetexplicit_body_data() { explicit_body_dataSpecified = false; }
+    
 
-    private bool _may_parallelize = default(bool);
+    private bool? _may_parallelize;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"may_parallelize", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool may_parallelize
     {
-      get { return _may_parallelize; }
+      get { return _may_parallelize?? default(bool); }
       set { _may_parallelize = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool may_parallelizeSpecified
+    {
+      get { return _may_parallelize != null; }
+      set { if (value == (_may_parallelize== null)) _may_parallelize = value ? this.may_parallelize : (bool?)null; }
+    }
+    private bool ShouldSerializemay_parallelize() { return may_parallelizeSpecified; }
+    private void Resetmay_parallelize() { may_parallelizeSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"HTTPHeaders")]
   public partial class HTTPHeaders : global::ProtoBuf.IExtensible
   {
     public HTTPHeaders() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -936,14 +1595,23 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientBeginFileUpload_Response() {}
     
 
-    private bool _encrypt_file = default(bool);
+    private bool? _encrypt_file;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"encrypt_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool encrypt_file
     {
-      get { return _encrypt_file; }
+      get { return _encrypt_file?? default(bool); }
       set { _encrypt_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encrypt_fileSpecified
+    {
+      get { return _encrypt_file != null; }
+      set { if (value == (_encrypt_file== null)) _encrypt_file = value ? this.encrypt_file : (bool?)null; }
+    }
+    private bool ShouldSerializeencrypt_file() { return encrypt_fileSpecified; }
+    private void Resetencrypt_file() { encrypt_fileSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails> _block_requests = new global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails>();
     [global::ProtoBuf.ProtoMember(2, Name=@"block_requests", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ClientCloudFileUploadBlockDetails> block_requests
@@ -962,41 +1630,77 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientCommitFileUpload_Request() {}
     
 
-    private bool _transfer_succeeded = default(bool);
+    private bool? _transfer_succeeded;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"transfer_succeeded", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool transfer_succeeded
     {
-      get { return _transfer_succeeded; }
+      get { return _transfer_succeeded?? default(bool); }
       set { _transfer_succeeded = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool transfer_succeededSpecified
+    {
+      get { return _transfer_succeeded != null; }
+      set { if (value == (_transfer_succeeded== null)) _transfer_succeeded = value ? this.transfer_succeeded : (bool?)null; }
+    }
+    private bool ShouldSerializetransfer_succeeded() { return transfer_succeededSpecified; }
+    private void Resettransfer_succeeded() { transfer_succeededSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private byte[] _file_sha = null;
+    private byte[] _file_sha;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] file_sha
     {
-      get { return _file_sha; }
+      get { return _file_sha?? null; }
       set { _file_sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_shaSpecified
+    {
+      get { return _file_sha != null; }
+      set { if (value == (_file_sha== null)) _file_sha = value ? this.file_sha : (byte[])null; }
+    }
+    private bool ShouldSerializefile_sha() { return file_shaSpecified; }
+    private void Resetfile_sha() { file_shaSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1008,14 +1712,23 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientCommitFileUpload_Response() {}
     
 
-    private bool _file_committed = default(bool);
+    private bool? _file_committed;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_committed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool file_committed
     {
-      get { return _file_committed; }
+      get { return _file_committed?? default(bool); }
       set { _file_committed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_committedSpecified
+    {
+      get { return _file_committed != null; }
+      set { if (value == (_file_committed== null)) _file_committed = value ? this.file_committed : (bool?)null; }
+    }
+    private bool ShouldSerializefile_committed() { return file_committedSpecified; }
+    private void Resetfile_committed() { file_committedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1027,23 +1740,41 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientFileDownload_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1055,86 +1786,167 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientFileDownload_Response() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _file_size = default(uint);
+    private uint? _file_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(uint); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (uint?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private uint _raw_file_size = default(uint);
+    private uint? _raw_file_size;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"raw_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint raw_file_size
     {
-      get { return _raw_file_size; }
+      get { return _raw_file_size?? default(uint); }
       set { _raw_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool raw_file_sizeSpecified
+    {
+      get { return _raw_file_size != null; }
+      set { if (value == (_raw_file_size== null)) _raw_file_size = value ? this.raw_file_size : (uint?)null; }
+    }
+    private bool ShouldSerializeraw_file_size() { return raw_file_sizeSpecified; }
+    private void Resetraw_file_size() { raw_file_sizeSpecified = false; }
+    
 
-    private byte[] _sha_file = null;
+    private byte[] _sha_file;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sha_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_file
     {
-      get { return _sha_file; }
+      get { return _sha_file?? null; }
       set { _sha_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_fileSpecified
+    {
+      get { return _sha_file != null; }
+      set { if (value == (_sha_file== null)) _sha_file = value ? this.sha_file : (byte[])null; }
+    }
+    private bool ShouldSerializesha_file() { return sha_fileSpecified; }
+    private void Resetsha_file() { sha_fileSpecified = false; }
+    
 
-    private ulong _time_stamp = default(ulong);
+    private ulong? _time_stamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_stamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong time_stamp
     {
-      get { return _time_stamp; }
+      get { return _time_stamp?? default(ulong); }
       set { _time_stamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_stampSpecified
+    {
+      get { return _time_stamp != null; }
+      set { if (value == (_time_stamp== null)) _time_stamp = value ? this.time_stamp : (ulong?)null; }
+    }
+    private bool ShouldSerializetime_stamp() { return time_stampSpecified; }
+    private void Resettime_stamp() { time_stampSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
 
-    private string _url_host = "";
+    private string _url_host;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"url_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_host
     {
-      get { return _url_host; }
+      get { return _url_host?? ""; }
       set { _url_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_hostSpecified
+    {
+      get { return _url_host != null; }
+      set { if (value == (_url_host== null)) _url_host = value ? this.url_host : (string)null; }
+    }
+    private bool ShouldSerializeurl_host() { return url_hostSpecified; }
+    private void Reseturl_host() { url_hostSpecified = false; }
+    
 
-    private string _url_path = "";
+    private string _url_path;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"url_path", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_path
     {
-      get { return _url_path; }
+      get { return _url_path?? ""; }
       set { _url_path = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_pathSpecified
+    {
+      get { return _url_path != null; }
+      set { if (value == (_url_path== null)) _url_path = value ? this.url_path : (string)null; }
+    }
+    private bool ShouldSerializeurl_path() { return url_pathSpecified; }
+    private void Reseturl_path() { url_pathSpecified = false; }
+    
 
-    private bool _use_https = default(bool);
+    private bool? _use_https;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"use_https", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool use_https
     {
-      get { return _use_https; }
+      get { return _use_https?? default(bool); }
       set { _use_https = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool use_httpsSpecified
+    {
+      get { return _use_https != null; }
+      set { if (value == (_use_https== null)) _use_https = value ? this.use_https : (bool?)null; }
+    }
+    private bool ShouldSerializeuse_https() { return use_httpsSpecified; }
+    private void Resetuse_https() { use_httpsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CCloud_ClientFileDownload_Response.HTTPHeaders> _request_headers = new global::System.Collections.Generic.List<CCloud_ClientFileDownload_Response.HTTPHeaders>();
     [global::ProtoBuf.ProtoMember(10, Name=@"request_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CCloud_ClientFileDownload_Response.HTTPHeaders> request_headers
@@ -1143,37 +1955,64 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _encrypted = default(bool);
+    private bool? _encrypted;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"encrypted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool encrypted
     {
-      get { return _encrypted; }
+      get { return _encrypted?? default(bool); }
       set { _encrypted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryptedSpecified
+    {
+      get { return _encrypted != null; }
+      set { if (value == (_encrypted== null)) _encrypted = value ? this.encrypted : (bool?)null; }
+    }
+    private bool ShouldSerializeencrypted() { return encryptedSpecified; }
+    private void Resetencrypted() { encryptedSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"HTTPHeaders")]
   public partial class HTTPHeaders : global::ProtoBuf.IExtensible
   {
     public HTTPHeaders() {}
     
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1190,32 +2029,59 @@ namespace SteamKit2.Unified.Internal
     public CCloud_ClientDeleteFile_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private bool _is_explicit_delete = default(bool);
+    private bool? _is_explicit_delete;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_explicit_delete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_explicit_delete
     {
-      get { return _is_explicit_delete; }
+      get { return _is_explicit_delete?? default(bool); }
       set { _is_explicit_delete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_explicit_deleteSpecified
+    {
+      get { return _is_explicit_delete != null; }
+      set { if (value == (_is_explicit_delete== null)) _is_explicit_delete = value ? this.is_explicit_delete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_explicit_delete() { return is_explicit_deleteSpecified; }
+    private void Resetis_explicit_delete() { is_explicit_deleteSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgCredentials.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgCredentials.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_credentials.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,32 +20,59 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_TestAvailablePassword_Request() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private byte[] _sha_digest_password = null;
+    private byte[] _sha_digest_password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sha_digest_password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha_digest_password
     {
-      get { return _sha_digest_password; }
+      get { return _sha_digest_password?? null; }
       set { _sha_digest_password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sha_digest_passwordSpecified
+    {
+      get { return _sha_digest_password != null; }
+      set { if (value == (_sha_digest_password== null)) _sha_digest_password = value ? this.sha_digest_password : (byte[])null; }
+    }
+    private bool ShouldSerializesha_digest_password() { return sha_digest_passwordSpecified; }
+    private void Resetsha_digest_password() { sha_digest_passwordSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -55,14 +84,23 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_TestAvailablePassword_Response() {}
     
 
-    private bool _is_valid = default(bool);
+    private bool? _is_valid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_valid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_valid
     {
-      get { return _is_valid; }
+      get { return _is_valid?? default(bool); }
       set { _is_valid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_validSpecified
+    {
+      get { return _is_valid != null; }
+      set { if (value == (_is_valid== null)) _is_valid = value ? this.is_valid : (bool?)null; }
+    }
+    private bool ShouldSerializeis_valid() { return is_validSpecified; }
+    private void Resetis_valid() { is_validSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -74,41 +112,77 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_GetSteamGuardDetails_Request() {}
     
 
-    private bool _include_new_authentications = (bool)true;
+    private bool? _include_new_authentications;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"include_new_authentications", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool include_new_authentications
     {
-      get { return _include_new_authentications; }
+      get { return _include_new_authentications?? (bool)true; }
       set { _include_new_authentications = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_new_authenticationsSpecified
+    {
+      get { return _include_new_authentications != null; }
+      set { if (value == (_include_new_authentications== null)) _include_new_authentications = value ? this.include_new_authentications : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_new_authentications() { return include_new_authenticationsSpecified; }
+    private void Resetinclude_new_authentications() { include_new_authenticationsSpecified = false; }
+    
 
-    private string _webcookie = "";
+    private string _webcookie;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"webcookie", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string webcookie
     {
-      get { return _webcookie; }
+      get { return _webcookie?? ""; }
       set { _webcookie = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool webcookieSpecified
+    {
+      get { return _webcookie != null; }
+      set { if (value == (_webcookie== null)) _webcookie = value ? this.webcookie : (string)null; }
+    }
+    private bool ShouldSerializewebcookie() { return webcookieSpecified; }
+    private void Resetwebcookie() { webcookieSpecified = false; }
+    
 
-    private uint _timestamp_minimum_wanted = default(uint);
+    private uint? _timestamp_minimum_wanted;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp_minimum_wanted", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_minimum_wanted
     {
-      get { return _timestamp_minimum_wanted; }
+      get { return _timestamp_minimum_wanted?? default(uint); }
       set { _timestamp_minimum_wanted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_minimum_wantedSpecified
+    {
+      get { return _timestamp_minimum_wanted != null; }
+      set { if (value == (_timestamp_minimum_wanted== null)) _timestamp_minimum_wanted = value ? this.timestamp_minimum_wanted : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_minimum_wanted() { return timestamp_minimum_wantedSpecified; }
+    private void Resettimestamp_minimum_wanted() { timestamp_minimum_wantedSpecified = false; }
+    
 
-    private int _ipaddress = default(int);
+    private int? _ipaddress;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"ipaddress", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ipaddress
     {
-      get { return _ipaddress; }
+      get { return _ipaddress?? default(int); }
       set { _ipaddress = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipaddressSpecified
+    {
+      get { return _ipaddress != null; }
+      set { if (value == (_ipaddress== null)) _ipaddress = value ? this.ipaddress : (int?)null; }
+    }
+    private bool ShouldSerializeipaddress() { return ipaddressSpecified; }
+    private void Resetipaddress() { ipaddressSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -120,23 +194,41 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_GetSteamGuardDetails_Response() {}
     
 
-    private bool _is_steamguard_enabled = default(bool);
+    private bool? _is_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_steamguard_enabled
     {
-      get { return _is_steamguard_enabled; }
+      get { return _is_steamguard_enabled?? default(bool); }
       set { _is_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_steamguard_enabledSpecified
+    {
+      get { return _is_steamguard_enabled != null; }
+      set { if (value == (_is_steamguard_enabled== null)) _is_steamguard_enabled = value ? this.is_steamguard_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_steamguard_enabled() { return is_steamguard_enabledSpecified; }
+    private void Resetis_steamguard_enabled() { is_steamguard_enabledSpecified = false; }
+    
 
-    private uint _timestamp_steamguard_enabled = default(uint);
+    private uint? _timestamp_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_steamguard_enabled
     {
-      get { return _timestamp_steamguard_enabled; }
+      get { return _timestamp_steamguard_enabled?? default(uint); }
       set { _timestamp_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_steamguard_enabledSpecified
+    {
+      get { return _timestamp_steamguard_enabled != null; }
+      set { if (value == (_timestamp_steamguard_enabled== null)) _timestamp_steamguard_enabled = value ? this.timestamp_steamguard_enabled : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_steamguard_enabled() { return timestamp_steamguard_enabledSpecified; }
+    private void Resettimestamp_steamguard_enabled() { timestamp_steamguard_enabledSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication> _deprecated_newauthentication = new global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication>();
     [global::ProtoBuf.ProtoMember(3, Name=@"deprecated_newauthentication", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication> deprecated_newauthentication
@@ -145,41 +237,77 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _deprecated_machine_name_userchosen = "";
+    private string _deprecated_machine_name_userchosen;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"deprecated_machine_name_userchosen", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string deprecated_machine_name_userchosen
     {
-      get { return _deprecated_machine_name_userchosen; }
+      get { return _deprecated_machine_name_userchosen?? ""; }
       set { _deprecated_machine_name_userchosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deprecated_machine_name_userchosenSpecified
+    {
+      get { return _deprecated_machine_name_userchosen != null; }
+      set { if (value == (_deprecated_machine_name_userchosen== null)) _deprecated_machine_name_userchosen = value ? this.deprecated_machine_name_userchosen : (string)null; }
+    }
+    private bool ShouldSerializedeprecated_machine_name_userchosen() { return deprecated_machine_name_userchosenSpecified; }
+    private void Resetdeprecated_machine_name_userchosen() { deprecated_machine_name_userchosenSpecified = false; }
+    
 
-    private uint _deprecated_timestamp_machine_steamguard_enabled = default(uint);
+    private uint? _deprecated_timestamp_machine_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"deprecated_timestamp_machine_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint deprecated_timestamp_machine_steamguard_enabled
     {
-      get { return _deprecated_timestamp_machine_steamguard_enabled; }
+      get { return _deprecated_timestamp_machine_steamguard_enabled?? default(uint); }
       set { _deprecated_timestamp_machine_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deprecated_timestamp_machine_steamguard_enabledSpecified
+    {
+      get { return _deprecated_timestamp_machine_steamguard_enabled != null; }
+      set { if (value == (_deprecated_timestamp_machine_steamguard_enabled== null)) _deprecated_timestamp_machine_steamguard_enabled = value ? this.deprecated_timestamp_machine_steamguard_enabled : (uint?)null; }
+    }
+    private bool ShouldSerializedeprecated_timestamp_machine_steamguard_enabled() { return deprecated_timestamp_machine_steamguard_enabledSpecified; }
+    private void Resetdeprecated_timestamp_machine_steamguard_enabled() { deprecated_timestamp_machine_steamguard_enabledSpecified = false; }
+    
 
-    private bool _deprecated_authentication_exists_from_geoloc_before_mintime = default(bool);
+    private bool? _deprecated_authentication_exists_from_geoloc_before_mintime;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"deprecated_authentication_exists_from_geoloc_before_mintime", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool deprecated_authentication_exists_from_geoloc_before_mintime
     {
-      get { return _deprecated_authentication_exists_from_geoloc_before_mintime; }
+      get { return _deprecated_authentication_exists_from_geoloc_before_mintime?? default(bool); }
       set { _deprecated_authentication_exists_from_geoloc_before_mintime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deprecated_authentication_exists_from_geoloc_before_mintimeSpecified
+    {
+      get { return _deprecated_authentication_exists_from_geoloc_before_mintime != null; }
+      set { if (value == (_deprecated_authentication_exists_from_geoloc_before_mintime== null)) _deprecated_authentication_exists_from_geoloc_before_mintime = value ? this.deprecated_authentication_exists_from_geoloc_before_mintime : (bool?)null; }
+    }
+    private bool ShouldSerializedeprecated_authentication_exists_from_geoloc_before_mintime() { return deprecated_authentication_exists_from_geoloc_before_mintimeSpecified; }
+    private void Resetdeprecated_authentication_exists_from_geoloc_before_mintime() { deprecated_authentication_exists_from_geoloc_before_mintimeSpecified = false; }
+    
 
-    private ulong _deprecated_machine_id = default(ulong);
+    private ulong? _deprecated_machine_id;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deprecated_machine_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong deprecated_machine_id
     {
-      get { return _deprecated_machine_id; }
+      get { return _deprecated_machine_id?? default(ulong); }
       set { _deprecated_machine_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deprecated_machine_idSpecified
+    {
+      get { return _deprecated_machine_id != null; }
+      set { if (value == (_deprecated_machine_id== null)) _deprecated_machine_id = value ? this.deprecated_machine_id : (ulong?)null; }
+    }
+    private bool ShouldSerializedeprecated_machine_id() { return deprecated_machine_idSpecified; }
+    private void Resetdeprecated_machine_id() { deprecated_machine_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.SessionData> _session_data = new global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.SessionData>();
     [global::ProtoBuf.ProtoMember(8, Name=@"session_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.SessionData> session_data
@@ -188,100 +316,190 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _is_twofactor_enabled = default(bool);
+    private bool? _is_twofactor_enabled;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_twofactor_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_twofactor_enabled
     {
-      get { return _is_twofactor_enabled; }
+      get { return _is_twofactor_enabled?? default(bool); }
       set { _is_twofactor_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_twofactor_enabledSpecified
+    {
+      get { return _is_twofactor_enabled != null; }
+      set { if (value == (_is_twofactor_enabled== null)) _is_twofactor_enabled = value ? this.is_twofactor_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_twofactor_enabled() { return is_twofactor_enabledSpecified; }
+    private void Resetis_twofactor_enabled() { is_twofactor_enabledSpecified = false; }
+    
 
-    private uint _timestamp_twofactor_enabled = default(uint);
+    private uint? _timestamp_twofactor_enabled;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"timestamp_twofactor_enabled", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_twofactor_enabled
     {
-      get { return _timestamp_twofactor_enabled; }
+      get { return _timestamp_twofactor_enabled?? default(uint); }
       set { _timestamp_twofactor_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_twofactor_enabledSpecified
+    {
+      get { return _timestamp_twofactor_enabled != null; }
+      set { if (value == (_timestamp_twofactor_enabled== null)) _timestamp_twofactor_enabled = value ? this.timestamp_twofactor_enabled : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_twofactor_enabled() { return timestamp_twofactor_enabledSpecified; }
+    private void Resettimestamp_twofactor_enabled() { timestamp_twofactor_enabledSpecified = false; }
+    
 
-    private bool _is_phone_verified = default(bool);
+    private bool? _is_phone_verified;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"is_phone_verified", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_phone_verified
     {
-      get { return _is_phone_verified; }
+      get { return _is_phone_verified?? default(bool); }
       set { _is_phone_verified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_phone_verifiedSpecified
+    {
+      get { return _is_phone_verified != null; }
+      set { if (value == (_is_phone_verified== null)) _is_phone_verified = value ? this.is_phone_verified : (bool?)null; }
+    }
+    private bool ShouldSerializeis_phone_verified() { return is_phone_verifiedSpecified; }
+    private void Resetis_phone_verified() { is_phone_verifiedSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"NewAuthentication")]
   public partial class NewAuthentication : global::ProtoBuf.IExtensible
   {
     public NewAuthentication() {}
     
 
-    private uint _timestamp_steamguard_enabled = default(uint);
+    private uint? _timestamp_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_steamguard_enabled
     {
-      get { return _timestamp_steamguard_enabled; }
+      get { return _timestamp_steamguard_enabled?? default(uint); }
       set { _timestamp_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_steamguard_enabledSpecified
+    {
+      get { return _timestamp_steamguard_enabled != null; }
+      set { if (value == (_timestamp_steamguard_enabled== null)) _timestamp_steamguard_enabled = value ? this.timestamp_steamguard_enabled : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_steamguard_enabled() { return timestamp_steamguard_enabledSpecified; }
+    private void Resettimestamp_steamguard_enabled() { timestamp_steamguard_enabledSpecified = false; }
+    
 
-    private bool _is_web_cookie = default(bool);
+    private bool? _is_web_cookie;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_web_cookie", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_web_cookie
     {
-      get { return _is_web_cookie; }
+      get { return _is_web_cookie?? default(bool); }
       set { _is_web_cookie = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_web_cookieSpecified
+    {
+      get { return _is_web_cookie != null; }
+      set { if (value == (_is_web_cookie== null)) _is_web_cookie = value ? this.is_web_cookie : (bool?)null; }
+    }
+    private bool ShouldSerializeis_web_cookie() { return is_web_cookieSpecified; }
+    private void Resetis_web_cookie() { is_web_cookieSpecified = false; }
+    
 
-    private int _ipaddress = default(int);
+    private int? _ipaddress;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"ipaddress", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int ipaddress
     {
-      get { return _ipaddress; }
+      get { return _ipaddress?? default(int); }
       set { _ipaddress = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipaddressSpecified
+    {
+      get { return _ipaddress != null; }
+      set { if (value == (_ipaddress== null)) _ipaddress = value ? this.ipaddress : (int?)null; }
+    }
+    private bool ShouldSerializeipaddress() { return ipaddressSpecified; }
+    private void Resetipaddress() { ipaddressSpecified = false; }
+    
 
-    private string _geoloc_info = "";
+    private string _geoloc_info;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"geoloc_info", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string geoloc_info
     {
-      get { return _geoloc_info; }
+      get { return _geoloc_info?? ""; }
       set { _geoloc_info = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool geoloc_infoSpecified
+    {
+      get { return _geoloc_info != null; }
+      set { if (value == (_geoloc_info== null)) _geoloc_info = value ? this.geoloc_info : (string)null; }
+    }
+    private bool ShouldSerializegeoloc_info() { return geoloc_infoSpecified; }
+    private void Resetgeoloc_info() { geoloc_infoSpecified = false; }
+    
 
-    private bool _is_remembered = default(bool);
+    private bool? _is_remembered;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"is_remembered", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_remembered
     {
-      get { return _is_remembered; }
+      get { return _is_remembered?? default(bool); }
       set { _is_remembered = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_rememberedSpecified
+    {
+      get { return _is_remembered != null; }
+      set { if (value == (_is_remembered== null)) _is_remembered = value ? this.is_remembered : (bool?)null; }
+    }
+    private bool ShouldSerializeis_remembered() { return is_rememberedSpecified; }
+    private void Resetis_remembered() { is_rememberedSpecified = false; }
+    
 
-    private string _machine_name_user_supplied = "";
+    private string _machine_name_user_supplied;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"machine_name_user_supplied", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name_user_supplied
     {
-      get { return _machine_name_user_supplied; }
+      get { return _machine_name_user_supplied?? ""; }
       set { _machine_name_user_supplied = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_name_user_suppliedSpecified
+    {
+      get { return _machine_name_user_supplied != null; }
+      set { if (value == (_machine_name_user_supplied== null)) _machine_name_user_supplied = value ? this.machine_name_user_supplied : (string)null; }
+    }
+    private bool ShouldSerializemachine_name_user_supplied() { return machine_name_user_suppliedSpecified; }
+    private void Resetmachine_name_user_supplied() { machine_name_user_suppliedSpecified = false; }
+    
 
-    private int _status = default(int);
+    private int? _status;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int status
     {
-      get { return _status; }
+      get { return _status?? default(int); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (int?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -293,41 +511,77 @@ namespace SteamKit2.Unified.Internal
     public SessionData() {}
     
 
-    private ulong _machine_id = default(ulong);
+    private ulong? _machine_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"machine_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong machine_id
     {
-      get { return _machine_id; }
+      get { return _machine_id?? default(ulong); }
       set { _machine_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_idSpecified
+    {
+      get { return _machine_id != null; }
+      set { if (value == (_machine_id== null)) _machine_id = value ? this.machine_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemachine_id() { return machine_idSpecified; }
+    private void Resetmachine_id() { machine_idSpecified = false; }
+    
 
-    private string _machine_name_userchosen = "";
+    private string _machine_name_userchosen;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"machine_name_userchosen", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string machine_name_userchosen
     {
-      get { return _machine_name_userchosen; }
+      get { return _machine_name_userchosen?? ""; }
       set { _machine_name_userchosen = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool machine_name_userchosenSpecified
+    {
+      get { return _machine_name_userchosen != null; }
+      set { if (value == (_machine_name_userchosen== null)) _machine_name_userchosen = value ? this.machine_name_userchosen : (string)null; }
+    }
+    private bool ShouldSerializemachine_name_userchosen() { return machine_name_userchosenSpecified; }
+    private void Resetmachine_name_userchosen() { machine_name_userchosenSpecified = false; }
+    
 
-    private uint _timestamp_machine_steamguard_enabled = default(uint);
+    private uint? _timestamp_machine_steamguard_enabled;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp_machine_steamguard_enabled", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_machine_steamguard_enabled
     {
-      get { return _timestamp_machine_steamguard_enabled; }
+      get { return _timestamp_machine_steamguard_enabled?? default(uint); }
       set { _timestamp_machine_steamguard_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_machine_steamguard_enabledSpecified
+    {
+      get { return _timestamp_machine_steamguard_enabled != null; }
+      set { if (value == (_timestamp_machine_steamguard_enabled== null)) _timestamp_machine_steamguard_enabled = value ? this.timestamp_machine_steamguard_enabled : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_machine_steamguard_enabled() { return timestamp_machine_steamguard_enabledSpecified; }
+    private void Resettimestamp_machine_steamguard_enabled() { timestamp_machine_steamguard_enabledSpecified = false; }
+    
 
-    private bool _authentication_exists_from_geoloc_before_mintime = default(bool);
+    private bool? _authentication_exists_from_geoloc_before_mintime;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"authentication_exists_from_geoloc_before_mintime", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool authentication_exists_from_geoloc_before_mintime
     {
-      get { return _authentication_exists_from_geoloc_before_mintime; }
+      get { return _authentication_exists_from_geoloc_before_mintime?? default(bool); }
       set { _authentication_exists_from_geoloc_before_mintime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authentication_exists_from_geoloc_before_mintimeSpecified
+    {
+      get { return _authentication_exists_from_geoloc_before_mintime != null; }
+      set { if (value == (_authentication_exists_from_geoloc_before_mintime== null)) _authentication_exists_from_geoloc_before_mintime = value ? this.authentication_exists_from_geoloc_before_mintime : (bool?)null; }
+    }
+    private bool ShouldSerializeauthentication_exists_from_geoloc_before_mintime() { return authentication_exists_from_geoloc_before_mintimeSpecified; }
+    private void Resetauthentication_exists_from_geoloc_before_mintime() { authentication_exists_from_geoloc_before_mintimeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication> _newauthentication = new global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication>();
     [global::ProtoBuf.ProtoMember(5, Name=@"newauthentication", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CCredentials_GetSteamGuardDetails_Response.NewAuthentication> newauthentication
@@ -336,23 +590,41 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _authentication_exists_from_same_ip_before_mintime = default(bool);
+    private bool? _authentication_exists_from_same_ip_before_mintime;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"authentication_exists_from_same_ip_before_mintime", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool authentication_exists_from_same_ip_before_mintime
     {
-      get { return _authentication_exists_from_same_ip_before_mintime; }
+      get { return _authentication_exists_from_same_ip_before_mintime?? default(bool); }
       set { _authentication_exists_from_same_ip_before_mintime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authentication_exists_from_same_ip_before_mintimeSpecified
+    {
+      get { return _authentication_exists_from_same_ip_before_mintime != null; }
+      set { if (value == (_authentication_exists_from_same_ip_before_mintime== null)) _authentication_exists_from_same_ip_before_mintime = value ? this.authentication_exists_from_same_ip_before_mintime : (bool?)null; }
+    }
+    private bool ShouldSerializeauthentication_exists_from_same_ip_before_mintime() { return authentication_exists_from_same_ip_before_mintimeSpecified; }
+    private void Resetauthentication_exists_from_same_ip_before_mintime() { authentication_exists_from_same_ip_before_mintimeSpecified = false; }
+    
 
-    private uint _public_ipv4 = default(uint);
+    private uint? _public_ipv4;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"public_ipv4", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint public_ipv4
     {
-      get { return _public_ipv4; }
+      get { return _public_ipv4?? default(uint); }
       set { _public_ipv4 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool public_ipv4Specified
+    {
+      get { return _public_ipv4 != null; }
+      set { if (value == (_public_ipv4== null)) _public_ipv4 = value ? this.public_ipv4 : (uint?)null; }
+    }
+    private bool ShouldSerializepublic_ipv4() { return public_ipv4Specified; }
+    private void Resetpublic_ipv4() { public_ipv4Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -369,23 +641,41 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_NewMachineNotificationDialog_Request() {}
     
 
-    private bool _is_approved = default(bool);
+    private bool? _is_approved;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_approved", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_approved
     {
-      get { return _is_approved; }
+      get { return _is_approved?? default(bool); }
       set { _is_approved = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_approvedSpecified
+    {
+      get { return _is_approved != null; }
+      set { if (value == (_is_approved== null)) _is_approved = value ? this.is_approved : (bool?)null; }
+    }
+    private bool ShouldSerializeis_approved() { return is_approvedSpecified; }
+    private void Resetis_approved() { is_approvedSpecified = false; }
+    
 
-    private bool _is_wizard_complete = default(bool);
+    private bool? _is_wizard_complete;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_wizard_complete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_wizard_complete
     {
-      get { return _is_wizard_complete; }
+      get { return _is_wizard_complete?? default(bool); }
       set { _is_wizard_complete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_wizard_completeSpecified
+    {
+      get { return _is_wizard_complete != null; }
+      set { if (value == (_is_wizard_complete== null)) _is_wizard_complete = value ? this.is_wizard_complete : (bool?)null; }
+    }
+    private bool ShouldSerializeis_wizard_complete() { return is_wizard_completeSpecified; }
+    private void Resetis_wizard_complete() { is_wizard_completeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -407,14 +697,23 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_ValidateEmailAddress_Request() {}
     
 
-    private string _stoken = "";
+    private string _stoken;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"stoken", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string stoken
     {
-      get { return _stoken; }
+      get { return _stoken?? ""; }
       set { _stoken = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stokenSpecified
+    {
+      get { return _stoken != null; }
+      set { if (value == (_stoken== null)) _stoken = value ? this.stoken : (string)null; }
+    }
+    private bool ShouldSerializestoken() { return stokenSpecified; }
+    private void Resetstoken() { stokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -426,14 +725,23 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_ValidateEmailAddress_Response() {}
     
 
-    private bool _was_validated = default(bool);
+    private bool? _was_validated;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"was_validated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool was_validated
     {
-      get { return _was_validated; }
+      get { return _was_validated?? default(bool); }
       set { _was_validated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool was_validatedSpecified
+    {
+      get { return _was_validated != null; }
+      set { if (value == (_was_validated== null)) _was_validated = value ? this.was_validated : (bool?)null; }
+    }
+    private bool ShouldSerializewas_validated() { return was_validatedSpecified; }
+    private void Resetwas_validated() { was_validatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -445,23 +753,41 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_SteamGuardPhishingReport_Request() {}
     
 
-    private string _param_string = "";
+    private string _param_string;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"param_string", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string param_string
     {
-      get { return _param_string; }
+      get { return _param_string?? ""; }
       set { _param_string = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool param_stringSpecified
+    {
+      get { return _param_string != null; }
+      set { if (value == (_param_string== null)) _param_string = value ? this.param_string : (string)null; }
+    }
+    private bool ShouldSerializeparam_string() { return param_stringSpecified; }
+    private void Resetparam_string() { param_stringSpecified = false; }
+    
 
-    private uint _ipaddress_actual = default(uint);
+    private uint? _ipaddress_actual;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"ipaddress_actual", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ipaddress_actual
     {
-      get { return _ipaddress_actual; }
+      get { return _ipaddress_actual?? default(uint); }
       set { _ipaddress_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipaddress_actualSpecified
+    {
+      get { return _ipaddress_actual != null; }
+      set { if (value == (_ipaddress_actual== null)) _ipaddress_actual = value ? this.ipaddress_actual : (uint?)null; }
+    }
+    private bool ShouldSerializeipaddress_actual() { return ipaddress_actualSpecified; }
+    private void Resetipaddress_actual() { ipaddress_actualSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -473,86 +799,167 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_SteamGuardPhishingReport_Response() {}
     
 
-    private uint _ipaddress_loginattempt = default(uint);
+    private uint? _ipaddress_loginattempt;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"ipaddress_loginattempt", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ipaddress_loginattempt
     {
-      get { return _ipaddress_loginattempt; }
+      get { return _ipaddress_loginattempt?? default(uint); }
       set { _ipaddress_loginattempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipaddress_loginattemptSpecified
+    {
+      get { return _ipaddress_loginattempt != null; }
+      set { if (value == (_ipaddress_loginattempt== null)) _ipaddress_loginattempt = value ? this.ipaddress_loginattempt : (uint?)null; }
+    }
+    private bool ShouldSerializeipaddress_loginattempt() { return ipaddress_loginattemptSpecified; }
+    private void Resetipaddress_loginattempt() { ipaddress_loginattemptSpecified = false; }
+    
 
-    private string _countryname_loginattempt = "";
+    private string _countryname_loginattempt;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"countryname_loginattempt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string countryname_loginattempt
     {
-      get { return _countryname_loginattempt; }
+      get { return _countryname_loginattempt?? ""; }
       set { _countryname_loginattempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countryname_loginattemptSpecified
+    {
+      get { return _countryname_loginattempt != null; }
+      set { if (value == (_countryname_loginattempt== null)) _countryname_loginattempt = value ? this.countryname_loginattempt : (string)null; }
+    }
+    private bool ShouldSerializecountryname_loginattempt() { return countryname_loginattemptSpecified; }
+    private void Resetcountryname_loginattempt() { countryname_loginattemptSpecified = false; }
+    
 
-    private string _statename_loginattempt = "";
+    private string _statename_loginattempt;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"statename_loginattempt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string statename_loginattempt
     {
-      get { return _statename_loginattempt; }
+      get { return _statename_loginattempt?? ""; }
       set { _statename_loginattempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statename_loginattemptSpecified
+    {
+      get { return _statename_loginattempt != null; }
+      set { if (value == (_statename_loginattempt== null)) _statename_loginattempt = value ? this.statename_loginattempt : (string)null; }
+    }
+    private bool ShouldSerializestatename_loginattempt() { return statename_loginattemptSpecified; }
+    private void Resetstatename_loginattempt() { statename_loginattemptSpecified = false; }
+    
 
-    private string _cityname_loginattempt = "";
+    private string _cityname_loginattempt;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"cityname_loginattempt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string cityname_loginattempt
     {
-      get { return _cityname_loginattempt; }
+      get { return _cityname_loginattempt?? ""; }
       set { _cityname_loginattempt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cityname_loginattemptSpecified
+    {
+      get { return _cityname_loginattempt != null; }
+      set { if (value == (_cityname_loginattempt== null)) _cityname_loginattempt = value ? this.cityname_loginattempt : (string)null; }
+    }
+    private bool ShouldSerializecityname_loginattempt() { return cityname_loginattemptSpecified; }
+    private void Resetcityname_loginattempt() { cityname_loginattemptSpecified = false; }
+    
 
-    private uint _ipaddress_actual = default(uint);
+    private uint? _ipaddress_actual;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ipaddress_actual", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint ipaddress_actual
     {
-      get { return _ipaddress_actual; }
+      get { return _ipaddress_actual?? default(uint); }
       set { _ipaddress_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ipaddress_actualSpecified
+    {
+      get { return _ipaddress_actual != null; }
+      set { if (value == (_ipaddress_actual== null)) _ipaddress_actual = value ? this.ipaddress_actual : (uint?)null; }
+    }
+    private bool ShouldSerializeipaddress_actual() { return ipaddress_actualSpecified; }
+    private void Resetipaddress_actual() { ipaddress_actualSpecified = false; }
+    
 
-    private string _countryname_actual = "";
+    private string _countryname_actual;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"countryname_actual", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string countryname_actual
     {
-      get { return _countryname_actual; }
+      get { return _countryname_actual?? ""; }
       set { _countryname_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countryname_actualSpecified
+    {
+      get { return _countryname_actual != null; }
+      set { if (value == (_countryname_actual== null)) _countryname_actual = value ? this.countryname_actual : (string)null; }
+    }
+    private bool ShouldSerializecountryname_actual() { return countryname_actualSpecified; }
+    private void Resetcountryname_actual() { countryname_actualSpecified = false; }
+    
 
-    private string _statename_actual = "";
+    private string _statename_actual;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"statename_actual", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string statename_actual
     {
-      get { return _statename_actual; }
+      get { return _statename_actual?? ""; }
       set { _statename_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statename_actualSpecified
+    {
+      get { return _statename_actual != null; }
+      set { if (value == (_statename_actual== null)) _statename_actual = value ? this.statename_actual : (string)null; }
+    }
+    private bool ShouldSerializestatename_actual() { return statename_actualSpecified; }
+    private void Resetstatename_actual() { statename_actualSpecified = false; }
+    
 
-    private string _cityname_actual = "";
+    private string _cityname_actual;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"cityname_actual", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string cityname_actual
     {
-      get { return _cityname_actual; }
+      get { return _cityname_actual?? ""; }
       set { _cityname_actual = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cityname_actualSpecified
+    {
+      get { return _cityname_actual != null; }
+      set { if (value == (_cityname_actual== null)) _cityname_actual = value ? this.cityname_actual : (string)null; }
+    }
+    private bool ShouldSerializecityname_actual() { return cityname_actualSpecified; }
+    private void Resetcityname_actual() { cityname_actualSpecified = false; }
+    
 
-    private string _steamguard_code = "";
+    private string _steamguard_code;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"steamguard_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string steamguard_code
     {
-      get { return _steamguard_code; }
+      get { return _steamguard_code?? ""; }
       set { _steamguard_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_codeSpecified
+    {
+      get { return _steamguard_code != null; }
+      set { if (value == (_steamguard_code== null)) _steamguard_code = value ? this.steamguard_code : (string)null; }
+    }
+    private bool ShouldSerializesteamguard_code() { return steamguard_codeSpecified; }
+    private void Resetsteamguard_code() { steamguard_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -574,32 +981,59 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_LastCredentialChangeTime_Response() {}
     
 
-    private uint _timestamp_last_password_change = default(uint);
+    private uint? _timestamp_last_password_change;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp_last_password_change", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_last_password_change
     {
-      get { return _timestamp_last_password_change; }
+      get { return _timestamp_last_password_change?? default(uint); }
       set { _timestamp_last_password_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_last_password_changeSpecified
+    {
+      get { return _timestamp_last_password_change != null; }
+      set { if (value == (_timestamp_last_password_change== null)) _timestamp_last_password_change = value ? this.timestamp_last_password_change : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_last_password_change() { return timestamp_last_password_changeSpecified; }
+    private void Resettimestamp_last_password_change() { timestamp_last_password_changeSpecified = false; }
+    
 
-    private uint _timestamp_last_email_change = default(uint);
+    private uint? _timestamp_last_email_change;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp_last_email_change", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_last_email_change
     {
-      get { return _timestamp_last_email_change; }
+      get { return _timestamp_last_email_change?? default(uint); }
       set { _timestamp_last_email_change = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_last_email_changeSpecified
+    {
+      get { return _timestamp_last_email_change != null; }
+      set { if (value == (_timestamp_last_email_change== null)) _timestamp_last_email_change = value ? this.timestamp_last_email_change : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_last_email_change() { return timestamp_last_email_changeSpecified; }
+    private void Resettimestamp_last_email_change() { timestamp_last_email_changeSpecified = false; }
+    
 
-    private uint _timestamp_last_password_reset = default(uint);
+    private uint? _timestamp_last_password_reset;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"timestamp_last_password_reset", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp_last_password_reset
     {
-      get { return _timestamp_last_password_reset; }
+      get { return _timestamp_last_password_reset?? default(uint); }
       set { _timestamp_last_password_reset = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestamp_last_password_resetSpecified
+    {
+      get { return _timestamp_last_password_reset != null; }
+      set { if (value == (_timestamp_last_password_reset== null)) _timestamp_last_password_reset = value ? this.timestamp_last_password_reset : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp_last_password_reset() { return timestamp_last_password_resetSpecified; }
+    private void Resettimestamp_last_password_reset() { timestamp_last_password_resetSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -621,23 +1055,41 @@ namespace SteamKit2.Unified.Internal
     public CCredentials_GetAccountAuthSecret_Response() {}
     
 
-    private int _secret_id = default(int);
+    private int? _secret_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"secret_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int secret_id
     {
-      get { return _secret_id; }
+      get { return _secret_id?? default(int); }
       set { _secret_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secret_idSpecified
+    {
+      get { return _secret_id != null; }
+      set { if (value == (_secret_id== null)) _secret_id = value ? this.secret_id : (int?)null; }
+    }
+    private bool ShouldSerializesecret_id() { return secret_idSpecified; }
+    private void Resetsecret_id() { secret_idSpecified = false; }
+    
 
-    private byte[] _secret = null;
+    private byte[] _secret;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"secret", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] secret
     {
-      get { return _secret; }
+      get { return _secret?? null; }
       set { _secret = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secretSpecified
+    {
+      get { return _secret != null; }
+      set { if (value == (_secret== null)) _secret = value ? this.secret : (byte[])null; }
+    }
+    private bool ShouldSerializesecret() { return secretSpecified; }
+    private void Resetsecret() { secretSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgDepotBuilder.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgDepotBuilder.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_depotbuilder.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_InitDepotBuild_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _depotid = default(uint);
+    private uint? _depotid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depotid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depotid
     {
-      get { return _depotid; }
+      get { return _depotid?? default(uint); }
       set { _depotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depotidSpecified
+    {
+      get { return _depotid != null; }
+      set { if (value == (_depotid== null)) _depotid = value ? this.depotid : (uint?)null; }
+    }
+    private bool ShouldSerializedepotid() { return depotidSpecified; }
+    private void Resetdepotid() { depotidSpecified = false; }
+    
 
-    private ulong _workshop_itemid = default(ulong);
+    private ulong? _workshop_itemid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"workshop_itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong workshop_itemid
     {
-      get { return _workshop_itemid; }
+      get { return _workshop_itemid?? default(ulong); }
       set { _workshop_itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_itemidSpecified
+    {
+      get { return _workshop_itemid != null; }
+      set { if (value == (_workshop_itemid== null)) _workshop_itemid = value ? this.workshop_itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeworkshop_itemid() { return workshop_itemidSpecified; }
+    private void Resetworkshop_itemid() { workshop_itemidSpecified = false; }
+    
 
-    private bool _for_local_cs = default(bool);
+    private bool? _for_local_cs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"for_local_cs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool for_local_cs
     {
-      get { return _for_local_cs; }
+      get { return _for_local_cs?? default(bool); }
       set { _for_local_cs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool for_local_csSpecified
+    {
+      get { return _for_local_cs != null; }
+      set { if (value == (_for_local_cs== null)) _for_local_cs = value ? this.for_local_cs : (bool?)null; }
+    }
+    private bool ShouldSerializefor_local_cs() { return for_local_csSpecified; }
+    private void Resetfor_local_cs() { for_local_csSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -64,50 +102,95 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_InitDepotBuild_Response() {}
     
 
-    private ulong _baseline_manifestid = default(ulong);
+    private ulong? _baseline_manifestid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"baseline_manifestid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong baseline_manifestid
     {
-      get { return _baseline_manifestid; }
+      get { return _baseline_manifestid?? default(ulong); }
       set { _baseline_manifestid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool baseline_manifestidSpecified
+    {
+      get { return _baseline_manifestid != null; }
+      set { if (value == (_baseline_manifestid== null)) _baseline_manifestid = value ? this.baseline_manifestid : (ulong?)null; }
+    }
+    private bool ShouldSerializebaseline_manifestid() { return baseline_manifestidSpecified; }
+    private void Resetbaseline_manifestid() { baseline_manifestidSpecified = false; }
+    
 
-    private uint _chunk_size = default(uint);
+    private uint? _chunk_size;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"chunk_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint chunk_size
     {
-      get { return _chunk_size; }
+      get { return _chunk_size?? default(uint); }
       set { _chunk_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool chunk_sizeSpecified
+    {
+      get { return _chunk_size != null; }
+      set { if (value == (_chunk_size== null)) _chunk_size = value ? this.chunk_size : (uint?)null; }
+    }
+    private bool ShouldSerializechunk_size() { return chunk_sizeSpecified; }
+    private void Resetchunk_size() { chunk_sizeSpecified = false; }
+    
 
-    private byte[] _aes_key = null;
+    private byte[] _aes_key;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"aes_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] aes_key
     {
-      get { return _aes_key; }
+      get { return _aes_key?? null; }
       set { _aes_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool aes_keySpecified
+    {
+      get { return _aes_key != null; }
+      set { if (value == (_aes_key== null)) _aes_key = value ? this.aes_key : (byte[])null; }
+    }
+    private bool ShouldSerializeaes_key() { return aes_keySpecified; }
+    private void Resetaes_key() { aes_keySpecified = false; }
+    
 
-    private byte[] _rsa_key = null;
+    private byte[] _rsa_key;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"rsa_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] rsa_key
     {
-      get { return _rsa_key; }
+      get { return _rsa_key?? null; }
       set { _rsa_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rsa_keySpecified
+    {
+      get { return _rsa_key != null; }
+      set { if (value == (_rsa_key== null)) _rsa_key = value ? this.rsa_key : (byte[])null; }
+    }
+    private bool ShouldSerializersa_key() { return rsa_keySpecified; }
+    private void Resetrsa_key() { rsa_keySpecified = false; }
+    
 
-    private string _url_host = "";
+    private string _url_host;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"url_host", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url_host
     {
-      get { return _url_host; }
+      get { return _url_host?? ""; }
       set { _url_host = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool url_hostSpecified
+    {
+      get { return _url_host != null; }
+      set { if (value == (_url_host== null)) _url_host = value ? this.url_host : (string)null; }
+    }
+    private bool ShouldSerializeurl_host() { return url_hostSpecified; }
+    private void Reseturl_host() { url_hostSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -119,59 +202,113 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_StartDepotUpload_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _depotid = default(uint);
+    private uint? _depotid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depotid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depotid
     {
-      get { return _depotid; }
+      get { return _depotid?? default(uint); }
       set { _depotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depotidSpecified
+    {
+      get { return _depotid != null; }
+      set { if (value == (_depotid== null)) _depotid = value ? this.depotid : (uint?)null; }
+    }
+    private bool ShouldSerializedepotid() { return depotidSpecified; }
+    private void Resetdepotid() { depotidSpecified = false; }
+    
 
-    private ulong _workshop_itemid = default(ulong);
+    private ulong? _workshop_itemid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"workshop_itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong workshop_itemid
     {
-      get { return _workshop_itemid; }
+      get { return _workshop_itemid?? default(ulong); }
       set { _workshop_itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_itemidSpecified
+    {
+      get { return _workshop_itemid != null; }
+      set { if (value == (_workshop_itemid== null)) _workshop_itemid = value ? this.workshop_itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeworkshop_itemid() { return workshop_itemidSpecified; }
+    private void Resetworkshop_itemid() { workshop_itemidSpecified = false; }
+    
 
-    private bool _for_local_cs = default(bool);
+    private bool? _for_local_cs;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"for_local_cs", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool for_local_cs
     {
-      get { return _for_local_cs; }
+      get { return _for_local_cs?? default(bool); }
       set { _for_local_cs = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool for_local_csSpecified
+    {
+      get { return _for_local_cs != null; }
+      set { if (value == (_for_local_cs== null)) _for_local_cs = value ? this.for_local_cs : (bool?)null; }
+    }
+    private bool ShouldSerializefor_local_cs() { return for_local_csSpecified; }
+    private void Resetfor_local_cs() { for_local_csSpecified = false; }
+    
 
-    private ulong _baseline_manifestid = default(ulong);
+    private ulong? _baseline_manifestid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"baseline_manifestid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong baseline_manifestid
     {
-      get { return _baseline_manifestid; }
+      get { return _baseline_manifestid?? default(ulong); }
       set { _baseline_manifestid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool baseline_manifestidSpecified
+    {
+      get { return _baseline_manifestid != null; }
+      set { if (value == (_baseline_manifestid== null)) _baseline_manifestid = value ? this.baseline_manifestid : (ulong?)null; }
+    }
+    private bool ShouldSerializebaseline_manifestid() { return baseline_manifestidSpecified; }
+    private void Resetbaseline_manifestid() { baseline_manifestidSpecified = false; }
+    
 
-    private uint _manifest_size = default(uint);
+    private uint? _manifest_size;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"manifest_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint manifest_size
     {
-      get { return _manifest_size; }
+      get { return _manifest_size?? default(uint); }
       set { _manifest_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifest_sizeSpecified
+    {
+      get { return _manifest_size != null; }
+      set { if (value == (_manifest_size== null)) _manifest_size = value ? this.manifest_size : (uint?)null; }
+    }
+    private bool ShouldSerializemanifest_size() { return manifest_sizeSpecified; }
+    private void Resetmanifest_size() { manifest_sizeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -183,14 +320,23 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_StartDepotUpload_Response() {}
     
 
-    private ulong _depot_build_handle = default(ulong);
+    private ulong? _depot_build_handle;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"depot_build_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong depot_build_handle
     {
-      get { return _depot_build_handle; }
+      get { return _depot_build_handle?? default(ulong); }
       set { _depot_build_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_build_handleSpecified
+    {
+      get { return _depot_build_handle != null; }
+      set { if (value == (_depot_build_handle== null)) _depot_build_handle = value ? this.depot_build_handle : (ulong?)null; }
+    }
+    private bool ShouldSerializedepot_build_handle() { return depot_build_handleSpecified; }
+    private void Resetdepot_build_handle() { depot_build_handleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -202,23 +348,41 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_GetMissingDepotChunks_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _depot_build_handle = default(ulong);
+    private ulong? _depot_build_handle;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depot_build_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong depot_build_handle
     {
-      get { return _depot_build_handle; }
+      get { return _depot_build_handle?? default(ulong); }
       set { _depot_build_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_build_handleSpecified
+    {
+      get { return _depot_build_handle != null; }
+      set { if (value == (_depot_build_handle== null)) _depot_build_handle = value ? this.depot_build_handle : (ulong?)null; }
+    }
+    private bool ShouldSerializedepot_build_handle() { return depot_build_handleSpecified; }
+    private void Resetdepot_build_handle() { depot_build_handleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -237,37 +401,64 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _total_missing_chunks = default(uint);
+    private uint? _total_missing_chunks;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_missing_chunks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total_missing_chunks
     {
-      get { return _total_missing_chunks; }
+      get { return _total_missing_chunks?? default(uint); }
       set { _total_missing_chunks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_missing_chunksSpecified
+    {
+      get { return _total_missing_chunks != null; }
+      set { if (value == (_total_missing_chunks== null)) _total_missing_chunks = value ? this.total_missing_chunks : (uint?)null; }
+    }
+    private bool ShouldSerializetotal_missing_chunks() { return total_missing_chunksSpecified; }
+    private void Resettotal_missing_chunks() { total_missing_chunksSpecified = false; }
+    
 
-    private ulong _total_missing_bytes = default(ulong);
+    private ulong? _total_missing_bytes;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"total_missing_bytes", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong total_missing_bytes
     {
-      get { return _total_missing_bytes; }
+      get { return _total_missing_bytes?? default(ulong); }
       set { _total_missing_bytes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_missing_bytesSpecified
+    {
+      get { return _total_missing_bytes != null; }
+      set { if (value == (_total_missing_bytes== null)) _total_missing_bytes = value ? this.total_missing_bytes : (ulong?)null; }
+    }
+    private bool ShouldSerializetotal_missing_bytes() { return total_missing_bytesSpecified; }
+    private void Resettotal_missing_bytes() { total_missing_bytesSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Chunks")]
   public partial class Chunks : global::ProtoBuf.IExtensible
   {
     public Chunks() {}
     
 
-    private byte[] _sha = null;
+    private byte[] _sha;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sha", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] sha
     {
-      get { return _sha; }
+      get { return _sha?? null; }
       set { _sha = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shaSpecified
+    {
+      get { return _sha != null; }
+      set { if (value == (_sha== null)) _sha = value ? this.sha : (byte[])null; }
+    }
+    private bool ShouldSerializesha() { return shaSpecified; }
+    private void Resetsha() { shaSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -284,23 +475,41 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_FinishDepotUpload_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _depot_build_handle = default(ulong);
+    private ulong? _depot_build_handle;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depot_build_handle", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong depot_build_handle
     {
-      get { return _depot_build_handle; }
+      get { return _depot_build_handle?? default(ulong); }
       set { _depot_build_handle = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depot_build_handleSpecified
+    {
+      get { return _depot_build_handle != null; }
+      set { if (value == (_depot_build_handle== null)) _depot_build_handle = value ? this.depot_build_handle : (ulong?)null; }
+    }
+    private bool ShouldSerializedepot_build_handle() { return depot_build_handleSpecified; }
+    private void Resetdepot_build_handle() { depot_build_handleSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -312,23 +521,41 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_FinishDepotUpload_Response() {}
     
 
-    private ulong _manifestid = default(ulong);
+    private ulong? _manifestid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"manifestid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong manifestid
     {
-      get { return _manifestid; }
+      get { return _manifestid?? default(ulong); }
       set { _manifestid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifestidSpecified
+    {
+      get { return _manifestid != null; }
+      set { if (value == (_manifestid== null)) _manifestid = value ? this.manifestid : (ulong?)null; }
+    }
+    private bool ShouldSerializemanifestid() { return manifestidSpecified; }
+    private void Resetmanifestid() { manifestidSpecified = false; }
+    
 
-    private bool _prev_reused = default(bool);
+    private bool? _prev_reused;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"prev_reused", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool prev_reused
     {
-      get { return _prev_reused; }
+      get { return _prev_reused?? default(bool); }
       set { _prev_reused = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prev_reusedSpecified
+    {
+      get { return _prev_reused != null; }
+      set { if (value == (_prev_reused== null)) _prev_reused = value ? this.prev_reused : (bool?)null; }
+    }
+    private bool ShouldSerializeprev_reused() { return prev_reusedSpecified; }
+    private void Resetprev_reused() { prev_reusedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -340,14 +567,23 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_CommitAppBuild_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CContentBuilder_CommitAppBuild_Request.Depots> _depot_manifests = new global::System.Collections.Generic.List<CContentBuilder_CommitAppBuild_Request.Depots>();
     [global::ProtoBuf.ProtoMember(2, Name=@"depot_manifests", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CContentBuilder_CommitAppBuild_Request.Depots> depot_manifests
@@ -356,46 +592,82 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _build_notes = "";
+    private string _build_notes;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"build_notes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string build_notes
     {
-      get { return _build_notes; }
+      get { return _build_notes?? ""; }
       set { _build_notes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool build_notesSpecified
+    {
+      get { return _build_notes != null; }
+      set { if (value == (_build_notes== null)) _build_notes = value ? this.build_notes : (string)null; }
+    }
+    private bool ShouldSerializebuild_notes() { return build_notesSpecified; }
+    private void Resetbuild_notes() { build_notesSpecified = false; }
+    
 
-    private string _live_branch = "";
+    private string _live_branch;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"live_branch", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string live_branch
     {
-      get { return _live_branch; }
+      get { return _live_branch?? ""; }
       set { _live_branch = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool live_branchSpecified
+    {
+      get { return _live_branch != null; }
+      set { if (value == (_live_branch== null)) _live_branch = value ? this.live_branch : (string)null; }
+    }
+    private bool ShouldSerializelive_branch() { return live_branchSpecified; }
+    private void Resetlive_branch() { live_branchSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Depots")]
   public partial class Depots : global::ProtoBuf.IExtensible
   {
     public Depots() {}
     
 
-    private uint _depotid = default(uint);
+    private uint? _depotid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"depotid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depotid
     {
-      get { return _depotid; }
+      get { return _depotid?? default(uint); }
       set { _depotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depotidSpecified
+    {
+      get { return _depotid != null; }
+      set { if (value == (_depotid== null)) _depotid = value ? this.depotid : (uint?)null; }
+    }
+    private bool ShouldSerializedepotid() { return depotidSpecified; }
+    private void Resetdepotid() { depotidSpecified = false; }
+    
 
-    private ulong _manifestid = default(ulong);
+    private ulong? _manifestid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"manifestid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong manifestid
     {
-      get { return _manifestid; }
+      get { return _manifestid?? default(ulong); }
       set { _manifestid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifestidSpecified
+    {
+      get { return _manifestid != null; }
+      set { if (value == (_manifestid== null)) _manifestid = value ? this.manifestid : (ulong?)null; }
+    }
+    private bool ShouldSerializemanifestid() { return manifestidSpecified; }
+    private void Resetmanifestid() { manifestidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -412,14 +684,23 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_CommitAppBuild_Response() {}
     
 
-    private uint _buildid = default(uint);
+    private uint? _buildid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"buildid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint buildid
     {
-      get { return _buildid; }
+      get { return _buildid?? default(uint); }
       set { _buildid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool buildidSpecified
+    {
+      get { return _buildid != null; }
+      set { if (value == (_buildid== null)) _buildid = value ? this.buildid : (uint?)null; }
+    }
+    private bool ShouldSerializebuildid() { return buildidSpecified; }
+    private void Resetbuildid() { buildidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -431,32 +712,59 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_SignInstallScript_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _depotid = default(uint);
+    private uint? _depotid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"depotid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint depotid
     {
-      get { return _depotid; }
+      get { return _depotid?? default(uint); }
       set { _depotid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool depotidSpecified
+    {
+      get { return _depotid != null; }
+      set { if (value == (_depotid== null)) _depotid = value ? this.depotid : (uint?)null; }
+    }
+    private bool ShouldSerializedepotid() { return depotidSpecified; }
+    private void Resetdepotid() { depotidSpecified = false; }
+    
 
-    private string _install_script = "";
+    private string _install_script;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"install_script", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string install_script
     {
-      get { return _install_script; }
+      get { return _install_script?? ""; }
       set { _install_script = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool install_scriptSpecified
+    {
+      get { return _install_script != null; }
+      set { if (value == (_install_script== null)) _install_script = value ? this.install_script : (string)null; }
+    }
+    private bool ShouldSerializeinstall_script() { return install_scriptSpecified; }
+    private void Resetinstall_script() { install_scriptSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -468,14 +776,23 @@ namespace SteamKit2.Unified.Internal
     public CContentBuilder_SignInstallScript_Response() {}
     
 
-    private string _signed_install_script = "";
+    private string _signed_install_script;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"signed_install_script", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string signed_install_script
     {
-      get { return _signed_install_script; }
+      get { return _signed_install_script?? ""; }
       set { _signed_install_script = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signed_install_scriptSpecified
+    {
+      get { return _signed_install_script != null; }
+      set { if (value == (_signed_install_script== null)) _signed_install_script = value ? this.signed_install_script : (string)null; }
+    }
+    private bool ShouldSerializesigned_install_script() { return signed_install_scriptSpecified; }
+    private void Resetsigned_install_script() { signed_install_scriptSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgDeviceAuth.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgDeviceAuth.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_deviceauth.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_GetOwnAuthorizedDevices_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _include_canceled = default(bool);
+    private bool? _include_canceled;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"include_canceled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_canceled
     {
-      get { return _include_canceled; }
+      get { return _include_canceled?? default(bool); }
       set { _include_canceled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_canceledSpecified
+    {
+      get { return _include_canceled != null; }
+      set { if (value == (_include_canceled== null)) _include_canceled = value ? this.include_canceled : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_canceled() { return include_canceledSpecified; }
+    private void Resetinclude_canceled() { include_canceledSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -58,77 +78,149 @@ namespace SteamKit2.Unified.Internal
     public Device() {}
     
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
 
-    private string _device_name = "";
+    private string _device_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"device_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_name
     {
-      get { return _device_name; }
+      get { return _device_name?? ""; }
       set { _device_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_nameSpecified
+    {
+      get { return _device_name != null; }
+      set { if (value == (_device_name== null)) _device_name = value ? this.device_name : (string)null; }
+    }
+    private bool ShouldSerializedevice_name() { return device_nameSpecified; }
+    private void Resetdevice_name() { device_nameSpecified = false; }
+    
 
-    private bool _is_pending = default(bool);
+    private bool? _is_pending;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_pending", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pending
     {
-      get { return _is_pending; }
+      get { return _is_pending?? default(bool); }
       set { _is_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_pendingSpecified
+    {
+      get { return _is_pending != null; }
+      set { if (value == (_is_pending== null)) _is_pending = value ? this.is_pending : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pending() { return is_pendingSpecified; }
+    private void Resetis_pending() { is_pendingSpecified = false; }
+    
 
-    private bool _is_canceled = default(bool);
+    private bool? _is_canceled;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"is_canceled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_canceled
     {
-      get { return _is_canceled; }
+      get { return _is_canceled?? default(bool); }
       set { _is_canceled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_canceledSpecified
+    {
+      get { return _is_canceled != null; }
+      set { if (value == (_is_canceled== null)) _is_canceled = value ? this.is_canceled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_canceled() { return is_canceledSpecified; }
+    private void Resetis_canceled() { is_canceledSpecified = false; }
+    
 
-    private uint _last_time_used = default(uint);
+    private uint? _last_time_used;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"last_time_used", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_used
     {
-      get { return _last_time_used; }
+      get { return _last_time_used?? default(uint); }
       set { _last_time_used = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_usedSpecified
+    {
+      get { return _last_time_used != null; }
+      set { if (value == (_last_time_used== null)) _last_time_used = value ? this.last_time_used : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_used() { return last_time_usedSpecified; }
+    private void Resetlast_time_used() { last_time_usedSpecified = false; }
+    
 
-    private ulong _last_borrower_id = default(ulong);
+    private ulong? _last_borrower_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"last_borrower_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong last_borrower_id
     {
-      get { return _last_borrower_id; }
+      get { return _last_borrower_id?? default(ulong); }
       set { _last_borrower_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_borrower_idSpecified
+    {
+      get { return _last_borrower_id != null; }
+      set { if (value == (_last_borrower_id== null)) _last_borrower_id = value ? this.last_borrower_id : (ulong?)null; }
+    }
+    private bool ShouldSerializelast_borrower_id() { return last_borrower_idSpecified; }
+    private void Resetlast_borrower_id() { last_borrower_idSpecified = false; }
+    
 
-    private uint _last_app_played = default(uint);
+    private uint? _last_app_played;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"last_app_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_app_played
     {
-      get { return _last_app_played; }
+      get { return _last_app_played?? default(uint); }
       set { _last_app_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_app_playedSpecified
+    {
+      get { return _last_app_played != null; }
+      set { if (value == (_last_app_played== null)) _last_app_played = value ? this.last_app_played : (uint?)null; }
+    }
+    private bool ShouldSerializelast_app_played() { return last_app_playedSpecified; }
+    private void Resetlast_app_played() { last_app_playedSpecified = false; }
+    
 
-    private bool _is_limited = default(bool);
+    private bool? _is_limited;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"is_limited", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_limited
     {
-      get { return _is_limited; }
+      get { return _is_limited?? default(bool); }
       set { _is_limited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_limitedSpecified
+    {
+      get { return _is_limited != null; }
+      set { if (value == (_is_limited== null)) _is_limited = value ? this.is_limited : (bool?)null; }
+    }
+    private bool ShouldSerializeis_limited() { return is_limitedSpecified; }
+    private void Resetis_limited() { is_limitedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -145,41 +237,77 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_AcceptAuthorizationRequest_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
 
-    private ulong _auth_code = default(ulong);
+    private ulong? _auth_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"auth_code", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_code
     {
-      get { return _auth_code; }
+      get { return _auth_code?? default(ulong); }
       set { _auth_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_codeSpecified
+    {
+      get { return _auth_code != null; }
+      set { if (value == (_auth_code== null)) _auth_code = value ? this.auth_code : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_code() { return auth_codeSpecified; }
+    private void Resetauth_code() { auth_codeSpecified = false; }
+    
 
-    private ulong _from_steamid = default(ulong);
+    private ulong? _from_steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"from_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong from_steamid
     {
-      get { return _from_steamid; }
+      get { return _from_steamid?? default(ulong); }
       set { _from_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool from_steamidSpecified
+    {
+      get { return _from_steamid != null; }
+      set { if (value == (_from_steamid== null)) _from_steamid = value ? this.from_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializefrom_steamid() { return from_steamidSpecified; }
+    private void Resetfrom_steamid() { from_steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -201,23 +329,41 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_AuthorizeRemoteDevice_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -239,23 +385,41 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_DeauthorizeRemoteDevice_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -277,14 +441,23 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_GetUsedAuthorizedDevices_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -308,50 +481,95 @@ namespace SteamKit2.Unified.Internal
     public Device() {}
     
 
-    private ulong _auth_device_token = default(ulong);
+    private ulong? _auth_device_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"auth_device_token", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong auth_device_token
     {
-      get { return _auth_device_token; }
+      get { return _auth_device_token?? default(ulong); }
       set { _auth_device_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool auth_device_tokenSpecified
+    {
+      get { return _auth_device_token != null; }
+      set { if (value == (_auth_device_token== null)) _auth_device_token = value ? this.auth_device_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeauth_device_token() { return auth_device_tokenSpecified; }
+    private void Resetauth_device_token() { auth_device_tokenSpecified = false; }
+    
 
-    private string _device_name = "";
+    private string _device_name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"device_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_name
     {
-      get { return _device_name; }
+      get { return _device_name?? ""; }
       set { _device_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_nameSpecified
+    {
+      get { return _device_name != null; }
+      set { if (value == (_device_name== null)) _device_name = value ? this.device_name : (string)null; }
+    }
+    private bool ShouldSerializedevice_name() { return device_nameSpecified; }
+    private void Resetdevice_name() { device_nameSpecified = false; }
+    
 
-    private ulong _owner_steamid = default(ulong);
+    private ulong? _owner_steamid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"owner_steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong owner_steamid
     {
-      get { return _owner_steamid; }
+      get { return _owner_steamid?? default(ulong); }
       set { _owner_steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool owner_steamidSpecified
+    {
+      get { return _owner_steamid != null; }
+      set { if (value == (_owner_steamid== null)) _owner_steamid = value ? this.owner_steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializeowner_steamid() { return owner_steamidSpecified; }
+    private void Resetowner_steamid() { owner_steamidSpecified = false; }
+    
 
-    private uint _last_time_used = default(uint);
+    private uint? _last_time_used;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"last_time_used", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_used
     {
-      get { return _last_time_used; }
+      get { return _last_time_used?? default(uint); }
       set { _last_time_used = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_usedSpecified
+    {
+      get { return _last_time_used != null; }
+      set { if (value == (_last_time_used== null)) _last_time_used = value ? this.last_time_used : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_used() { return last_time_usedSpecified; }
+    private void Resetlast_time_used() { last_time_usedSpecified = false; }
+    
 
-    private uint _last_app_played = default(uint);
+    private uint? _last_app_played;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"last_app_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_app_played
     {
-      get { return _last_app_played; }
+      get { return _last_app_played?? default(uint); }
       set { _last_app_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_app_playedSpecified
+    {
+      get { return _last_app_played != null; }
+      set { if (value == (_last_app_played== null)) _last_app_played = value ? this.last_app_played : (uint?)null; }
+    }
+    private bool ShouldSerializelast_app_played() { return last_app_playedSpecified; }
+    private void Resetlast_app_played() { last_app_playedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -368,32 +586,59 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_GetAuthorizedBorrowers_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _include_canceled = default(bool);
+    private bool? _include_canceled;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"include_canceled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_canceled
     {
-      get { return _include_canceled; }
+      get { return _include_canceled?? default(bool); }
       set { _include_canceled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_canceledSpecified
+    {
+      get { return _include_canceled != null; }
+      set { if (value == (_include_canceled== null)) _include_canceled = value ? this.include_canceled : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_canceled() { return include_canceledSpecified; }
+    private void Resetinclude_canceled() { include_canceledSpecified = false; }
+    
 
-    private bool _include_pending = default(bool);
+    private bool? _include_pending;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"include_pending", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_pending
     {
-      get { return _include_pending; }
+      get { return _include_pending?? default(bool); }
       set { _include_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_pendingSpecified
+    {
+      get { return _include_pending != null; }
+      set { if (value == (_include_pending== null)) _include_pending = value ? this.include_pending : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_pending() { return include_pendingSpecified; }
+    private void Resetinclude_pending() { include_pendingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -417,41 +662,77 @@ namespace SteamKit2.Unified.Internal
     public Borrower() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _is_pending = default(bool);
+    private bool? _is_pending;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_pending", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_pending
     {
-      get { return _is_pending; }
+      get { return _is_pending?? default(bool); }
       set { _is_pending = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_pendingSpecified
+    {
+      get { return _is_pending != null; }
+      set { if (value == (_is_pending== null)) _is_pending = value ? this.is_pending : (bool?)null; }
+    }
+    private bool ShouldSerializeis_pending() { return is_pendingSpecified; }
+    private void Resetis_pending() { is_pendingSpecified = false; }
+    
 
-    private bool _is_canceled = default(bool);
+    private bool? _is_canceled;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"is_canceled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_canceled
     {
-      get { return _is_canceled; }
+      get { return _is_canceled?? default(bool); }
       set { _is_canceled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_canceledSpecified
+    {
+      get { return _is_canceled != null; }
+      set { if (value == (_is_canceled== null)) _is_canceled = value ? this.is_canceled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_canceled() { return is_canceledSpecified; }
+    private void Resetis_canceled() { is_canceledSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -468,14 +749,23 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_AddAuthorizedBorrowers_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamid_borrower = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"steamid_borrower", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamid_borrower
@@ -494,14 +784,23 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_AddAuthorizedBorrowers_Response() {}
     
 
-    private int _seconds_to_wait = default(int);
+    private int? _seconds_to_wait;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"seconds_to_wait", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int seconds_to_wait
     {
-      get { return _seconds_to_wait; }
+      get { return _seconds_to_wait?? default(int); }
       set { _seconds_to_wait = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_to_waitSpecified
+    {
+      get { return _seconds_to_wait != null; }
+      set { if (value == (_seconds_to_wait== null)) _seconds_to_wait = value ? this.seconds_to_wait : (int?)null; }
+    }
+    private bool ShouldSerializeseconds_to_wait() { return seconds_to_waitSpecified; }
+    private void Resetseconds_to_wait() { seconds_to_waitSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -513,14 +812,23 @@ namespace SteamKit2.Unified.Internal
     public CDeviceAuth_RemoveAuthorizedBorrowers_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _steamid_borrower = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"steamid_borrower", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
     public global::System.Collections.Generic.List<ulong> steamid_borrower

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgEcon.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgEcon.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_econ.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public CEcon_ClientGetItemShopOverlayAuthURL_Request() {}
     
 
-    private string _return_url = "";
+    private string _return_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"return_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string return_url
     {
-      get { return _return_url; }
+      get { return _return_url?? ""; }
       set { _return_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_urlSpecified
+    {
+      get { return _return_url != null; }
+      set { if (value == (_return_url== null)) _return_url = value ? this.return_url : (string)null; }
+    }
+    private bool ShouldSerializereturn_url() { return return_urlSpecified; }
+    private void Resetreturn_url() { return_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,14 +48,23 @@ namespace SteamKit2.Unified.Internal
     public CEcon_ClientGetItemShopOverlayAuthURL_Response() {}
     
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgGameNotifications.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgGameNotifications.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_gamenotifications.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_Variable() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,14 +66,23 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_LocalizedText() {}
     
 
-    private string _token = "";
+    private string _token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token
     {
-      get { return _token; }
+      get { return _token?? ""; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (string)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGameNotifications_Variable> _variables = new global::System.Collections.Generic.List<CGameNotifications_Variable>();
     [global::ProtoBuf.ProtoMember(2, Name=@"variables", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGameNotifications_Variable> variables
@@ -62,14 +91,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _rendered_text = "";
+    private string _rendered_text;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"rendered_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string rendered_text
     {
-      get { return _rendered_text; }
+      get { return _rendered_text?? ""; }
       set { _rendered_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rendered_textSpecified
+    {
+      get { return _rendered_text != null; }
+      set { if (value == (_rendered_text== null)) _rendered_text = value ? this.rendered_text : (string)null; }
+    }
+    private bool ShouldSerializerendered_text() { return rendered_textSpecified; }
+    private void Resetrendered_text() { rendered_textSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -81,23 +119,41 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_UserStatus() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _state = "";
+    private string _state;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string state
     {
-      get { return _state; }
+      get { return _state?? ""; }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (string)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
     private CGameNotifications_LocalizedText _title = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -127,23 +183,41 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_CreateSession_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _context = default(ulong);
+    private ulong? _context;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"context", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong context
     {
-      get { return _context; }
+      get { return _context?? default(ulong); }
       set { _context = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contextSpecified
+    {
+      get { return _context != null; }
+      set { if (value == (_context== null)) _context = value ? this.context : (ulong?)null; }
+    }
+    private bool ShouldSerializecontext() { return contextSpecified; }
+    private void Resetcontext() { contextSpecified = false; }
+    
 
     private CGameNotifications_LocalizedText _title = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -161,14 +235,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -180,14 +263,23 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_CreateSession_Response() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -199,32 +291,59 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_DeleteSession_Request() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -246,23 +365,41 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_UpdateSession_Request() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
     private CGameNotifications_LocalizedText _title = null;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -280,14 +417,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -309,41 +455,77 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_EnumerateSessions_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _include_all_user_messages = default(bool);
+    private bool? _include_all_user_messages;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"include_all_user_messages", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_all_user_messages
     {
-      get { return _include_all_user_messages; }
+      get { return _include_all_user_messages?? default(bool); }
       set { _include_all_user_messages = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_all_user_messagesSpecified
+    {
+      get { return _include_all_user_messages != null; }
+      set { if (value == (_include_all_user_messages== null)) _include_all_user_messages = value ? this.include_all_user_messages : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_all_user_messages() { return include_all_user_messagesSpecified; }
+    private void Resetinclude_all_user_messages() { include_all_user_messagesSpecified = false; }
+    
 
-    private bool _include_auth_user_message = default(bool);
+    private bool? _include_auth_user_message;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"include_auth_user_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_auth_user_message
     {
-      get { return _include_auth_user_message; }
+      get { return _include_auth_user_message?? default(bool); }
       set { _include_auth_user_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_auth_user_messageSpecified
+    {
+      get { return _include_auth_user_message != null; }
+      set { if (value == (_include_auth_user_message== null)) _include_auth_user_message = value ? this.include_auth_user_message : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_auth_user_message() { return include_auth_user_messageSpecified; }
+    private void Resetinclude_auth_user_message() { include_auth_user_messageSpecified = false; }
+    
 
-    private string _language = "";
+    private string _language;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language
     {
-      get { return _language; }
+      get { return _language?? ""; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (string)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -355,32 +537,59 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_Session() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private ulong _appid = default(ulong);
+    private ulong? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong appid
     {
-      get { return _appid; }
+      get { return _appid?? default(ulong); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (ulong?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _context = default(ulong);
+    private ulong? _context;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"context", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong context
     {
-      get { return _context; }
+      get { return _context?? default(ulong); }
       set { _context = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool contextSpecified
+    {
+      get { return _context != null; }
+      set { if (value == (_context== null)) _context = value ? this.context : (ulong?)null; }
+    }
+    private bool ShouldSerializecontext() { return contextSpecified; }
+    private void Resetcontext() { contextSpecified = false; }
+    
 
     private CGameNotifications_LocalizedText _title = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -391,23 +600,41 @@ namespace SteamKit2.Unified.Internal
       set { _title = value; }
     }
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CGameNotifications_UserStatus> _user_status = new global::System.Collections.Generic.List<CGameNotifications_UserStatus>();
     [global::ProtoBuf.ProtoMember(7, Name=@"user_status", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CGameNotifications_UserStatus> user_status
@@ -450,46 +677,82 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _language = "";
+    private string _language;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string language
     {
-      get { return _language; }
+      get { return _language?? ""; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (string)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"RequestedSession")]
   public partial class RequestedSession : global::ProtoBuf.IExtensible
   {
     public RequestedSession() {}
     
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private bool _include_auth_user_message = default(bool);
+    private bool? _include_auth_user_message;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"include_auth_user_message", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_auth_user_message
     {
-      get { return _include_auth_user_message; }
+      get { return _include_auth_user_message?? default(bool); }
       set { _include_auth_user_message = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_auth_user_messageSpecified
+    {
+      get { return _include_auth_user_message != null; }
+      set { if (value == (_include_auth_user_message== null)) _include_auth_user_message = value ? this.include_auth_user_message : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_auth_user_message() { return include_auth_user_messageSpecified; }
+    private void Resetinclude_auth_user_message() { include_auth_user_messageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -523,23 +786,41 @@ namespace SteamKit2.Unified.Internal
     public GameNotificationSettings() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _allow_notifications = default(bool);
+    private bool? _allow_notifications;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"allow_notifications", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_notifications
     {
-      get { return _allow_notifications; }
+      get { return _allow_notifications?? default(bool); }
       set { _allow_notifications = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_notificationsSpecified
+    {
+      get { return _allow_notifications != null; }
+      set { if (value == (_allow_notifications== null)) _allow_notifications = value ? this.allow_notifications : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_notifications() { return allow_notificationsSpecified; }
+    private void Resetallow_notifications() { allow_notificationsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -578,23 +859,41 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_OnNotificationsRequested_Notification() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -606,32 +905,59 @@ namespace SteamKit2.Unified.Internal
     public CGameNotifications_OnUserStatusChanged_Notification() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _sessionid = default(ulong);
+    private ulong? _sessionid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? default(ulong); }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (ulong?)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
     private CGameNotifications_UserStatus _status = null;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -642,14 +968,23 @@ namespace SteamKit2.Unified.Internal
       set { _status = value; }
     }
 
-    private bool _removed = default(bool);
+    private bool? _removed;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"removed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool removed
     {
-      get { return _removed; }
+      get { return _removed?? default(bool); }
       set { _removed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool removedSpecified
+    {
+      get { return _removed != null; }
+      set { if (value == (_removed== null)) _removed = value ? this.removed : (bool?)null; }
+    }
+    private bool ShouldSerializeremoved() { return removedSpecified; }
+    private void Resetremoved() { removedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgGameServers.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgGameServers.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_gameservers.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CGameServers_GetServerList_Request() {}
     
 
-    private string _filter = "";
+    private string _filter;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filter", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filter
     {
-      get { return _filter; }
+      get { return _filter?? ""; }
       set { _filter = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filterSpecified
+    {
+      get { return _filter != null; }
+      set { if (value == (_filter== null)) _filter = value ? this.filter : (string)null; }
+    }
+    private bool ShouldSerializefilter() { return filterSpecified; }
+    private void Resetfilter() { filterSpecified = false; }
+    
 
-    private uint _limit = (uint)100;
+    private uint? _limit;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"limit", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)100)]
     public uint limit
     {
-      get { return _limit; }
+      get { return _limit?? (uint)100; }
       set { _limit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool limitSpecified
+    {
+      get { return _limit != null; }
+      set { if (value == (_limit== null)) _limit = value ? this.limit : (uint?)null; }
+    }
+    private bool ShouldSerializelimit() { return limitSpecified; }
+    private void Resetlimit() { limitSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -58,167 +78,329 @@ namespace SteamKit2.Unified.Internal
     public Server() {}
     
 
-    private string _addr = "";
+    private string _addr;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"addr", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string addr
     {
-      get { return _addr; }
+      get { return _addr?? ""; }
       set { _addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool addrSpecified
+    {
+      get { return _addr != null; }
+      set { if (value == (_addr== null)) _addr = value ? this.addr : (string)null; }
+    }
+    private bool ShouldSerializeaddr() { return addrSpecified; }
+    private void Resetaddr() { addrSpecified = false; }
+    
 
-    private uint _gameport = default(uint);
+    private uint? _gameport;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"gameport", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint gameport
     {
-      get { return _gameport; }
+      get { return _gameport?? default(uint); }
       set { _gameport = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gameportSpecified
+    {
+      get { return _gameport != null; }
+      set { if (value == (_gameport== null)) _gameport = value ? this.gameport : (uint?)null; }
+    }
+    private bool ShouldSerializegameport() { return gameportSpecified; }
+    private void Resetgameport() { gameportSpecified = false; }
+    
 
-    private uint _specport = default(uint);
+    private uint? _specport;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"specport", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint specport
     {
-      get { return _specport; }
+      get { return _specport?? default(uint); }
       set { _specport = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool specportSpecified
+    {
+      get { return _specport != null; }
+      set { if (value == (_specport== null)) _specport = value ? this.specport : (uint?)null; }
+    }
+    private bool ShouldSerializespecport() { return specportSpecified; }
+    private void Resetspecport() { specportSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _gamedir = "";
+    private string _gamedir;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"gamedir", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gamedir
     {
-      get { return _gamedir; }
+      get { return _gamedir?? ""; }
       set { _gamedir = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gamedirSpecified
+    {
+      get { return _gamedir != null; }
+      set { if (value == (_gamedir== null)) _gamedir = value ? this.gamedir : (string)null; }
+    }
+    private bool ShouldSerializegamedir() { return gamedirSpecified; }
+    private void Resetgamedir() { gamedirSpecified = false; }
+    
 
-    private string _version = "";
+    private string _version;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string version
     {
-      get { return _version; }
+      get { return _version?? ""; }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (string)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private string _product = "";
+    private string _product;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"product", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string product
     {
-      get { return _product; }
+      get { return _product?? ""; }
       set { _product = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool productSpecified
+    {
+      get { return _product != null; }
+      set { if (value == (_product== null)) _product = value ? this.product : (string)null; }
+    }
+    private bool ShouldSerializeproduct() { return productSpecified; }
+    private void Resetproduct() { productSpecified = false; }
+    
 
-    private int _region = default(int);
+    private int? _region;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"region", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int region
     {
-      get { return _region; }
+      get { return _region?? default(int); }
       set { _region = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool regionSpecified
+    {
+      get { return _region != null; }
+      set { if (value == (_region== null)) _region = value ? this.region : (int?)null; }
+    }
+    private bool ShouldSerializeregion() { return regionSpecified; }
+    private void Resetregion() { regionSpecified = false; }
+    
 
-    private int _players = default(int);
+    private int? _players;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int players
     {
-      get { return _players; }
+      get { return _players?? default(int); }
       set { _players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playersSpecified
+    {
+      get { return _players != null; }
+      set { if (value == (_players== null)) _players = value ? this.players : (int?)null; }
+    }
+    private bool ShouldSerializeplayers() { return playersSpecified; }
+    private void Resetplayers() { playersSpecified = false; }
+    
 
-    private int _max_players = default(int);
+    private int? _max_players;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"max_players", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int max_players
     {
-      get { return _max_players; }
+      get { return _max_players?? default(int); }
       set { _max_players = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool max_playersSpecified
+    {
+      get { return _max_players != null; }
+      set { if (value == (_max_players== null)) _max_players = value ? this.max_players : (int?)null; }
+    }
+    private bool ShouldSerializemax_players() { return max_playersSpecified; }
+    private void Resetmax_players() { max_playersSpecified = false; }
+    
 
-    private int _bots = default(int);
+    private int? _bots;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"bots", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int bots
     {
-      get { return _bots; }
+      get { return _bots?? default(int); }
       set { _bots = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool botsSpecified
+    {
+      get { return _bots != null; }
+      set { if (value == (_bots== null)) _bots = value ? this.bots : (int?)null; }
+    }
+    private bool ShouldSerializebots() { return botsSpecified; }
+    private void Resetbots() { botsSpecified = false; }
+    
 
-    private string _map = "";
+    private string _map;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"map", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string map
     {
-      get { return _map; }
+      get { return _map?? ""; }
       set { _map = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mapSpecified
+    {
+      get { return _map != null; }
+      set { if (value == (_map== null)) _map = value ? this.map : (string)null; }
+    }
+    private bool ShouldSerializemap() { return mapSpecified; }
+    private void Resetmap() { mapSpecified = false; }
+    
 
-    private bool _secure = default(bool);
+    private bool? _secure;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"secure", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool secure
     {
-      get { return _secure; }
+      get { return _secure?? default(bool); }
       set { _secure = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secureSpecified
+    {
+      get { return _secure != null; }
+      set { if (value == (_secure== null)) _secure = value ? this.secure : (bool?)null; }
+    }
+    private bool ShouldSerializesecure() { return secureSpecified; }
+    private void Resetsecure() { secureSpecified = false; }
+    
 
-    private bool _dedicated = default(bool);
+    private bool? _dedicated;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"dedicated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool dedicated
     {
-      get { return _dedicated; }
+      get { return _dedicated?? default(bool); }
       set { _dedicated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool dedicatedSpecified
+    {
+      get { return _dedicated != null; }
+      set { if (value == (_dedicated== null)) _dedicated = value ? this.dedicated : (bool?)null; }
+    }
+    private bool ShouldSerializededicated() { return dedicatedSpecified; }
+    private void Resetdedicated() { dedicatedSpecified = false; }
+    
 
-    private string _os = "";
+    private string _os;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"os", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string os
     {
-      get { return _os; }
+      get { return _os?? ""; }
       set { _os = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool osSpecified
+    {
+      get { return _os != null; }
+      set { if (value == (_os== null)) _os = value ? this.os : (string)null; }
+    }
+    private bool ShouldSerializeos() { return osSpecified; }
+    private void Resetos() { osSpecified = false; }
+    
 
-    private string _gametype = "";
+    private string _gametype;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"gametype", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string gametype
     {
-      get { return _gametype; }
+      get { return _gametype?? ""; }
       set { _gametype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool gametypeSpecified
+    {
+      get { return _gametype != null; }
+      set { if (value == (_gametype== null)) _gametype = value ? this.gametype : (string)null; }
+    }
+    private bool ShouldSerializegametype() { return gametypeSpecified; }
+    private void Resetgametype() { gametypeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -264,23 +446,41 @@ namespace SteamKit2.Unified.Internal
     public Server() {}
     
 
-    private string _addr = "";
+    private string _addr;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"addr", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string addr
     {
-      get { return _addr; }
+      get { return _addr?? ""; }
       set { _addr = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool addrSpecified
+    {
+      get { return _addr != null; }
+      set { if (value == (_addr== null)) _addr = value ? this.addr : (string)null; }
+    }
+    private bool ShouldSerializeaddr() { return addrSpecified; }
+    private void Resetaddr() { addrSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgInventory.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgInventory.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_inventory.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CInventory_GetInventory_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,14 +66,23 @@ namespace SteamKit2.Unified.Internal
     public CInventory_Response() {}
     
 
-    private string _etag = "";
+    private string _etag;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"etag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string etag
     {
-      get { return _etag; }
+      get { return _etag?? ""; }
       set { _etag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool etagSpecified
+    {
+      get { return _etag != null; }
+      set { if (value == (_etag== null)) _etag = value ? this.etag : (string)null; }
+    }
+    private bool ShouldSerializeetag() { return etagSpecified; }
+    private void Resetetag() { etagSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _removeditemids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"removeditemids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> removeditemids
@@ -62,32 +91,59 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _item_json = "";
+    private string _item_json;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"item_json", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string item_json
     {
-      get { return _item_json; }
+      get { return _item_json?? ""; }
       set { _item_json = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool item_jsonSpecified
+    {
+      get { return _item_json != null; }
+      set { if (value == (_item_json== null)) _item_json = value ? this.item_json : (string)null; }
+    }
+    private bool ShouldSerializeitem_json() { return item_jsonSpecified; }
+    private void Resetitem_json() { item_jsonSpecified = false; }
+    
 
-    private string _itemdef_json = "";
+    private string _itemdef_json;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"itemdef_json", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string itemdef_json
     {
-      get { return _itemdef_json; }
+      get { return _itemdef_json?? ""; }
       set { _itemdef_json = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdef_jsonSpecified
+    {
+      get { return _itemdef_json != null; }
+      set { if (value == (_itemdef_json== null)) _itemdef_json = value ? this.itemdef_json : (string)null; }
+    }
+    private bool ShouldSerializeitemdef_json() { return itemdef_jsonSpecified; }
+    private void Resetitemdef_json() { itemdef_jsonSpecified = false; }
+    
 
-    private byte[] _ticket = null;
+    private byte[] _ticket;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] ticket
     {
-      get { return _ticket; }
+      get { return _ticket?? null; }
       set { _ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ticketSpecified
+    {
+      get { return _ticket != null; }
+      set { if (value == (_ticket== null)) _ticket = value ? this.ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeticket() { return ticketSpecified; }
+    private void Resetticket() { ticketSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -99,23 +155,41 @@ namespace SteamKit2.Unified.Internal
     public CInventory_ExchangeItem_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _materialsitemid = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(3, Name=@"materialsitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> materialsitemid
@@ -131,14 +205,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private ulong _outputitemdefid = default(ulong);
+    private ulong? _outputitemdefid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"outputitemdefid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong outputitemdefid
     {
-      get { return _outputitemdefid; }
+      get { return _outputitemdefid?? default(ulong); }
       set { _outputitemdefid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool outputitemdefidSpecified
+    {
+      get { return _outputitemdefid != null; }
+      set { if (value == (_outputitemdefid== null)) _outputitemdefid = value ? this.outputitemdefid : (ulong?)null; }
+    }
+    private bool ShouldSerializeoutputitemdefid() { return outputitemdefidSpecified; }
+    private void Resetoutputitemdefid() { outputitemdefidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -150,14 +233,23 @@ namespace SteamKit2.Unified.Internal
     public CInventory_AddItem_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _itemdefid = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"itemdefid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> itemdefid
@@ -173,23 +265,41 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private bool _notify = default(bool);
+    private bool? _notify;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"notify", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool notify
     {
-      get { return _notify; }
+      get { return _notify?? default(bool); }
       set { _notify = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notifySpecified
+    {
+      get { return _notify != null; }
+      set { if (value == (_notify== null)) _notify = value ? this.notify : (bool?)null; }
+    }
+    private bool ShouldSerializenotify() { return notifySpecified; }
+    private void Resetnotify() { notifySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -201,41 +311,77 @@ namespace SteamKit2.Unified.Internal
     public CInventory_SafeModifyItem_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _acctid = default(ulong);
+    private ulong? _acctid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"acctid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong acctid
     {
-      get { return _acctid; }
+      get { return _acctid?? default(ulong); }
       set { _acctid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool acctidSpecified
+    {
+      get { return _acctid != null; }
+      set { if (value == (_acctid== null)) _acctid = value ? this.acctid : (ulong?)null; }
+    }
+    private bool ShouldSerializeacctid() { return acctidSpecified; }
+    private void Resetacctid() { acctidSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
 
-    private string _itempropsjson = "";
+    private string _itempropsjson;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"itempropsjson", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string itempropsjson
     {
-      get { return _itempropsjson; }
+      get { return _itempropsjson?? ""; }
       set { _itempropsjson = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itempropsjsonSpecified
+    {
+      get { return _itempropsjson != null; }
+      set { if (value == (_itempropsjson== null)) _itempropsjson = value ? this.itempropsjson : (string)null; }
+    }
+    private bool ShouldSerializeitempropsjson() { return itempropsjsonSpecified; }
+    private void Resetitempropsjson() { itempropsjsonSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -247,23 +393,41 @@ namespace SteamKit2.Unified.Internal
     public CInventory_ConsumePlaytime_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _itemdefid = default(ulong);
+    private ulong? _itemdefid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemdefid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemdefid
     {
-      get { return _itemdefid; }
+      get { return _itemdefid?? default(ulong); }
       set { _itemdefid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdefidSpecified
+    {
+      get { return _itemdefid != null; }
+      set { if (value == (_itemdefid== null)) _itemdefid = value ? this.itemdefid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemdefid() { return itemdefidSpecified; }
+    private void Resetitemdefid() { itemdefidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -275,23 +439,41 @@ namespace SteamKit2.Unified.Internal
     public CInventory_GetItemDefs_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _modifiedsince = "";
+    private string _modifiedsince;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"modifiedsince", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string modifiedsince
     {
-      get { return _modifiedsince; }
+      get { return _modifiedsince?? ""; }
       set { _modifiedsince = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifiedsinceSpecified
+    {
+      get { return _modifiedsince != null; }
+      set { if (value == (_modifiedsince== null)) _modifiedsince = value ? this.modifiedsince : (string)null; }
+    }
+    private bool ShouldSerializemodifiedsince() { return modifiedsinceSpecified; }
+    private void Resetmodifiedsince() { modifiedsinceSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _itemdefids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(4, Name=@"itemdefids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> itemdefids
@@ -307,14 +489,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _cache_max_age_seconds = (uint)0;
+    private uint? _cache_max_age_seconds;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"cache_max_age_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint cache_max_age_seconds
     {
-      get { return _cache_max_age_seconds; }
+      get { return _cache_max_age_seconds?? (uint)0; }
       set { _cache_max_age_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cache_max_age_secondsSpecified
+    {
+      get { return _cache_max_age_seconds != null; }
+      set { if (value == (_cache_max_age_seconds== null)) _cache_max_age_seconds = value ? this.cache_max_age_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializecache_max_age_seconds() { return cache_max_age_secondsSpecified; }
+    private void Resetcache_max_age_seconds() { cache_max_age_secondsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -326,50 +517,95 @@ namespace SteamKit2.Unified.Internal
     public CInventory_ConsumeItem_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private string _timestamp = "";
+    private string _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? ""; }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (string)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -381,32 +617,59 @@ namespace SteamKit2.Unified.Internal
     public CInventory_DevSetNextDrop_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _itemdefid = default(ulong);
+    private ulong? _itemdefid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemdefid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemdefid
     {
-      get { return _itemdefid; }
+      get { return _itemdefid?? default(ulong); }
       set { _itemdefid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemdefidSpecified
+    {
+      get { return _itemdefid != null; }
+      set { if (value == (_itemdefid== null)) _itemdefid = value ? this.itemdefid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemdefid() { return itemdefidSpecified; }
+    private void Resetitemdefid() { itemdefidSpecified = false; }
+    
 
-    private string _droptime = "";
+    private string _droptime;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"droptime", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string droptime
     {
-      get { return _droptime; }
+      get { return _droptime?? ""; }
       set { _droptime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool droptimeSpecified
+    {
+      get { return _droptime != null; }
+      set { if (value == (_droptime== null)) _droptime = value ? this.droptime : (string)null; }
+    }
+    private bool ShouldSerializedroptime() { return droptimeSpecified; }
+    private void Resetdroptime() { droptimeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -418,41 +681,77 @@ namespace SteamKit2.Unified.Internal
     public CInventory_SplitItemStack_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _itemid = default(ulong);
+    private ulong? _itemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"itemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong itemid
     {
-      get { return _itemid; }
+      get { return _itemid?? default(ulong); }
       set { _itemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool itemidSpecified
+    {
+      get { return _itemid != null; }
+      set { if (value == (_itemid== null)) _itemid = value ? this.itemid : (ulong?)null; }
+    }
+    private bool ShouldSerializeitemid() { return itemidSpecified; }
+    private void Resetitemid() { itemidSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private string _timestamp = "";
+    private string _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? ""; }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (string)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -464,59 +763,113 @@ namespace SteamKit2.Unified.Internal
     public CInventory_CombineItemStacks_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _fromitemid = default(ulong);
+    private ulong? _fromitemid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"fromitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong fromitemid
     {
-      get { return _fromitemid; }
+      get { return _fromitemid?? default(ulong); }
       set { _fromitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fromitemidSpecified
+    {
+      get { return _fromitemid != null; }
+      set { if (value == (_fromitemid== null)) _fromitemid = value ? this.fromitemid : (ulong?)null; }
+    }
+    private bool ShouldSerializefromitemid() { return fromitemidSpecified; }
+    private void Resetfromitemid() { fromitemidSpecified = false; }
+    
 
-    private ulong _destitemid = default(ulong);
+    private ulong? _destitemid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"destitemid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong destitemid
     {
-      get { return _destitemid; }
+      get { return _destitemid?? default(ulong); }
       set { _destitemid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool destitemidSpecified
+    {
+      get { return _destitemid != null; }
+      set { if (value == (_destitemid== null)) _destitemid = value ? this.destitemid : (ulong?)null; }
+    }
+    private bool ShouldSerializedestitemid() { return destitemidSpecified; }
+    private void Resetdestitemid() { destitemidSpecified = false; }
+    
 
-    private uint _quantity = default(uint);
+    private uint? _quantity;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"quantity", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint quantity
     {
-      get { return _quantity; }
+      get { return _quantity?? default(uint); }
       set { _quantity = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool quantitySpecified
+    {
+      get { return _quantity != null; }
+      set { if (value == (_quantity== null)) _quantity = value ? this.quantity : (uint?)null; }
+    }
+    private bool ShouldSerializequantity() { return quantitySpecified; }
+    private void Resetquantity() { quantitySpecified = false; }
+    
 
-    private string _fromtimestamp = "";
+    private string _fromtimestamp;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"fromtimestamp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string fromtimestamp
     {
-      get { return _fromtimestamp; }
+      get { return _fromtimestamp?? ""; }
       set { _fromtimestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fromtimestampSpecified
+    {
+      get { return _fromtimestamp != null; }
+      set { if (value == (_fromtimestamp== null)) _fromtimestamp = value ? this.fromtimestamp : (string)null; }
+    }
+    private bool ShouldSerializefromtimestamp() { return fromtimestampSpecified; }
+    private void Resetfromtimestamp() { fromtimestampSpecified = false; }
+    
 
-    private string _desttimestamp = "";
+    private string _desttimestamp;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"desttimestamp", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string desttimestamp
     {
-      get { return _desttimestamp; }
+      get { return _desttimestamp?? ""; }
       set { _desttimestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desttimestampSpecified
+    {
+      get { return _desttimestamp != null; }
+      set { if (value == (_desttimestamp== null)) _desttimestamp = value ? this.desttimestamp : (string)null; }
+    }
+    private bool ShouldSerializedesttimestamp() { return desttimestampSpecified; }
+    private void Resetdesttimestamp() { desttimestampSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -528,14 +881,23 @@ namespace SteamKit2.Unified.Internal
     public CInventory_GetItemDefMeta_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -547,23 +909,41 @@ namespace SteamKit2.Unified.Internal
     public CInventory_GetItemDefMeta_Response() {}
     
 
-    private uint _modified = default(uint);
+    private uint? _modified;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"modified", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint modified
     {
-      get { return _modified; }
+      get { return _modified?? default(uint); }
       set { _modified = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool modifiedSpecified
+    {
+      get { return _modified != null; }
+      set { if (value == (_modified== null)) _modified = value ? this.modified : (uint?)null; }
+    }
+    private bool ShouldSerializemodified() { return modifiedSpecified; }
+    private void Resetmodified() { modifiedSpecified = false; }
+    
 
-    private string _digest = "";
+    private string _digest;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"digest", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string digest
     {
-      get { return _digest; }
+      get { return _digest?? ""; }
       set { _digest = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool digestSpecified
+    {
+      get { return _digest != null; }
+      set { if (value == (_digest== null)) _digest = value ? this.digest : (string)null; }
+    }
+    private bool ShouldSerializedigest() { return digestSpecified; }
+    private void Resetdigest() { digestSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgLinkFilter.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgLinkFilter.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_linkfilter.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,32 +20,59 @@ namespace SteamKit2.Unified.Internal
     public CCommunity_GetLinkFilterHashPrefixes_Request() {}
     
 
-    private uint _hit_type = default(uint);
+    private uint? _hit_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hit_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hit_type
     {
-      get { return _hit_type; }
+      get { return _hit_type?? default(uint); }
       set { _hit_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hit_typeSpecified
+    {
+      get { return _hit_type != null; }
+      set { if (value == (_hit_type== null)) _hit_type = value ? this.hit_type : (uint?)null; }
+    }
+    private bool ShouldSerializehit_type() { return hit_typeSpecified; }
+    private void Resethit_type() { hit_typeSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private ulong _start = default(ulong);
+    private ulong? _start;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong start
     {
-      get { return _start; }
+      get { return _start?? default(ulong); }
       set { _start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool startSpecified
+    {
+      get { return _start != null; }
+      set { if (value == (_start== null)) _start = value ? this.start : (ulong?)null; }
+    }
+    private bool ShouldSerializestart() { return startSpecified; }
+    private void Resetstart() { startSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -72,32 +101,59 @@ namespace SteamKit2.Unified.Internal
     public CCommunity_GetLinkFilterHashes_Request() {}
     
 
-    private uint _hit_type = default(uint);
+    private uint? _hit_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hit_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hit_type
     {
-      get { return _hit_type; }
+      get { return _hit_type?? default(uint); }
       set { _hit_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hit_typeSpecified
+    {
+      get { return _hit_type != null; }
+      set { if (value == (_hit_type== null)) _hit_type = value ? this.hit_type : (uint?)null; }
+    }
+    private bool ShouldSerializehit_type() { return hit_typeSpecified; }
+    private void Resethit_type() { hit_typeSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private ulong _start = default(ulong);
+    private ulong? _start;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"start", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong start
     {
-      get { return _start; }
+      get { return _start?? default(ulong); }
       set { _start = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool startSpecified
+    {
+      get { return _start != null; }
+      set { if (value == (_start== null)) _start = value ? this.start : (ulong?)null; }
+    }
+    private bool ShouldSerializestart() { return startSpecified; }
+    private void Resetstart() { startSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -126,14 +182,23 @@ namespace SteamKit2.Unified.Internal
     public CCommunity_GetLinkFilterListVersion_Request() {}
     
 
-    private uint _hit_type = default(uint);
+    private uint? _hit_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"hit_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint hit_type
     {
-      get { return _hit_type; }
+      get { return _hit_type?? default(uint); }
       set { _hit_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hit_typeSpecified
+    {
+      get { return _hit_type != null; }
+      set { if (value == (_hit_type== null)) _hit_type = value ? this.hit_type : (uint?)null; }
+    }
+    private bool ShouldSerializehit_type() { return hit_typeSpecified; }
+    private void Resethit_type() { hit_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -145,23 +210,41 @@ namespace SteamKit2.Unified.Internal
     public CCommunity_GetLinkFilterListVersion_Response() {}
     
 
-    private string _version = "";
+    private string _version;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string version
     {
-      get { return _version; }
+      get { return _version?? ""; }
       set { _version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool versionSpecified
+    {
+      get { return _version != null; }
+      set { if (value == (_version== null)) _version = value ? this.version : (string)null; }
+    }
+    private bool ShouldSerializeversion() { return versionSpecified; }
+    private void Resetversion() { versionSpecified = false; }
+    
 
-    private ulong _count = default(ulong);
+    private ulong? _count;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong count
     {
-      get { return _count; }
+      get { return _count?? default(ulong); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (ulong?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgOffline.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgOffline.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_offline.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public COffline_GetOfflineLogonTicket_Request() {}
     
 
-    private uint _priority = default(uint);
+    private uint? _priority;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"priority", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint priority
     {
-      get { return _priority; }
+      get { return _priority?? default(uint); }
       set { _priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prioritySpecified
+    {
+      get { return _priority != null; }
+      set { if (value == (_priority== null)) _priority = value ? this.priority : (uint?)null; }
+    }
+    private bool ShouldSerializepriority() { return prioritySpecified; }
+    private void Resetpriority() { prioritySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,23 +48,41 @@ namespace SteamKit2.Unified.Internal
     public COffline_GetOfflineLogonTicket_Response() {}
     
 
-    private byte[] _serialized_ticket = null;
+    private byte[] _serialized_ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serialized_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_ticket
     {
-      get { return _serialized_ticket; }
+      get { return _serialized_ticket?? null; }
       set { _serialized_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_ticketSpecified
+    {
+      get { return _serialized_ticket != null; }
+      set { if (value == (_serialized_ticket== null)) _serialized_ticket = value ? this.serialized_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_ticket() { return serialized_ticketSpecified; }
+    private void Resetserialized_ticket() { serialized_ticketSpecified = false; }
+    
 
-    private byte[] _signature = null;
+    private byte[] _signature;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signature
     {
-      get { return _signature; }
+      get { return _signature?? null; }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (byte[])null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -75,23 +104,41 @@ namespace SteamKit2.Unified.Internal
     public COffline_OfflineLogonTicket() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private uint _rtime32_creation_time = default(uint);
+    private uint? _rtime32_creation_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"rtime32_creation_time", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint rtime32_creation_time
     {
-      get { return _rtime32_creation_time; }
+      get { return _rtime32_creation_time?? default(uint); }
       set { _rtime32_creation_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rtime32_creation_timeSpecified
+    {
+      get { return _rtime32_creation_time != null; }
+      set { if (value == (_rtime32_creation_time== null)) _rtime32_creation_time = value ? this.rtime32_creation_time : (uint?)null; }
+    }
+    private bool ShouldSerializertime32_creation_time() { return rtime32_creation_timeSpecified; }
+    private void Resetrtime32_creation_time() { rtime32_creation_timeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgParental.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgParental.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_parental.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public ParentalApp() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _is_allowed = default(bool);
+    private bool? _is_allowed;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"is_allowed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_allowed
     {
-      get { return _is_allowed; }
+      get { return _is_allowed?? default(bool); }
       set { _is_allowed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_allowedSpecified
+    {
+      get { return _is_allowed != null; }
+      set { if (value == (_is_allowed== null)) _is_allowed = value ? this.is_allowed : (bool?)null; }
+    }
+    private bool ShouldSerializeis_allowed() { return is_allowedSpecified; }
+    private void Resetis_allowed() { is_allowedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,32 +66,59 @@ namespace SteamKit2.Unified.Internal
     public ParentalSettings() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _applist_base_id = default(uint);
+    private uint? _applist_base_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"applist_base_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint applist_base_id
     {
-      get { return _applist_base_id; }
+      get { return _applist_base_id?? default(uint); }
       set { _applist_base_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool applist_base_idSpecified
+    {
+      get { return _applist_base_id != null; }
+      set { if (value == (_applist_base_id== null)) _applist_base_id = value ? this.applist_base_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapplist_base_id() { return applist_base_idSpecified; }
+    private void Resetapplist_base_id() { applist_base_idSpecified = false; }
+    
 
-    private string _applist_base_description = "";
+    private string _applist_base_description;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"applist_base_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string applist_base_description
     {
-      get { return _applist_base_description; }
+      get { return _applist_base_description?? ""; }
       set { _applist_base_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool applist_base_descriptionSpecified
+    {
+      get { return _applist_base_description != null; }
+      set { if (value == (_applist_base_description== null)) _applist_base_description = value ? this.applist_base_description : (string)null; }
+    }
+    private bool ShouldSerializeapplist_base_description() { return applist_base_descriptionSpecified; }
+    private void Resetapplist_base_description() { applist_base_descriptionSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ParentalApp> _applist_base = new global::System.Collections.Generic.List<ParentalApp>();
     [global::ProtoBuf.ProtoMember(4, Name=@"applist_base", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<ParentalApp> applist_base
@@ -87,59 +134,113 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _passwordhashtype = default(uint);
+    private uint? _passwordhashtype;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"passwordhashtype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint passwordhashtype
     {
-      get { return _passwordhashtype; }
+      get { return _passwordhashtype?? default(uint); }
       set { _passwordhashtype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordhashtypeSpecified
+    {
+      get { return _passwordhashtype != null; }
+      set { if (value == (_passwordhashtype== null)) _passwordhashtype = value ? this.passwordhashtype : (uint?)null; }
+    }
+    private bool ShouldSerializepasswordhashtype() { return passwordhashtypeSpecified; }
+    private void Resetpasswordhashtype() { passwordhashtypeSpecified = false; }
+    
 
-    private byte[] _salt = null;
+    private byte[] _salt;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"salt", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] salt
     {
-      get { return _salt; }
+      get { return _salt?? null; }
       set { _salt = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool saltSpecified
+    {
+      get { return _salt != null; }
+      set { if (value == (_salt== null)) _salt = value ? this.salt : (byte[])null; }
+    }
+    private bool ShouldSerializesalt() { return saltSpecified; }
+    private void Resetsalt() { saltSpecified = false; }
+    
 
-    private byte[] _passwordhash = null;
+    private byte[] _passwordhash;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"passwordhash", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] passwordhash
     {
-      get { return _passwordhash; }
+      get { return _passwordhash?? null; }
       set { _passwordhash = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordhashSpecified
+    {
+      get { return _passwordhash != null; }
+      set { if (value == (_passwordhash== null)) _passwordhash = value ? this.passwordhash : (byte[])null; }
+    }
+    private bool ShouldSerializepasswordhash() { return passwordhashSpecified; }
+    private void Resetpasswordhash() { passwordhashSpecified = false; }
+    
 
-    private bool _is_enabled = default(bool);
+    private bool? _is_enabled;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"is_enabled", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_enabled
     {
-      get { return _is_enabled; }
+      get { return _is_enabled?? default(bool); }
       set { _is_enabled = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_enabledSpecified
+    {
+      get { return _is_enabled != null; }
+      set { if (value == (_is_enabled== null)) _is_enabled = value ? this.is_enabled : (bool?)null; }
+    }
+    private bool ShouldSerializeis_enabled() { return is_enabledSpecified; }
+    private void Resetis_enabled() { is_enabledSpecified = false; }
+    
 
-    private uint _enabled_features = default(uint);
+    private uint? _enabled_features;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"enabled_features", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint enabled_features
     {
-      get { return _enabled_features; }
+      get { return _enabled_features?? default(uint); }
       set { _enabled_features = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool enabled_featuresSpecified
+    {
+      get { return _enabled_features != null; }
+      set { if (value == (_enabled_features== null)) _enabled_features = value ? this.enabled_features : (uint?)null; }
+    }
+    private bool ShouldSerializeenabled_features() { return enabled_featuresSpecified; }
+    private void Resetenabled_features() { enabled_featuresSpecified = false; }
+    
 
-    private string _recovery_email = "";
+    private string _recovery_email;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"recovery_email", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string recovery_email
     {
-      get { return _recovery_email; }
+      get { return _recovery_email?? ""; }
       set { _recovery_email = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recovery_emailSpecified
+    {
+      get { return _recovery_email != null; }
+      set { if (value == (_recovery_email== null)) _recovery_email = value ? this.recovery_email : (string)null; }
+    }
+    private bool ShouldSerializerecovery_email() { return recovery_emailSpecified; }
+    private void Resetrecovery_email() { recovery_emailSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -151,14 +252,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_EnableParentalSettings_Request() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
     private ParentalSettings _settings = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"settings", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -169,32 +279,59 @@ namespace SteamKit2.Unified.Internal
       set { _settings = value; }
     }
 
-    private string _sessionid = "";
+    private string _sessionid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? ""; }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (string)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private uint _enablecode = default(uint);
+    private uint? _enablecode;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"enablecode", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint enablecode
     {
-      get { return _enablecode; }
+      get { return _enablecode?? default(uint); }
       set { _enablecode = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool enablecodeSpecified
+    {
+      get { return _enablecode != null; }
+      set { if (value == (_enablecode== null)) _enablecode = value ? this.enablecode : (uint?)null; }
+    }
+    private bool ShouldSerializeenablecode() { return enablecodeSpecified; }
+    private void Resetenablecode() { enablecodeSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -216,23 +353,41 @@ namespace SteamKit2.Unified.Internal
     public CParental_DisableParentalSettings_Request() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -254,14 +409,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_GetParentalSettings_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -292,14 +456,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_GetSignedParentalSettings_Request() {}
     
 
-    private uint _priority = default(uint);
+    private uint? _priority;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"priority", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint priority
     {
-      get { return _priority; }
+      get { return _priority?? default(uint); }
       set { _priority = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool prioritySpecified
+    {
+      get { return _priority != null; }
+      set { if (value == (_priority== null)) _priority = value ? this.priority : (uint?)null; }
+    }
+    private bool ShouldSerializepriority() { return prioritySpecified; }
+    private void Resetpriority() { prioritySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -311,23 +484,41 @@ namespace SteamKit2.Unified.Internal
     public CParental_GetSignedParentalSettings_Response() {}
     
 
-    private byte[] _serialized_settings = null;
+    private byte[] _serialized_settings;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serialized_settings", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_settings
     {
-      get { return _serialized_settings; }
+      get { return _serialized_settings?? null; }
       set { _serialized_settings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_settingsSpecified
+    {
+      get { return _serialized_settings != null; }
+      set { if (value == (_serialized_settings== null)) _serialized_settings = value ? this.serialized_settings : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_settings() { return serialized_settingsSpecified; }
+    private void Resetserialized_settings() { serialized_settingsSpecified = false; }
+    
 
-    private byte[] _signature = null;
+    private byte[] _signature;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signature
     {
-      get { return _signature; }
+      get { return _signature?? null; }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (byte[])null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -339,14 +530,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_SetParentalSettings_Request() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
     private ParentalSettings _settings = null;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"settings", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -357,32 +557,59 @@ namespace SteamKit2.Unified.Internal
       set { _settings = value; }
     }
 
-    private string _new_password = "";
+    private string _new_password;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"new_password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string new_password
     {
-      get { return _new_password; }
+      get { return _new_password?? ""; }
       set { _new_password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool new_passwordSpecified
+    {
+      get { return _new_password != null; }
+      set { if (value == (_new_password== null)) _new_password = value ? this.new_password : (string)null; }
+    }
+    private bool ShouldSerializenew_password() { return new_passwordSpecified; }
+    private void Resetnew_password() { new_passwordSpecified = false; }
+    
 
-    private string _sessionid = "";
+    private string _sessionid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? ""; }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (string)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -404,14 +631,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_ValidateToken_Request() {}
     
 
-    private string _unlock_token = "";
+    private string _unlock_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"unlock_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string unlock_token
     {
-      get { return _unlock_token; }
+      get { return _unlock_token?? ""; }
       set { _unlock_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool unlock_tokenSpecified
+    {
+      get { return _unlock_token != null; }
+      set { if (value == (_unlock_token== null)) _unlock_token = value ? this.unlock_token : (string)null; }
+    }
+    private bool ShouldSerializeunlock_token() { return unlock_tokenSpecified; }
+    private void Resetunlock_token() { unlock_tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -433,32 +669,59 @@ namespace SteamKit2.Unified.Internal
     public CParental_ValidatePassword_Request() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _session = "";
+    private string _session;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"session", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string session
     {
-      get { return _session; }
+      get { return _session?? ""; }
       set { _session = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionSpecified
+    {
+      get { return _session != null; }
+      set { if (value == (_session== null)) _session = value ? this.session : (string)null; }
+    }
+    private bool ShouldSerializesession() { return sessionSpecified; }
+    private void Resetsession() { sessionSpecified = false; }
+    
 
-    private bool _send_unlock_on_success = default(bool);
+    private bool? _send_unlock_on_success;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"send_unlock_on_success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool send_unlock_on_success
     {
-      get { return _send_unlock_on_success; }
+      get { return _send_unlock_on_success?? default(bool); }
       set { _send_unlock_on_success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool send_unlock_on_successSpecified
+    {
+      get { return _send_unlock_on_success != null; }
+      set { if (value == (_send_unlock_on_success== null)) _send_unlock_on_success = value ? this.send_unlock_on_success : (bool?)null; }
+    }
+    private bool ShouldSerializesend_unlock_on_success() { return send_unlock_on_successSpecified; }
+    private void Resetsend_unlock_on_success() { send_unlock_on_successSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -470,14 +733,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_ValidatePassword_Response() {}
     
 
-    private string _token = "";
+    private string _token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token
     {
-      get { return _token; }
+      get { return _token?? ""; }
       set { _token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tokenSpecified
+    {
+      get { return _token != null; }
+      set { if (value == (_token== null)) _token = value ? this.token : (string)null; }
+    }
+    private bool ShouldSerializetoken() { return tokenSpecified; }
+    private void Resettoken() { tokenSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -489,14 +761,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_LockClient_Request() {}
     
 
-    private string _session = "";
+    private string _session;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"session", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string session
     {
-      get { return _session; }
+      get { return _session?? ""; }
       set { _session = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionSpecified
+    {
+      get { return _session != null; }
+      set { if (value == (_session== null)) _session = value ? this.session : (string)null; }
+    }
+    private bool ShouldSerializesession() { return sessionSpecified; }
+    private void Resetsession() { sessionSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -538,23 +819,41 @@ namespace SteamKit2.Unified.Internal
     public CParental_DisableWithRecoveryCode_Request() {}
     
 
-    private uint _recovery_code = default(uint);
+    private uint? _recovery_code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"recovery_code", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint recovery_code
     {
-      get { return _recovery_code; }
+      get { return _recovery_code?? default(uint); }
       set { _recovery_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool recovery_codeSpecified
+    {
+      get { return _recovery_code != null; }
+      set { if (value == (_recovery_code== null)) _recovery_code = value ? this.recovery_code : (uint?)null; }
+    }
+    private bool ShouldSerializerecovery_code() { return recovery_codeSpecified; }
+    private void Resetrecovery_code() { recovery_codeSpecified = false; }
+    
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -576,41 +875,77 @@ namespace SteamKit2.Unified.Internal
     public CParental_ParentalSettingsChange_Notification() {}
     
 
-    private byte[] _serialized_settings = null;
+    private byte[] _serialized_settings;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serialized_settings", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] serialized_settings
     {
-      get { return _serialized_settings; }
+      get { return _serialized_settings?? null; }
       set { _serialized_settings = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serialized_settingsSpecified
+    {
+      get { return _serialized_settings != null; }
+      set { if (value == (_serialized_settings== null)) _serialized_settings = value ? this.serialized_settings : (byte[])null; }
+    }
+    private bool ShouldSerializeserialized_settings() { return serialized_settingsSpecified; }
+    private void Resetserialized_settings() { serialized_settingsSpecified = false; }
+    
 
-    private byte[] _signature = null;
+    private byte[] _signature;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"signature", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] signature
     {
-      get { return _signature; }
+      get { return _signature?? null; }
       set { _signature = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signatureSpecified
+    {
+      get { return _signature != null; }
+      set { if (value == (_signature== null)) _signature = value ? this.signature : (byte[])null; }
+    }
+    private bool ShouldSerializesignature() { return signatureSpecified; }
+    private void Resetsignature() { signatureSpecified = false; }
+    
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _sessionid = "";
+    private string _sessionid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? ""; }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (string)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -622,23 +957,41 @@ namespace SteamKit2.Unified.Internal
     public CParental_ParentalUnlock_Notification() {}
     
 
-    private string _password = "";
+    private string _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string password
     {
-      get { return _password; }
+      get { return _password?? ""; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (string)null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private string _sessionid = "";
+    private string _sessionid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? ""; }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (string)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -650,14 +1003,23 @@ namespace SteamKit2.Unified.Internal
     public CParental_ParentalLock_Notification() {}
     
 
-    private string _sessionid = "";
+    private string _sessionid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"sessionid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sessionid
     {
-      get { return _sessionid; }
+      get { return _sessionid?? ""; }
       set { _sessionid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sessionidSpecified
+    {
+      get { return _sessionid != null; }
+      set { if (value == (_sessionid== null)) _sessionid = value ? this.sessionid : (string)null; }
+    }
+    private bool ShouldSerializesessionid() { return sessionidSpecified; }
+    private void Resetsessionid() { sessionidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPartnerApps.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPartnerApps.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_partnerapps.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_RequestUploadToken_Request() {}
     
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,32 +66,59 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_RequestUploadToken_Response() {}
     
 
-    private ulong _upload_token = default(ulong);
+    private ulong? _upload_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upload_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upload_token
     {
-      get { return _upload_token; }
+      get { return _upload_token?? default(ulong); }
       set { _upload_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_tokenSpecified
+    {
+      get { return _upload_token != null; }
+      set { if (value == (_upload_token== null)) _upload_token = value ? this.upload_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeupload_token() { return upload_tokenSpecified; }
+    private void Resetupload_token() { upload_tokenSpecified = false; }
+    
 
-    private string _location = "";
+    private string _location;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"location", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string location
     {
-      get { return _location; }
+      get { return _location?? ""; }
       set { _location = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool locationSpecified
+    {
+      get { return _location != null; }
+      set { if (value == (_location== null)) _location = value ? this.location : (string)null; }
+    }
+    private bool ShouldSerializelocation() { return locationSpecified; }
+    private void Resetlocation() { locationSpecified = false; }
+    
 
-    private ulong _routing_id = default(ulong);
+    private ulong? _routing_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"routing_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong routing_id
     {
-      get { return _routing_id; }
+      get { return _routing_id?? default(ulong); }
       set { _routing_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_idSpecified
+    {
+      get { return _routing_id != null; }
+      set { if (value == (_routing_id== null)) _routing_id = value ? this.routing_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerouting_id() { return routing_idSpecified; }
+    private void Resetrouting_id() { routing_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -83,32 +130,59 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_FinishUpload_Request() {}
     
 
-    private ulong _upload_token = default(ulong);
+    private ulong? _upload_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upload_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upload_token
     {
-      get { return _upload_token; }
+      get { return _upload_token?? default(ulong); }
       set { _upload_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_tokenSpecified
+    {
+      get { return _upload_token != null; }
+      set { if (value == (_upload_token== null)) _upload_token = value ? this.upload_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeupload_token() { return upload_tokenSpecified; }
+    private void Resetupload_token() { upload_tokenSpecified = false; }
+    
 
-    private ulong _routing_id = default(ulong);
+    private ulong? _routing_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"routing_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong routing_id
     {
-      get { return _routing_id; }
+      get { return _routing_id?? default(ulong); }
       set { _routing_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_idSpecified
+    {
+      get { return _routing_id != null; }
+      set { if (value == (_routing_id== null)) _routing_id = value ? this.routing_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerouting_id() { return routing_idSpecified; }
+    private void Resetrouting_id() { routing_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -120,14 +194,23 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_FinishUploadKVSign_Response() {}
     
 
-    private string _signed_installscript = "";
+    private string _signed_installscript;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"signed_installscript", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string signed_installscript
     {
-      get { return _signed_installscript; }
+      get { return _signed_installscript?? ""; }
       set { _signed_installscript = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool signed_installscriptSpecified
+    {
+      get { return _signed_installscript != null; }
+      set { if (value == (_signed_installscript== null)) _signed_installscript = value ? this.signed_installscript : (string)null; }
+    }
+    private bool ShouldSerializesigned_installscript() { return signed_installscriptSpecified; }
+    private void Resetsigned_installscript() { signed_installscriptSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -139,50 +222,95 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_FinishUploadLegacyDRM_Request() {}
     
 
-    private ulong _upload_token = default(ulong);
+    private ulong? _upload_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"upload_token", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong upload_token
     {
-      get { return _upload_token; }
+      get { return _upload_token?? default(ulong); }
       set { _upload_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool upload_tokenSpecified
+    {
+      get { return _upload_token != null; }
+      set { if (value == (_upload_token== null)) _upload_token = value ? this.upload_token : (ulong?)null; }
+    }
+    private bool ShouldSerializeupload_token() { return upload_tokenSpecified; }
+    private void Resetupload_token() { upload_tokenSpecified = false; }
+    
 
-    private ulong _routing_id = default(ulong);
+    private ulong? _routing_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"routing_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong routing_id
     {
-      get { return _routing_id; }
+      get { return _routing_id?? default(ulong); }
       set { _routing_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool routing_idSpecified
+    {
+      get { return _routing_id != null; }
+      set { if (value == (_routing_id== null)) _routing_id = value ? this.routing_id : (ulong?)null; }
+    }
+    private bool ShouldSerializerouting_id() { return routing_idSpecified; }
+    private void Resetrouting_id() { routing_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private string _tool_name = "";
+    private string _tool_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"tool_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tool_name
     {
-      get { return _tool_name; }
+      get { return _tool_name?? ""; }
       set { _tool_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tool_nameSpecified
+    {
+      get { return _tool_name != null; }
+      set { if (value == (_tool_name== null)) _tool_name = value ? this.tool_name : (string)null; }
+    }
+    private bool ShouldSerializetool_name() { return tool_nameSpecified; }
+    private void Resettool_name() { tool_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -194,14 +322,23 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_FinishUploadLegacyDRM_Response() {}
     
 
-    private string _file_id = "";
+    private string _file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_id
     {
-      get { return _file_id; }
+      get { return _file_id?? ""; }
       set { _file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_idSpecified
+    {
+      get { return _file_id != null; }
+      set { if (value == (_file_id== null)) _file_id = value ? this.file_id : (string)null; }
+    }
+    private bool ShouldSerializefile_id() { return file_idSpecified; }
+    private void Resetfile_id() { file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -223,14 +360,23 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_FindDRMUploads_Request() {}
     
 
-    private int _app_id = default(int);
+    private int? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(int); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (int?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -242,77 +388,149 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_ExistingDRMUpload() {}
     
 
-    private string _file_id = "";
+    private string _file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_id
     {
-      get { return _file_id; }
+      get { return _file_id?? ""; }
       set { _file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_idSpecified
+    {
+      get { return _file_id != null; }
+      set { if (value == (_file_id== null)) _file_id = value ? this.file_id : (string)null; }
+    }
+    private bool ShouldSerializefile_id() { return file_idSpecified; }
+    private void Resetfile_id() { file_idSpecified = false; }
+    
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private int _actor_id = default(int);
+    private int? _actor_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"actor_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int actor_id
     {
-      get { return _actor_id; }
+      get { return _actor_id?? default(int); }
       set { _actor_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool actor_idSpecified
+    {
+      get { return _actor_id != null; }
+      set { if (value == (_actor_id== null)) _actor_id = value ? this.actor_id : (int?)null; }
+    }
+    private bool ShouldSerializeactor_id() { return actor_idSpecified; }
+    private void Resetactor_id() { actor_idSpecified = false; }
+    
 
-    private string _supplied_name = "";
+    private string _supplied_name;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"supplied_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string supplied_name
     {
-      get { return _supplied_name; }
+      get { return _supplied_name?? ""; }
       set { _supplied_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool supplied_nameSpecified
+    {
+      get { return _supplied_name != null; }
+      set { if (value == (_supplied_name== null)) _supplied_name = value ? this.supplied_name : (string)null; }
+    }
+    private bool ShouldSerializesupplied_name() { return supplied_nameSpecified; }
+    private void Resetsupplied_name() { supplied_nameSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private string _mod_type = "";
+    private string _mod_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"mod_type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string mod_type
     {
-      get { return _mod_type; }
+      get { return _mod_type?? ""; }
       set { _mod_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool mod_typeSpecified
+    {
+      get { return _mod_type != null; }
+      set { if (value == (_mod_type== null)) _mod_type = value ? this.mod_type : (string)null; }
+    }
+    private bool ShouldSerializemod_type() { return mod_typeSpecified; }
+    private void Resetmod_type() { mod_typeSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _orig_file_id = "";
+    private string _orig_file_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"orig_file_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string orig_file_id
     {
-      get { return _orig_file_id; }
+      get { return _orig_file_id?? ""; }
       set { _orig_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool orig_file_idSpecified
+    {
+      get { return _orig_file_id != null; }
+      set { if (value == (_orig_file_id== null)) _orig_file_id = value ? this.orig_file_id : (string)null; }
+    }
+    private bool ShouldSerializeorig_file_id() { return orig_file_idSpecified; }
+    private void Resetorig_file_id() { orig_file_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -341,23 +559,41 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_Download_Request() {}
     
 
-    private string _file_id = "";
+    private string _file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"file_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_id
     {
-      get { return _file_id; }
+      get { return _file_id?? ""; }
       set { _file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_idSpecified
+    {
+      get { return _file_id != null; }
+      set { if (value == (_file_id== null)) _file_id = value ? this.file_id : (string)null; }
+    }
+    private bool ShouldSerializefile_id() { return file_idSpecified; }
+    private void Resetfile_id() { file_idSpecified = false; }
+    
 
-    private int _app_id = default(int);
+    private int? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(int); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (int?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -369,23 +605,41 @@ namespace SteamKit2.Unified.Internal
     public CPartnerApps_Download_Response() {}
     
 
-    private string _download_url = "";
+    private string _download_url;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"download_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string download_url
     {
-      get { return _download_url; }
+      get { return _download_url?? ""; }
       set { _download_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool download_urlSpecified
+    {
+      get { return _download_url != null; }
+      set { if (value == (_download_url== null)) _download_url = value ? this.download_url : (string)null; }
+    }
+    private bool ShouldSerializedownload_url() { return download_urlSpecified; }
+    private void Resetdownload_url() { download_urlSpecified = false; }
+    
 
-    private int _app_id = default(int);
+    private int? _app_id;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(int); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (int?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPhysicalGoods.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPhysicalGoods.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_physicalgoods.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_RegisterSteamController_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -56,23 +76,41 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_CompleteSteamControllerRegistration_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -94,23 +132,41 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_QueryAccountsRegisteredToSerial_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -122,23 +178,41 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_QueryAccountsRegisteredToSerial_Accounts() {}
     
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private bool _registration_complete = default(bool);
+    private bool? _registration_complete;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"registration_complete", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool registration_complete
     {
-      get { return _registration_complete; }
+      get { return _registration_complete?? default(bool); }
       set { _registration_complete = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool registration_completeSpecified
+    {
+      get { return _registration_complete != null; }
+      set { if (value == (_registration_complete== null)) _registration_complete = value ? this.registration_complete : (bool?)null; }
+    }
+    private bool ShouldSerializeregistration_complete() { return registration_completeSpecified; }
+    private void Resetregistration_complete() { registration_completeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -167,32 +241,59 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_SteamControllerSetConfig_ControllerConfig() {}
     
 
-    private string _appidorname = "";
+    private string _appidorname;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appidorname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string appidorname
     {
-      get { return _appidorname; }
+      get { return _appidorname?? ""; }
       set { _appidorname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidornameSpecified
+    {
+      get { return _appidorname != null; }
+      set { if (value == (_appidorname== null)) _appidorname = value ? this.appidorname : (string)null; }
+    }
+    private bool ShouldSerializeappidorname() { return appidornameSpecified; }
+    private void Resetappidorname() { appidornameSpecified = false; }
+    
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private string _templatename = "";
+    private string _templatename;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"templatename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string templatename
     {
-      get { return _templatename; }
+      get { return _templatename?? ""; }
       set { _templatename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool templatenameSpecified
+    {
+      get { return _templatename != null; }
+      set { if (value == (_templatename== null)) _templatename = value ? this.templatename : (string)null; }
+    }
+    private bool ShouldSerializetemplatename() { return templatenameSpecified; }
+    private void Resettemplatename() { templatenameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -204,32 +305,59 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_SteamControllerSetConfig_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPhysicalGoods_SteamControllerSetConfig_ControllerConfig> _configurations = new global::System.Collections.Generic.List<CPhysicalGoods_SteamControllerSetConfig_ControllerConfig>();
     [global::ProtoBuf.ProtoMember(4, Name=@"configurations", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPhysicalGoods_SteamControllerSetConfig_ControllerConfig> configurations
@@ -258,41 +386,77 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_SteamControllerGetConfig_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
 
-    private string _appidorname = "";
+    private string _appidorname;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"appidorname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string appidorname
     {
-      get { return _appidorname; }
+      get { return _appidorname?? ""; }
       set { _appidorname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidornameSpecified
+    {
+      get { return _appidorname != null; }
+      set { if (value == (_appidorname== null)) _appidorname = value ? this.appidorname : (string)null; }
+    }
+    private bool ShouldSerializeappidorname() { return appidornameSpecified; }
+    private void Resetappidorname() { appidornameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -304,32 +468,59 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_SteamControllerGetConfig_ControllerConfig() {}
     
 
-    private string _appidorname = "";
+    private string _appidorname;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appidorname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string appidorname
     {
-      get { return _appidorname; }
+      get { return _appidorname?? ""; }
       set { _appidorname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidornameSpecified
+    {
+      get { return _appidorname != null; }
+      set { if (value == (_appidorname== null)) _appidorname = value ? this.appidorname : (string)null; }
+    }
+    private bool ShouldSerializeappidorname() { return appidornameSpecified; }
+    private void Resetappidorname() { appidornameSpecified = false; }
+    
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private string _templatename = "";
+    private string _templatename;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"templatename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string templatename
     {
-      get { return _templatename; }
+      get { return _templatename?? ""; }
       set { _templatename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool templatenameSpecified
+    {
+      get { return _templatename != null; }
+      set { if (value == (_templatename== null)) _templatename = value ? this.templatename : (string)null; }
+    }
+    private bool ShouldSerializetemplatename() { return templatenameSpecified; }
+    private void Resettemplatename() { templatenameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -358,32 +549,59 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_DeRegisterSteamController_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _controller_code = "";
+    private string _controller_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"controller_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string controller_code
     {
-      get { return _controller_code; }
+      get { return _controller_code?? ""; }
       set { _controller_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool controller_codeSpecified
+    {
+      get { return _controller_code != null; }
+      set { if (value == (_controller_code== null)) _controller_code = value ? this.controller_code : (string)null; }
+    }
+    private bool ShouldSerializecontroller_code() { return controller_codeSpecified; }
+    private void Resetcontroller_code() { controller_codeSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -405,32 +623,59 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_SetPersonalizationFile_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -452,23 +697,41 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_GetPersonalizationFile_Request() {}
     
 
-    private string _serial_number = "";
+    private string _serial_number;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? ""; }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (string)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private uint _accountid = default(uint);
+    private uint? _accountid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"accountid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint accountid
     {
-      get { return _accountid; }
+      get { return _accountid?? default(uint); }
       set { _accountid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool accountidSpecified
+    {
+      get { return _accountid != null; }
+      set { if (value == (_accountid== null)) _accountid = value ? this.accountid : (uint?)null; }
+    }
+    private bool ShouldSerializeaccountid() { return accountidSpecified; }
+    private void Resetaccountid() { accountidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -480,14 +743,23 @@ namespace SteamKit2.Unified.Internal
     public CPhysicalGoods_GetPersonalizationFile_Response() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPlayer.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPlayer.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_player.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public CPlayer_GetGameBadgeLevels_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,14 +48,23 @@ namespace SteamKit2.Unified.Internal
     public CPlayer_GetGameBadgeLevels_Response() {}
     
 
-    private uint _player_level = default(uint);
+    private uint? _player_level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"player_level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint player_level
     {
-      get { return _player_level; }
+      get { return _player_level?? default(uint); }
       set { _player_level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool player_levelSpecified
+    {
+      get { return _player_level != null; }
+      set { if (value == (_player_level== null)) _player_level = value ? this.player_level : (uint?)null; }
+    }
+    private bool ShouldSerializeplayer_level() { return player_levelSpecified; }
+    private void Resetplayer_level() { player_levelSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPlayer_GetGameBadgeLevels_Response.Badge> _badges = new global::System.Collections.Generic.List<CPlayer_GetGameBadgeLevels_Response.Badge>();
     [global::ProtoBuf.ProtoMember(2, Name=@"badges", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPlayer_GetGameBadgeLevels_Response.Badge> badges
@@ -58,32 +78,59 @@ namespace SteamKit2.Unified.Internal
     public Badge() {}
     
 
-    private int _level = default(int);
+    private int? _level;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"level", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int level
     {
-      get { return _level; }
+      get { return _level?? default(int); }
       set { _level = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool levelSpecified
+    {
+      get { return _level != null; }
+      set { if (value == (_level== null)) _level = value ? this.level : (int?)null; }
+    }
+    private bool ShouldSerializelevel() { return levelSpecified; }
+    private void Resetlevel() { levelSpecified = false; }
+    
 
-    private int _series = default(int);
+    private int? _series;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"series", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int series
     {
-      get { return _series; }
+      get { return _series?? default(int); }
       set { _series = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seriesSpecified
+    {
+      get { return _series != null; }
+      set { if (value == (_series== null)) _series = value ? this.series : (int?)null; }
+    }
+    private bool ShouldSerializeseries() { return seriesSpecified; }
+    private void Resetseries() { seriesSpecified = false; }
+    
 
-    private uint _border_color = default(uint);
+    private uint? _border_color;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"border_color", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint border_color
     {
-      get { return _border_color; }
+      get { return _border_color?? default(uint); }
       set { _border_color = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool border_colorSpecified
+    {
+      get { return _border_color != null; }
+      set { if (value == (_border_color== null)) _border_color = value ? this.border_color : (uint?)null; }
+    }
+    private bool ShouldSerializeborder_color() { return border_colorSpecified; }
+    private void Resetborder_color() { border_colorSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -100,14 +147,23 @@ namespace SteamKit2.Unified.Internal
     public CPlayer_GetLastPlayedTimes_Request() {}
     
 
-    private uint _min_last_played = default(uint);
+    private uint? _min_last_played;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"min_last_played", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint min_last_played
     {
-      get { return _min_last_played; }
+      get { return _min_last_played?? default(uint); }
       set { _min_last_played = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool min_last_playedSpecified
+    {
+      get { return _min_last_played != null; }
+      set { if (value == (_min_last_played== null)) _min_last_played = value ? this.min_last_played : (uint?)null; }
+    }
+    private bool ShouldSerializemin_last_played() { return min_last_playedSpecified; }
+    private void Resetmin_last_played() { min_last_playedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -131,41 +187,77 @@ namespace SteamKit2.Unified.Internal
     public Game() {}
     
 
-    private int _appid = default(int);
+    private int? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int appid
     {
-      get { return _appid; }
+      get { return _appid?? default(int); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (int?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _last_playtime = default(uint);
+    private uint? _last_playtime;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_playtime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_playtime
     {
-      get { return _last_playtime; }
+      get { return _last_playtime?? default(uint); }
       set { _last_playtime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_playtimeSpecified
+    {
+      get { return _last_playtime != null; }
+      set { if (value == (_last_playtime== null)) _last_playtime = value ? this.last_playtime : (uint?)null; }
+    }
+    private bool ShouldSerializelast_playtime() { return last_playtimeSpecified; }
+    private void Resetlast_playtime() { last_playtimeSpecified = false; }
+    
 
-    private int _playtime_2weeks = default(int);
+    private int? _playtime_2weeks;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"playtime_2weeks", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int playtime_2weeks
     {
-      get { return _playtime_2weeks; }
+      get { return _playtime_2weeks?? default(int); }
       set { _playtime_2weeks = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playtime_2weeksSpecified
+    {
+      get { return _playtime_2weeks != null; }
+      set { if (value == (_playtime_2weeks== null)) _playtime_2weeks = value ? this.playtime_2weeks : (int?)null; }
+    }
+    private bool ShouldSerializeplaytime_2weeks() { return playtime_2weeksSpecified; }
+    private void Resetplaytime_2weeks() { playtime_2weeksSpecified = false; }
+    
 
-    private int _playtime_forever = default(int);
+    private int? _playtime_forever;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"playtime_forever", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int playtime_forever
     {
-      get { return _playtime_forever; }
+      get { return _playtime_forever?? default(int); }
       set { _playtime_forever = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool playtime_foreverSpecified
+    {
+      get { return _playtime_forever != null; }
+      set { if (value == (_playtime_forever== null)) _playtime_forever = value ? this.playtime_forever : (int?)null; }
+    }
+    private bool ShouldSerializeplaytime_forever() { return playtime_foreverSpecified; }
+    private void Resetplaytime_forever() { playtime_foreverSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -247,163 +339,316 @@ namespace SteamKit2.Unified.Internal
       set { _video_card = value; }
     }
 
-    private string _operating_system = "";
+    private string _operating_system;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"operating_system", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string operating_system
     {
-      get { return _operating_system; }
+      get { return _operating_system?? ""; }
       set { _operating_system = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool operating_systemSpecified
+    {
+      get { return _operating_system != null; }
+      set { if (value == (_operating_system== null)) _operating_system = value ? this.operating_system : (string)null; }
+    }
+    private bool ShouldSerializeoperating_system() { return operating_systemSpecified; }
+    private void Resetoperating_system() { operating_systemSpecified = false; }
+    
 
-    private bool _os_64bit = default(bool);
+    private bool? _os_64bit;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"os_64bit", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool os_64bit
     {
-      get { return _os_64bit; }
+      get { return _os_64bit?? default(bool); }
       set { _os_64bit = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool os_64bitSpecified
+    {
+      get { return _os_64bit != null; }
+      set { if (value == (_os_64bit== null)) _os_64bit = value ? this.os_64bit : (bool?)null; }
+    }
+    private bool ShouldSerializeos_64bit() { return os_64bitSpecified; }
+    private void Resetos_64bit() { os_64bitSpecified = false; }
+    
 
-    private int _system_ram_mb = default(int);
+    private int? _system_ram_mb;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"system_ram_mb", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int system_ram_mb
     {
-      get { return _system_ram_mb; }
+      get { return _system_ram_mb?? default(int); }
       set { _system_ram_mb = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool system_ram_mbSpecified
+    {
+      get { return _system_ram_mb != null; }
+      set { if (value == (_system_ram_mb== null)) _system_ram_mb = value ? this.system_ram_mb : (int?)null; }
+    }
+    private bool ShouldSerializesystem_ram_mb() { return system_ram_mbSpecified; }
+    private void Resetsystem_ram_mb() { system_ram_mbSpecified = false; }
+    
 
-    private string _audio_device = "";
+    private string _audio_device;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"audio_device", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string audio_device
     {
-      get { return _audio_device; }
+      get { return _audio_device?? ""; }
       set { _audio_device = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audio_deviceSpecified
+    {
+      get { return _audio_device != null; }
+      set { if (value == (_audio_device== null)) _audio_device = value ? this.audio_device : (string)null; }
+    }
+    private bool ShouldSerializeaudio_device() { return audio_deviceSpecified; }
+    private void Resetaudio_device() { audio_deviceSpecified = false; }
+    
 
-    private string _audio_driver_version = "";
+    private string _audio_driver_version;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"audio_driver_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string audio_driver_version
     {
-      get { return _audio_driver_version; }
+      get { return _audio_driver_version?? ""; }
       set { _audio_driver_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool audio_driver_versionSpecified
+    {
+      get { return _audio_driver_version != null; }
+      set { if (value == (_audio_driver_version== null)) _audio_driver_version = value ? this.audio_driver_version : (string)null; }
+    }
+    private bool ShouldSerializeaudio_driver_version() { return audio_driver_versionSpecified; }
+    private void Resetaudio_driver_version() { audio_driver_versionSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"CPU")]
   public partial class CPU : global::ProtoBuf.IExtensible
   {
     public CPU() {}
     
 
-    private int _speed_mhz = default(int);
+    private int? _speed_mhz;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"speed_mhz", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int speed_mhz
     {
-      get { return _speed_mhz; }
+      get { return _speed_mhz?? default(int); }
       set { _speed_mhz = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool speed_mhzSpecified
+    {
+      get { return _speed_mhz != null; }
+      set { if (value == (_speed_mhz== null)) _speed_mhz = value ? this.speed_mhz : (int?)null; }
+    }
+    private bool ShouldSerializespeed_mhz() { return speed_mhzSpecified; }
+    private void Resetspeed_mhz() { speed_mhzSpecified = false; }
+    
 
-    private string _vendor = "";
+    private string _vendor;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"vendor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string vendor
     {
-      get { return _vendor; }
+      get { return _vendor?? ""; }
       set { _vendor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vendorSpecified
+    {
+      get { return _vendor != null; }
+      set { if (value == (_vendor== null)) _vendor = value ? this.vendor : (string)null; }
+    }
+    private bool ShouldSerializevendor() { return vendorSpecified; }
+    private void Resetvendor() { vendorSpecified = false; }
+    
 
-    private int _logical_processors = default(int);
+    private int? _logical_processors;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"logical_processors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int logical_processors
     {
-      get { return _logical_processors; }
+      get { return _logical_processors?? default(int); }
       set { _logical_processors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool logical_processorsSpecified
+    {
+      get { return _logical_processors != null; }
+      set { if (value == (_logical_processors== null)) _logical_processors = value ? this.logical_processors : (int?)null; }
+    }
+    private bool ShouldSerializelogical_processors() { return logical_processorsSpecified; }
+    private void Resetlogical_processors() { logical_processorsSpecified = false; }
+    
 
-    private int _physical_processors = default(int);
+    private int? _physical_processors;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"physical_processors", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int physical_processors
     {
-      get { return _physical_processors; }
+      get { return _physical_processors?? default(int); }
       set { _physical_processors = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool physical_processorsSpecified
+    {
+      get { return _physical_processors != null; }
+      set { if (value == (_physical_processors== null)) _physical_processors = value ? this.physical_processors : (int?)null; }
+    }
+    private bool ShouldSerializephysical_processors() { return physical_processorsSpecified; }
+    private void Resetphysical_processors() { physical_processorsSpecified = false; }
+    
 
-    private bool _hyperthreading = default(bool);
+    private bool? _hyperthreading;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"hyperthreading", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool hyperthreading
     {
-      get { return _hyperthreading; }
+      get { return _hyperthreading?? default(bool); }
       set { _hyperthreading = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hyperthreadingSpecified
+    {
+      get { return _hyperthreading != null; }
+      set { if (value == (_hyperthreading== null)) _hyperthreading = value ? this.hyperthreading : (bool?)null; }
+    }
+    private bool ShouldSerializehyperthreading() { return hyperthreadingSpecified; }
+    private void Resethyperthreading() { hyperthreadingSpecified = false; }
+    
 
-    private bool _fcmov = default(bool);
+    private bool? _fcmov;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"fcmov", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool fcmov
     {
-      get { return _fcmov; }
+      get { return _fcmov?? default(bool); }
       set { _fcmov = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool fcmovSpecified
+    {
+      get { return _fcmov != null; }
+      set { if (value == (_fcmov== null)) _fcmov = value ? this.fcmov : (bool?)null; }
+    }
+    private bool ShouldSerializefcmov() { return fcmovSpecified; }
+    private void Resetfcmov() { fcmovSpecified = false; }
+    
 
-    private bool _sse2 = default(bool);
+    private bool? _sse2;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sse2", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sse2
     {
-      get { return _sse2; }
+      get { return _sse2?? default(bool); }
       set { _sse2 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sse2Specified
+    {
+      get { return _sse2 != null; }
+      set { if (value == (_sse2== null)) _sse2 = value ? this.sse2 : (bool?)null; }
+    }
+    private bool ShouldSerializesse2() { return sse2Specified; }
+    private void Resetsse2() { sse2Specified = false; }
+    
 
-    private bool _sse3 = default(bool);
+    private bool? _sse3;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"sse3", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sse3
     {
-      get { return _sse3; }
+      get { return _sse3?? default(bool); }
       set { _sse3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sse3Specified
+    {
+      get { return _sse3 != null; }
+      set { if (value == (_sse3== null)) _sse3 = value ? this.sse3 : (bool?)null; }
+    }
+    private bool ShouldSerializesse3() { return sse3Specified; }
+    private void Resetsse3() { sse3Specified = false; }
+    
 
-    private bool _ssse3 = default(bool);
+    private bool? _ssse3;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"ssse3", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ssse3
     {
-      get { return _ssse3; }
+      get { return _ssse3?? default(bool); }
       set { _ssse3 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ssse3Specified
+    {
+      get { return _ssse3 != null; }
+      set { if (value == (_ssse3== null)) _ssse3 = value ? this.ssse3 : (bool?)null; }
+    }
+    private bool ShouldSerializessse3() { return ssse3Specified; }
+    private void Resetssse3() { ssse3Specified = false; }
+    
 
-    private bool _sse4a = default(bool);
+    private bool? _sse4a;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"sse4a", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sse4a
     {
-      get { return _sse4a; }
+      get { return _sse4a?? default(bool); }
       set { _sse4a = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sse4aSpecified
+    {
+      get { return _sse4a != null; }
+      set { if (value == (_sse4a== null)) _sse4a = value ? this.sse4a : (bool?)null; }
+    }
+    private bool ShouldSerializesse4a() { return sse4aSpecified; }
+    private void Resetsse4a() { sse4aSpecified = false; }
+    
 
-    private bool _sse41 = default(bool);
+    private bool? _sse41;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"sse41", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sse41
     {
-      get { return _sse41; }
+      get { return _sse41?? default(bool); }
       set { _sse41 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sse41Specified
+    {
+      get { return _sse41 != null; }
+      set { if (value == (_sse41== null)) _sse41 = value ? this.sse41 : (bool?)null; }
+    }
+    private bool ShouldSerializesse41() { return sse41Specified; }
+    private void Resetsse41() { sse41Specified = false; }
+    
 
-    private bool _sse42 = default(bool);
+    private bool? _sse42;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"sse42", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool sse42
     {
-      get { return _sse42; }
+      get { return _sse42?? default(bool); }
       set { _sse42 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sse42Specified
+    {
+      get { return _sse42 != null; }
+      set { if (value == (_sse42== null)) _sse42 = value ? this.sse42 : (bool?)null; }
+    }
+    private bool ShouldSerializesse42() { return sse42Specified; }
+    private void Resetsse42() { sse42Specified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -415,77 +660,149 @@ namespace SteamKit2.Unified.Internal
     public VideoCard() {}
     
 
-    private string _driver = "";
+    private string _driver;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"driver", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string driver
     {
-      get { return _driver; }
+      get { return _driver?? ""; }
       set { _driver = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool driverSpecified
+    {
+      get { return _driver != null; }
+      set { if (value == (_driver== null)) _driver = value ? this.driver : (string)null; }
+    }
+    private bool ShouldSerializedriver() { return driverSpecified; }
+    private void Resetdriver() { driverSpecified = false; }
+    
 
-    private string _driver_version = "";
+    private string _driver_version;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"driver_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string driver_version
     {
-      get { return _driver_version; }
+      get { return _driver_version?? ""; }
       set { _driver_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool driver_versionSpecified
+    {
+      get { return _driver_version != null; }
+      set { if (value == (_driver_version== null)) _driver_version = value ? this.driver_version : (string)null; }
+    }
+    private bool ShouldSerializedriver_version() { return driver_versionSpecified; }
+    private void Resetdriver_version() { driver_versionSpecified = false; }
+    
 
-    private uint _driver_date = default(uint);
+    private uint? _driver_date;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"driver_date", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint driver_date
     {
-      get { return _driver_date; }
+      get { return _driver_date?? default(uint); }
       set { _driver_date = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool driver_dateSpecified
+    {
+      get { return _driver_date != null; }
+      set { if (value == (_driver_date== null)) _driver_date = value ? this.driver_date : (uint?)null; }
+    }
+    private bool ShouldSerializedriver_date() { return driver_dateSpecified; }
+    private void Resetdriver_date() { driver_dateSpecified = false; }
+    
 
-    private string _directx_version = "";
+    private string _directx_version;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"directx_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string directx_version
     {
-      get { return _directx_version; }
+      get { return _directx_version?? ""; }
       set { _directx_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool directx_versionSpecified
+    {
+      get { return _directx_version != null; }
+      set { if (value == (_directx_version== null)) _directx_version = value ? this.directx_version : (string)null; }
+    }
+    private bool ShouldSerializedirectx_version() { return directx_versionSpecified; }
+    private void Resetdirectx_version() { directx_versionSpecified = false; }
+    
 
-    private string _opengl_version = "";
+    private string _opengl_version;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"opengl_version", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string opengl_version
     {
-      get { return _opengl_version; }
+      get { return _opengl_version?? ""; }
       set { _opengl_version = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool opengl_versionSpecified
+    {
+      get { return _opengl_version != null; }
+      set { if (value == (_opengl_version== null)) _opengl_version = value ? this.opengl_version : (string)null; }
+    }
+    private bool ShouldSerializeopengl_version() { return opengl_versionSpecified; }
+    private void Resetopengl_version() { opengl_versionSpecified = false; }
+    
 
-    private int _vendorid = default(int);
+    private int? _vendorid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"vendorid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int vendorid
     {
-      get { return _vendorid; }
+      get { return _vendorid?? default(int); }
       set { _vendorid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vendoridSpecified
+    {
+      get { return _vendorid != null; }
+      set { if (value == (_vendorid== null)) _vendorid = value ? this.vendorid : (int?)null; }
+    }
+    private bool ShouldSerializevendorid() { return vendoridSpecified; }
+    private void Resetvendorid() { vendoridSpecified = false; }
+    
 
-    private int _deviceid = default(int);
+    private int? _deviceid;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"deviceid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int deviceid
     {
-      get { return _deviceid; }
+      get { return _deviceid?? default(int); }
       set { _deviceid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool deviceidSpecified
+    {
+      get { return _deviceid != null; }
+      set { if (value == (_deviceid== null)) _deviceid = value ? this.deviceid : (int?)null; }
+    }
+    private bool ShouldSerializedeviceid() { return deviceidSpecified; }
+    private void Resetdeviceid() { deviceidSpecified = false; }
+    
 
-    private int _vram_mb = default(int);
+    private int? _vram_mb;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"vram_mb", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int vram_mb
     {
-      get { return _vram_mb; }
+      get { return _vram_mb?? default(int); }
       set { _vram_mb = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool vram_mbSpecified
+    {
+      get { return _vram_mb != null; }
+      set { if (value == (_vram_mb== null)) _vram_mb = value ? this.vram_mb : (int?)null; }
+    }
+    private bool ShouldSerializevram_mb() { return vram_mbSpecified; }
+    private void Resetvram_mb() { vram_mbSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPublishedFile.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgPublishedFile.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_publishedfile.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_Subscribe_Request() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private uint _list_type = default(uint);
+    private uint? _list_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"list_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint list_type
     {
-      get { return _list_type; }
+      get { return _list_type?? default(uint); }
       set { _list_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool list_typeSpecified
+    {
+      get { return _list_type != null; }
+      set { if (value == (_list_type== null)) _list_type = value ? this.list_type : (uint?)null; }
+    }
+    private bool ShouldSerializelist_type() { return list_typeSpecified; }
+    private void Resetlist_type() { list_typeSpecified = false; }
+    
 
-    private int _appid = default(int);
+    private int? _appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int appid
     {
-      get { return _appid; }
+      get { return _appid?? default(int); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (int?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _notify_client = default(bool);
+    private bool? _notify_client;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"notify_client", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool notify_client
     {
-      get { return _notify_client; }
+      get { return _notify_client?? default(bool); }
       set { _notify_client = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notify_clientSpecified
+    {
+      get { return _notify_client != null; }
+      set { if (value == (_notify_client== null)) _notify_client = value ? this.notify_client : (bool?)null; }
+    }
+    private bool ShouldSerializenotify_client() { return notify_clientSpecified; }
+    private void Resetnotify_client() { notify_clientSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -74,41 +112,77 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_Unsubscribe_Request() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private uint _list_type = default(uint);
+    private uint? _list_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"list_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint list_type
     {
-      get { return _list_type; }
+      get { return _list_type?? default(uint); }
       set { _list_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool list_typeSpecified
+    {
+      get { return _list_type != null; }
+      set { if (value == (_list_type== null)) _list_type = value ? this.list_type : (uint?)null; }
+    }
+    private bool ShouldSerializelist_type() { return list_typeSpecified; }
+    private void Resetlist_type() { list_typeSpecified = false; }
+    
 
-    private int _appid = default(int);
+    private int? _appid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int appid
     {
-      get { return _appid; }
+      get { return _appid?? default(int); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (int?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private bool _notify_client = default(bool);
+    private bool? _notify_client;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"notify_client", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool notify_client
     {
-      get { return _notify_client; }
+      get { return _notify_client?? default(bool); }
       set { _notify_client = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool notify_clientSpecified
+    {
+      get { return _notify_client != null; }
+      set { if (value == (_notify_client== null)) _notify_client = value ? this.notify_client : (bool?)null; }
+    }
+    private bool ShouldSerializenotify_client() { return notify_clientSpecified; }
+    private void Resetnotify_client() { notify_clientSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -130,14 +204,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_CanSubscribe_Request() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -149,14 +232,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_CanSubscribe_Response() {}
     
 
-    private bool _can_subscribe = default(bool);
+    private bool? _can_subscribe;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"can_subscribe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_subscribe
     {
-      get { return _can_subscribe; }
+      get { return _can_subscribe?? default(bool); }
       set { _can_subscribe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_subscribeSpecified
+    {
+      get { return _can_subscribe != null; }
+      set { if (value == (_can_subscribe== null)) _can_subscribe = value ? this.can_subscribe : (bool?)null; }
+    }
+    private bool ShouldSerializecan_subscribe() { return can_subscribeSpecified; }
+    private void Resetcan_subscribe() { can_subscribeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -168,113 +260,221 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_Publish_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _consumer_appid = default(uint);
+    private uint? _consumer_appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"consumer_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint consumer_appid
     {
-      get { return _consumer_appid; }
+      get { return _consumer_appid?? default(uint); }
       set { _consumer_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool consumer_appidSpecified
+    {
+      get { return _consumer_appid != null; }
+      set { if (value == (_consumer_appid== null)) _consumer_appid = value ? this.consumer_appid : (uint?)null; }
+    }
+    private bool ShouldSerializeconsumer_appid() { return consumer_appidSpecified; }
+    private void Resetconsumer_appid() { consumer_appidSpecified = false; }
+    
 
-    private string _cloudfilename = "";
+    private string _cloudfilename;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"cloudfilename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string cloudfilename
     {
-      get { return _cloudfilename; }
+      get { return _cloudfilename?? ""; }
       set { _cloudfilename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cloudfilenameSpecified
+    {
+      get { return _cloudfilename != null; }
+      set { if (value == (_cloudfilename== null)) _cloudfilename = value ? this.cloudfilename : (string)null; }
+    }
+    private bool ShouldSerializecloudfilename() { return cloudfilenameSpecified; }
+    private void Resetcloudfilename() { cloudfilenameSpecified = false; }
+    
 
-    private string _preview_cloudfilename = "";
+    private string _preview_cloudfilename;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"preview_cloudfilename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preview_cloudfilename
     {
-      get { return _preview_cloudfilename; }
+      get { return _preview_cloudfilename?? ""; }
       set { _preview_cloudfilename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_cloudfilenameSpecified
+    {
+      get { return _preview_cloudfilename != null; }
+      set { if (value == (_preview_cloudfilename== null)) _preview_cloudfilename = value ? this.preview_cloudfilename : (string)null; }
+    }
+    private bool ShouldSerializepreview_cloudfilename() { return preview_cloudfilenameSpecified; }
+    private void Resetpreview_cloudfilename() { preview_cloudfilenameSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _file_description = "";
+    private string _file_description;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"file_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_description
     {
-      get { return _file_description; }
+      get { return _file_description?? ""; }
       set { _file_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_descriptionSpecified
+    {
+      get { return _file_description != null; }
+      set { if (value == (_file_description== null)) _file_description = value ? this.file_description : (string)null; }
+    }
+    private bool ShouldSerializefile_description() { return file_descriptionSpecified; }
+    private void Resetfile_description() { file_descriptionSpecified = false; }
+    
 
-    private uint _file_type = default(uint);
+    private uint? _file_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_type
     {
-      get { return _file_type; }
+      get { return _file_type?? default(uint); }
       set { _file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_typeSpecified
+    {
+      get { return _file_type != null; }
+      set { if (value == (_file_type== null)) _file_type = value ? this.file_type : (uint?)null; }
+    }
+    private bool ShouldSerializefile_type() { return file_typeSpecified; }
+    private void Resetfile_type() { file_typeSpecified = false; }
+    
 
-    private string _consumer_shortcut_name = "";
+    private string _consumer_shortcut_name;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"consumer_shortcut_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string consumer_shortcut_name
     {
-      get { return _consumer_shortcut_name; }
+      get { return _consumer_shortcut_name?? ""; }
       set { _consumer_shortcut_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool consumer_shortcut_nameSpecified
+    {
+      get { return _consumer_shortcut_name != null; }
+      set { if (value == (_consumer_shortcut_name== null)) _consumer_shortcut_name = value ? this.consumer_shortcut_name : (string)null; }
+    }
+    private bool ShouldSerializeconsumer_shortcut_name() { return consumer_shortcut_nameSpecified; }
+    private void Resetconsumer_shortcut_name() { consumer_shortcut_nameSpecified = false; }
+    
 
-    private string _youtube_username = "";
+    private string _youtube_username;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"youtube_username", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_username
     {
-      get { return _youtube_username; }
+      get { return _youtube_username?? ""; }
       set { _youtube_username = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_usernameSpecified
+    {
+      get { return _youtube_username != null; }
+      set { if (value == (_youtube_username== null)) _youtube_username = value ? this.youtube_username : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_username() { return youtube_usernameSpecified; }
+    private void Resetyoutube_username() { youtube_usernameSpecified = false; }
+    
 
-    private string _youtube_videoid = "";
+    private string _youtube_videoid;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"youtube_videoid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtube_videoid
     {
-      get { return _youtube_videoid; }
+      get { return _youtube_videoid?? ""; }
       set { _youtube_videoid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtube_videoidSpecified
+    {
+      get { return _youtube_videoid != null; }
+      set { if (value == (_youtube_videoid== null)) _youtube_videoid = value ? this.youtube_videoid : (string)null; }
+    }
+    private bool ShouldSerializeyoutube_videoid() { return youtube_videoidSpecified; }
+    private void Resetyoutube_videoid() { youtube_videoidSpecified = false; }
+    
 
-    private uint _visibility = default(uint);
+    private uint? _visibility;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? default(uint); }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (uint?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private string _redirect_uri = "";
+    private string _redirect_uri;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"redirect_uri", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string redirect_uri
     {
-      get { return _redirect_uri; }
+      get { return _redirect_uri?? ""; }
       set { _redirect_uri = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool redirect_uriSpecified
+    {
+      get { return _redirect_uri != null; }
+      set { if (value == (_redirect_uri== null)) _redirect_uri = value ? this.redirect_uri : (string)null; }
+    }
+    private bool ShouldSerializeredirect_uri() { return redirect_uriSpecified; }
+    private void Resetredirect_uri() { redirect_uriSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(13, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -283,32 +483,59 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _collection_type = "";
+    private string _collection_type;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"collection_type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string collection_type
     {
-      get { return _collection_type; }
+      get { return _collection_type?? ""; }
       set { _collection_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool collection_typeSpecified
+    {
+      get { return _collection_type != null; }
+      set { if (value == (_collection_type== null)) _collection_type = value ? this.collection_type : (string)null; }
+    }
+    private bool ShouldSerializecollection_type() { return collection_typeSpecified; }
+    private void Resetcollection_type() { collection_typeSpecified = false; }
+    
 
-    private string _game_type = "";
+    private string _game_type;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"game_type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string game_type
     {
-      get { return _game_type; }
+      get { return _game_type?? ""; }
       set { _game_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool game_typeSpecified
+    {
+      get { return _game_type != null; }
+      set { if (value == (_game_type== null)) _game_type = value ? this.game_type : (string)null; }
+    }
+    private bool ShouldSerializegame_type() { return game_typeSpecified; }
+    private void Resetgame_type() { game_typeSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -320,23 +547,41 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_Publish_Response() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private string _redirect_uri = "";
+    private string _redirect_uri;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"redirect_uri", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string redirect_uri
     {
-      get { return _redirect_uri; }
+      get { return _redirect_uri?? ""; }
       set { _redirect_uri = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool redirect_uriSpecified
+    {
+      get { return _redirect_uri != null; }
+      set { if (value == (_redirect_uri== null)) _redirect_uri = value ? this.redirect_uri : (string)null; }
+    }
+    private bool ShouldSerializeredirect_uri() { return redirect_uriSpecified; }
+    private void Resetredirect_uri() { redirect_uriSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -355,86 +600,167 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _includetags = default(bool);
+    private bool? _includetags;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"includetags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includetags
     {
-      get { return _includetags; }
+      get { return _includetags?? default(bool); }
       set { _includetags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includetagsSpecified
+    {
+      get { return _includetags != null; }
+      set { if (value == (_includetags== null)) _includetags = value ? this.includetags : (bool?)null; }
+    }
+    private bool ShouldSerializeincludetags() { return includetagsSpecified; }
+    private void Resetincludetags() { includetagsSpecified = false; }
+    
 
-    private bool _includeadditionalpreviews = default(bool);
+    private bool? _includeadditionalpreviews;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"includeadditionalpreviews", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includeadditionalpreviews
     {
-      get { return _includeadditionalpreviews; }
+      get { return _includeadditionalpreviews?? default(bool); }
       set { _includeadditionalpreviews = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includeadditionalpreviewsSpecified
+    {
+      get { return _includeadditionalpreviews != null; }
+      set { if (value == (_includeadditionalpreviews== null)) _includeadditionalpreviews = value ? this.includeadditionalpreviews : (bool?)null; }
+    }
+    private bool ShouldSerializeincludeadditionalpreviews() { return includeadditionalpreviewsSpecified; }
+    private void Resetincludeadditionalpreviews() { includeadditionalpreviewsSpecified = false; }
+    
 
-    private bool _includechildren = default(bool);
+    private bool? _includechildren;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"includechildren", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includechildren
     {
-      get { return _includechildren; }
+      get { return _includechildren?? default(bool); }
       set { _includechildren = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includechildrenSpecified
+    {
+      get { return _includechildren != null; }
+      set { if (value == (_includechildren== null)) _includechildren = value ? this.includechildren : (bool?)null; }
+    }
+    private bool ShouldSerializeincludechildren() { return includechildrenSpecified; }
+    private void Resetincludechildren() { includechildrenSpecified = false; }
+    
 
-    private bool _includekvtags = default(bool);
+    private bool? _includekvtags;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"includekvtags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includekvtags
     {
-      get { return _includekvtags; }
+      get { return _includekvtags?? default(bool); }
       set { _includekvtags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includekvtagsSpecified
+    {
+      get { return _includekvtags != null; }
+      set { if (value == (_includekvtags== null)) _includekvtags = value ? this.includekvtags : (bool?)null; }
+    }
+    private bool ShouldSerializeincludekvtags() { return includekvtagsSpecified; }
+    private void Resetincludekvtags() { includekvtagsSpecified = false; }
+    
 
-    private bool _includevotes = default(bool);
+    private bool? _includevotes;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"includevotes", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includevotes
     {
-      get { return _includevotes; }
+      get { return _includevotes?? default(bool); }
       set { _includevotes = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includevotesSpecified
+    {
+      get { return _includevotes != null; }
+      set { if (value == (_includevotes== null)) _includevotes = value ? this.includevotes : (bool?)null; }
+    }
+    private bool ShouldSerializeincludevotes() { return includevotesSpecified; }
+    private void Resetincludevotes() { includevotesSpecified = false; }
+    
 
-    private bool _short_description = default(bool);
+    private bool? _short_description;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"short_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool short_description
     {
-      get { return _short_description; }
+      get { return _short_description?? default(bool); }
       set { _short_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool short_descriptionSpecified
+    {
+      get { return _short_description != null; }
+      set { if (value == (_short_description== null)) _short_description = value ? this.short_description : (bool?)null; }
+    }
+    private bool ShouldSerializeshort_description() { return short_descriptionSpecified; }
+    private void Resetshort_description() { short_descriptionSpecified = false; }
+    
 
-    private bool _includeforsaledata = default(bool);
+    private bool? _includeforsaledata;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"includeforsaledata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includeforsaledata
     {
-      get { return _includeforsaledata; }
+      get { return _includeforsaledata?? default(bool); }
       set { _includeforsaledata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includeforsaledataSpecified
+    {
+      get { return _includeforsaledata != null; }
+      set { if (value == (_includeforsaledata== null)) _includeforsaledata = value ? this.includeforsaledata : (bool?)null; }
+    }
+    private bool ShouldSerializeincludeforsaledata() { return includeforsaledataSpecified; }
+    private void Resetincludeforsaledata() { includeforsaledataSpecified = false; }
+    
 
-    private bool _includemetadata = default(bool);
+    private bool? _includemetadata;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"includemetadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool includemetadata
     {
-      get { return _includemetadata; }
+      get { return _includemetadata?? default(bool); }
       set { _includemetadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool includemetadataSpecified
+    {
+      get { return _includemetadata != null; }
+      set { if (value == (_includemetadata== null)) _includemetadata = value ? this.includemetadata : (bool?)null; }
+    }
+    private bool ShouldSerializeincludemetadata() { return includemetadataSpecified; }
+    private void Resetincludemetadata() { includemetadataSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -446,473 +772,941 @@ namespace SteamKit2.Unified.Internal
     public PublishedFileDetails() {}
     
 
-    private uint _result = default(uint);
+    private uint? _result;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"result", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint result
     {
-      get { return _result; }
+      get { return _result?? default(uint); }
       set { _result = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool resultSpecified
+    {
+      get { return _result != null; }
+      set { if (value == (_result== null)) _result = value ? this.result : (uint?)null; }
+    }
+    private bool ShouldSerializeresult() { return resultSpecified; }
+    private void Resetresult() { resultSpecified = false; }
+    
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private ulong _creator = default(ulong);
+    private ulong? _creator;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"creator", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong creator
     {
-      get { return _creator; }
+      get { return _creator?? default(ulong); }
       set { _creator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creatorSpecified
+    {
+      get { return _creator != null; }
+      set { if (value == (_creator== null)) _creator = value ? this.creator : (ulong?)null; }
+    }
+    private bool ShouldSerializecreator() { return creatorSpecified; }
+    private void Resetcreator() { creatorSpecified = false; }
+    
 
-    private uint _creator_appid = default(uint);
+    private uint? _creator_appid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"creator_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creator_appid
     {
-      get { return _creator_appid; }
+      get { return _creator_appid?? default(uint); }
       set { _creator_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creator_appidSpecified
+    {
+      get { return _creator_appid != null; }
+      set { if (value == (_creator_appid== null)) _creator_appid = value ? this.creator_appid : (uint?)null; }
+    }
+    private bool ShouldSerializecreator_appid() { return creator_appidSpecified; }
+    private void Resetcreator_appid() { creator_appidSpecified = false; }
+    
 
-    private uint _consumer_appid = default(uint);
+    private uint? _consumer_appid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"consumer_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint consumer_appid
     {
-      get { return _consumer_appid; }
+      get { return _consumer_appid?? default(uint); }
       set { _consumer_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool consumer_appidSpecified
+    {
+      get { return _consumer_appid != null; }
+      set { if (value == (_consumer_appid== null)) _consumer_appid = value ? this.consumer_appid : (uint?)null; }
+    }
+    private bool ShouldSerializeconsumer_appid() { return consumer_appidSpecified; }
+    private void Resetconsumer_appid() { consumer_appidSpecified = false; }
+    
 
-    private uint _consumer_shortcutid = default(uint);
+    private uint? _consumer_shortcutid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"consumer_shortcutid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint consumer_shortcutid
     {
-      get { return _consumer_shortcutid; }
+      get { return _consumer_shortcutid?? default(uint); }
       set { _consumer_shortcutid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool consumer_shortcutidSpecified
+    {
+      get { return _consumer_shortcutid != null; }
+      set { if (value == (_consumer_shortcutid== null)) _consumer_shortcutid = value ? this.consumer_shortcutid : (uint?)null; }
+    }
+    private bool ShouldSerializeconsumer_shortcutid() { return consumer_shortcutidSpecified; }
+    private void Resetconsumer_shortcutid() { consumer_shortcutidSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private ulong _file_size = default(ulong);
+    private ulong? _file_size;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong file_size
     {
-      get { return _file_size; }
+      get { return _file_size?? default(ulong); }
       set { _file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_sizeSpecified
+    {
+      get { return _file_size != null; }
+      set { if (value == (_file_size== null)) _file_size = value ? this.file_size : (ulong?)null; }
+    }
+    private bool ShouldSerializefile_size() { return file_sizeSpecified; }
+    private void Resetfile_size() { file_sizeSpecified = false; }
+    
 
-    private ulong _preview_file_size = default(ulong);
+    private ulong? _preview_file_size;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"preview_file_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong preview_file_size
     {
-      get { return _preview_file_size; }
+      get { return _preview_file_size?? default(ulong); }
       set { _preview_file_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_file_sizeSpecified
+    {
+      get { return _preview_file_size != null; }
+      set { if (value == (_preview_file_size== null)) _preview_file_size = value ? this.preview_file_size : (ulong?)null; }
+    }
+    private bool ShouldSerializepreview_file_size() { return preview_file_sizeSpecified; }
+    private void Resetpreview_file_size() { preview_file_sizeSpecified = false; }
+    
 
-    private string _file_url = "";
+    private string _file_url;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"file_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_url
     {
-      get { return _file_url; }
+      get { return _file_url?? ""; }
       set { _file_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_urlSpecified
+    {
+      get { return _file_url != null; }
+      set { if (value == (_file_url== null)) _file_url = value ? this.file_url : (string)null; }
+    }
+    private bool ShouldSerializefile_url() { return file_urlSpecified; }
+    private void Resetfile_url() { file_urlSpecified = false; }
+    
 
-    private string _preview_url = "";
+    private string _preview_url;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"preview_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preview_url
     {
-      get { return _preview_url; }
+      get { return _preview_url?? ""; }
       set { _preview_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_urlSpecified
+    {
+      get { return _preview_url != null; }
+      set { if (value == (_preview_url== null)) _preview_url = value ? this.preview_url : (string)null; }
+    }
+    private bool ShouldSerializepreview_url() { return preview_urlSpecified; }
+    private void Resetpreview_url() { preview_urlSpecified = false; }
+    
 
-    private string _youtubevideoid = "";
+    private string _youtubevideoid;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"youtubevideoid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtubevideoid
     {
-      get { return _youtubevideoid; }
+      get { return _youtubevideoid?? ""; }
       set { _youtubevideoid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtubevideoidSpecified
+    {
+      get { return _youtubevideoid != null; }
+      set { if (value == (_youtubevideoid== null)) _youtubevideoid = value ? this.youtubevideoid : (string)null; }
+    }
+    private bool ShouldSerializeyoutubevideoid() { return youtubevideoidSpecified; }
+    private void Resetyoutubevideoid() { youtubevideoidSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private ulong _hcontent_file = default(ulong);
+    private ulong? _hcontent_file;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"hcontent_file", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong hcontent_file
     {
-      get { return _hcontent_file; }
+      get { return _hcontent_file?? default(ulong); }
       set { _hcontent_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hcontent_fileSpecified
+    {
+      get { return _hcontent_file != null; }
+      set { if (value == (_hcontent_file== null)) _hcontent_file = value ? this.hcontent_file : (ulong?)null; }
+    }
+    private bool ShouldSerializehcontent_file() { return hcontent_fileSpecified; }
+    private void Resethcontent_file() { hcontent_fileSpecified = false; }
+    
 
-    private ulong _hcontent_preview = default(ulong);
+    private ulong? _hcontent_preview;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"hcontent_preview", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong hcontent_preview
     {
-      get { return _hcontent_preview; }
+      get { return _hcontent_preview?? default(ulong); }
       set { _hcontent_preview = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool hcontent_previewSpecified
+    {
+      get { return _hcontent_preview != null; }
+      set { if (value == (_hcontent_preview== null)) _hcontent_preview = value ? this.hcontent_preview : (ulong?)null; }
+    }
+    private bool ShouldSerializehcontent_preview() { return hcontent_previewSpecified; }
+    private void Resethcontent_preview() { hcontent_previewSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _file_description = "";
+    private string _file_description;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"file_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_description
     {
-      get { return _file_description; }
+      get { return _file_description?? ""; }
       set { _file_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_descriptionSpecified
+    {
+      get { return _file_description != null; }
+      set { if (value == (_file_description== null)) _file_description = value ? this.file_description : (string)null; }
+    }
+    private bool ShouldSerializefile_description() { return file_descriptionSpecified; }
+    private void Resetfile_description() { file_descriptionSpecified = false; }
+    
 
-    private string _short_description = "";
+    private string _short_description;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"short_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string short_description
     {
-      get { return _short_description; }
+      get { return _short_description?? ""; }
       set { _short_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool short_descriptionSpecified
+    {
+      get { return _short_description != null; }
+      set { if (value == (_short_description== null)) _short_description = value ? this.short_description : (string)null; }
+    }
+    private bool ShouldSerializeshort_description() { return short_descriptionSpecified; }
+    private void Resetshort_description() { short_descriptionSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
 
-    private uint _visibility = default(uint);
+    private uint? _visibility;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? default(uint); }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (uint?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
 
-    private bool _workshop_file = default(bool);
+    private bool? _workshop_file;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"workshop_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool workshop_file
     {
-      get { return _workshop_file; }
+      get { return _workshop_file?? default(bool); }
       set { _workshop_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_fileSpecified
+    {
+      get { return _workshop_file != null; }
+      set { if (value == (_workshop_file== null)) _workshop_file = value ? this.workshop_file : (bool?)null; }
+    }
+    private bool ShouldSerializeworkshop_file() { return workshop_fileSpecified; }
+    private void Resetworkshop_file() { workshop_fileSpecified = false; }
+    
 
-    private bool _workshop_accepted = default(bool);
+    private bool? _workshop_accepted;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"workshop_accepted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool workshop_accepted
     {
-      get { return _workshop_accepted; }
+      get { return _workshop_accepted?? default(bool); }
       set { _workshop_accepted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool workshop_acceptedSpecified
+    {
+      get { return _workshop_accepted != null; }
+      set { if (value == (_workshop_accepted== null)) _workshop_accepted = value ? this.workshop_accepted : (bool?)null; }
+    }
+    private bool ShouldSerializeworkshop_accepted() { return workshop_acceptedSpecified; }
+    private void Resetworkshop_accepted() { workshop_acceptedSpecified = false; }
+    
 
-    private bool _show_subscribe_all = default(bool);
+    private bool? _show_subscribe_all;
     [global::ProtoBuf.ProtoMember(25, IsRequired = false, Name=@"show_subscribe_all", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool show_subscribe_all
     {
-      get { return _show_subscribe_all; }
+      get { return _show_subscribe_all?? default(bool); }
       set { _show_subscribe_all = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool show_subscribe_allSpecified
+    {
+      get { return _show_subscribe_all != null; }
+      set { if (value == (_show_subscribe_all== null)) _show_subscribe_all = value ? this.show_subscribe_all : (bool?)null; }
+    }
+    private bool ShouldSerializeshow_subscribe_all() { return show_subscribe_allSpecified; }
+    private void Resetshow_subscribe_all() { show_subscribe_allSpecified = false; }
+    
 
-    private int _num_comments_developer = default(int);
+    private int? _num_comments_developer;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"num_comments_developer", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_comments_developer
     {
-      get { return _num_comments_developer; }
+      get { return _num_comments_developer?? default(int); }
       set { _num_comments_developer = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_comments_developerSpecified
+    {
+      get { return _num_comments_developer != null; }
+      set { if (value == (_num_comments_developer== null)) _num_comments_developer = value ? this.num_comments_developer : (int?)null; }
+    }
+    private bool ShouldSerializenum_comments_developer() { return num_comments_developerSpecified; }
+    private void Resetnum_comments_developer() { num_comments_developerSpecified = false; }
+    
 
-    private int _num_comments_public = default(int);
+    private int? _num_comments_public;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"num_comments_public", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int num_comments_public
     {
-      get { return _num_comments_public; }
+      get { return _num_comments_public?? default(int); }
       set { _num_comments_public = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_comments_publicSpecified
+    {
+      get { return _num_comments_public != null; }
+      set { if (value == (_num_comments_public== null)) _num_comments_public = value ? this.num_comments_public : (int?)null; }
+    }
+    private bool ShouldSerializenum_comments_public() { return num_comments_publicSpecified; }
+    private void Resetnum_comments_public() { num_comments_publicSpecified = false; }
+    
 
-    private bool _banned = default(bool);
+    private bool? _banned;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"banned", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool banned
     {
-      get { return _banned; }
+      get { return _banned?? default(bool); }
       set { _banned = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bannedSpecified
+    {
+      get { return _banned != null; }
+      set { if (value == (_banned== null)) _banned = value ? this.banned : (bool?)null; }
+    }
+    private bool ShouldSerializebanned() { return bannedSpecified; }
+    private void Resetbanned() { bannedSpecified = false; }
+    
 
-    private string _ban_reason = "";
+    private string _ban_reason;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"ban_reason", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string ban_reason
     {
-      get { return _ban_reason; }
+      get { return _ban_reason?? ""; }
       set { _ban_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ban_reasonSpecified
+    {
+      get { return _ban_reason != null; }
+      set { if (value == (_ban_reason== null)) _ban_reason = value ? this.ban_reason : (string)null; }
+    }
+    private bool ShouldSerializeban_reason() { return ban_reasonSpecified; }
+    private void Resetban_reason() { ban_reasonSpecified = false; }
+    
 
-    private ulong _banner = default(ulong);
+    private ulong? _banner;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"banner", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong banner
     {
-      get { return _banner; }
+      get { return _banner?? default(ulong); }
       set { _banner = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool bannerSpecified
+    {
+      get { return _banner != null; }
+      set { if (value == (_banner== null)) _banner = value ? this.banner : (ulong?)null; }
+    }
+    private bool ShouldSerializebanner() { return bannerSpecified; }
+    private void Resetbanner() { bannerSpecified = false; }
+    
 
-    private bool _can_be_deleted = default(bool);
+    private bool? _can_be_deleted;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"can_be_deleted", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_be_deleted
     {
-      get { return _can_be_deleted; }
+      get { return _can_be_deleted?? default(bool); }
       set { _can_be_deleted = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_be_deletedSpecified
+    {
+      get { return _can_be_deleted != null; }
+      set { if (value == (_can_be_deleted== null)) _can_be_deleted = value ? this.can_be_deleted : (bool?)null; }
+    }
+    private bool ShouldSerializecan_be_deleted() { return can_be_deletedSpecified; }
+    private void Resetcan_be_deleted() { can_be_deletedSpecified = false; }
+    
 
-    private bool _incompatible = default(bool);
+    private bool? _incompatible;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"incompatible", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool incompatible
     {
-      get { return _incompatible; }
+      get { return _incompatible?? default(bool); }
       set { _incompatible = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incompatibleSpecified
+    {
+      get { return _incompatible != null; }
+      set { if (value == (_incompatible== null)) _incompatible = value ? this.incompatible : (bool?)null; }
+    }
+    private bool ShouldSerializeincompatible() { return incompatibleSpecified; }
+    private void Resetincompatible() { incompatibleSpecified = false; }
+    
 
-    private string _app_name = "";
+    private string _app_name;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"app_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string app_name
     {
-      get { return _app_name; }
+      get { return _app_name?? ""; }
       set { _app_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_nameSpecified
+    {
+      get { return _app_name != null; }
+      set { if (value == (_app_name== null)) _app_name = value ? this.app_name : (string)null; }
+    }
+    private bool ShouldSerializeapp_name() { return app_nameSpecified; }
+    private void Resetapp_name() { app_nameSpecified = false; }
+    
 
-    private uint _file_type = default(uint);
+    private uint? _file_type;
     [global::ProtoBuf.ProtoMember(34, IsRequired = false, Name=@"file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_type
     {
-      get { return _file_type; }
+      get { return _file_type?? default(uint); }
       set { _file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_typeSpecified
+    {
+      get { return _file_type != null; }
+      set { if (value == (_file_type== null)) _file_type = value ? this.file_type : (uint?)null; }
+    }
+    private bool ShouldSerializefile_type() { return file_typeSpecified; }
+    private void Resetfile_type() { file_typeSpecified = false; }
+    
 
-    private bool _can_subscribe = default(bool);
+    private bool? _can_subscribe;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"can_subscribe", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool can_subscribe
     {
-      get { return _can_subscribe; }
+      get { return _can_subscribe?? default(bool); }
       set { _can_subscribe = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool can_subscribeSpecified
+    {
+      get { return _can_subscribe != null; }
+      set { if (value == (_can_subscribe== null)) _can_subscribe = value ? this.can_subscribe : (bool?)null; }
+    }
+    private bool ShouldSerializecan_subscribe() { return can_subscribeSpecified; }
+    private void Resetcan_subscribe() { can_subscribeSpecified = false; }
+    
 
-    private uint _subscriptions = default(uint);
+    private uint? _subscriptions;
     [global::ProtoBuf.ProtoMember(36, IsRequired = false, Name=@"subscriptions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint subscriptions
     {
-      get { return _subscriptions; }
+      get { return _subscriptions?? default(uint); }
       set { _subscriptions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool subscriptionsSpecified
+    {
+      get { return _subscriptions != null; }
+      set { if (value == (_subscriptions== null)) _subscriptions = value ? this.subscriptions : (uint?)null; }
+    }
+    private bool ShouldSerializesubscriptions() { return subscriptionsSpecified; }
+    private void Resetsubscriptions() { subscriptionsSpecified = false; }
+    
 
-    private uint _favorited = default(uint);
+    private uint? _favorited;
     [global::ProtoBuf.ProtoMember(37, IsRequired = false, Name=@"favorited", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint favorited
     {
-      get { return _favorited; }
+      get { return _favorited?? default(uint); }
       set { _favorited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool favoritedSpecified
+    {
+      get { return _favorited != null; }
+      set { if (value == (_favorited== null)) _favorited = value ? this.favorited : (uint?)null; }
+    }
+    private bool ShouldSerializefavorited() { return favoritedSpecified; }
+    private void Resetfavorited() { favoritedSpecified = false; }
+    
 
-    private uint _followers = default(uint);
+    private uint? _followers;
     [global::ProtoBuf.ProtoMember(38, IsRequired = false, Name=@"followers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint followers
     {
-      get { return _followers; }
+      get { return _followers?? default(uint); }
       set { _followers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool followersSpecified
+    {
+      get { return _followers != null; }
+      set { if (value == (_followers== null)) _followers = value ? this.followers : (uint?)null; }
+    }
+    private bool ShouldSerializefollowers() { return followersSpecified; }
+    private void Resetfollowers() { followersSpecified = false; }
+    
 
-    private uint _lifetime_subscriptions = default(uint);
+    private uint? _lifetime_subscriptions;
     [global::ProtoBuf.ProtoMember(39, IsRequired = false, Name=@"lifetime_subscriptions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lifetime_subscriptions
     {
-      get { return _lifetime_subscriptions; }
+      get { return _lifetime_subscriptions?? default(uint); }
       set { _lifetime_subscriptions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lifetime_subscriptionsSpecified
+    {
+      get { return _lifetime_subscriptions != null; }
+      set { if (value == (_lifetime_subscriptions== null)) _lifetime_subscriptions = value ? this.lifetime_subscriptions : (uint?)null; }
+    }
+    private bool ShouldSerializelifetime_subscriptions() { return lifetime_subscriptionsSpecified; }
+    private void Resetlifetime_subscriptions() { lifetime_subscriptionsSpecified = false; }
+    
 
-    private uint _lifetime_favorited = default(uint);
+    private uint? _lifetime_favorited;
     [global::ProtoBuf.ProtoMember(40, IsRequired = false, Name=@"lifetime_favorited", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lifetime_favorited
     {
-      get { return _lifetime_favorited; }
+      get { return _lifetime_favorited?? default(uint); }
       set { _lifetime_favorited = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lifetime_favoritedSpecified
+    {
+      get { return _lifetime_favorited != null; }
+      set { if (value == (_lifetime_favorited== null)) _lifetime_favorited = value ? this.lifetime_favorited : (uint?)null; }
+    }
+    private bool ShouldSerializelifetime_favorited() { return lifetime_favoritedSpecified; }
+    private void Resetlifetime_favorited() { lifetime_favoritedSpecified = false; }
+    
 
-    private uint _lifetime_followers = default(uint);
+    private uint? _lifetime_followers;
     [global::ProtoBuf.ProtoMember(41, IsRequired = false, Name=@"lifetime_followers", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint lifetime_followers
     {
-      get { return _lifetime_followers; }
+      get { return _lifetime_followers?? default(uint); }
       set { _lifetime_followers = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lifetime_followersSpecified
+    {
+      get { return _lifetime_followers != null; }
+      set { if (value == (_lifetime_followers== null)) _lifetime_followers = value ? this.lifetime_followers : (uint?)null; }
+    }
+    private bool ShouldSerializelifetime_followers() { return lifetime_followersSpecified; }
+    private void Resetlifetime_followers() { lifetime_followersSpecified = false; }
+    
 
-    private ulong _lifetime_playtime = default(ulong);
+    private ulong? _lifetime_playtime;
     [global::ProtoBuf.ProtoMember(62, IsRequired = false, Name=@"lifetime_playtime", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lifetime_playtime
     {
-      get { return _lifetime_playtime; }
+      get { return _lifetime_playtime?? default(ulong); }
       set { _lifetime_playtime = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lifetime_playtimeSpecified
+    {
+      get { return _lifetime_playtime != null; }
+      set { if (value == (_lifetime_playtime== null)) _lifetime_playtime = value ? this.lifetime_playtime : (ulong?)null; }
+    }
+    private bool ShouldSerializelifetime_playtime() { return lifetime_playtimeSpecified; }
+    private void Resetlifetime_playtime() { lifetime_playtimeSpecified = false; }
+    
 
-    private ulong _lifetime_playtime_sessions = default(ulong);
+    private ulong? _lifetime_playtime_sessions;
     [global::ProtoBuf.ProtoMember(63, IsRequired = false, Name=@"lifetime_playtime_sessions", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong lifetime_playtime_sessions
     {
-      get { return _lifetime_playtime_sessions; }
+      get { return _lifetime_playtime_sessions?? default(ulong); }
       set { _lifetime_playtime_sessions = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool lifetime_playtime_sessionsSpecified
+    {
+      get { return _lifetime_playtime_sessions != null; }
+      set { if (value == (_lifetime_playtime_sessions== null)) _lifetime_playtime_sessions = value ? this.lifetime_playtime_sessions : (ulong?)null; }
+    }
+    private bool ShouldSerializelifetime_playtime_sessions() { return lifetime_playtime_sessionsSpecified; }
+    private void Resetlifetime_playtime_sessions() { lifetime_playtime_sessionsSpecified = false; }
+    
 
-    private uint _views = default(uint);
+    private uint? _views;
     [global::ProtoBuf.ProtoMember(42, IsRequired = false, Name=@"views", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint views
     {
-      get { return _views; }
+      get { return _views?? default(uint); }
       set { _views = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool viewsSpecified
+    {
+      get { return _views != null; }
+      set { if (value == (_views== null)) _views = value ? this.views : (uint?)null; }
+    }
+    private bool ShouldSerializeviews() { return viewsSpecified; }
+    private void Resetviews() { viewsSpecified = false; }
+    
 
-    private uint _image_width = default(uint);
+    private uint? _image_width;
     [global::ProtoBuf.ProtoMember(43, IsRequired = false, Name=@"image_width", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint image_width
     {
-      get { return _image_width; }
+      get { return _image_width?? default(uint); }
       set { _image_width = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool image_widthSpecified
+    {
+      get { return _image_width != null; }
+      set { if (value == (_image_width== null)) _image_width = value ? this.image_width : (uint?)null; }
+    }
+    private bool ShouldSerializeimage_width() { return image_widthSpecified; }
+    private void Resetimage_width() { image_widthSpecified = false; }
+    
 
-    private uint _image_height = default(uint);
+    private uint? _image_height;
     [global::ProtoBuf.ProtoMember(44, IsRequired = false, Name=@"image_height", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint image_height
     {
-      get { return _image_height; }
+      get { return _image_height?? default(uint); }
       set { _image_height = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool image_heightSpecified
+    {
+      get { return _image_height != null; }
+      set { if (value == (_image_height== null)) _image_height = value ? this.image_height : (uint?)null; }
+    }
+    private bool ShouldSerializeimage_height() { return image_heightSpecified; }
+    private void Resetimage_height() { image_heightSpecified = false; }
+    
 
-    private string _image_url = "";
+    private string _image_url;
     [global::ProtoBuf.ProtoMember(45, IsRequired = false, Name=@"image_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string image_url
     {
-      get { return _image_url; }
+      get { return _image_url?? ""; }
       set { _image_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool image_urlSpecified
+    {
+      get { return _image_url != null; }
+      set { if (value == (_image_url== null)) _image_url = value ? this.image_url : (string)null; }
+    }
+    private bool ShouldSerializeimage_url() { return image_urlSpecified; }
+    private void Resetimage_url() { image_urlSpecified = false; }
+    
 
-    private bool _spoiler_tag = default(bool);
+    private bool? _spoiler_tag;
     [global::ProtoBuf.ProtoMember(46, IsRequired = false, Name=@"spoiler_tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool spoiler_tag
     {
-      get { return _spoiler_tag; }
+      get { return _spoiler_tag?? default(bool); }
       set { _spoiler_tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool spoiler_tagSpecified
+    {
+      get { return _spoiler_tag != null; }
+      set { if (value == (_spoiler_tag== null)) _spoiler_tag = value ? this.spoiler_tag : (bool?)null; }
+    }
+    private bool ShouldSerializespoiler_tag() { return spoiler_tagSpecified; }
+    private void Resetspoiler_tag() { spoiler_tagSpecified = false; }
+    
 
-    private uint _shortcutid = default(uint);
+    private uint? _shortcutid;
     [global::ProtoBuf.ProtoMember(47, IsRequired = false, Name=@"shortcutid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint shortcutid
     {
-      get { return _shortcutid; }
+      get { return _shortcutid?? default(uint); }
       set { _shortcutid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shortcutidSpecified
+    {
+      get { return _shortcutid != null; }
+      set { if (value == (_shortcutid== null)) _shortcutid = value ? this.shortcutid : (uint?)null; }
+    }
+    private bool ShouldSerializeshortcutid() { return shortcutidSpecified; }
+    private void Resetshortcutid() { shortcutidSpecified = false; }
+    
 
-    private string _shortcutname = "";
+    private string _shortcutname;
     [global::ProtoBuf.ProtoMember(48, IsRequired = false, Name=@"shortcutname", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string shortcutname
     {
-      get { return _shortcutname; }
+      get { return _shortcutname?? ""; }
       set { _shortcutname = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shortcutnameSpecified
+    {
+      get { return _shortcutname != null; }
+      set { if (value == (_shortcutname== null)) _shortcutname = value ? this.shortcutname : (string)null; }
+    }
+    private bool ShouldSerializeshortcutname() { return shortcutnameSpecified; }
+    private void Resetshortcutname() { shortcutnameSpecified = false; }
+    
 
-    private uint _num_children = default(uint);
+    private uint? _num_children;
     [global::ProtoBuf.ProtoMember(49, IsRequired = false, Name=@"num_children", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_children
     {
-      get { return _num_children; }
+      get { return _num_children?? default(uint); }
       set { _num_children = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_childrenSpecified
+    {
+      get { return _num_children != null; }
+      set { if (value == (_num_children== null)) _num_children = value ? this.num_children : (uint?)null; }
+    }
+    private bool ShouldSerializenum_children() { return num_childrenSpecified; }
+    private void Resetnum_children() { num_childrenSpecified = false; }
+    
 
-    private uint _num_reports = default(uint);
+    private uint? _num_reports;
     [global::ProtoBuf.ProtoMember(50, IsRequired = false, Name=@"num_reports", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint num_reports
     {
-      get { return _num_reports; }
+      get { return _num_reports?? default(uint); }
       set { _num_reports = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool num_reportsSpecified
+    {
+      get { return _num_reports != null; }
+      set { if (value == (_num_reports== null)) _num_reports = value ? this.num_reports : (uint?)null; }
+    }
+    private bool ShouldSerializenum_reports() { return num_reportsSpecified; }
+    private void Resetnum_reports() { num_reportsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<PublishedFileDetails.Preview> _previews = new global::System.Collections.Generic.List<PublishedFileDetails.Preview>();
     [global::ProtoBuf.ProtoMember(51, Name=@"previews", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<PublishedFileDetails.Preview> previews
@@ -951,14 +1745,23 @@ namespace SteamKit2.Unified.Internal
       set { _vote_data = value; }
     }
 
-    private uint _time_subscribed = default(uint);
+    private uint? _time_subscribed;
     [global::ProtoBuf.ProtoMember(56, IsRequired = false, Name=@"time_subscribed", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_subscribed
     {
-      get { return _time_subscribed; }
+      get { return _time_subscribed?? default(uint); }
       set { _time_subscribed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_subscribedSpecified
+    {
+      get { return _time_subscribed != null; }
+      set { if (value == (_time_subscribed== null)) _time_subscribed = value ? this.time_subscribed : (uint?)null; }
+    }
+    private bool ShouldSerializetime_subscribed() { return time_subscribedSpecified; }
+    private void Resettime_subscribed() { time_subscribedSpecified = false; }
+    
 
     private PublishedFileDetails.ForSaleData _for_sale_data = null;
     [global::ProtoBuf.ProtoMember(57, IsRequired = false, Name=@"for_sale_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
@@ -969,64 +1772,118 @@ namespace SteamKit2.Unified.Internal
       set { _for_sale_data = value; }
     }
 
-    private string _metadata = "";
+    private string _metadata;
     [global::ProtoBuf.ProtoMember(58, IsRequired = false, Name=@"metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string metadata
     {
-      get { return _metadata; }
+      get { return _metadata?? ""; }
       set { _metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool metadataSpecified
+    {
+      get { return _metadata != null; }
+      set { if (value == (_metadata== null)) _metadata = value ? this.metadata : (string)null; }
+    }
+    private bool ShouldSerializemetadata() { return metadataSpecified; }
+    private void Resetmetadata() { metadataSpecified = false; }
+    
 
-    private ulong _incompatible_actor = default(ulong);
+    private ulong? _incompatible_actor;
     [global::ProtoBuf.ProtoMember(59, IsRequired = false, Name=@"incompatible_actor", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong incompatible_actor
     {
-      get { return _incompatible_actor; }
+      get { return _incompatible_actor?? default(ulong); }
       set { _incompatible_actor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incompatible_actorSpecified
+    {
+      get { return _incompatible_actor != null; }
+      set { if (value == (_incompatible_actor== null)) _incompatible_actor = value ? this.incompatible_actor : (ulong?)null; }
+    }
+    private bool ShouldSerializeincompatible_actor() { return incompatible_actorSpecified; }
+    private void Resetincompatible_actor() { incompatible_actorSpecified = false; }
+    
 
-    private uint _incompatible_timestamp = default(uint);
+    private uint? _incompatible_timestamp;
     [global::ProtoBuf.ProtoMember(60, IsRequired = false, Name=@"incompatible_timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint incompatible_timestamp
     {
-      get { return _incompatible_timestamp; }
+      get { return _incompatible_timestamp?? default(uint); }
       set { _incompatible_timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool incompatible_timestampSpecified
+    {
+      get { return _incompatible_timestamp != null; }
+      set { if (value == (_incompatible_timestamp== null)) _incompatible_timestamp = value ? this.incompatible_timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializeincompatible_timestamp() { return incompatible_timestampSpecified; }
+    private void Resetincompatible_timestamp() { incompatible_timestampSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(61, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Tag")]
   public partial class Tag : global::ProtoBuf.IExtensible
   {
     public Tag() {}
     
 
-    private string _tag = "";
+    private string _tag;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"tag", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string tag
     {
-      get { return _tag; }
+      get { return _tag?? ""; }
       set { _tag = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool tagSpecified
+    {
+      get { return _tag != null; }
+      set { if (value == (_tag== null)) _tag = value ? this.tag : (string)null; }
+    }
+    private bool ShouldSerializetag() { return tagSpecified; }
+    private void Resettag() { tagSpecified = false; }
+    
 
-    private bool _adminonly = default(bool);
+    private bool? _adminonly;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"adminonly", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool adminonly
     {
-      get { return _adminonly; }
+      get { return _adminonly?? default(bool); }
       set { _adminonly = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool adminonlySpecified
+    {
+      get { return _adminonly != null; }
+      set { if (value == (_adminonly== null)) _adminonly = value ? this.adminonly : (bool?)null; }
+    }
+    private bool ShouldSerializeadminonly() { return adminonlySpecified; }
+    private void Resetadminonly() { adminonlySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1038,77 +1895,149 @@ namespace SteamKit2.Unified.Internal
     public Preview() {}
     
 
-    private ulong _previewid = default(ulong);
+    private ulong? _previewid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"previewid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong previewid
     {
-      get { return _previewid; }
+      get { return _previewid?? default(ulong); }
       set { _previewid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool previewidSpecified
+    {
+      get { return _previewid != null; }
+      set { if (value == (_previewid== null)) _previewid = value ? this.previewid : (ulong?)null; }
+    }
+    private bool ShouldSerializepreviewid() { return previewidSpecified; }
+    private void Resetpreviewid() { previewidSpecified = false; }
+    
 
-    private uint _sortorder = default(uint);
+    private uint? _sortorder;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sortorder", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sortorder
     {
-      get { return _sortorder; }
+      get { return _sortorder?? default(uint); }
       set { _sortorder = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sortorderSpecified
+    {
+      get { return _sortorder != null; }
+      set { if (value == (_sortorder== null)) _sortorder = value ? this.sortorder : (uint?)null; }
+    }
+    private bool ShouldSerializesortorder() { return sortorderSpecified; }
+    private void Resetsortorder() { sortorderSpecified = false; }
+    
 
-    private string _url = "";
+    private string _url;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string url
     {
-      get { return _url; }
+      get { return _url?? ""; }
       set { _url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool urlSpecified
+    {
+      get { return _url != null; }
+      set { if (value == (_url== null)) _url = value ? this.url : (string)null; }
+    }
+    private bool ShouldSerializeurl() { return urlSpecified; }
+    private void Reseturl() { urlSpecified = false; }
+    
 
-    private uint _size = default(uint);
+    private uint? _size;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint size
     {
-      get { return _size; }
+      get { return _size?? default(uint); }
       set { _size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sizeSpecified
+    {
+      get { return _size != null; }
+      set { if (value == (_size== null)) _size = value ? this.size : (uint?)null; }
+    }
+    private bool ShouldSerializesize() { return sizeSpecified; }
+    private void Resetsize() { sizeSpecified = false; }
+    
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private string _youtubevideoid = "";
+    private string _youtubevideoid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"youtubevideoid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string youtubevideoid
     {
-      get { return _youtubevideoid; }
+      get { return _youtubevideoid?? ""; }
       set { _youtubevideoid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool youtubevideoidSpecified
+    {
+      get { return _youtubevideoid != null; }
+      set { if (value == (_youtubevideoid== null)) _youtubevideoid = value ? this.youtubevideoid : (string)null; }
+    }
+    private bool ShouldSerializeyoutubevideoid() { return youtubevideoidSpecified; }
+    private void Resetyoutubevideoid() { youtubevideoidSpecified = false; }
+    
 
-    private uint _preview_type = default(uint);
+    private uint? _preview_type;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"preview_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint preview_type
     {
-      get { return _preview_type; }
+      get { return _preview_type?? default(uint); }
       set { _preview_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_typeSpecified
+    {
+      get { return _preview_type != null; }
+      set { if (value == (_preview_type== null)) _preview_type = value ? this.preview_type : (uint?)null; }
+    }
+    private bool ShouldSerializepreview_type() { return preview_typeSpecified; }
+    private void Resetpreview_type() { preview_typeSpecified = false; }
+    
 
-    private string _external_reference = "";
+    private string _external_reference;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"external_reference", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string external_reference
     {
-      get { return _external_reference; }
+      get { return _external_reference?? ""; }
       set { _external_reference = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool external_referenceSpecified
+    {
+      get { return _external_reference != null; }
+      set { if (value == (_external_reference== null)) _external_reference = value ? this.external_reference : (string)null; }
+    }
+    private bool ShouldSerializeexternal_reference() { return external_referenceSpecified; }
+    private void Resetexternal_reference() { external_referenceSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1120,32 +2049,59 @@ namespace SteamKit2.Unified.Internal
     public Child() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private uint _sortorder = default(uint);
+    private uint? _sortorder;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"sortorder", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint sortorder
     {
-      get { return _sortorder; }
+      get { return _sortorder?? default(uint); }
       set { _sortorder = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sortorderSpecified
+    {
+      get { return _sortorder != null; }
+      set { if (value == (_sortorder== null)) _sortorder = value ? this.sortorder : (uint?)null; }
+    }
+    private bool ShouldSerializesortorder() { return sortorderSpecified; }
+    private void Resetsortorder() { sortorderSpecified = false; }
+    
 
-    private uint _file_type = default(uint);
+    private uint? _file_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint file_type
     {
-      get { return _file_type; }
+      get { return _file_type?? default(uint); }
       set { _file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_typeSpecified
+    {
+      get { return _file_type != null; }
+      set { if (value == (_file_type== null)) _file_type = value ? this.file_type : (uint?)null; }
+    }
+    private bool ShouldSerializefile_type() { return file_typeSpecified; }
+    private void Resetfile_type() { file_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1157,23 +2113,41 @@ namespace SteamKit2.Unified.Internal
     public KVTag() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1185,32 +2159,59 @@ namespace SteamKit2.Unified.Internal
     public VoteData() {}
     
 
-    private float _score = default(float);
+    private float? _score;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"score", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float score
     {
-      get { return _score; }
+      get { return _score?? default(float); }
       set { _score = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool scoreSpecified
+    {
+      get { return _score != null; }
+      set { if (value == (_score== null)) _score = value ? this.score : (float?)null; }
+    }
+    private bool ShouldSerializescore() { return scoreSpecified; }
+    private void Resetscore() { scoreSpecified = false; }
+    
 
-    private uint _votes_up = default(uint);
+    private uint? _votes_up;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"votes_up", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint votes_up
     {
-      get { return _votes_up; }
+      get { return _votes_up?? default(uint); }
       set { _votes_up = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_upSpecified
+    {
+      get { return _votes_up != null; }
+      set { if (value == (_votes_up== null)) _votes_up = value ? this.votes_up : (uint?)null; }
+    }
+    private bool ShouldSerializevotes_up() { return votes_upSpecified; }
+    private void Resetvotes_up() { votes_upSpecified = false; }
+    
 
-    private uint _votes_down = default(uint);
+    private uint? _votes_down;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"votes_down", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint votes_down
     {
-      get { return _votes_down; }
+      get { return _votes_down?? default(uint); }
       set { _votes_down = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool votes_downSpecified
+    {
+      get { return _votes_down != null; }
+      set { if (value == (_votes_down== null)) _votes_down = value ? this.votes_down : (uint?)null; }
+    }
+    private bool ShouldSerializevotes_down() { return votes_downSpecified; }
+    private void Resetvotes_down() { votes_downSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1222,59 +2223,113 @@ namespace SteamKit2.Unified.Internal
     public ForSaleData() {}
     
 
-    private bool _is_for_sale = default(bool);
+    private bool? _is_for_sale;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"is_for_sale", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool is_for_sale
     {
-      get { return _is_for_sale; }
+      get { return _is_for_sale?? default(bool); }
       set { _is_for_sale = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool is_for_saleSpecified
+    {
+      get { return _is_for_sale != null; }
+      set { if (value == (_is_for_sale== null)) _is_for_sale = value ? this.is_for_sale : (bool?)null; }
+    }
+    private bool ShouldSerializeis_for_sale() { return is_for_saleSpecified; }
+    private void Resetis_for_sale() { is_for_saleSpecified = false; }
+    
 
-    private uint _price_category = default(uint);
+    private uint? _price_category;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"price_category", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_category
     {
-      get { return _price_category; }
+      get { return _price_category?? default(uint); }
       set { _price_category = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_categorySpecified
+    {
+      get { return _price_category != null; }
+      set { if (value == (_price_category== null)) _price_category = value ? this.price_category : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_category() { return price_categorySpecified; }
+    private void Resetprice_category() { price_categorySpecified = false; }
+    
 
-    private PublishedFileDetails.EPublishedFileForSaleStatus _estatus = PublishedFileDetails.EPublishedFileForSaleStatus.k_PFFSS_NotForSale;
+    private PublishedFileDetails.EPublishedFileForSaleStatus? _estatus;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"estatus", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(PublishedFileDetails.EPublishedFileForSaleStatus.k_PFFSS_NotForSale)]
     public PublishedFileDetails.EPublishedFileForSaleStatus estatus
     {
-      get { return _estatus; }
+      get { return _estatus?? PublishedFileDetails.EPublishedFileForSaleStatus.k_PFFSS_NotForSale; }
       set { _estatus = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool estatusSpecified
+    {
+      get { return _estatus != null; }
+      set { if (value == (_estatus== null)) _estatus = value ? this.estatus : (PublishedFileDetails.EPublishedFileForSaleStatus?)null; }
+    }
+    private bool ShouldSerializeestatus() { return estatusSpecified; }
+    private void Resetestatus() { estatusSpecified = false; }
+    
 
-    private uint _price_category_floor = default(uint);
+    private uint? _price_category_floor;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"price_category_floor", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint price_category_floor
     {
-      get { return _price_category_floor; }
+      get { return _price_category_floor?? default(uint); }
       set { _price_category_floor = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_category_floorSpecified
+    {
+      get { return _price_category_floor != null; }
+      set { if (value == (_price_category_floor== null)) _price_category_floor = value ? this.price_category_floor : (uint?)null; }
+    }
+    private bool ShouldSerializeprice_category_floor() { return price_category_floorSpecified; }
+    private void Resetprice_category_floor() { price_category_floorSpecified = false; }
+    
 
-    private bool _price_is_pay_what_you_want = default(bool);
+    private bool? _price_is_pay_what_you_want;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"price_is_pay_what_you_want", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool price_is_pay_what_you_want
     {
-      get { return _price_is_pay_what_you_want; }
+      get { return _price_is_pay_what_you_want?? default(bool); }
       set { _price_is_pay_what_you_want = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool price_is_pay_what_you_wantSpecified
+    {
+      get { return _price_is_pay_what_you_want != null; }
+      set { if (value == (_price_is_pay_what_you_want== null)) _price_is_pay_what_you_want = value ? this.price_is_pay_what_you_want : (bool?)null; }
+    }
+    private bool ShouldSerializeprice_is_pay_what_you_want() { return price_is_pay_what_you_wantSpecified; }
+    private void Resetprice_is_pay_what_you_want() { price_is_pay_what_you_wantSpecified = false; }
+    
 
-    private uint _discount_percentage = default(uint);
+    private uint? _discount_percentage;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"discount_percentage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint discount_percentage
     {
-      get { return _discount_percentage; }
+      get { return _discount_percentage?? default(uint); }
       set { _discount_percentage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool discount_percentageSpecified
+    {
+      get { return _discount_percentage != null; }
+      set { if (value == (_discount_percentage== null)) _discount_percentage = value ? this.discount_percentage : (uint?)null; }
+    }
+    private bool ShouldSerializediscount_percentage() { return discount_percentageSpecified; }
+    private void Resetdiscount_percentage() { discount_percentageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1331,23 +2386,41 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetItemInfo_Request() {}
     
 
-    private uint _app_id = default(uint);
+    private uint? _app_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"app_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint app_id
     {
-      get { return _app_id; }
+      get { return _app_id?? default(uint); }
       set { _app_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool app_idSpecified
+    {
+      get { return _app_id != null; }
+      set { if (value == (_app_id== null)) _app_id = value ? this.app_id : (uint?)null; }
+    }
+    private bool ShouldSerializeapp_id() { return app_idSpecified; }
+    private void Resetapp_id() { app_idSpecified = false; }
+    
 
-    private uint _last_time_updated = default(uint);
+    private uint? _last_time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"last_time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint last_time_updated
     {
-      get { return _last_time_updated; }
+      get { return _last_time_updated?? default(uint); }
       set { _last_time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool last_time_updatedSpecified
+    {
+      get { return _last_time_updated != null; }
+      set { if (value == (_last_time_updated== null)) _last_time_updated = value ? this.last_time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializelast_time_updated() { return last_time_updatedSpecified; }
+    private void Resetlast_time_updated() { last_time_updatedSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Request.WorkshopItem> _workshop_items = new global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Request.WorkshopItem>();
     [global::ProtoBuf.ProtoMember(3, Name=@"workshop_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Request.WorkshopItem> workshop_items
@@ -1361,23 +2434,41 @@ namespace SteamKit2.Unified.Internal
     public WorkshopItem() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1394,14 +2485,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetItemInfo_Response() {}
     
 
-    private uint _update_time = default(uint);
+    private uint? _update_time;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"update_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint update_time
     {
-      get { return _update_time; }
+      get { return _update_time?? default(uint); }
       set { _update_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool update_timeSpecified
+    {
+      get { return _update_time != null; }
+      set { if (value == (_update_time== null)) _update_time = value ? this.update_time : (uint?)null; }
+    }
+    private bool ShouldSerializeupdate_time() { return update_timeSpecified; }
+    private void Resetupdate_time() { update_timeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Response.WorkshopItemInfo> _workshop_items = new global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Response.WorkshopItemInfo>();
     [global::ProtoBuf.ProtoMember(2, Name=@"workshop_items", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPublishedFile_GetItemInfo_Response.WorkshopItemInfo> workshop_items
@@ -1415,41 +2515,77 @@ namespace SteamKit2.Unified.Internal
     public WorkshopItemInfo() {}
     
 
-    private ulong _published_file_id = default(ulong);
+    private ulong? _published_file_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"published_file_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong published_file_id
     {
-      get { return _published_file_id; }
+      get { return _published_file_id?? default(ulong); }
       set { _published_file_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool published_file_idSpecified
+    {
+      get { return _published_file_id != null; }
+      set { if (value == (_published_file_id== null)) _published_file_id = value ? this.published_file_id : (ulong?)null; }
+    }
+    private bool ShouldSerializepublished_file_id() { return published_file_idSpecified; }
+    private void Resetpublished_file_id() { published_file_idSpecified = false; }
+    
 
-    private uint _time_updated = default(uint);
+    private uint? _time_updated;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"time_updated", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_updated
     {
-      get { return _time_updated; }
+      get { return _time_updated?? default(uint); }
       set { _time_updated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_updatedSpecified
+    {
+      get { return _time_updated != null; }
+      set { if (value == (_time_updated== null)) _time_updated = value ? this.time_updated : (uint?)null; }
+    }
+    private bool ShouldSerializetime_updated() { return time_updatedSpecified; }
+    private void Resettime_updated() { time_updatedSpecified = false; }
+    
 
-    private ulong _manifest_id = default(ulong);
+    private ulong? _manifest_id;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"manifest_id", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong manifest_id
     {
-      get { return _manifest_id; }
+      get { return _manifest_id?? default(ulong); }
       set { _manifest_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool manifest_idSpecified
+    {
+      get { return _manifest_id != null; }
+      set { if (value == (_manifest_id== null)) _manifest_id = value ? this.manifest_id : (ulong?)null; }
+    }
+    private bool ShouldSerializemanifest_id() { return manifest_idSpecified; }
+    private void Resetmanifest_id() { manifest_idSpecified = false; }
+    
 
-    private uint _flags = default(uint);
+    private uint? _flags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"flags", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint flags
     {
-      get { return _flags; }
+      get { return _flags?? default(uint); }
       set { _flags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool flagsSpecified
+    {
+      get { return _flags != null; }
+      set { if (value == (_flags== null)) _flags = value ? this.flags : (uint?)null; }
+    }
+    private bool ShouldSerializeflags() { return flagsSpecified; }
+    private void Resetflags() { flagsSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1466,68 +2602,131 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetUserFiles_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _page = (uint)1;
+    private uint? _page;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"page", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint page
     {
-      get { return _page; }
+      get { return _page?? (uint)1; }
       set { _page = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pageSpecified
+    {
+      get { return _page != null; }
+      set { if (value == (_page== null)) _page = value ? this.page : (uint?)null; }
+    }
+    private bool ShouldSerializepage() { return pageSpecified; }
+    private void Resetpage() { pageSpecified = false; }
+    
 
-    private uint _numperpage = (uint)1;
+    private uint? _numperpage;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"numperpage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint numperpage
     {
-      get { return _numperpage; }
+      get { return _numperpage?? (uint)1; }
       set { _numperpage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool numperpageSpecified
+    {
+      get { return _numperpage != null; }
+      set { if (value == (_numperpage== null)) _numperpage = value ? this.numperpage : (uint?)null; }
+    }
+    private bool ShouldSerializenumperpage() { return numperpageSpecified; }
+    private void Resetnumperpage() { numperpageSpecified = false; }
+    
 
-    private string _type = @"myfiles";
+    private string _type;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"type", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(@"myfiles")]
     public string type
     {
-      get { return _type; }
+      get { return _type?? @"myfiles"; }
       set { _type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool typeSpecified
+    {
+      get { return _type != null; }
+      set { if (value == (_type== null)) _type = value ? this.type : (string)null; }
+    }
+    private bool ShouldSerializetype() { return typeSpecified; }
+    private void Resettype() { typeSpecified = false; }
+    
 
-    private string _sortmethod = @"lastupdated";
+    private string _sortmethod;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"sortmethod", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(@"lastupdated")]
     public string sortmethod
     {
-      get { return _sortmethod; }
+      get { return _sortmethod?? @"lastupdated"; }
       set { _sortmethod = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sortmethodSpecified
+    {
+      get { return _sortmethod != null; }
+      set { if (value == (_sortmethod== null)) _sortmethod = value ? this.sortmethod : (string)null; }
+    }
+    private bool ShouldSerializesortmethod() { return sortmethodSpecified; }
+    private void Resetsortmethod() { sortmethodSpecified = false; }
+    
 
-    private uint _privacy = default(uint);
+    private uint? _privacy;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"privacy", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint privacy
     {
-      get { return _privacy; }
+      get { return _privacy?? default(uint); }
       set { _privacy = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool privacySpecified
+    {
+      get { return _privacy != null; }
+      set { if (value == (_privacy== null)) _privacy = value ? this.privacy : (uint?)null; }
+    }
+    private bool ShouldSerializeprivacy() { return privacySpecified; }
+    private void Resetprivacy() { privacySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _requiredtags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(10, Name=@"requiredtags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> requiredtags
@@ -1550,163 +2749,316 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _filetype = default(uint);
+    private uint? _filetype;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"filetype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filetype
     {
-      get { return _filetype; }
+      get { return _filetype?? default(uint); }
       set { _filetype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filetypeSpecified
+    {
+      get { return _filetype != null; }
+      set { if (value == (_filetype== null)) _filetype = value ? this.filetype : (uint?)null; }
+    }
+    private bool ShouldSerializefiletype() { return filetypeSpecified; }
+    private void Resetfiletype() { filetypeSpecified = false; }
+    
 
-    private uint _creator_appid = default(uint);
+    private uint? _creator_appid;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"creator_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creator_appid
     {
-      get { return _creator_appid; }
+      get { return _creator_appid?? default(uint); }
       set { _creator_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creator_appidSpecified
+    {
+      get { return _creator_appid != null; }
+      set { if (value == (_creator_appid== null)) _creator_appid = value ? this.creator_appid : (uint?)null; }
+    }
+    private bool ShouldSerializecreator_appid() { return creator_appidSpecified; }
+    private void Resetcreator_appid() { creator_appidSpecified = false; }
+    
 
-    private string _match_cloud_filename = "";
+    private string _match_cloud_filename;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"match_cloud_filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string match_cloud_filename
     {
-      get { return _match_cloud_filename; }
+      get { return _match_cloud_filename?? ""; }
       set { _match_cloud_filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_cloud_filenameSpecified
+    {
+      get { return _match_cloud_filename != null; }
+      set { if (value == (_match_cloud_filename== null)) _match_cloud_filename = value ? this.match_cloud_filename : (string)null; }
+    }
+    private bool ShouldSerializematch_cloud_filename() { return match_cloud_filenameSpecified; }
+    private void Resetmatch_cloud_filename() { match_cloud_filenameSpecified = false; }
+    
 
-    private uint _cache_max_age_seconds = (uint)0;
+    private uint? _cache_max_age_seconds;
     [global::ProtoBuf.ProtoMember(27, IsRequired = false, Name=@"cache_max_age_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint cache_max_age_seconds
     {
-      get { return _cache_max_age_seconds; }
+      get { return _cache_max_age_seconds?? (uint)0; }
       set { _cache_max_age_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cache_max_age_secondsSpecified
+    {
+      get { return _cache_max_age_seconds != null; }
+      set { if (value == (_cache_max_age_seconds== null)) _cache_max_age_seconds = value ? this.cache_max_age_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializecache_max_age_seconds() { return cache_max_age_secondsSpecified; }
+    private void Resetcache_max_age_seconds() { cache_max_age_secondsSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(29, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
 
-    private bool _totalonly = default(bool);
+    private bool? _totalonly;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"totalonly", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool totalonly
     {
-      get { return _totalonly; }
+      get { return _totalonly?? default(bool); }
       set { _totalonly = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalonlySpecified
+    {
+      get { return _totalonly != null; }
+      set { if (value == (_totalonly== null)) _totalonly = value ? this.totalonly : (bool?)null; }
+    }
+    private bool ShouldSerializetotalonly() { return totalonlySpecified; }
+    private void Resettotalonly() { totalonlySpecified = false; }
+    
 
-    private bool _ids_only = default(bool);
+    private bool? _ids_only;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"ids_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ids_only
     {
-      get { return _ids_only; }
+      get { return _ids_only?? default(bool); }
       set { _ids_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ids_onlySpecified
+    {
+      get { return _ids_only != null; }
+      set { if (value == (_ids_only== null)) _ids_only = value ? this.ids_only : (bool?)null; }
+    }
+    private bool ShouldSerializeids_only() { return ids_onlySpecified; }
+    private void Resetids_only() { ids_onlySpecified = false; }
+    
 
-    private bool _return_vote_data = (bool)true;
+    private bool? _return_vote_data;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"return_vote_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool return_vote_data
     {
-      get { return _return_vote_data; }
+      get { return _return_vote_data?? (bool)true; }
       set { _return_vote_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_vote_dataSpecified
+    {
+      get { return _return_vote_data != null; }
+      set { if (value == (_return_vote_data== null)) _return_vote_data = value ? this.return_vote_data : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_vote_data() { return return_vote_dataSpecified; }
+    private void Resetreturn_vote_data() { return_vote_dataSpecified = false; }
+    
 
-    private bool _return_tags = default(bool);
+    private bool? _return_tags;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"return_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_tags
     {
-      get { return _return_tags; }
+      get { return _return_tags?? default(bool); }
       set { _return_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_tagsSpecified
+    {
+      get { return _return_tags != null; }
+      set { if (value == (_return_tags== null)) _return_tags = value ? this.return_tags : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_tags() { return return_tagsSpecified; }
+    private void Resetreturn_tags() { return_tagsSpecified = false; }
+    
 
-    private bool _return_kv_tags = (bool)true;
+    private bool? _return_kv_tags;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"return_kv_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool return_kv_tags
     {
-      get { return _return_kv_tags; }
+      get { return _return_kv_tags?? (bool)true; }
       set { _return_kv_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_kv_tagsSpecified
+    {
+      get { return _return_kv_tags != null; }
+      set { if (value == (_return_kv_tags== null)) _return_kv_tags = value ? this.return_kv_tags : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_kv_tags() { return return_kv_tagsSpecified; }
+    private void Resetreturn_kv_tags() { return_kv_tagsSpecified = false; }
+    
 
-    private bool _return_previews = default(bool);
+    private bool? _return_previews;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"return_previews", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_previews
     {
-      get { return _return_previews; }
+      get { return _return_previews?? default(bool); }
       set { _return_previews = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_previewsSpecified
+    {
+      get { return _return_previews != null; }
+      set { if (value == (_return_previews== null)) _return_previews = value ? this.return_previews : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_previews() { return return_previewsSpecified; }
+    private void Resetreturn_previews() { return_previewsSpecified = false; }
+    
 
-    private bool _return_children = default(bool);
+    private bool? _return_children;
     [global::ProtoBuf.ProtoMember(23, IsRequired = false, Name=@"return_children", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_children
     {
-      get { return _return_children; }
+      get { return _return_children?? default(bool); }
       set { _return_children = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_childrenSpecified
+    {
+      get { return _return_children != null; }
+      set { if (value == (_return_children== null)) _return_children = value ? this.return_children : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_children() { return return_childrenSpecified; }
+    private void Resetreturn_children() { return_childrenSpecified = false; }
+    
 
-    private bool _return_short_description = (bool)true;
+    private bool? _return_short_description;
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"return_short_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool return_short_description
     {
-      get { return _return_short_description; }
+      get { return _return_short_description?? (bool)true; }
       set { _return_short_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_short_descriptionSpecified
+    {
+      get { return _return_short_description != null; }
+      set { if (value == (_return_short_description== null)) _return_short_description = value ? this.return_short_description : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_short_description() { return return_short_descriptionSpecified; }
+    private void Resetreturn_short_description() { return_short_descriptionSpecified = false; }
+    
 
-    private bool _return_for_sale_data = default(bool);
+    private bool? _return_for_sale_data;
     [global::ProtoBuf.ProtoMember(26, IsRequired = false, Name=@"return_for_sale_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_for_sale_data
     {
-      get { return _return_for_sale_data; }
+      get { return _return_for_sale_data?? default(bool); }
       set { _return_for_sale_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_for_sale_dataSpecified
+    {
+      get { return _return_for_sale_data != null; }
+      set { if (value == (_return_for_sale_data== null)) _return_for_sale_data = value ? this.return_for_sale_data : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_for_sale_data() { return return_for_sale_dataSpecified; }
+    private void Resetreturn_for_sale_data() { return_for_sale_dataSpecified = false; }
+    
 
-    private bool _return_metadata = (bool)false;
+    private bool? _return_metadata;
     [global::ProtoBuf.ProtoMember(28, IsRequired = false, Name=@"return_metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool return_metadata
     {
-      get { return _return_metadata; }
+      get { return _return_metadata?? (bool)false; }
       set { _return_metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_metadataSpecified
+    {
+      get { return _return_metadata != null; }
+      set { if (value == (_return_metadata== null)) _return_metadata = value ? this.return_metadata : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_metadata() { return return_metadataSpecified; }
+    private void Resetreturn_metadata() { return_metadataSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"KVTag")]
   public partial class KVTag : global::ProtoBuf.IExtensible
   {
     public KVTag() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1723,23 +3075,41 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetUserFiles_Response() {}
     
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
 
-    private uint _startindex = default(uint);
+    private uint? _startindex;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"startindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint startindex
     {
-      get { return _startindex; }
+      get { return _startindex?? default(uint); }
       set { _startindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool startindexSpecified
+    {
+      get { return _startindex != null; }
+      set { if (value == (_startindex== null)) _startindex = value ? this.startindex : (uint?)null; }
+    }
+    private bool ShouldSerializestartindex() { return startindexSpecified; }
+    private void Resetstartindex() { startindexSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<PublishedFileDetails> _publishedfiledetails = new global::System.Collections.Generic.List<PublishedFileDetails>();
     [global::ProtoBuf.ProtoMember(3, Name=@"publishedfiledetails", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<PublishedFileDetails> publishedfiledetails
@@ -1760,41 +3130,77 @@ namespace SteamKit2.Unified.Internal
     public App() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private string _name = "";
+    private string _name;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string name
     {
-      get { return _name; }
+      get { return _name?? ""; }
       set { _name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool nameSpecified
+    {
+      get { return _name != null; }
+      set { if (value == (_name== null)) _name = value ? this.name : (string)null; }
+    }
+    private bool ShouldSerializename() { return nameSpecified; }
+    private void Resetname() { nameSpecified = false; }
+    
 
-    private uint _shortcutid = default(uint);
+    private uint? _shortcutid;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"shortcutid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint shortcutid
     {
-      get { return _shortcutid; }
+      get { return _shortcutid?? default(uint); }
       set { _shortcutid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shortcutidSpecified
+    {
+      get { return _shortcutid != null; }
+      set { if (value == (_shortcutid== null)) _shortcutid = value ? this.shortcutid : (uint?)null; }
+    }
+    private bool ShouldSerializeshortcutid() { return shortcutidSpecified; }
+    private void Resetshortcutid() { shortcutidSpecified = false; }
+    
 
-    private bool _private = default(bool);
+    private bool? _private;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"private", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool @private
     {
-      get { return _private; }
+      get { return _private?? default(bool); }
       set { _private = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool privateSpecified
+    {
+      get { return _private != null; }
+      set { if (value == (_private== null)) _private = value ? this.@private : (bool?)null; }
+    }
+    private bool ShouldSerializeprivate() { return privateSpecified; }
+    private void Resetprivate() { privateSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1811,50 +3217,95 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_Update_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private string _title = "";
+    private string _title;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"title", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string title
     {
-      get { return _title; }
+      get { return _title?? ""; }
       set { _title = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool titleSpecified
+    {
+      get { return _title != null; }
+      set { if (value == (_title== null)) _title = value ? this.title : (string)null; }
+    }
+    private bool ShouldSerializetitle() { return titleSpecified; }
+    private void Resettitle() { titleSpecified = false; }
+    
 
-    private string _file_description = "";
+    private string _file_description;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"file_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string file_description
     {
-      get { return _file_description; }
+      get { return _file_description?? ""; }
       set { _file_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool file_descriptionSpecified
+    {
+      get { return _file_description != null; }
+      set { if (value == (_file_description== null)) _file_description = value ? this.file_description : (string)null; }
+    }
+    private bool ShouldSerializefile_description() { return file_descriptionSpecified; }
+    private void Resetfile_description() { file_descriptionSpecified = false; }
+    
 
-    private uint _visibility = default(uint);
+    private uint? _visibility;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"visibility", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint visibility
     {
-      get { return _visibility; }
+      get { return _visibility?? default(uint); }
       set { _visibility = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool visibilitySpecified
+    {
+      get { return _visibility != null; }
+      set { if (value == (_visibility== null)) _visibility = value ? this.visibility : (uint?)null; }
+    }
+    private bool ShouldSerializevisibility() { return visibilitySpecified; }
+    private void Resetvisibility() { visibilitySpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(6, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -1863,41 +3314,77 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _filename = "";
+    private string _filename;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string filename
     {
-      get { return _filename; }
+      get { return _filename?? ""; }
       set { _filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filenameSpecified
+    {
+      get { return _filename != null; }
+      set { if (value == (_filename== null)) _filename = value ? this.filename : (string)null; }
+    }
+    private bool ShouldSerializefilename() { return filenameSpecified; }
+    private void Resetfilename() { filenameSpecified = false; }
+    
 
-    private string _preview_filename = "";
+    private string _preview_filename;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"preview_filename", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string preview_filename
     {
-      get { return _preview_filename; }
+      get { return _preview_filename?? ""; }
       set { _preview_filename = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool preview_filenameSpecified
+    {
+      get { return _preview_filename != null; }
+      set { if (value == (_preview_filename== null)) _preview_filename = value ? this.preview_filename : (string)null; }
+    }
+    private bool ShouldSerializepreview_filename() { return preview_filenameSpecified; }
+    private void Resetpreview_filename() { preview_filenameSpecified = false; }
+    
 
-    private uint _image_width = default(uint);
+    private uint? _image_width;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"image_width", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint image_width
     {
-      get { return _image_width; }
+      get { return _image_width?? default(uint); }
       set { _image_width = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool image_widthSpecified
+    {
+      get { return _image_width != null; }
+      set { if (value == (_image_width== null)) _image_width = value ? this.image_width : (uint?)null; }
+    }
+    private bool ShouldSerializeimage_width() { return image_widthSpecified; }
+    private void Resetimage_width() { image_widthSpecified = false; }
+    
 
-    private uint _image_height = default(uint);
+    private uint? _image_height;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"image_height", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint image_height
     {
-      get { return _image_height; }
+      get { return _image_height?? default(uint); }
       set { _image_height = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool image_heightSpecified
+    {
+      get { return _image_height != null; }
+      set { if (value == (_image_height== null)) _image_height = value ? this.image_height : (uint?)null; }
+    }
+    private bool ShouldSerializeimage_height() { return image_heightSpecified; }
+    private void Resetimage_height() { image_heightSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1919,32 +3406,59 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetChangeHistoryEntry_Request() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1956,23 +3470,41 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetChangeHistoryEntry_Response() {}
     
 
-    private string _change_description = "";
+    private string _change_description;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"change_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string change_description
     {
-      get { return _change_description; }
+      get { return _change_description?? ""; }
       set { _change_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_descriptionSpecified
+    {
+      get { return _change_description != null; }
+      set { if (value == (_change_description== null)) _change_description = value ? this.change_description : (string)null; }
+    }
+    private bool ShouldSerializechange_description() { return change_descriptionSpecified; }
+    private void Resetchange_description() { change_descriptionSpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -1984,50 +3516,95 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_GetChangeHistory_Request() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private bool _total_only = default(bool);
+    private bool? _total_only;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool total_only
     {
-      get { return _total_only; }
+      get { return _total_only?? default(bool); }
       set { _total_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool total_onlySpecified
+    {
+      get { return _total_only != null; }
+      set { if (value == (_total_only== null)) _total_only = value ? this.total_only : (bool?)null; }
+    }
+    private bool ShouldSerializetotal_only() { return total_onlySpecified; }
+    private void Resettotal_only() { total_onlySpecified = false; }
+    
 
-    private uint _startindex = default(uint);
+    private uint? _startindex;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"startindex", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint startindex
     {
-      get { return _startindex; }
+      get { return _startindex?? default(uint); }
       set { _startindex = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool startindexSpecified
+    {
+      get { return _startindex != null; }
+      set { if (value == (_startindex== null)) _startindex = value ? this.startindex : (uint?)null; }
+    }
+    private bool ShouldSerializestartindex() { return startindexSpecified; }
+    private void Resetstartindex() { startindexSpecified = false; }
+    
 
-    private uint _count = default(uint);
+    private uint? _count;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"count", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint count
     {
-      get { return _count; }
+      get { return _count?? default(uint); }
       set { _count = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool countSpecified
+    {
+      get { return _count != null; }
+      set { if (value == (_count== null)) _count = value ? this.count : (uint?)null; }
+    }
+    private bool ShouldSerializecount() { return countSpecified; }
+    private void Resetcount() { countSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2046,46 +3623,82 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ChangeLog")]
   public partial class ChangeLog : global::ProtoBuf.IExtensible
   {
     public ChangeLog() {}
     
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private string _change_description = "";
+    private string _change_description;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"change_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string change_description
     {
-      get { return _change_description; }
+      get { return _change_description?? ""; }
       set { _change_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool change_descriptionSpecified
+    {
+      get { return _change_description != null; }
+      set { if (value == (_change_description== null)) _change_description = value ? this.change_description : (string)null; }
+    }
+    private bool ShouldSerializechange_description() { return change_descriptionSpecified; }
+    private void Resetchange_description() { change_descriptionSpecified = false; }
+    
 
-    private int _language = default(int);
+    private int? _language;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int language
     {
-      get { return _language; }
+      get { return _language?? default(int); }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2102,23 +3715,41 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_RefreshVotingQueue_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
 
-    private uint _matching_file_type = default(uint);
+    private uint? _matching_file_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"matching_file_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint matching_file_type
     {
-      get { return _matching_file_type; }
+      get { return _matching_file_type?? default(uint); }
       set { _matching_file_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool matching_file_typeSpecified
+    {
+      get { return _matching_file_type != null; }
+      set { if (value == (_matching_file_type== null)) _matching_file_type = value ? this.matching_file_type : (uint?)null; }
+    }
+    private bool ShouldSerializematching_file_type() { return matching_file_typeSpecified; }
+    private void Resetmatching_file_type() { matching_file_typeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(3, Name=@"tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> tags
@@ -2127,14 +3758,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _match_all_tags = (bool)true;
+    private bool? _match_all_tags;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"match_all_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool match_all_tags
     {
-      get { return _match_all_tags; }
+      get { return _match_all_tags?? (bool)true; }
       set { _match_all_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_all_tagsSpecified
+    {
+      get { return _match_all_tags != null; }
+      set { if (value == (_match_all_tags== null)) _match_all_tags = value ? this.match_all_tags : (bool?)null; }
+    }
+    private bool ShouldSerializematch_all_tags() { return match_all_tagsSpecified; }
+    private void Resetmatch_all_tags() { match_all_tagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _excluded_tags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(5, Name=@"excluded_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> excluded_tags
@@ -2143,14 +3783,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private uint _desired_queue_size = default(uint);
+    private uint? _desired_queue_size;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"desired_queue_size", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint desired_queue_size
     {
-      get { return _desired_queue_size; }
+      get { return _desired_queue_size?? default(uint); }
       set { _desired_queue_size = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool desired_queue_sizeSpecified
+    {
+      get { return _desired_queue_size != null; }
+      set { if (value == (_desired_queue_size== null)) _desired_queue_size = value ? this.desired_queue_size : (uint?)null; }
+    }
+    private bool ShouldSerializedesired_queue_size() { return desired_queue_sizeSpecified; }
+    private void Resetdesired_queue_size() { desired_queue_sizeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2172,50 +3821,95 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_QueryFiles_Request() {}
     
 
-    private uint _query_type = default(uint);
+    private uint? _query_type;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"query_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint query_type
     {
-      get { return _query_type; }
+      get { return _query_type?? default(uint); }
       set { _query_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool query_typeSpecified
+    {
+      get { return _query_type != null; }
+      set { if (value == (_query_type== null)) _query_type = value ? this.query_type : (uint?)null; }
+    }
+    private bool ShouldSerializequery_type() { return query_typeSpecified; }
+    private void Resetquery_type() { query_typeSpecified = false; }
+    
 
-    private uint _page = default(uint);
+    private uint? _page;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"page", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint page
     {
-      get { return _page; }
+      get { return _page?? default(uint); }
       set { _page = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool pageSpecified
+    {
+      get { return _page != null; }
+      set { if (value == (_page== null)) _page = value ? this.page : (uint?)null; }
+    }
+    private bool ShouldSerializepage() { return pageSpecified; }
+    private void Resetpage() { pageSpecified = false; }
+    
 
-    private uint _numperpage = (uint)1;
+    private uint? _numperpage;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"numperpage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)1)]
     public uint numperpage
     {
-      get { return _numperpage; }
+      get { return _numperpage?? (uint)1; }
       set { _numperpage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool numperpageSpecified
+    {
+      get { return _numperpage != null; }
+      set { if (value == (_numperpage== null)) _numperpage = value ? this.numperpage : (uint?)null; }
+    }
+    private bool ShouldSerializenumperpage() { return numperpageSpecified; }
+    private void Resetnumperpage() { numperpageSpecified = false; }
+    
 
-    private uint _creator_appid = default(uint);
+    private uint? _creator_appid;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"creator_appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint creator_appid
     {
-      get { return _creator_appid; }
+      get { return _creator_appid?? default(uint); }
       set { _creator_appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool creator_appidSpecified
+    {
+      get { return _creator_appid != null; }
+      set { if (value == (_creator_appid== null)) _creator_appid = value ? this.creator_appid : (uint?)null; }
+    }
+    private bool ShouldSerializecreator_appid() { return creator_appidSpecified; }
+    private void Resetcreator_appid() { creator_appidSpecified = false; }
+    
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _requiredtags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(6, Name=@"requiredtags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> requiredtags
@@ -2231,14 +3925,23 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _match_all_tags = (bool)true;
+    private bool? _match_all_tags;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"match_all_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)true)]
     public bool match_all_tags
     {
-      get { return _match_all_tags; }
+      get { return _match_all_tags?? (bool)true; }
       set { _match_all_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool match_all_tagsSpecified
+    {
+      get { return _match_all_tags != null; }
+      set { if (value == (_match_all_tags== null)) _match_all_tags = value ? this.match_all_tags : (bool?)null; }
+    }
+    private bool ShouldSerializematch_all_tags() { return match_all_tagsSpecified; }
+    private void Resetmatch_all_tags() { match_all_tagsSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _required_flags = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(9, Name=@"required_flags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> required_flags
@@ -2254,68 +3957,131 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private string _search_text = "";
+    private string _search_text;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"search_text", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string search_text
     {
-      get { return _search_text; }
+      get { return _search_text?? ""; }
       set { _search_text = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool search_textSpecified
+    {
+      get { return _search_text != null; }
+      set { if (value == (_search_text== null)) _search_text = value ? this.search_text : (string)null; }
+    }
+    private bool ShouldSerializesearch_text() { return search_textSpecified; }
+    private void Resetsearch_text() { search_textSpecified = false; }
+    
 
-    private uint _filetype = default(uint);
+    private uint? _filetype;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"filetype", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint filetype
     {
-      get { return _filetype; }
+      get { return _filetype?? default(uint); }
       set { _filetype = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool filetypeSpecified
+    {
+      get { return _filetype != null; }
+      set { if (value == (_filetype== null)) _filetype = value ? this.filetype : (uint?)null; }
+    }
+    private bool ShouldSerializefiletype() { return filetypeSpecified; }
+    private void Resetfiletype() { filetypeSpecified = false; }
+    
 
-    private ulong _child_publishedfileid = default(ulong);
+    private ulong? _child_publishedfileid;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"child_publishedfileid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong child_publishedfileid
     {
-      get { return _child_publishedfileid; }
+      get { return _child_publishedfileid?? default(ulong); }
       set { _child_publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool child_publishedfileidSpecified
+    {
+      get { return _child_publishedfileid != null; }
+      set { if (value == (_child_publishedfileid== null)) _child_publishedfileid = value ? this.child_publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializechild_publishedfileid() { return child_publishedfileidSpecified; }
+    private void Resetchild_publishedfileid() { child_publishedfileidSpecified = false; }
+    
 
-    private uint _days = default(uint);
+    private uint? _days;
     [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name=@"days", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint days
     {
-      get { return _days; }
+      get { return _days?? default(uint); }
       set { _days = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool daysSpecified
+    {
+      get { return _days != null; }
+      set { if (value == (_days== null)) _days = value ? this.days : (uint?)null; }
+    }
+    private bool ShouldSerializedays() { return daysSpecified; }
+    private void Resetdays() { daysSpecified = false; }
+    
 
-    private bool _include_recent_votes_only = default(bool);
+    private bool? _include_recent_votes_only;
     [global::ProtoBuf.ProtoMember(15, IsRequired = false, Name=@"include_recent_votes_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_recent_votes_only
     {
-      get { return _include_recent_votes_only; }
+      get { return _include_recent_votes_only?? default(bool); }
       set { _include_recent_votes_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_recent_votes_onlySpecified
+    {
+      get { return _include_recent_votes_only != null; }
+      set { if (value == (_include_recent_votes_only== null)) _include_recent_votes_only = value ? this.include_recent_votes_only : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_recent_votes_only() { return include_recent_votes_onlySpecified; }
+    private void Resetinclude_recent_votes_only() { include_recent_votes_onlySpecified = false; }
+    
 
-    private uint _cache_max_age_seconds = (uint)0;
+    private uint? _cache_max_age_seconds;
     [global::ProtoBuf.ProtoMember(31, IsRequired = false, Name=@"cache_max_age_seconds", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((uint)0)]
     public uint cache_max_age_seconds
     {
-      get { return _cache_max_age_seconds; }
+      get { return _cache_max_age_seconds?? (uint)0; }
       set { _cache_max_age_seconds = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool cache_max_age_secondsSpecified
+    {
+      get { return _cache_max_age_seconds != null; }
+      set { if (value == (_cache_max_age_seconds== null)) _cache_max_age_seconds = value ? this.cache_max_age_seconds : (uint?)null; }
+    }
+    private bool ShouldSerializecache_max_age_seconds() { return cache_max_age_secondsSpecified; }
+    private void Resetcache_max_age_seconds() { cache_max_age_secondsSpecified = false; }
+    
 
-    private int _language = (int)0;
+    private int? _language;
     [global::ProtoBuf.ProtoMember(33, IsRequired = false, Name=@"language", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue((int)0)]
     public int language
     {
-      get { return _language; }
+      get { return _language?? (int)0; }
       set { _language = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool languageSpecified
+    {
+      get { return _language != null; }
+      set { if (value == (_language== null)) _language = value ? this.language : (int?)null; }
+    }
+    private bool ShouldSerializelanguage() { return languageSpecified; }
+    private void Resetlanguage() { languageSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPublishedFile_QueryFiles_Request.KVTag> _required_kv_tags = new global::System.Collections.Generic.List<CPublishedFile_QueryFiles_Request.KVTag>();
     [global::ProtoBuf.ProtoMember(34, Name=@"required_kv_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPublishedFile_QueryFiles_Request.KVTag> required_kv_tags
@@ -2324,118 +4090,226 @@ namespace SteamKit2.Unified.Internal
     }
   
 
-    private bool _totalonly = default(bool);
+    private bool? _totalonly;
     [global::ProtoBuf.ProtoMember(16, IsRequired = false, Name=@"totalonly", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool totalonly
     {
-      get { return _totalonly; }
+      get { return _totalonly?? default(bool); }
       set { _totalonly = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalonlySpecified
+    {
+      get { return _totalonly != null; }
+      set { if (value == (_totalonly== null)) _totalonly = value ? this.totalonly : (bool?)null; }
+    }
+    private bool ShouldSerializetotalonly() { return totalonlySpecified; }
+    private void Resettotalonly() { totalonlySpecified = false; }
+    
 
-    private bool _ids_only = default(bool);
+    private bool? _ids_only;
     [global::ProtoBuf.ProtoMember(35, IsRequired = false, Name=@"ids_only", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool ids_only
     {
-      get { return _ids_only; }
+      get { return _ids_only?? default(bool); }
       set { _ids_only = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool ids_onlySpecified
+    {
+      get { return _ids_only != null; }
+      set { if (value == (_ids_only== null)) _ids_only = value ? this.ids_only : (bool?)null; }
+    }
+    private bool ShouldSerializeids_only() { return ids_onlySpecified; }
+    private void Resetids_only() { ids_onlySpecified = false; }
+    
 
-    private bool _return_vote_data = default(bool);
+    private bool? _return_vote_data;
     [global::ProtoBuf.ProtoMember(17, IsRequired = false, Name=@"return_vote_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_vote_data
     {
-      get { return _return_vote_data; }
+      get { return _return_vote_data?? default(bool); }
       set { _return_vote_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_vote_dataSpecified
+    {
+      get { return _return_vote_data != null; }
+      set { if (value == (_return_vote_data== null)) _return_vote_data = value ? this.return_vote_data : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_vote_data() { return return_vote_dataSpecified; }
+    private void Resetreturn_vote_data() { return_vote_dataSpecified = false; }
+    
 
-    private bool _return_tags = default(bool);
+    private bool? _return_tags;
     [global::ProtoBuf.ProtoMember(18, IsRequired = false, Name=@"return_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_tags
     {
-      get { return _return_tags; }
+      get { return _return_tags?? default(bool); }
       set { _return_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_tagsSpecified
+    {
+      get { return _return_tags != null; }
+      set { if (value == (_return_tags== null)) _return_tags = value ? this.return_tags : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_tags() { return return_tagsSpecified; }
+    private void Resetreturn_tags() { return_tagsSpecified = false; }
+    
 
-    private bool _return_kv_tags = default(bool);
+    private bool? _return_kv_tags;
     [global::ProtoBuf.ProtoMember(19, IsRequired = false, Name=@"return_kv_tags", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_kv_tags
     {
-      get { return _return_kv_tags; }
+      get { return _return_kv_tags?? default(bool); }
       set { _return_kv_tags = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_kv_tagsSpecified
+    {
+      get { return _return_kv_tags != null; }
+      set { if (value == (_return_kv_tags== null)) _return_kv_tags = value ? this.return_kv_tags : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_kv_tags() { return return_kv_tagsSpecified; }
+    private void Resetreturn_kv_tags() { return_kv_tagsSpecified = false; }
+    
 
-    private bool _return_previews = default(bool);
+    private bool? _return_previews;
     [global::ProtoBuf.ProtoMember(20, IsRequired = false, Name=@"return_previews", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_previews
     {
-      get { return _return_previews; }
+      get { return _return_previews?? default(bool); }
       set { _return_previews = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_previewsSpecified
+    {
+      get { return _return_previews != null; }
+      set { if (value == (_return_previews== null)) _return_previews = value ? this.return_previews : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_previews() { return return_previewsSpecified; }
+    private void Resetreturn_previews() { return_previewsSpecified = false; }
+    
 
-    private bool _return_children = default(bool);
+    private bool? _return_children;
     [global::ProtoBuf.ProtoMember(21, IsRequired = false, Name=@"return_children", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_children
     {
-      get { return _return_children; }
+      get { return _return_children?? default(bool); }
       set { _return_children = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_childrenSpecified
+    {
+      get { return _return_children != null; }
+      set { if (value == (_return_children== null)) _return_children = value ? this.return_children : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_children() { return return_childrenSpecified; }
+    private void Resetreturn_children() { return_childrenSpecified = false; }
+    
 
-    private bool _return_short_description = default(bool);
+    private bool? _return_short_description;
     [global::ProtoBuf.ProtoMember(22, IsRequired = false, Name=@"return_short_description", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_short_description
     {
-      get { return _return_short_description; }
+      get { return _return_short_description?? default(bool); }
       set { _return_short_description = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_short_descriptionSpecified
+    {
+      get { return _return_short_description != null; }
+      set { if (value == (_return_short_description== null)) _return_short_description = value ? this.return_short_description : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_short_description() { return return_short_descriptionSpecified; }
+    private void Resetreturn_short_description() { return_short_descriptionSpecified = false; }
+    
 
-    private bool _return_for_sale_data = default(bool);
+    private bool? _return_for_sale_data;
     [global::ProtoBuf.ProtoMember(30, IsRequired = false, Name=@"return_for_sale_data", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool return_for_sale_data
     {
-      get { return _return_for_sale_data; }
+      get { return _return_for_sale_data?? default(bool); }
       set { _return_for_sale_data = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_for_sale_dataSpecified
+    {
+      get { return _return_for_sale_data != null; }
+      set { if (value == (_return_for_sale_data== null)) _return_for_sale_data = value ? this.return_for_sale_data : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_for_sale_data() { return return_for_sale_dataSpecified; }
+    private void Resetreturn_for_sale_data() { return_for_sale_dataSpecified = false; }
+    
 
-    private bool _return_metadata = (bool)false;
+    private bool? _return_metadata;
     [global::ProtoBuf.ProtoMember(32, IsRequired = false, Name=@"return_metadata", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue((bool)false)]
     public bool return_metadata
     {
-      get { return _return_metadata; }
+      get { return _return_metadata?? (bool)false; }
       set { _return_metadata = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool return_metadataSpecified
+    {
+      get { return _return_metadata != null; }
+      set { if (value == (_return_metadata== null)) _return_metadata = value ? this.return_metadata : (bool?)null; }
+    }
+    private bool ShouldSerializereturn_metadata() { return return_metadataSpecified; }
+    private void Resetreturn_metadata() { return_metadataSpecified = false; }
+    
   [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"KVTag")]
   public partial class KVTag : global::ProtoBuf.IExtensible
   {
     public KVTag() {}
     
 
-    private string _key = "";
+    private string _key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string key
     {
-      get { return _key; }
+      get { return _key?? ""; }
       set { _key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool keySpecified
+    {
+      get { return _key != null; }
+      set { if (value == (_key== null)) _key = value ? this.key : (string)null; }
+    }
+    private bool ShouldSerializekey() { return keySpecified; }
+    private void Resetkey() { keySpecified = false; }
+    
 
-    private string _value = "";
+    private string _value;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"value", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string value
     {
-      get { return _value; }
+      get { return _value?? ""; }
       set { _value = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool valueSpecified
+    {
+      get { return _value != null; }
+      set { if (value == (_value== null)) _value = value ? this.value : (string)null; }
+    }
+    private bool ShouldSerializevalue() { return valueSpecified; }
+    private void Resetvalue() { valueSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2452,14 +4326,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_QueryFiles_Response() {}
     
 
-    private uint _total = default(uint);
+    private uint? _total;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"total", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint total
     {
-      get { return _total; }
+      get { return _total?? default(uint); }
       set { _total = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool totalSpecified
+    {
+      get { return _total != null; }
+      set { if (value == (_total== null)) _total = value ? this.total : (uint?)null; }
+    }
+    private bool ShouldSerializetotal() { return totalSpecified; }
+    private void Resettotal() { totalSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<PublishedFileDetails> _publishedfiledetails = new global::System.Collections.Generic.List<PublishedFileDetails>();
     [global::ProtoBuf.ProtoMember(2, Name=@"publishedfiledetails", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<PublishedFileDetails> publishedfiledetails
@@ -2478,14 +4361,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_StartPlaytimeTracking_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _publishedfileids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"publishedfileids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> publishedfileids
@@ -2514,14 +4406,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_StopPlaytimeTracking_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<ulong> _publishedfileids = new global::System.Collections.Generic.List<ulong>();
     [global::ProtoBuf.ProtoMember(2, Name=@"publishedfileids", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public global::System.Collections.Generic.List<ulong> publishedfileids
@@ -2550,14 +4451,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_StopPlaytimeTrackingForAllAppItems_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -2579,14 +4489,23 @@ namespace SteamKit2.Unified.Internal
     public CPublishedFile_SetPlaytimeForControllerConfigs_Request() {}
     
 
-    private uint _appid = default(uint);
+    private uint? _appid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"appid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint appid
     {
-      get { return _appid; }
+      get { return _appid?? default(uint); }
       set { _appid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool appidSpecified
+    {
+      get { return _appid != null; }
+      set { if (value == (_appid== null)) _appid = value ? this.appid : (uint?)null; }
+    }
+    private bool ShouldSerializeappid() { return appidSpecified; }
+    private void Resetappid() { appidSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<CPublishedFile_SetPlaytimeForControllerConfigs_Request.ControllerConfigUsage> _controller_config_usage = new global::System.Collections.Generic.List<CPublishedFile_SetPlaytimeForControllerConfigs_Request.ControllerConfigUsage>();
     [global::ProtoBuf.ProtoMember(2, Name=@"controller_config_usage", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<CPublishedFile_SetPlaytimeForControllerConfigs_Request.ControllerConfigUsage> controller_config_usage
@@ -2600,23 +4519,41 @@ namespace SteamKit2.Unified.Internal
     public ControllerConfigUsage() {}
     
 
-    private ulong _publishedfileid = default(ulong);
+    private ulong? _publishedfileid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"publishedfileid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong publishedfileid
     {
-      get { return _publishedfileid; }
+      get { return _publishedfileid?? default(ulong); }
       set { _publishedfileid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool publishedfileidSpecified
+    {
+      get { return _publishedfileid != null; }
+      set { if (value == (_publishedfileid== null)) _publishedfileid = value ? this.publishedfileid : (ulong?)null; }
+    }
+    private bool ShouldSerializepublishedfileid() { return publishedfileidSpecified; }
+    private void Resetpublishedfileid() { publishedfileidSpecified = false; }
+    
 
-    private float _seconds_active = default(float);
+    private float? _seconds_active;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"seconds_active", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(float))]
     public float seconds_active
     {
-      get { return _seconds_active; }
+      get { return _seconds_active?? default(float); }
       set { _seconds_active = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool seconds_activeSpecified
+    {
+      get { return _seconds_active != null; }
+      set { if (value == (_seconds_active== null)) _seconds_active = value ? this.seconds_active : (float?)null; }
+    }
+    private bool ShouldSerializeseconds_active() { return seconds_activeSpecified; }
+    private void Resetseconds_active() { seconds_activeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgSecrets.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgSecrets.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_secrets.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,41 +20,77 @@ namespace SteamKit2.Unified.Internal
     public CKeyEscrow_Request() {}
     
 
-    private byte[] _rsa_oaep_sha_ticket = null;
+    private byte[] _rsa_oaep_sha_ticket;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"rsa_oaep_sha_ticket", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] rsa_oaep_sha_ticket
     {
-      get { return _rsa_oaep_sha_ticket; }
+      get { return _rsa_oaep_sha_ticket?? null; }
       set { _rsa_oaep_sha_ticket = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool rsa_oaep_sha_ticketSpecified
+    {
+      get { return _rsa_oaep_sha_ticket != null; }
+      set { if (value == (_rsa_oaep_sha_ticket== null)) _rsa_oaep_sha_ticket = value ? this.rsa_oaep_sha_ticket : (byte[])null; }
+    }
+    private bool ShouldSerializersa_oaep_sha_ticket() { return rsa_oaep_sha_ticketSpecified; }
+    private void Resetrsa_oaep_sha_ticket() { rsa_oaep_sha_ticketSpecified = false; }
+    
 
-    private byte[] _password = null;
+    private byte[] _password;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] password
     {
-      get { return _password; }
+      get { return _password?? null; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (byte[])null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private EKeyEscrowUsage _usage = EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice;
+    private EKeyEscrowUsage? _usage;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"usage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice)]
     public EKeyEscrowUsage usage
     {
-      get { return _usage; }
+      get { return _usage?? EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice; }
       set { _usage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usageSpecified
+    {
+      get { return _usage != null; }
+      set { if (value == (_usage== null)) _usage = value ? this.usage : (EKeyEscrowUsage?)null; }
+    }
+    private bool ShouldSerializeusage() { return usageSpecified; }
+    private void Resetusage() { usageSpecified = false; }
+    
 
-    private string _device_name = "";
+    private string _device_name;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"device_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_name
     {
-      get { return _device_name; }
+      get { return _device_name?? ""; }
       set { _device_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_nameSpecified
+    {
+      get { return _device_name != null; }
+      set { if (value == (_device_name== null)) _device_name = value ? this.device_name : (string)null; }
+    }
+    private bool ShouldSerializedevice_name() { return device_nameSpecified; }
+    private void Resetdevice_name() { device_nameSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -64,86 +102,167 @@ namespace SteamKit2.Unified.Internal
     public CKeyEscrow_Ticket() {}
     
 
-    private byte[] _password = null;
+    private byte[] _password;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"password", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] password
     {
-      get { return _password; }
+      get { return _password?? null; }
       set { _password = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool passwordSpecified
+    {
+      get { return _password != null; }
+      set { if (value == (_password== null)) _password = value ? this.password : (byte[])null; }
+    }
+    private bool ShouldSerializepassword() { return passwordSpecified; }
+    private void Resetpassword() { passwordSpecified = false; }
+    
 
-    private ulong _identifier = default(ulong);
+    private ulong? _identifier;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"identifier", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong identifier
     {
-      get { return _identifier; }
+      get { return _identifier?? default(ulong); }
       set { _identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool identifierSpecified
+    {
+      get { return _identifier != null; }
+      set { if (value == (_identifier== null)) _identifier = value ? this.identifier : (ulong?)null; }
+    }
+    private bool ShouldSerializeidentifier() { return identifierSpecified; }
+    private void Resetidentifier() { identifierSpecified = false; }
+    
 
-    private byte[] _payload = null;
+    private byte[] _payload;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"payload", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] payload
     {
-      get { return _payload; }
+      get { return _payload?? null; }
       set { _payload = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool payloadSpecified
+    {
+      get { return _payload != null; }
+      set { if (value == (_payload== null)) _payload = value ? this.payload : (byte[])null; }
+    }
+    private bool ShouldSerializepayload() { return payloadSpecified; }
+    private void Resetpayload() { payloadSpecified = false; }
+    
 
-    private uint _timestamp = default(uint);
+    private uint? _timestamp;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"timestamp", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint timestamp
     {
-      get { return _timestamp; }
+      get { return _timestamp?? default(uint); }
       set { _timestamp = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool timestampSpecified
+    {
+      get { return _timestamp != null; }
+      set { if (value == (_timestamp== null)) _timestamp = value ? this.timestamp : (uint?)null; }
+    }
+    private bool ShouldSerializetimestamp() { return timestampSpecified; }
+    private void Resettimestamp() { timestampSpecified = false; }
+    
 
-    private EKeyEscrowUsage _usage = EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice;
+    private EKeyEscrowUsage? _usage;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"usage", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice)]
     public EKeyEscrowUsage usage
     {
-      get { return _usage; }
+      get { return _usage?? EKeyEscrowUsage.k_EKeyEscrowUsageStreamingDevice; }
       set { _usage = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool usageSpecified
+    {
+      get { return _usage != null; }
+      set { if (value == (_usage== null)) _usage = value ? this.usage : (EKeyEscrowUsage?)null; }
+    }
+    private bool ShouldSerializeusage() { return usageSpecified; }
+    private void Resetusage() { usageSpecified = false; }
+    
 
-    private string _device_name = "";
+    private string _device_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"device_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_name
     {
-      get { return _device_name; }
+      get { return _device_name?? ""; }
       set { _device_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_nameSpecified
+    {
+      get { return _device_name != null; }
+      set { if (value == (_device_name== null)) _device_name = value ? this.device_name : (string)null; }
+    }
+    private bool ShouldSerializedevice_name() { return device_nameSpecified; }
+    private void Resetdevice_name() { device_nameSpecified = false; }
+    
 
-    private string _device_model = "";
+    private string _device_model;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"device_model", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_model
     {
-      get { return _device_model; }
+      get { return _device_model?? ""; }
       set { _device_model = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_modelSpecified
+    {
+      get { return _device_model != null; }
+      set { if (value == (_device_model== null)) _device_model = value ? this.device_model : (string)null; }
+    }
+    private bool ShouldSerializedevice_model() { return device_modelSpecified; }
+    private void Resetdevice_model() { device_modelSpecified = false; }
+    
 
-    private string _device_serial = "";
+    private string _device_serial;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"device_serial", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_serial
     {
-      get { return _device_serial; }
+      get { return _device_serial?? ""; }
       set { _device_serial = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_serialSpecified
+    {
+      get { return _device_serial != null; }
+      set { if (value == (_device_serial== null)) _device_serial = value ? this.device_serial : (string)null; }
+    }
+    private bool ShouldSerializedevice_serial() { return device_serialSpecified; }
+    private void Resetdevice_serial() { device_serialSpecified = false; }
+    
 
-    private uint _device_provisioning_id = default(uint);
+    private uint? _device_provisioning_id;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"device_provisioning_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint device_provisioning_id
     {
-      get { return _device_provisioning_id; }
+      get { return _device_provisioning_id?? default(uint); }
       set { _device_provisioning_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_provisioning_idSpecified
+    {
+      get { return _device_provisioning_id != null; }
+      set { if (value == (_device_provisioning_id== null)) _device_provisioning_id = value ? this.device_provisioning_id : (uint?)null; }
+    }
+    private bool ShouldSerializedevice_provisioning_id() { return device_provisioning_idSpecified; }
+    private void Resetdevice_provisioning_id() { device_provisioning_idSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgSiteLicense.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgSiteLicense.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_site_license.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public CSiteLicense_ClientSiteAssociation_Notification() {}
     
 
-    private byte[] _site_association_file = null;
+    private byte[] _site_association_file;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"site_association_file", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] site_association_file
     {
-      get { return _site_association_file; }
+      get { return _site_association_file?? null; }
       set { _site_association_file = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool site_association_fileSpecified
+    {
+      get { return _site_association_file != null; }
+      set { if (value == (_site_association_file== null)) _site_association_file = value ? this.site_association_file : (byte[])null; }
+    }
+    private bool ShouldSerializesite_association_file() { return site_association_fileSpecified; }
+    private void Resetsite_association_file() { site_association_fileSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgTwoFactor.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgTwoFactor.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_twofactor.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_Status_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,122 +48,239 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_Status_Response() {}
     
 
-    private uint _state = default(uint);
+    private uint? _state;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"state", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint state
     {
-      get { return _state; }
+      get { return _state?? default(uint); }
       set { _state = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool stateSpecified
+    {
+      get { return _state != null; }
+      set { if (value == (_state== null)) _state = value ? this.state : (uint?)null; }
+    }
+    private bool ShouldSerializestate() { return stateSpecified; }
+    private void Resetstate() { stateSpecified = false; }
+    
 
-    private uint _inactivation_reason = default(uint);
+    private uint? _inactivation_reason;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"inactivation_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint inactivation_reason
     {
-      get { return _inactivation_reason; }
+      get { return _inactivation_reason?? default(uint); }
       set { _inactivation_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool inactivation_reasonSpecified
+    {
+      get { return _inactivation_reason != null; }
+      set { if (value == (_inactivation_reason== null)) _inactivation_reason = value ? this.inactivation_reason : (uint?)null; }
+    }
+    private bool ShouldSerializeinactivation_reason() { return inactivation_reasonSpecified; }
+    private void Resetinactivation_reason() { inactivation_reasonSpecified = false; }
+    
 
-    private uint _authenticator_type = default(uint);
+    private uint? _authenticator_type;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"authenticator_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint authenticator_type
     {
-      get { return _authenticator_type; }
+      get { return _authenticator_type?? default(uint); }
       set { _authenticator_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_typeSpecified
+    {
+      get { return _authenticator_type != null; }
+      set { if (value == (_authenticator_type== null)) _authenticator_type = value ? this.authenticator_type : (uint?)null; }
+    }
+    private bool ShouldSerializeauthenticator_type() { return authenticator_typeSpecified; }
+    private void Resetauthenticator_type() { authenticator_typeSpecified = false; }
+    
 
-    private bool _authenticator_allowed = default(bool);
+    private bool? _authenticator_allowed;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"authenticator_allowed", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool authenticator_allowed
     {
-      get { return _authenticator_allowed; }
+      get { return _authenticator_allowed?? default(bool); }
       set { _authenticator_allowed = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_allowedSpecified
+    {
+      get { return _authenticator_allowed != null; }
+      set { if (value == (_authenticator_allowed== null)) _authenticator_allowed = value ? this.authenticator_allowed : (bool?)null; }
+    }
+    private bool ShouldSerializeauthenticator_allowed() { return authenticator_allowedSpecified; }
+    private void Resetauthenticator_allowed() { authenticator_allowedSpecified = false; }
+    
 
-    private uint _steamguard_scheme = default(uint);
+    private uint? _steamguard_scheme;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"steamguard_scheme", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamguard_scheme
     {
-      get { return _steamguard_scheme; }
+      get { return _steamguard_scheme?? default(uint); }
       set { _steamguard_scheme = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_schemeSpecified
+    {
+      get { return _steamguard_scheme != null; }
+      set { if (value == (_steamguard_scheme== null)) _steamguard_scheme = value ? this.steamguard_scheme : (uint?)null; }
+    }
+    private bool ShouldSerializesteamguard_scheme() { return steamguard_schemeSpecified; }
+    private void Resetsteamguard_scheme() { steamguard_schemeSpecified = false; }
+    
 
-    private string _token_gid = "";
+    private string _token_gid;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"token_gid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_gid
     {
-      get { return _token_gid; }
+      get { return _token_gid?? ""; }
       set { _token_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_gidSpecified
+    {
+      get { return _token_gid != null; }
+      set { if (value == (_token_gid== null)) _token_gid = value ? this.token_gid : (string)null; }
+    }
+    private bool ShouldSerializetoken_gid() { return token_gidSpecified; }
+    private void Resettoken_gid() { token_gidSpecified = false; }
+    
 
-    private bool _email_validated = default(bool);
+    private bool? _email_validated;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"email_validated", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool email_validated
     {
-      get { return _email_validated; }
+      get { return _email_validated?? default(bool); }
       set { _email_validated = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_validatedSpecified
+    {
+      get { return _email_validated != null; }
+      set { if (value == (_email_validated== null)) _email_validated = value ? this.email_validated : (bool?)null; }
+    }
+    private bool ShouldSerializeemail_validated() { return email_validatedSpecified; }
+    private void Resetemail_validated() { email_validatedSpecified = false; }
+    
 
-    private string _device_identifier = "";
+    private string _device_identifier;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"device_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_identifier
     {
-      get { return _device_identifier; }
+      get { return _device_identifier?? ""; }
       set { _device_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_identifierSpecified
+    {
+      get { return _device_identifier != null; }
+      set { if (value == (_device_identifier== null)) _device_identifier = value ? this.device_identifier : (string)null; }
+    }
+    private bool ShouldSerializedevice_identifier() { return device_identifierSpecified; }
+    private void Resetdevice_identifier() { device_identifierSpecified = false; }
+    
 
-    private uint _time_created = default(uint);
+    private uint? _time_created;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"time_created", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint time_created
     {
-      get { return _time_created; }
+      get { return _time_created?? default(uint); }
       set { _time_created = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool time_createdSpecified
+    {
+      get { return _time_created != null; }
+      set { if (value == (_time_created== null)) _time_created = value ? this.time_created : (uint?)null; }
+    }
+    private bool ShouldSerializetime_created() { return time_createdSpecified; }
+    private void Resettime_created() { time_createdSpecified = false; }
+    
 
-    private uint _revocation_attempts_remaining = default(uint);
+    private uint? _revocation_attempts_remaining;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"revocation_attempts_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint revocation_attempts_remaining
     {
-      get { return _revocation_attempts_remaining; }
+      get { return _revocation_attempts_remaining?? default(uint); }
       set { _revocation_attempts_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revocation_attempts_remainingSpecified
+    {
+      get { return _revocation_attempts_remaining != null; }
+      set { if (value == (_revocation_attempts_remaining== null)) _revocation_attempts_remaining = value ? this.revocation_attempts_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializerevocation_attempts_remaining() { return revocation_attempts_remainingSpecified; }
+    private void Resetrevocation_attempts_remaining() { revocation_attempts_remainingSpecified = false; }
+    
 
-    private string _classified_agent = "";
+    private string _classified_agent;
     [global::ProtoBuf.ProtoMember(11, IsRequired = false, Name=@"classified_agent", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string classified_agent
     {
-      get { return _classified_agent; }
+      get { return _classified_agent?? ""; }
       set { _classified_agent = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool classified_agentSpecified
+    {
+      get { return _classified_agent != null; }
+      set { if (value == (_classified_agent== null)) _classified_agent = value ? this.classified_agent : (string)null; }
+    }
+    private bool ShouldSerializeclassified_agent() { return classified_agentSpecified; }
+    private void Resetclassified_agent() { classified_agentSpecified = false; }
+    
 
-    private bool _allow_external_authenticator = default(bool);
+    private bool? _allow_external_authenticator;
     [global::ProtoBuf.ProtoMember(12, IsRequired = false, Name=@"allow_external_authenticator", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool allow_external_authenticator
     {
-      get { return _allow_external_authenticator; }
+      get { return _allow_external_authenticator?? default(bool); }
       set { _allow_external_authenticator = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool allow_external_authenticatorSpecified
+    {
+      get { return _allow_external_authenticator != null; }
+      set { if (value == (_allow_external_authenticator== null)) _allow_external_authenticator = value ? this.allow_external_authenticator : (bool?)null; }
+    }
+    private bool ShouldSerializeallow_external_authenticator() { return allow_external_authenticatorSpecified; }
+    private void Resetallow_external_authenticator() { allow_external_authenticatorSpecified = false; }
+    
 
-    private uint _external_authenticator_type = default(uint);
+    private uint? _external_authenticator_type;
     [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name=@"external_authenticator_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint external_authenticator_type
     {
-      get { return _external_authenticator_type; }
+      get { return _external_authenticator_type?? default(uint); }
       set { _external_authenticator_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool external_authenticator_typeSpecified
+    {
+      get { return _external_authenticator_type != null; }
+      set { if (value == (_external_authenticator_type== null)) _external_authenticator_type = value ? this.external_authenticator_type : (uint?)null; }
+    }
+    private bool ShouldSerializeexternal_authenticator_type() { return external_authenticator_typeSpecified; }
+    private void Resetexternal_authenticator_type() { external_authenticator_typeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -164,59 +292,113 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_AddAuthenticator_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private ulong _authenticator_time = default(ulong);
+    private ulong? _authenticator_time;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"authenticator_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong authenticator_time
     {
-      get { return _authenticator_time; }
+      get { return _authenticator_time?? default(ulong); }
       set { _authenticator_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_timeSpecified
+    {
+      get { return _authenticator_time != null; }
+      set { if (value == (_authenticator_time== null)) _authenticator_time = value ? this.authenticator_time : (ulong?)null; }
+    }
+    private bool ShouldSerializeauthenticator_time() { return authenticator_timeSpecified; }
+    private void Resetauthenticator_time() { authenticator_timeSpecified = false; }
+    
 
-    private ulong _serial_number = default(ulong);
+    private ulong? _serial_number;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? default(ulong); }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (ulong?)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private uint _authenticator_type = default(uint);
+    private uint? _authenticator_type;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"authenticator_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint authenticator_type
     {
-      get { return _authenticator_type; }
+      get { return _authenticator_type?? default(uint); }
       set { _authenticator_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_typeSpecified
+    {
+      get { return _authenticator_type != null; }
+      set { if (value == (_authenticator_type== null)) _authenticator_type = value ? this.authenticator_type : (uint?)null; }
+    }
+    private bool ShouldSerializeauthenticator_type() { return authenticator_typeSpecified; }
+    private void Resetauthenticator_type() { authenticator_typeSpecified = false; }
+    
 
-    private string _device_identifier = "";
+    private string _device_identifier;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"device_identifier", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string device_identifier
     {
-      get { return _device_identifier; }
+      get { return _device_identifier?? ""; }
       set { _device_identifier = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool device_identifierSpecified
+    {
+      get { return _device_identifier != null; }
+      set { if (value == (_device_identifier== null)) _device_identifier = value ? this.device_identifier : (string)null; }
+    }
+    private bool ShouldSerializedevice_identifier() { return device_identifierSpecified; }
+    private void Resetdevice_identifier() { device_identifierSpecified = false; }
+    
 
-    private string _sms_phone_id = "";
+    private string _sms_phone_id;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"sms_phone_id", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string sms_phone_id
     {
-      get { return _sms_phone_id; }
+      get { return _sms_phone_id?? ""; }
       set { _sms_phone_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool sms_phone_idSpecified
+    {
+      get { return _sms_phone_id != null; }
+      set { if (value == (_sms_phone_id== null)) _sms_phone_id = value ? this.sms_phone_id : (string)null; }
+    }
+    private bool ShouldSerializesms_phone_id() { return sms_phone_idSpecified; }
+    private void Resetsms_phone_id() { sms_phone_idSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _http_headers = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(7, Name=@"http_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> http_headers
@@ -235,95 +417,185 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_AddAuthenticator_Response() {}
     
 
-    private byte[] _shared_secret = null;
+    private byte[] _shared_secret;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"shared_secret", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] shared_secret
     {
-      get { return _shared_secret; }
+      get { return _shared_secret?? null; }
       set { _shared_secret = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool shared_secretSpecified
+    {
+      get { return _shared_secret != null; }
+      set { if (value == (_shared_secret== null)) _shared_secret = value ? this.shared_secret : (byte[])null; }
+    }
+    private bool ShouldSerializeshared_secret() { return shared_secretSpecified; }
+    private void Resetshared_secret() { shared_secretSpecified = false; }
+    
 
-    private ulong _serial_number = default(ulong);
+    private ulong? _serial_number;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"serial_number", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong serial_number
     {
-      get { return _serial_number; }
+      get { return _serial_number?? default(ulong); }
       set { _serial_number = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool serial_numberSpecified
+    {
+      get { return _serial_number != null; }
+      set { if (value == (_serial_number== null)) _serial_number = value ? this.serial_number : (ulong?)null; }
+    }
+    private bool ShouldSerializeserial_number() { return serial_numberSpecified; }
+    private void Resetserial_number() { serial_numberSpecified = false; }
+    
 
-    private string _revocation_code = "";
+    private string _revocation_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"revocation_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string revocation_code
     {
-      get { return _revocation_code; }
+      get { return _revocation_code?? ""; }
       set { _revocation_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revocation_codeSpecified
+    {
+      get { return _revocation_code != null; }
+      set { if (value == (_revocation_code== null)) _revocation_code = value ? this.revocation_code : (string)null; }
+    }
+    private bool ShouldSerializerevocation_code() { return revocation_codeSpecified; }
+    private void Resetrevocation_code() { revocation_codeSpecified = false; }
+    
 
-    private string _uri = "";
+    private string _uri;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"uri", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string uri
     {
-      get { return _uri; }
+      get { return _uri?? ""; }
       set { _uri = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool uriSpecified
+    {
+      get { return _uri != null; }
+      set { if (value == (_uri== null)) _uri = value ? this.uri : (string)null; }
+    }
+    private bool ShouldSerializeuri() { return uriSpecified; }
+    private void Reseturi() { uriSpecified = false; }
+    
 
-    private ulong _server_time = default(ulong);
+    private ulong? _server_time;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"server_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_time
     {
-      get { return _server_time; }
+      get { return _server_time?? default(ulong); }
       set { _server_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_timeSpecified
+    {
+      get { return _server_time != null; }
+      set { if (value == (_server_time== null)) _server_time = value ? this.server_time : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_time() { return server_timeSpecified; }
+    private void Resetserver_time() { server_timeSpecified = false; }
+    
 
-    private string _account_name = "";
+    private string _account_name;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"account_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string account_name
     {
-      get { return _account_name; }
+      get { return _account_name?? ""; }
       set { _account_name = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool account_nameSpecified
+    {
+      get { return _account_name != null; }
+      set { if (value == (_account_name== null)) _account_name = value ? this.account_name : (string)null; }
+    }
+    private bool ShouldSerializeaccount_name() { return account_nameSpecified; }
+    private void Resetaccount_name() { account_nameSpecified = false; }
+    
 
-    private string _token_gid = "";
+    private string _token_gid;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"token_gid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string token_gid
     {
-      get { return _token_gid; }
+      get { return _token_gid?? ""; }
       set { _token_gid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool token_gidSpecified
+    {
+      get { return _token_gid != null; }
+      set { if (value == (_token_gid== null)) _token_gid = value ? this.token_gid : (string)null; }
+    }
+    private bool ShouldSerializetoken_gid() { return token_gidSpecified; }
+    private void Resettoken_gid() { token_gidSpecified = false; }
+    
 
-    private byte[] _identity_secret = null;
+    private byte[] _identity_secret;
     [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name=@"identity_secret", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] identity_secret
     {
-      get { return _identity_secret; }
+      get { return _identity_secret?? null; }
       set { _identity_secret = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool identity_secretSpecified
+    {
+      get { return _identity_secret != null; }
+      set { if (value == (_identity_secret== null)) _identity_secret = value ? this.identity_secret : (byte[])null; }
+    }
+    private bool ShouldSerializeidentity_secret() { return identity_secretSpecified; }
+    private void Resetidentity_secret() { identity_secretSpecified = false; }
+    
 
-    private byte[] _secret_1 = null;
+    private byte[] _secret_1;
     [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name=@"secret_1", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] secret_1
     {
-      get { return _secret_1; }
+      get { return _secret_1?? null; }
       set { _secret_1 = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool secret_1Specified
+    {
+      get { return _secret_1 != null; }
+      set { if (value == (_secret_1== null)) _secret_1 = value ? this.secret_1 : (byte[])null; }
+    }
+    private bool ShouldSerializesecret_1() { return secret_1Specified; }
+    private void Resetsecret_1() { secret_1Specified = false; }
+    
 
-    private int _status = default(int);
+    private int? _status;
     [global::ProtoBuf.ProtoMember(10, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int status
     {
-      get { return _status; }
+      get { return _status?? default(int); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (int?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -335,32 +607,59 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_SendEmail_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private uint _email_type = default(uint);
+    private uint? _email_type;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"email_type", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint email_type
     {
-      get { return _email_type; }
+      get { return _email_type?? default(uint); }
       set { _email_type = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool email_typeSpecified
+    {
+      get { return _email_type != null; }
+      set { if (value == (_email_type== null)) _email_type = value ? this.email_type : (uint?)null; }
+    }
+    private bool ShouldSerializeemail_type() { return email_typeSpecified; }
+    private void Resetemail_type() { email_typeSpecified = false; }
+    
 
-    private bool _include_activation_code = default(bool);
+    private bool? _include_activation_code;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"include_activation_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool include_activation_code
     {
-      get { return _include_activation_code; }
+      get { return _include_activation_code?? default(bool); }
       set { _include_activation_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool include_activation_codeSpecified
+    {
+      get { return _include_activation_code != null; }
+      set { if (value == (_include_activation_code== null)) _include_activation_code = value ? this.include_activation_code : (bool?)null; }
+    }
+    private bool ShouldSerializeinclude_activation_code() { return include_activation_codeSpecified; }
+    private void Resetinclude_activation_code() { include_activation_codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -382,41 +681,77 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_FinalizeAddAuthenticator_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
 
-    private string _authenticator_code = "";
+    private string _authenticator_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"authenticator_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string authenticator_code
     {
-      get { return _authenticator_code; }
+      get { return _authenticator_code?? ""; }
       set { _authenticator_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_codeSpecified
+    {
+      get { return _authenticator_code != null; }
+      set { if (value == (_authenticator_code== null)) _authenticator_code = value ? this.authenticator_code : (string)null; }
+    }
+    private bool ShouldSerializeauthenticator_code() { return authenticator_codeSpecified; }
+    private void Resetauthenticator_code() { authenticator_codeSpecified = false; }
+    
 
-    private ulong _authenticator_time = default(ulong);
+    private ulong? _authenticator_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"authenticator_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong authenticator_time
     {
-      get { return _authenticator_time; }
+      get { return _authenticator_time?? default(ulong); }
       set { _authenticator_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool authenticator_timeSpecified
+    {
+      get { return _authenticator_time != null; }
+      set { if (value == (_authenticator_time== null)) _authenticator_time = value ? this.authenticator_time : (ulong?)null; }
+    }
+    private bool ShouldSerializeauthenticator_time() { return authenticator_timeSpecified; }
+    private void Resetauthenticator_time() { authenticator_timeSpecified = false; }
+    
 
-    private string _activation_code = "";
+    private string _activation_code;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"activation_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string activation_code
     {
-      get { return _activation_code; }
+      get { return _activation_code?? ""; }
       set { _activation_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool activation_codeSpecified
+    {
+      get { return _activation_code != null; }
+      set { if (value == (_activation_code== null)) _activation_code = value ? this.activation_code : (string)null; }
+    }
+    private bool ShouldSerializeactivation_code() { return activation_codeSpecified; }
+    private void Resetactivation_code() { activation_codeSpecified = false; }
+    
     private readonly global::System.Collections.Generic.List<string> _http_headers = new global::System.Collections.Generic.List<string>();
     [global::ProtoBuf.ProtoMember(5, Name=@"http_headers", DataFormat = global::ProtoBuf.DataFormat.Default)]
     public global::System.Collections.Generic.List<string> http_headers
@@ -435,41 +770,77 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_FinalizeAddAuthenticator_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private bool _want_more = default(bool);
+    private bool? _want_more;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"want_more", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool want_more
     {
-      get { return _want_more; }
+      get { return _want_more?? default(bool); }
       set { _want_more = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool want_moreSpecified
+    {
+      get { return _want_more != null; }
+      set { if (value == (_want_more== null)) _want_more = value ? this.want_more : (bool?)null; }
+    }
+    private bool ShouldSerializewant_more() { return want_moreSpecified; }
+    private void Resetwant_more() { want_moreSpecified = false; }
+    
 
-    private ulong _server_time = default(ulong);
+    private ulong? _server_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_time
     {
-      get { return _server_time; }
+      get { return _server_time?? default(ulong); }
       set { _server_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_timeSpecified
+    {
+      get { return _server_time != null; }
+      set { if (value == (_server_time== null)) _server_time = value ? this.server_time : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_time() { return server_timeSpecified; }
+    private void Resetserver_time() { server_timeSpecified = false; }
+    
 
-    private int _status = default(int);
+    private int? _status;
     [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"status", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(int))]
     public int status
     {
-      get { return _status; }
+      get { return _status?? default(int); }
       set { _status = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool statusSpecified
+    {
+      get { return _status != null; }
+      set { if (value == (_status== null)) _status = value ? this.status : (int?)null; }
+    }
+    private bool ShouldSerializestatus() { return statusSpecified; }
+    private void Resetstatus() { statusSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -481,41 +852,77 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_RemoveAuthenticator_Request() {}
     
 
-    private string _revocation_code = "";
+    private string _revocation_code;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"revocation_code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string revocation_code
     {
-      get { return _revocation_code; }
+      get { return _revocation_code?? ""; }
       set { _revocation_code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revocation_codeSpecified
+    {
+      get { return _revocation_code != null; }
+      set { if (value == (_revocation_code== null)) _revocation_code = value ? this.revocation_code : (string)null; }
+    }
+    private bool ShouldSerializerevocation_code() { return revocation_codeSpecified; }
+    private void Resetrevocation_code() { revocation_codeSpecified = false; }
+    
 
-    private uint _revocation_reason = default(uint);
+    private uint? _revocation_reason;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"revocation_reason", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint revocation_reason
     {
-      get { return _revocation_reason; }
+      get { return _revocation_reason?? default(uint); }
       set { _revocation_reason = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revocation_reasonSpecified
+    {
+      get { return _revocation_reason != null; }
+      set { if (value == (_revocation_reason== null)) _revocation_reason = value ? this.revocation_reason : (uint?)null; }
+    }
+    private bool ShouldSerializerevocation_reason() { return revocation_reasonSpecified; }
+    private void Resetrevocation_reason() { revocation_reasonSpecified = false; }
+    
 
-    private uint _steamguard_scheme = default(uint);
+    private uint? _steamguard_scheme;
     [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"steamguard_scheme", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint steamguard_scheme
     {
-      get { return _steamguard_scheme; }
+      get { return _steamguard_scheme?? default(uint); }
       set { _steamguard_scheme = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamguard_schemeSpecified
+    {
+      get { return _steamguard_scheme != null; }
+      set { if (value == (_steamguard_scheme== null)) _steamguard_scheme = value ? this.steamguard_scheme : (uint?)null; }
+    }
+    private bool ShouldSerializesteamguard_scheme() { return steamguard_schemeSpecified; }
+    private void Resetsteamguard_scheme() { steamguard_schemeSpecified = false; }
+    
 
-    private bool _remove_all_steamguard_cookies = default(bool);
+    private bool? _remove_all_steamguard_cookies;
     [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"remove_all_steamguard_cookies", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool remove_all_steamguard_cookies
     {
-      get { return _remove_all_steamguard_cookies; }
+      get { return _remove_all_steamguard_cookies?? default(bool); }
       set { _remove_all_steamguard_cookies = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool remove_all_steamguard_cookiesSpecified
+    {
+      get { return _remove_all_steamguard_cookies != null; }
+      set { if (value == (_remove_all_steamguard_cookies== null)) _remove_all_steamguard_cookies = value ? this.remove_all_steamguard_cookies : (bool?)null; }
+    }
+    private bool ShouldSerializeremove_all_steamguard_cookies() { return remove_all_steamguard_cookiesSpecified; }
+    private void Resetremove_all_steamguard_cookies() { remove_all_steamguard_cookiesSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -527,32 +934,59 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_RemoveAuthenticator_Response() {}
     
 
-    private bool _success = default(bool);
+    private bool? _success;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"success", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool success
     {
-      get { return _success; }
+      get { return _success?? default(bool); }
       set { _success = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool successSpecified
+    {
+      get { return _success != null; }
+      set { if (value == (_success== null)) _success = value ? this.success : (bool?)null; }
+    }
+    private bool ShouldSerializesuccess() { return successSpecified; }
+    private void Resetsuccess() { successSpecified = false; }
+    
 
-    private ulong _server_time = default(ulong);
+    private ulong? _server_time;
     [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"server_time", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong server_time
     {
-      get { return _server_time; }
+      get { return _server_time?? default(ulong); }
       set { _server_time = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool server_timeSpecified
+    {
+      get { return _server_time != null; }
+      set { if (value == (_server_time== null)) _server_time = value ? this.server_time : (ulong?)null; }
+    }
+    private bool ShouldSerializeserver_time() { return server_timeSpecified; }
+    private void Resetserver_time() { server_timeSpecified = false; }
+    
 
-    private uint _revocation_attempts_remaining = default(uint);
+    private uint? _revocation_attempts_remaining;
     [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"revocation_attempts_remaining", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint revocation_attempts_remaining
     {
-      get { return _revocation_attempts_remaining; }
+      get { return _revocation_attempts_remaining?? default(uint); }
       set { _revocation_attempts_remaining = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool revocation_attempts_remainingSpecified
+    {
+      get { return _revocation_attempts_remaining != null; }
+      set { if (value == (_revocation_attempts_remaining== null)) _revocation_attempts_remaining = value ? this.revocation_attempts_remaining : (uint?)null; }
+    }
+    private bool ShouldSerializerevocation_attempts_remaining() { return revocation_attempts_remainingSpecified; }
+    private void Resetrevocation_attempts_remaining() { revocation_attempts_remainingSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -591,14 +1025,23 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_DestroyEmergencyCodes_Request() {}
     
 
-    private ulong _steamid = default(ulong);
+    private ulong? _steamid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"steamid", DataFormat = global::ProtoBuf.DataFormat.FixedSize)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong steamid
     {
-      get { return _steamid; }
+      get { return _steamid?? default(ulong); }
       set { _steamid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool steamidSpecified
+    {
+      get { return _steamid != null; }
+      set { if (value == (_steamid== null)) _steamid = value ? this.steamid : (ulong?)null; }
+    }
+    private bool ShouldSerializesteamid() { return steamidSpecified; }
+    private void Resetsteamid() { steamidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -620,14 +1063,23 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_ValidateToken_Request() {}
     
 
-    private string _code = "";
+    private string _code;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"code", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string code
     {
-      get { return _code; }
+      get { return _code?? ""; }
       set { _code = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool codeSpecified
+    {
+      get { return _code != null; }
+      set { if (value == (_code== null)) _code = value ? this.code : (string)null; }
+    }
+    private bool ShouldSerializecode() { return codeSpecified; }
+    private void Resetcode() { codeSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -639,14 +1091,23 @@ namespace SteamKit2.Unified.Internal
     public CTwoFactor_ValidateToken_Response() {}
     
 
-    private bool _valid = default(bool);
+    private bool? _valid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"valid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(default(bool))]
     public bool valid
     {
-      get { return _valid; }
+      get { return _valid?? default(bool); }
       set { _valid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool validSpecified
+    {
+      get { return _valid != null; }
+      set { if (value == (_valid== null)) _valid = value ? this.valid : (bool?)null; }
+    }
+    private bool ShouldSerializevalid() { return validSpecified; }
+    private void Resetvalid() { validSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgUnifiedBase.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgUnifiedBase.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_unified_base.steamclient.proto
 // Note: requires additional types generated from: google/protobuf/descriptor.proto
 namespace SteamKit2.Unified.Internal

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgVideo.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/SteamMsgVideo.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_video.steamclient.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamclient.proto
 namespace SteamKit2.Unified.Internal
@@ -18,23 +20,41 @@ namespace SteamKit2.Unified.Internal
     public CVideo_ClientGetVideoURL_Request() {}
     
 
-    private ulong _video_id = default(ulong);
+    private ulong? _video_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"video_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong video_id
     {
-      get { return _video_id; }
+      get { return _video_id?? default(ulong); }
       set { _video_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_idSpecified
+    {
+      get { return _video_id != null; }
+      set { if (value == (_video_id== null)) _video_id = value ? this.video_id : (ulong?)null; }
+    }
+    private bool ShouldSerializevideo_id() { return video_idSpecified; }
+    private void Resetvideo_id() { video_idSpecified = false; }
+    
 
-    private uint _client_cellid = default(uint);
+    private uint? _client_cellid;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"client_cellid", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(uint))]
     public uint client_cellid
     {
-      get { return _client_cellid; }
+      get { return _client_cellid?? default(uint); }
       set { _client_cellid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool client_cellidSpecified
+    {
+      get { return _client_cellid != null; }
+      set { if (value == (_client_cellid== null)) _client_cellid = value ? this.client_cellid : (uint?)null; }
+    }
+    private bool ShouldSerializeclient_cellid() { return client_cellidSpecified; }
+    private void Resetclient_cellid() { client_cellidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -46,23 +66,41 @@ namespace SteamKit2.Unified.Internal
     public CVideo_ClientGetVideoURL_Response() {}
     
 
-    private ulong _video_id = default(ulong);
+    private ulong? _video_id;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"video_id", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
-    [global::System.ComponentModel.DefaultValue(default(ulong))]
     public ulong video_id
     {
-      get { return _video_id; }
+      get { return _video_id?? default(ulong); }
       set { _video_id = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_idSpecified
+    {
+      get { return _video_id != null; }
+      set { if (value == (_video_id== null)) _video_id = value ? this.video_id : (ulong?)null; }
+    }
+    private bool ShouldSerializevideo_id() { return video_idSpecified; }
+    private void Resetvideo_id() { video_idSpecified = false; }
+    
 
-    private string _video_url = "";
+    private string _video_url;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"video_url", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string video_url
     {
-      get { return _video_url; }
+      get { return _video_url?? ""; }
       set { _video_url = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool video_urlSpecified
+    {
+      get { return _video_url != null; }
+      set { if (value == (_video_url== null)) _video_url = value ? this.video_url : (string)null; }
+    }
+    private bool ShouldSerializevideo_url() { return video_urlSpecified; }
+    private void Resetvideo_url() { video_urlSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -74,14 +112,23 @@ namespace SteamKit2.Unified.Internal
     public CVideo_UnlockedH264_Notification() {}
     
 
-    private byte[] _encryption_key = null;
+    private byte[] _encryption_key;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"encryption_key", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
     public byte[] encryption_key
     {
-      get { return _encryption_key; }
+      get { return _encryption_key?? null; }
       set { _encryption_key = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool encryption_keySpecified
+    {
+      get { return _encryption_key != null; }
+      set { if (value == (_encryption_key== null)) _encryption_key = value ? this.encryption_key : (byte[])null; }
+    }
+    private bool ShouldSerializeencryption_key() { return encryption_keySpecified; }
+    private void Resetencryption_key() { encryption_keySpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }

--- a/SteamKit2/SteamKit2/Base/Generated/Unified/Steamworks/SteamMsgOAuthSteamworks.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/Unified/Steamworks/SteamMsgOAuthSteamworks.cs
@@ -8,6 +8,8 @@
 //------------------------------------------------------------------------------
 #pragma warning disable 1591
 
+// Option: missing-value detection (*Specified/ShouldSerialize*/Reset*) enabled
+    
 // Generated from: steammessages_oauth.steamworkssdk.proto
 // Note: requires additional types generated from: steammessages_unified_base.steamworkssdk.proto
 namespace SteamKit2.Unified.Internal.Steamworks
@@ -18,14 +20,23 @@ namespace SteamKit2.Unified.Internal.Steamworks
     public COAuthToken_ImplicitGrantNoPrompt_Request() {}
     
 
-    private string _clientid = "";
+    private string _clientid;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"clientid", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string clientid
     {
-      get { return _clientid; }
+      get { return _clientid?? ""; }
       set { _clientid = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool clientidSpecified
+    {
+      get { return _clientid != null; }
+      set { if (value == (_clientid== null)) _clientid = value ? this.clientid : (string)null; }
+    }
+    private bool ShouldSerializeclientid() { return clientidSpecified; }
+    private void Resetclientid() { clientidSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
@@ -37,23 +48,41 @@ namespace SteamKit2.Unified.Internal.Steamworks
     public COAuthToken_ImplicitGrantNoPrompt_Response() {}
     
 
-    private string _access_token = "";
+    private string _access_token;
     [global::ProtoBuf.ProtoMember(1, IsRequired = false, Name=@"access_token", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string access_token
     {
-      get { return _access_token; }
+      get { return _access_token?? ""; }
       set { _access_token = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool access_tokenSpecified
+    {
+      get { return _access_token != null; }
+      set { if (value == (_access_token== null)) _access_token = value ? this.access_token : (string)null; }
+    }
+    private bool ShouldSerializeaccess_token() { return access_tokenSpecified; }
+    private void Resetaccess_token() { access_tokenSpecified = false; }
+    
 
-    private string _redirect_uri = "";
+    private string _redirect_uri;
     [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"redirect_uri", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
     public string redirect_uri
     {
-      get { return _redirect_uri; }
+      get { return _redirect_uri?? ""; }
       set { _redirect_uri = value; }
     }
+    [global::System.Xml.Serialization.XmlIgnore]
+    [global::System.ComponentModel.Browsable(false)]
+    public bool redirect_uriSpecified
+    {
+      get { return _redirect_uri != null; }
+      set { if (value == (_redirect_uri== null)) _redirect_uri = value ? this.redirect_uri : (string)null; }
+    }
+    private bool ShouldSerializeredirect_uri() { return redirect_uriSpecified; }
+    private void Resetredirect_uri() { redirect_uriSpecified = false; }
+    
     private global::ProtoBuf.IExtension extensionObject;
     global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
       { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }


### PR DESCRIPTION
For some protobuf message, there is a difference between how Valve handles them, particularly for some GC messages, for whether a field is set at all versus a field set to its default value.

NetHookAnalyzer2 makes no distinction here, always showing all fields it knows about as set, and showing the default value if they are not. This changes that to instead all like this.

Default - Fields that aren't set are hidden:
![Default](https://i.imgur.com/x6brTmJ.png)

Show All - All fields are shown, with their effective values, but still having distinction between what was set and what was not.
![ShowAll](https://i.imgur.com/HO3vyC2.png)

This does require altering our protogen options to generate a second property for each field, a bool that gets named "<field name>Specified". It's possible that the extra field could be a breaking change for third-parties, but it seems unlikely. It would have caused much extra clutter in NetHookAnalyzer, but not after part of the included changes here.