### PR TITLE
Fix dumping of net messages sent over websocket connections.

### DIFF
--- a/Resources/NetHook2/NetHook2/NetHook2.vcxproj
+++ b/Resources/NetHook2/NetHook2/NetHook2.vcxproj
@@ -97,6 +97,7 @@
     <ClCompile Include="csimplescan.cpp" />
     <ClCompile Include="injector.cpp" />
     <ClCompile Include="logger.cpp" />
+    <ClCompile Include="net.cpp" />
     <ClCompile Include="nethook.cpp" />
     <ClCompile Include="sedebug.cpp" />
     <ClCompile Include="sigscan.cpp" />
@@ -111,12 +112,14 @@
     <ClInclude Include="csimplescan.h" />
     <ClInclude Include="detours.h" />
     <ClInclude Include="logger.h" />
+    <ClInclude Include="net.h" />
     <ClInclude Include="sedebug.h" />
     <ClInclude Include="sigscan.h" />
     <ClInclude Include="steammessages_base.pb.h" />
     <ClInclude Include="steam\clientmsgs.h" />
     <ClInclude Include="steam\csteamid.h" />
     <ClInclude Include="steam\emsg.h" />
+    <ClInclude Include="steam\net.h" />
     <ClInclude Include="steam\steamtypes.h" />
     <ClInclude Include="steam\udppkt.h" />
     <ClInclude Include="nh2_string.h" />

--- a/Resources/NetHook2/NetHook2/NetHook2.vcxproj.filters
+++ b/Resources/NetHook2/NetHook2/NetHook2.vcxproj.filters
@@ -50,6 +50,9 @@
     <ClCompile Include="sedebug.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="net.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="binaryreader.h">
@@ -98,6 +101,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="sedebug.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="steam\net.h">
+      <Filter>Header Files\steam</Filter>
+    </ClInclude>
+    <ClInclude Include="net.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Resources/NetHook2/NetHook2/crypto.cpp
+++ b/Resources/NetHook2/NetHook2/crypto.cpp
@@ -154,7 +154,7 @@ CCrypto::~CCrypto()
 
 bool __cdecl CCrypto::SymmetricEncryptChosenIV( const uint8 *pubPlaintextData, uint32 cubPlaintextData, const uint8 *pIV, uint32 cubIV, uint8 *pubEncryptedData, uint32 *pcubEncryptedData, const uint8 *pubKey, uint32 cubKey )
 {
-	g_pLogger->LogNetMessage( k_eNetOutgoing, (uint8 *)pubPlaintextData, cubPlaintextData );
+	g_pLogger->LogNetMessage( k_eNetOutgoing, pubPlaintextData, cubPlaintextData );
 
 	return (*Encrypt_Orig)( pubPlaintextData, cubPlaintextData, pIV, cubIV, pubEncryptedData, pcubEncryptedData, pubKey, cubKey );
 }

--- a/Resources/NetHook2/NetHook2/crypto.h
+++ b/Resources/NetHook2/NetHook2/crypto.h
@@ -10,7 +10,6 @@
 #undef GetMessage
 
 typedef bool(__cdecl *SymmetricEncryptChosenIVFn)(const uint8*, uint32, const uint8*, uint32, uint8*, uint32*, const uint8*, uint32);
-typedef bool(__cdecl *SymmetricDecryptRecoverIVFn)(const uint8*, uint32, uint8*, uint32*, uint8*, uint32, const uint8*, uint32);
 
 class CCrypto
 {
@@ -22,11 +21,8 @@ public:
 	const char* GetMessage( EMsg eMsg, uint8 serverType );
 
 	CSimpleDetour* Encrypt_Detour;
-	CSimpleDetour* Decrypt_Detour;
 
 	static bool __cdecl SymmetricEncryptChosenIV( const uint8 *pubPlaintextData, uint32 cubPlaintextData, const uint8* pIV, uint32 cubIV, uint8 *pubEncryptedData, uint32 *pcubEncryptedData, const uint8 *pubKey, uint32 cubKey );
-	static bool __cdecl SymmetricDecryptRecoverIV( const uint8 *pubEncryptedData, uint32 cubEncryptedData, uint8 *pubPlaintextData, uint32 *pcubPlaintextData, uint8 *pubRecoveredIV, uint32 cubRecoveredIV, const uint8 *pubKey, uint32 cubKey );
-
 };
 
 extern CCrypto* g_pCrypto;

--- a/Resources/NetHook2/NetHook2/logger.cpp
+++ b/Resources/NetHook2/NetHook2/logger.cpp
@@ -70,7 +70,7 @@ void CLogger::DeleteFile( const char *szFileName, bool bSession )
 	DeleteFileA( outputFile.c_str() );
 }
 
-void CLogger::LogNetMessage( ENetDirection eDirection, uint8 *pData, uint32 cubData )
+void CLogger::LogNetMessage( ENetDirection eDirection, const uint8 *pData, uint32 cubData )
 {
 	EMsg eMsg = (EMsg)*(uint16*)pData;
 	eMsg = (EMsg)((int)eMsg & (~0x80000000));
@@ -84,7 +84,7 @@ void CLogger::LogNetMessage( ENetDirection eDirection, uint8 *pData, uint32 cubD
 	this->LogSessionData( eDirection, pData, cubData );
 }
 
-void CLogger::LogSessionData( ENetDirection eDirection, uint8 *pData, uint32 cubData )
+void CLogger::LogSessionData( ENetDirection eDirection, const uint8 *pData, uint32 cubData )
 {
 	std::string fullFile = m_LogDir;
 
@@ -159,7 +159,7 @@ const char *CLogger::GetFileNameBase( ENetDirection eDirection, EMsg eMsg, uint8
 	return szFileName;
 }
 
-void CLogger::MultiplexMulti( ENetDirection eDirection, uint8 *pData, uint32 cubData )
+void CLogger::MultiplexMulti( ENetDirection eDirection, const uint8 *pData, uint32 cubData )
 {
 	struct ProtoHdr 
 	{

--- a/Resources/NetHook2/NetHook2/logger.h
+++ b/Resources/NetHook2/NetHook2/logger.h
@@ -27,8 +27,8 @@ public:
 	CLogger();
 
 	void LogConsole( const char *szFmt, ... );
-	void LogNetMessage( ENetDirection eDirection, uint8 *pData, uint32 cubData );
-	void LogSessionData( ENetDirection eDirection, uint8 *pData, uint32 cubData );
+	void LogNetMessage( ENetDirection eDirection, const uint8 *pData, uint32 cubData );
+	void LogSessionData( ENetDirection eDirection, const uint8 *pData, uint32 cubData );
 	void LogOpenFile( HANDLE hFile, const char *szFmt, ... );
 
 	HANDLE OpenFile( const char *szFileName, bool bSession );
@@ -37,7 +37,7 @@ public:
 
 private:
 	const char *GetFileNameBase( ENetDirection eDirection, EMsg eMsg, uint8 serverType = 0xFF );
-	void MultiplexMulti( ENetDirection eDirection, uint8 *pData, uint32 cubData );
+	void MultiplexMulti( ENetDirection eDirection, const uint8 *pData, uint32 cubData );
 
 private:
 	std::string m_RootDir;

--- a/Resources/NetHook2/NetHook2/net.cpp
+++ b/Resources/NetHook2/NetHook2/net.cpp
@@ -97,7 +97,7 @@ bool CNet::BBuildAndAsyncSendFrame(void *webSocketConnection, void *unused, EWeb
 {
 	if (eWebSocketOpCode == k_eWebSocketOpCode_Binary)
 	{
-		g_pLogger->LogNetMessage(k_eNetOutgoing, const_cast<uint8 *>(pubData), cubData);
+		g_pLogger->LogNetMessage(k_eNetOutgoing, pubData, cubData);
 	}
 	else
 	{

--- a/Resources/NetHook2/NetHook2/net.cpp
+++ b/Resources/NetHook2/NetHook2/net.cpp
@@ -1,0 +1,120 @@
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+
+#include "net.h"
+
+#include "logger.h"
+#include "csimplescan.h"
+
+
+namespace NetHook
+{
+
+
+BBuildAndAsyncSendFrameFn BBuildAndAsyncSendFrame_Orig = NULL;
+RecvPktFn RecvPkt_Orig = NULL;
+
+CNet::CNet()
+	: m_RecvPktDetour(NULL),
+	  m_BuildDetour(NULL)
+{
+	CSimpleScan steamClientScan("steamclient.dll");
+
+	BBuildAndAsyncSendFrameFn pBuildFunc = NULL;
+	bool bFoundBuildFunc = steamClientScan.FindFunction(
+		"\x55\x8B\xEC\x83\xEC\x6C\x53\x8B\xD9\x89\x5D\xF4",
+		"xxxxxxxxxxxx",
+		(void **)&pBuildFunc
+	);
+
+	BBuildAndAsyncSendFrame_Orig = pBuildFunc;
+
+	g_pLogger->LogConsole("CWebSocketConnection::BBuildAndAsyncSendFrame = 0x%x\n", BBuildAndAsyncSendFrame_Orig);
+
+	RecvPktFn pRecvPktFunc = NULL;
+	bool bFoundRecvPktFunc = steamClientScan.FindFunction(
+		"\x55\x8B\xEC\x81\xEC\xA0\x09\x00\x00\x53",
+		"xxxxxxxxxx",
+		(void **)&pRecvPktFunc
+	);
+
+	RecvPkt_Orig = pRecvPktFunc;
+
+	g_pLogger->LogConsole("CCMInterface::RecvPkt = 0x%x\n", RecvPkt_Orig);
+
+
+	RecvPktFn thisRecvPktFunc = CNet::RecvPkt;
+
+	if (bFoundBuildFunc)
+	{
+		BBuildAndAsyncSendFrameFn thisBuildFunc = CNet::BBuildAndAsyncSendFrame;
+
+		m_BuildDetour = new CSimpleDetour((void **)&BBuildAndAsyncSendFrame_Orig, (void *)thisBuildFunc);
+		m_BuildDetour->Attach();
+
+		g_pLogger->LogConsole("Detoured CWebSocketConnection::BBuildAndAsyncSendFrame!\n");
+	}
+	else
+	{
+		g_pLogger->LogConsole("Unable to hook CWebSocketConnection::BBuildAndAsyncSendFrame: func scan failed.\n");
+	}
+
+	if (bFoundRecvPktFunc)
+	{
+		RecvPktFn thisRecvPktFunc = CNet::RecvPkt;
+
+		m_RecvPktDetour = new CSimpleDetour((void **)&RecvPkt_Orig, (void *)thisRecvPktFunc);
+		m_RecvPktDetour->Attach();
+
+		g_pLogger->LogConsole("Detoured CCMInterface::RecvPkt!\n");
+	}
+	else
+	{
+		g_pLogger->LogConsole("Unable to hook CCMInterface::RecvPkt: func scan failed.\n");
+	}
+
+}
+
+CNet::~CNet()
+{
+	if (m_RecvPktDetour)
+	{
+		m_RecvPktDetour->Detach();
+		delete m_RecvPktDetour;
+	}
+
+	if (m_BuildDetour)
+	{
+		m_BuildDetour->Detach();
+		delete m_BuildDetour;
+	}
+}
+
+
+bool CNet::BBuildAndAsyncSendFrame(void *webSocketConnection, void *unused, EWebSocketOpCode eWebSocketOpCode, const uint8 *pubData, uint32 cubData)
+{
+	if (eWebSocketOpCode == k_eWebSocketOpCode_Binary)
+	{
+		g_pLogger->LogNetMessage(k_eNetOutgoing, const_cast<uint8 *>(pubData), cubData);
+	}
+	else
+	{
+		g_pLogger->LogConsole("Sending websocket frame with opcode %d (%s), ignoring\n",
+			eWebSocketOpCode, EWebSocketOpCodeToName(eWebSocketOpCode)
+		);
+	}
+
+	return (*BBuildAndAsyncSendFrame_Orig)(webSocketConnection, unused, eWebSocketOpCode, pubData, cubData);
+}
+
+void CNet::RecvPkt(void *cmConnection, void *unused, CNetPacket *pPacket)
+{
+	g_pLogger->LogNetMessage(k_eNetIncoming, pPacket->m_pubData, pPacket->m_cubData);
+
+	(*RecvPkt_Orig)(cmConnection, unused, pPacket);
+}
+
+
+}

--- a/Resources/NetHook2/NetHook2/net.h
+++ b/Resources/NetHook2/NetHook2/net.h
@@ -1,0 +1,47 @@
+
+#ifndef NETHOOK_NET_H_
+#define NETHOOK_NET_H_
+#ifdef _WIN32
+#pragma once
+#endif
+
+
+#include "steam/steamtypes.h"
+#include "steam/net.h"
+
+#include "csimpledetour.h"
+
+
+namespace NetHook
+{
+
+typedef bool (__fastcall *BBuildAndAsyncSendFrameFn)(void *, void *, EWebSocketOpCode, const uint8 *, uint32);
+typedef void(__fastcall *RecvPktFn)(void *, void *, CNetPacket *);
+
+class CNet
+{
+
+public:
+	CNet();
+	~CNet();
+
+
+public:
+	// CWebSocketConnection::BBuildAndAsyncSendFrame(EWebSocketOpCode, uchar const*, int)
+	static bool __fastcall BBuildAndAsyncSendFrame(void *webSocketConnection, void *unused, EWebSocketOpCode eWebSocketOpCode, const uint8 *pubData, uint32 cubData);
+
+	// CCMInterface::RecvPkt(CNetPacket *)
+	static void __fastcall RecvPkt(void *cmConnection, void *unused, CNetPacket *pPacket);
+
+
+private:
+	CSimpleDetour *m_RecvPktDetour;
+	CSimpleDetour *m_BuildDetour;
+
+};
+
+extern CNet *g_pNet;
+
+}
+
+#endif // !NETHOOK_NET_H_

--- a/Resources/NetHook2/NetHook2/nethook.cpp
+++ b/Resources/NetHook2/NetHook2/nethook.cpp
@@ -3,12 +3,16 @@
 
 #include "logger.h"
 #include "crypto.h"
+#include "net.h"
+
 #include "nh2_string.h"
 
 #include "steammessages_base.pb.h"
 
 CLogger *g_pLogger = NULL;
 CCrypto* g_pCrypto = NULL;
+NetHook::CNet *g_pNet = NULL;
+
 BOOL g_bOwnsConsole = FALSE;
 
 BOOL IsRunDll32()
@@ -37,13 +41,15 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )
 		g_pLogger = new CLogger();
 
 		g_pCrypto = new CCrypto();
+		g_pNet = new NetHook::CNet();
 
 	}
 	else if ( fdwReason == DLL_PROCESS_DETACH )
 	{
-		delete g_pLogger;
-
+		delete g_pNet;
 		delete g_pCrypto;
+
+		delete g_pLogger;
 
 		if (g_bOwnsConsole)
 		{

--- a/Resources/NetHook2/NetHook2/steam/net.h
+++ b/Resources/NetHook2/NetHook2/steam/net.h
@@ -1,0 +1,71 @@
+
+#ifndef STEAM_NET_H_
+#define STEAM_NET_H_
+#ifdef _WIN32
+#pragma once
+#endif
+
+
+#include "steamtypes.h"
+
+
+typedef uint32 HCONNECTION;
+
+
+enum EWebSocketOpCode
+{
+	k_eWebSocketOpCode_Continuation	= 0x00,
+	k_eWebSocketOpCode_Text			= 0x01,
+	k_eWebSocketOpCode_Binary		= 0x02,
+
+	k_eWebSocketOpCode_Close		= 0x08,
+	k_eWebSocketOpCode_Ping			= 0x09,
+	k_eWebSocketOpCode_Pong			= 0x0A,
+};
+
+inline const char *EWebSocketOpCodeToName(EWebSocketOpCode eWebSocketOpCode)
+{
+	const char *rgchWebSocketOpCodeNames[] =
+	{
+		"Continuation",
+		"Text",
+		"Binary",
+		"<Reserved>", // 0x03
+		"<Reserved>", // 0x04
+		"<Reserved>", // 0x05
+		"<Reserved>", // 0x06
+		"<Reserved>", // 0x07
+		"Close",
+		"Ping",
+		"Pong",
+		"<Reserved>", // 0x0B
+		"<Reserved>", // 0x0C
+		"<Reserved>", // 0x0D
+		"<Reserved>", // 0x0E
+		"<Reserved>", // 0x0F
+	};
+
+	if (eWebSocketOpCode < 0 || eWebSocketOpCode >= sizeof(rgchWebSocketOpCodeNames))
+		return "<Invalid>";
+
+	return rgchWebSocketOpCodeNames[eWebSocketOpCode];
+}
+
+
+class CNetPacket
+{
+public:
+	HCONNECTION m_hConnection;
+
+	uint8* m_pubData;
+	uint32 m_cubData;
+
+	int m_cRef;
+
+	uint8* m_pubNetworkBuffer;
+
+	CNetPacket* m_pNext;
+};
+
+
+#endif // !STEAM_NET_H_


### PR DESCRIPTION
Also dropping the hook on SymmetricDecrypt since the new network hooking for websocket hooks `CCMInterface::RecvPkt` that will also handle UDP and TCP connections.

In the future we can look into removing the `SymmetricEncrypt` hook and hooking a more relevant method on `CCMInterface` or `CCMConnection`, since the encryption method ends up getting called for more than just encrypting net messages.

Should solve #438 and #432 .