### PR TITLE
[WIP] Started refactoring TCPConnection

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -15,166 +15,223 @@ namespace SteamKit2
 {
     class TcpConnection : Connection
     {
+        internal class ConnectionState
+        {
+            public IPEndPoint Destination { get; private set; }
+            public Socket Socket { get; private set; }
+            public INetFilterEncryption NetFilter { get; private set; }
+            public Thread NetThread { get; private set; }
+            public NetworkStream NetStream { get; private set; }
+            public BinaryReader NetReader { get; private set; }
+            public BinaryWriter NetWriter { get; private set; }
+
+            public bool Released { get; private set; }
+            public CancellationTokenSource CancellationToken { get; private set; }
+            public ManualResetEvent ConnectionReleased { get; private set; }
+            public ManualResetEvent IssuedDisconnectResult { get; private set; }
+
+            // netlock guards concurrent access to socket and network streams
+            public object NetLock { get; private set; }
+            // releaselock guards the actual disposal of the events and token source until anything consuming them releases it
+            public object ReleaseLock { get; private set; }
+
+            public ConnectionState( int timeout )
+            {
+                Destination = null;
+
+                Socket = new Socket( AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp );
+                Socket.ReceiveTimeout = timeout;
+                Socket.SendTimeout = timeout;
+
+                CancellationToken = new CancellationTokenSource();
+                ConnectionReleased = new ManualResetEvent( initialState: false );
+                IssuedDisconnectResult = new ManualResetEvent( initialState: false );
+
+                NetLock = new object();
+                ReleaseLock = new object();
+            }
+
+            internal void SetDestination( IPEndPoint destination )
+            {
+                Destination = destination;
+            }
+
+            internal void SetNetFilter( INetFilterEncryption filter )
+            {
+                NetFilter = filter;
+            }
+
+            public void StartWorker( ParameterizedThreadStart workFunction )
+            {
+                NetStream = new NetworkStream( Socket, false );
+                NetReader = new BinaryReader( NetStream );
+                NetWriter = new BinaryWriter( NetStream );
+                NetFilter = null;
+
+                NetThread = new Thread( workFunction );
+                NetThread.Name = "TcpConnection Network Thread";
+
+                NetThread.Start( this );
+            }
+
+            public void Disconnect()
+            {
+                try
+                {
+                    if ( Socket.Connected )
+                    {
+                        Socket.Shutdown( SocketShutdown.Both );
+#if NET46
+                        Socket.Disconnect( true );
+#endif
+                    }
+                }
+                catch
+                {
+                    // Shutdown is throwing when the remote end closes the connection before SteamKit attempts to
+                    // so this should be safe as a no-op
+                    // see: https://bitbucket.org/VoiDeD/steamre/issue/41/socketexception-thrown-when-closing
+                }
+            }
+
+            public void CleanupSocket()
+            {
+                lock ( NetLock )
+                {
+                    if ( NetWriter != null )
+                    {
+                        NetWriter.Dispose();
+                        NetWriter = null;
+                    }
+
+                    if ( NetReader != null )
+                    {
+                        NetReader.Dispose();
+                        NetReader = null;
+                    }
+
+                    if ( NetStream != null )
+                    {
+                        NetStream.Dispose();
+                        NetStream = null;
+                    }
+
+                    if ( Socket != null )
+                    {
+                        Socket.Dispose();
+                        Socket = null;
+                    }
+                }
+
+                NetFilter = null;
+
+                ConnectionReleased.Set();
+            }
+
+            public void PostRelease()
+            {
+                IssuedDisconnectResult.Set();
+
+                lock ( ReleaseLock )
+                {
+                    CancellationToken.Dispose();
+
+                    ConnectionReleased.Dispose();
+                    IssuedDisconnectResult.Dispose();
+
+                    Released = true;
+                }
+            }
+        }
+
         const uint MAGIC = 0x31305456; // "VT01"
 
-        private IPEndPoint destination;
-        private Socket socket;
-        private INetFilterEncryption netFilter;
-        private Thread netThread;
-        private NetworkStream netStream;
-        private BinaryReader netReader;
-        private BinaryWriter netWriter;
-
-        private CancellationTokenSource cancellationToken;
-        private ManualResetEvent connectionFree;
-        private object netLock, connectLock;
+        private ConnectionState activeConnectionState;
+        private object connectLock;
 
         public TcpConnection()
         {
-            netLock = new object();
+            activeConnectionState = null;
             connectLock = new object();
-            connectionFree = new ManualResetEvent(true);
         }
 
         public override IPEndPoint CurrentEndPoint
         {
-            get { return destination; }
-        }
-
-        private void Shutdown()
-        {
-            try
+            get
             {
-                if (socket.Connected)
-                {
-                    socket.Shutdown(SocketShutdown.Both);
-#if NET46
-                    socket.Disconnect( true );
-#endif
-                }
-            }
-            catch
-            {
-                // Shutdown is throwing when the remote end closes the connection before SteamKit attempts to
-                // so this should be safe as a no-op
-                // see: https://bitbucket.org/VoiDeD/steamre/issue/41/socketexception-thrown-when-closing
+                var connectionState = activeConnectionState;
+                return connectionState == null ? null : connectionState.Destination;
             }
         }
 
-        private void Release( bool userRequestedDisconnect )
+        private void Release( ConnectionState connectionState, bool userRequestedDisconnect )
         {
-            lock (netLock)
-            {
-                if (cancellationToken != null)
-                {
-                    cancellationToken.Dispose();
-                    cancellationToken = null;
-                }
-
-                if (netWriter != null)
-                {
-                    netWriter.Dispose();
-                    netWriter = null;
-                }
-
-                if (netReader != null)
-                {
-                    netReader.Dispose();
-                    netReader = null;
-                }
-
-                if (netStream != null)
-                {
-                    netStream.Dispose();
-                    netStream = null;
-                }
-
-                if (socket != null)
-                {
-                    socket.Dispose();
-                    socket = null;
-                }
-
-                netFilter = null;
-            }
+            connectionState.CleanupSocket();
 
             OnDisconnected( new DisconnectedEventArgs( userRequestedDisconnect ) );
 
-            connectionFree.Set();
+            connectionState.PostRelease();
         }
 
-        private void ConnectCompleted(bool success)
+        private void ConnectCompleted( ConnectionState connectionState, bool success )
         {
             // Always discard result if our request was cancelled
-            // If we have no cancellation token source, we were already Release()'ed
-            if (cancellationToken?.IsCancellationRequested ?? true)
+            if ( connectionState.CancellationToken.IsCancellationRequested )
             {
-                DebugLog.WriteLine("TcpConnection", "Connection request to {0} was cancelled", destination);
-                if (success) Shutdown();
-                Release( userRequestedDisconnect: true );
+                DebugLog.WriteLine( "TcpConnection", "Connection request to {0} was cancelled", connectionState.Destination );
+                if ( success ) connectionState.Disconnect();
+                Release( connectionState, userRequestedDisconnect: true );
                 return;
             }
-            else if (!success)
+            else if ( !success )
             {
-                DebugLog.WriteLine("TcpConnection", "Timed out while connecting to {0}", destination);
-                Release( userRequestedDisconnect: false );
+                DebugLog.WriteLine( "TcpConnection", "Timed out while connecting to {0}", connectionState.Destination );
+                Release( connectionState, userRequestedDisconnect: false );
                 return;
             }
 
-            DebugLog.WriteLine("TcpConnection", "Connected to {0}", destination);
+            DebugLog.WriteLine( "TcpConnection", "Connected to {0}", connectionState.Destination );
 
             try
             {
-                lock (netLock)
-                {
-                    netStream = new NetworkStream(socket, false);
-                    netReader = new BinaryReader(netStream);
-                    netWriter = new BinaryWriter(netStream);
-                    netFilter = null;
+                connectionState.StartWorker( NetLoop );
 
-                    netThread = new Thread(NetLoop);
-                    netThread.Name = "TcpConnection Thread";
-                }
-
-                netThread.Start();
-
-                OnConnected(EventArgs.Empty);
+                OnConnected( EventArgs.Empty );
             }
-            catch (Exception ex)
+            catch ( Exception ex )
             {
-                DebugLog.WriteLine("TcpConnection", "Exception while setting up connection to {0}: {1}", destination, ex);
-                Release( userRequestedDisconnect: false );
+                DebugLog.WriteLine( "TcpConnection", "Exception while setting up connection to {0}: {1}", connectionState.Destination, ex );
+                Release( connectionState, userRequestedDisconnect: false );
             }
         }
 
-        private void TryConnect(object sender)
+        private void TryConnect( ConnectionState connectionState, int timeout )
         {
-            int timeout = (int)sender;
-            if (cancellationToken.IsCancellationRequested)
+            if ( connectionState.CancellationToken.IsCancellationRequested )
             {
-                DebugLog.WriteLine("TcpConnection", "Connection to {0} cancelled by user", destination);
-                Release( userRequestedDisconnect: true );
+                DebugLog.WriteLine( "TcpConnection", "Connection to {0} cancelled by user", connectionState.Destination );
+                Release( connectionState, userRequestedDisconnect: true );
                 return;
             }
-            
-            var connectEventArgs = new SocketAsyncEventArgs { RemoteEndPoint = destination };
+
+            var connectEventArgs = new SocketAsyncEventArgs { RemoteEndPoint = connectionState.Destination, UserToken = connectionState };
             var asyncWaitHandle = new ManualResetEvent( initialState: false );
             EventHandler<SocketAsyncEventArgs> completionHandler = ( s, e ) =>
             {
                 asyncWaitHandle.Set();
 
                 var connected = e.ConnectSocket != null;
-                ConnectCompleted( connected );
-                (e as IDisposable)?.Dispose();
+                ConnectCompleted( e.UserToken as ConnectionState, connected );
+                ( e as IDisposable )?.Dispose();
             };
             connectEventArgs.Completed += completionHandler;
 
-            if ( !socket.ConnectAsync( connectEventArgs ) )
+            if ( !connectionState.Socket.ConnectAsync( connectEventArgs ) )
             {
-                completionHandler( socket, connectEventArgs );
+                completionHandler( connectionState.Socket, connectEventArgs );
             }
 
-            if ( WaitHandle.WaitAny( new WaitHandle[] { asyncWaitHandle, cancellationToken.Token.WaitHandle }, timeout) != 0 )
+            if ( WaitHandle.WaitAny( new WaitHandle[] { asyncWaitHandle, connectionState.CancellationToken.Token.WaitHandle }, timeout ) != 0 )
             {
                 Socket.CancelConnectAsync( connectEventArgs );
             }
@@ -185,77 +242,73 @@ namespace SteamKit2
         /// </summary>
         /// <param name="endPointTask">Task returning the end point.</param>
         /// <param name="timeout">Timeout in milliseconds</param>
-        public override void Connect(Task<IPEndPoint> endPointTask, int timeout)
+        public override void Connect( Task<IPEndPoint> endPointTask, int timeout )
         {
-            lock (connectLock)
+            // First, capture the lock around this flow to ensure that no two competing Connect calls can setup connections only to get immediately torn down
+            lock ( connectLock )
             {
                 Disconnect();
 
-                connectionFree.Reset();
+                Debug.Assert( activeConnectionState == null );
 
-                lock (netLock)
-                {
-                    Debug.Assert(cancellationToken == null);
-                    cancellationToken = new CancellationTokenSource();
+                // now that we own the connection lock and we've waited for the connection state to be released, we can setup another connection
+                activeConnectionState = new ConnectionState( timeout );
 
-                    socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-                    socket.ReceiveTimeout = timeout;
-                    socket.SendTimeout = timeout;
+                // now we wait for the result from the endpoint task. We will be leaving our connectLock guard if it's not already resolved
+                endPointTask.ContinueWith( ( t, sender ) =>
+                 {
+                     ConnectionState connectionState = ( ConnectionState )sender;
 
-                    endPointTask.ContinueWith( t =>
-                    {
-                        if (t.IsFaulted || t.IsCanceled)
-                        {
-                            if (t.Exception != null)
-                            {
-                                foreach (var ex in t.Exception.Flatten().InnerExceptions)
-                                {
-                                    DebugLog.WriteLine("TcpConnection", "Endpoint task threw exception: {0}", ex);
-                                }
-                            }
+                     if ( t.IsFaulted || t.IsCanceled )
+                     {
+                         if ( t.Exception != null )
+                         {
+                             foreach ( var ex in t.Exception.Flatten().InnerExceptions )
+                             {
+                                 DebugLog.WriteLine( "TcpConnection", "Endpoint task threw exception: {0}", ex );
+                             }
+                         }
 
-                            Release(userRequestedDisconnect: false);
-                            return;
-                        }
+                         Release( connectionState, userRequestedDisconnect: false );
+                         return;
+                     }
 
-                        destination = t.Result;
+                     var destination = t.Result;
+                     connectionState.SetDestination( destination );
 
-                        if (destination != null)
-                        {
-                            DebugLog.WriteLine("TcpConnection", "Connecting to {0}...", destination);
-                            TryConnect(timeout);
-                        }
-                        else
-                        {
-                            DebugLog.WriteLine("TcpConnection", "No destination supplied from endpoint task");
-                            Release(userRequestedDisconnect: false);
-                            return;
-                        }
-
-                    }, TaskContinuationOptions.LongRunning);
-
-                }
+                     if ( destination != null )
+                     {
+                         DebugLog.WriteLine( "TcpConnection", "Connecting to {0}...", destination );
+                         TryConnect( connectionState, timeout );
+                     }
+                     else
+                     {
+                         DebugLog.WriteLine( "TcpConnection", "No destination supplied from endpoint task" );
+                         Release( connectionState, userRequestedDisconnect: false );
+                         return;
+                     }
+                 }, activeConnectionState, TaskContinuationOptions.LongRunning );
             }
         }
 
         public override void Disconnect()
         {
-            lock (connectLock)
+            ConnectionState currentConnectionState = Interlocked.Exchange( ref activeConnectionState, null );
+
+            if ( currentConnectionState != null )
             {
-                lock (netLock)
+                lock ( currentConnectionState.ReleaseLock )
                 {
-                    if (cancellationToken != null)
+                    if ( currentConnectionState.Released )
                     {
-                        cancellationToken.Cancel();
-                    }
-                    else
-                    {
-                        // we already appear to be disconncted, nothing to wait for
+                        // nothing to do, it was already released
                         return;
                     }
-                }
 
-                connectionFree.WaitOne();
+                    // signal the current state to cancel regardless of where it is in the process. Wait for the post-release disconnect callback result to ensure it is queued
+                    currentConnectionState.CancellationToken.Cancel();
+                    currentConnectionState.IssuedDisconnectResult.WaitOne();
+                }
             }
         }
 
@@ -263,26 +316,28 @@ namespace SteamKit2
         /// <summary>
         /// Nets the loop.
         /// </summary>
-        void NetLoop()
+        void NetLoop( object sender )
         {
+            ConnectionState connectionState = ( ConnectionState )sender;
+
             // poll for readable data every 100ms
             const int POLL_MS = 100;
 
-            while (!cancellationToken.IsCancellationRequested)
+            while ( !connectionState.CancellationToken.IsCancellationRequested )
             {
                 bool canRead = false;
 
                 try
                 {
-                    canRead = socket.Poll(POLL_MS * 1000, SelectMode.SelectRead);
+                    canRead = connectionState.Socket.Poll( POLL_MS * 1000, SelectMode.SelectRead );
                 }
-                catch (SocketException ex)
+                catch ( SocketException ex )
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception while polling: {0}", ex);
+                    DebugLog.WriteLine( "TcpConnection", "Socket exception while polling: {0}", ex );
                     break;
                 }
 
-                if (!canRead)
+                if ( !canRead )
                 {
                     // nothing to read yet
                     continue;
@@ -293,42 +348,46 @@ namespace SteamKit2
                 try
                 {
                     // read the packet off the network
-                    packData = ReadPacket();
+                    packData = ReadPacket( connectionState );
 
                     // decrypt the data off the wire if needed
-                    if (netFilter != null)
+                    if ( connectionState.NetFilter != null )
                     {
-                        packData = netFilter.ProcessIncoming(packData);
+                        packData = connectionState.NetFilter.ProcessIncoming( packData );
                     }
                 }
-                catch (IOException ex)
+                catch ( IOException ex )
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception occurred while reading packet: {0}", ex);
+                    DebugLog.WriteLine( "TcpConnection", "Socket exception occurred while reading packet: {0}", ex );
                     break;
                 }
 
                 try
                 {
-                    OnNetMsgReceived(new NetMsgEventArgs(packData, destination));
+                    OnNetMsgReceived( new NetMsgEventArgs( packData, connectionState.Destination ) );
                 }
-                catch (Exception ex)
+                catch ( Exception ex )
                 {
-                    DebugLog.WriteLine("TcpConnection", "Unexpected exception propogated back to NetLoop: {0}", ex);
+                    DebugLog.WriteLine( "TcpConnection", "Unexpected exception propogated back to NetLoop: {0}", ex );
                 }
             }
 
             // Thread is shutting down, ensure socket is shut down and disposed
-            bool userShutdown = cancellationToken.IsCancellationRequested;
+            bool userShutdown = connectionState.CancellationToken.IsCancellationRequested;
 
             if ( userShutdown )
             {
-                Shutdown();
+                connectionState.Disconnect();
             }
-            Release( userShutdown );
+
+            Release( connectionState, userShutdown );
         }
 
-        byte[] ReadPacket()
+        byte[] ReadPacket( ConnectionState connectionState )
         {
+            var socket = connectionState.Socket;
+            var netReader = connectionState.NetReader;
+
             // the tcp packet header is considerably less complex than the udp one
             // it only consists of the packet length, followed by the "VT01" magic
             uint packetLen = 0;
@@ -339,87 +398,96 @@ namespace SteamKit2
                 packetLen = netReader.ReadUInt32();
                 packetMagic = netReader.ReadUInt32();
             }
-            catch (IOException ex)
+            catch ( IOException ex )
             {
-                throw new IOException("Connection lost while reading packet header.", ex);
+                throw new IOException( "Connection lost while reading packet header.", ex );
             }
 
-            if (packetMagic != TcpConnection.MAGIC)
+            if ( packetMagic != TcpConnection.MAGIC )
             {
-                throw new IOException("Got a packet with invalid magic!");
+                throw new IOException( "Got a packet with invalid magic!" );
             }
 
             // rest of the packet is the physical data
-            byte[] packData = netReader.ReadBytes((int)packetLen);
+            byte[] packData = netReader.ReadBytes( ( int )packetLen );
 
-            if (packData.Length != packetLen)
+            if ( packData.Length != packetLen )
             {
-                throw new IOException("Connection lost while reading packet payload");
+                throw new IOException( "Connection lost while reading packet payload" );
             }
 
             return packData;
         }
 
-        public override void Send(IClientMsg clientMsg)
+        public override void Send( IClientMsg clientMsg )
         {
-            lock (netLock)
+            var connectionState = activeConnectionState;
+
+            if ( connectionState == null )
             {
-                if (socket == null || netStream == null)
+                DebugLog.WriteLine( "TcpConnection", "Attempting to send client message when not connected: {0}", clientMsg.MsgType );
+                return;
+            }
+
+            lock ( connectionState.NetLock )
+            {
+                if ( connectionState.Socket == null || connectionState.NetStream == null )
                 {
-                    DebugLog.WriteLine("TcpConnection", "Attempting to send client message when not connected: {0}", clientMsg.MsgType);
+                    DebugLog.WriteLine( "TcpConnection", "Attempting to send client message when not connected: {0}", clientMsg.MsgType );
                     return;
                 }
 
                 var data = clientMsg.Serialize();
 
-                if (netFilter != null)
+                if ( connectionState.NetFilter != null )
                 {
-                    data = netFilter.ProcessOutgoing(data);
+                    data = connectionState.NetFilter.ProcessOutgoing( data );
                 }
 
                 try
                 {
-                    netWriter.Write((uint)data.Length);
-                    netWriter.Write(TcpConnection.MAGIC);
-                    netWriter.Write(data);
+                    connectionState.NetWriter.Write( ( uint )data.Length );
+                    connectionState.NetWriter.Write( TcpConnection.MAGIC );
+                    connectionState.NetWriter.Write( data );
                 }
-                catch (IOException ex)
+                catch ( IOException ex )
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception while writing data: {0}", ex);
+                    DebugLog.WriteLine( "TcpConnection", "Socket exception while writing data: {0}", ex );
                 }
             }
         }
 
         public override IPAddress GetLocalIP()
         {
-            lock (netLock)
-            {
-                if (socket == null)
-                {
-                    return IPAddress.None;
-                }
+            var connectionState = activeConnectionState;
 
-                try
+            if ( connectionState == null ) return IPAddress.None;
+
+            lock ( connectionState.NetLock )
+            {
+                if ( connectionState.Socket != null )
                 {
-                    return NetHelpers.GetLocalIP(socket);
-                }
-                catch (Exception ex)
-                {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception trying to read bound IP: {0}", ex);
-                    return IPAddress.None;
+                    try
+                    {
+                        return NetHelpers.GetLocalIP( connectionState.Socket );
+                    }
+                    catch ( Exception ex )
+                    {
+                        DebugLog.WriteLine( "TcpConnection", "Socket exception trying to read bound IP: {0}", ex );
+                        return IPAddress.None;
+                    }
                 }
             }
+
+            return IPAddress.None;
         }
 
         public override void SetNetEncryptionFilter( INetFilterEncryption filter )
         {
-            lock (netLock)
-            {
-                if (socket != null)
-                {
-                    netFilter = filter;
-                }
-            }
+            var connectionState = activeConnectionState;
+
+            if ( connectionState == null ) return;
+            connectionState.SetNetFilter( filter );
         }
     }
 }


### PR DESCRIPTION
Here's the justification for these changes:

The goal here is to simplify some of the rather ugly locking. There are two necessary locks: NetLock and ReleaseLock. 

Anything that can concurrently access a socket or stream needs to hold NetLock so that they don't disappear underneath them. The call to CleanupSocket locks and releases these objects. NetLock is held by GetLocalIP which inspects the socket and Send which competes for the ability to write to the socket.

The Disposable objects like the ManualResetEvent and CancellationToken have a slightly different lifetime. If something is actively waiting on them, it acquires ReleaseLock such that the final PostRelease call won't dispose them until this lock is given up. It's only important that these aren't Disposed underneath because:

The responsibility of signalling the CancellationToken and waiting for the DisconnectedCallback to be dispatch is given to the winning thread that calls Disconnect and wins the Interlocked.Exchange.

This should remove any ambiguity around the lifetime of objects re #400, as well as ensuring that if you call Disconnect while Connected, the DisconnectedCallback is on the queue (need to find my notes on why this was not the case). 

Concurrent Connect calls still have a connectLock so that a bunch of connections aren't opened only to be immediately destroyed.

After some thought, I'm also including connectLock in Disconnect so that you can't call Disconnect (exchanging with null) and then calling Connect without first letting the owning Disconnect call complete. Even if these calls are out of order globally, we should still enforce the order of callbacks.
