### PR TITLE
Remove dependencies on System.Diagnostics.Process and System.Threading.Thread

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -20,7 +20,7 @@ namespace SteamKit2
         private IPEndPoint destination;
         private Socket socket;
         private INetFilterEncryption netFilter;
-        private Thread netThread;
+        private Task netTask;
         private NetworkStream netStream;
         private BinaryReader netReader;
         private BinaryWriter netWriter;
@@ -132,11 +132,10 @@ namespace SteamKit2
                     netWriter = new BinaryWriter(netStream);
                     netFilter = null;
 
-                    netThread = new Thread(NetLoop);
-                    netThread.Name = "TcpConnection Thread";
+                    netTask = new Task(NetLoop, TaskCreationOptions.LongRunning);
                 }
 
-                netThread.Start();
+                netTask.Start();
 
                 OnConnected(EventArgs.Empty);
             }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -26,7 +26,7 @@ namespace SteamKit2
         Dictionary<Type, ClientMsgHandler> handlers;
 
         long currentJobId = 0;
-        DateTime processStartTime;
+        static DateTime processStartTime = DateTime.Now;
 
         object callbackLock = new object();
         Queue<ICallbackMsg> callbackQueue;
@@ -60,11 +60,6 @@ namespace SteamKit2
             this.AddHandler( new SteamTrading() );
             this.AddHandler( new SteamUnifiedMessages() );
             this.AddHandler( new SteamScreenshots() );
-
-            using ( var process = Process.GetCurrentProcess() )
-            {
-                this.processStartTime = process.StartTime;
-            }
 
             dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
             {

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -52,12 +52,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.AppContext" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/SteamKit2/Tests/SteamClientFacts.cs
+++ b/SteamKit2/Tests/SteamClientFacts.cs
@@ -78,23 +78,6 @@ namespace Tests
 		}
 
 		[Fact]
-		public void GetNextJobIDFillsProcessStartTime()
-		{
-			var steamClient = new SteamClient();
-			var jobID = steamClient.GetNextJobID();
-
-			using (var process = Process.GetCurrentProcess())
-			{
-				var processStartTime = process.StartTime;
-
-				// Recreate the datetime to get rid of milliseconds etc. and only keep the important bits
-				var expectedProcessStartTime = new DateTime(processStartTime.Year, processStartTime.Month, processStartTime.Day, processStartTime.Hour, processStartTime.Minute, processStartTime.Second);
-
-				Assert.Equal(expectedProcessStartTime, jobID.StartTime);
-			}
-		}
-
-		[Fact]
 		public void GetNextJobIDSetsBoxIDToZero()
 		{
 			var steamClient = new SteamClient();


### PR DESCRIPTION
System.Diagnostics.Process and System.Threading.Thread don't exist on UWP.
After these two modifications, I have tested SK2 now works with UWP.