### PR TITLE
Hugely improve time NetHook takes to inject.

### DIFF
--- a/Resources/NetHook2/NetHook2/crypto.cpp
+++ b/Resources/NetHook2/NetHook2/crypto.cpp
@@ -111,13 +111,19 @@ CCrypto::CCrypto()
 			g_pLogger->DeleteFile( "emsg_list.txt", false );
 			g_pLogger->DeleteFile( "emsg_list_detailed.txt", false );
 
+			HANDLE hListFile = g_pLogger->OpenFile( "emsg_list.txt", false );
+			HANDLE hListDetailedFile = g_pLogger->OpenFile( "emsg_list_detailed.txt", false );
+
 			for ( MsgList::iterator iter = eMsgList.begin() ; iter != eMsgList.end() ; iter++ )
 			{
 				MsgInfo_t *pInfo = iter->second;
 
-				g_pLogger->LogFile( "emsg_list.txt", false, "\t%s = %d,\r\n", pInfo->pchMsgName, pInfo->eMsg );
-				g_pLogger->LogFile( "emsg_list_detailed.txt", false, "\t%s = %d, // flags: %d, server type: %d\r\n", pInfo->pchMsgName, pInfo->eMsg, pInfo->nFlags, pInfo->k_EServerTarget );
+				g_pLogger->LogOpenFile( hListFile, "\t%s = %d,\r\n", pInfo->pchMsgName, pInfo->eMsg );
+				g_pLogger->LogOpenFile( hListDetailedFile, "\t%s = %d, // flags: %d, server type: %d\r\n", pInfo->pchMsgName, pInfo->eMsg, pInfo->nFlags, pInfo->k_EServerTarget );
 			}
+
+			g_pLogger->CloseFile( hListFile );
+			g_pLogger->CloseFile( hListDetailedFile );
 
 			g_pLogger->LogConsole( "Dumped emsg list! (%d messages)\n", eMsgList.size() );
 		}

--- a/Resources/NetHook2/NetHook2/logger.cpp
+++ b/Resources/NetHook2/NetHook2/logger.cpp
@@ -105,11 +105,21 @@ void CLogger::LogSessionData( ENetDirection eDirection, uint8 *pData, uint32 cub
 	this->LogConsole( "Wrote %d bytes to %s\n", cubData, outFile );
 }
 
-void CLogger::LogFile( const char *szFileName, bool bSession, const char *szFmt, ... )
+HANDLE CLogger::OpenFile( const char *szFileName, bool bSession )
 {
 	std::string outputFile = ( bSession ? m_LogDir : m_RootDir );
 	outputFile += szFileName;
 
+	return CreateFile( outputFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL );
+}
+
+void CLogger::CloseFile( HANDLE hFile )
+{
+	CloseHandle( hFile );
+}
+
+void CLogger::LogOpenFile( HANDLE hFile, const char *szFmt, ... )
+{
 	va_list args;
 	va_start( args, szFmt );
 
@@ -125,14 +135,10 @@ void CLogger::LogFile( const char *szFileName, bool bSession, const char *szFmt,
 
 	szBuff[ buffSize - 1 ] = 0;
 
-	HANDLE hFile = CreateFile( outputFile.c_str(), GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL );
-
 	SetFilePointer( hFile, 0, NULL, FILE_END );
 
 	DWORD numBytes = 0;
 	WriteFile( hFile, szBuff, len, &numBytes, NULL );
-
-	CloseHandle( hFile );
 
 	delete [] szBuff;
 }

--- a/Resources/NetHook2/NetHook2/logger.h
+++ b/Resources/NetHook2/NetHook2/logger.h
@@ -27,13 +27,13 @@ public:
 	CLogger();
 
 	void LogConsole( const char *szFmt, ... );
-
-	void DeleteFile( const char *szFileName, bool bSession );
-
 	void LogNetMessage( ENetDirection eDirection, uint8 *pData, uint32 cubData );
-
 	void LogSessionData( ENetDirection eDirection, uint8 *pData, uint32 cubData );
-	void LogFile( const char *szFileName, bool bSession, const char *szFmt, ... );
+	void LogOpenFile( HANDLE hFile, const char *szFmt, ... );
+
+	HANDLE OpenFile( const char *szFileName, bool bSession );
+	void CloseFile( HANDLE hFile);
+	void DeleteFile( const char *szFileName, bool bSession );
 
 private:
 	const char *GetFileNameBase( ENetDirection eDirection, EMsg eMsg, uint8 serverType = 0xFF );


### PR DESCRIPTION
Previously, we opened and closed a file handle twice for every existing emsg at time of injection. That was a huge slowdown and the real cause of issue on #365.

It's near-instant now.