### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,11 @@ SteamKit2 is released under the [LGPL-2.1 license](http://www.tldrlegal.com/lice
 
 In order to use SteamKit2 at runtime, the following dependencies are required:
 
-  - .NET 4.6, .NET Core 1.0, or [Mono ≥4.0](http://mono-project.com)
+  - .NET 4.6, .NET Core 1.0, or [Mono ≥4.8](http://mono-project.com)
 
 To compile SteamKit2, the following is required:
 
-  - C# 7.0 compiler &mdash; [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) or [.NET Core 1.1](https://www.microsoft.com/net/core)
+  - C# 7.0 compiler &mdash; [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) or [.NET Core 1.1](https://www.microsoft.com/net/core) or [Mono ≥5.0](http://mono-project.com)
   - [protobuf-net](http://code.google.com/p/protobuf-net/) ([NuGet package](http://nuget.org/packages/protobuf-net))
 
 Note: If you're using the NuGet package, the protobuf-net dependency _should_ be resolved for you. See the [Installation Guide](https://github.com/SteamRE/SteamKit/wiki/Installation) for more information.


### PR DESCRIPTION
Mono 4.8 required for using SK 2.0+, I couldn't connect with 4.6 or lower.
Mono 5.0 required for compilation - it supports C# 7.0.