### PR TITLE
Check arguments before attempting to use them

### DIFF
--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -28,14 +28,14 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsProto { get { return true; } }
+        public override bool IsProto => true;
         /// <summary>
         /// Gets the network message type of this client message.
         /// </summary>
         /// <value>
         /// The network message type.
         /// </value>
-        public override EMsg MsgType { get { return Header.Msg; } }
+        public override EMsg MsgType => Header.Msg;
 
         /// <summary>
         /// Gets or sets the session id for this client message.
@@ -45,8 +45,8 @@ namespace SteamKit2
         /// </value>
         public override int SessionID
         {
-            get { return ProtoHeader.client_sessionid; }
-            set { ProtoHeader.client_sessionid = value; }
+            get => ProtoHeader.client_sessionid;
+            set => ProtoHeader.client_sessionid = value;
         }
         /// <summary>
         /// Gets or sets the <see cref="SteamID"/> for this client message.
@@ -56,8 +56,8 @@ namespace SteamKit2
         /// </value>
         public override SteamID SteamID
         {
-            get { return ProtoHeader.steamid; }
-            set { ProtoHeader.steamid = value; }
+            get => ProtoHeader.steamid;
+            set => ProtoHeader.steamid = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
         /// <summary>
@@ -68,8 +68,8 @@ namespace SteamKit2
         /// </value>
         public override JobID TargetJobID
         {
-            get { return ProtoHeader.jobid_target; }
-            set { ProtoHeader.jobid_target = value; }
+            get => ProtoHeader.jobid_target;
+            set => ProtoHeader.jobid_target = value ?? throw new ArgumentNullException( nameof(value) );
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -79,15 +79,15 @@ namespace SteamKit2
         /// </value>
         public override JobID SourceJobID
         {
-            get { return ProtoHeader.jobid_source; }
-            set { ProtoHeader.jobid_source = value; }
+            get => ProtoHeader.jobid_source;
+            set => ProtoHeader.jobid_source = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
 
         /// <summary>
         /// Shorthand accessor for the protobuf header.
         /// </summary>
-        public CMsgProtoBufHeader ProtoHeader { get { return Header.Proto; } }
+        public CMsgProtoBufHeader ProtoHeader => Header.Proto;
 
 
         internal ClientMsgProtobuf( EMsg eMsg, int payloadReserve = 64 )
@@ -103,7 +103,7 @@ namespace SteamKit2
         /// </summary>
         /// <param name="msg">The packet message to build this client message from.</param>
         public ClientMsgProtobuf( IPacketMsg msg )
-            : this( msg.MsgType )
+            : this( msg.GetMsgTypeWithNullCheck( nameof(msg) ) )
         {
             DebugLog.Assert(msg.IsProto, "ClientMsgProtobuf", "ClientMsgProtobuf used for non-proto message!");
 
@@ -126,6 +126,11 @@ namespace SteamKit2
         /// <param name="data">The data representing a client message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
@@ -181,7 +186,7 @@ namespace SteamKit2
         /// </summary>
         /// <param name="msg">The packet message to build this client message from.</param>
         public ClientMsgProtobuf( IPacketMsg msg )
-            : this( msg.MsgType )
+            : this( msg.GetMsgTypeWithNullCheck( nameof(msg) ) )
         {
             DebugLog.Assert( msg.IsProto, "ClientMsgProtobuf<>", $"ClientMsgProtobuf<{typeof(BodyType).FullName}> used for non-proto message!" );
 
@@ -211,6 +216,11 @@ namespace SteamKit2
         /// <param name="data">The data representing a client message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
@@ -239,14 +249,14 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsProto { get { return false; } }
+        public override bool IsProto => false;
         /// <summary>
         /// Gets the network message type of this client message.
         /// </summary>
         /// <value>
         /// The network message type.
         /// </value>
-        public override EMsg MsgType { get { return Header.Msg; } }
+        public override EMsg MsgType => Header.Msg;
 
         /// <summary>
         /// Gets or sets the session id for this client message.
@@ -256,8 +266,8 @@ namespace SteamKit2
         /// </value>
         public override int SessionID
         {
-            get { return Header.SessionID; }
-            set { Header.SessionID = value; }
+            get => Header.SessionID;
+            set => Header.SessionID = value;
         }
         /// <summary>
         /// Gets or sets the <see cref="SteamID"/> for this client message.
@@ -267,8 +277,8 @@ namespace SteamKit2
         /// </value>
         public override SteamID SteamID
         {
-            get { return Header.SteamID; }
-            set { Header.SteamID = value; }
+            get => Header.SteamID;
+            set => Header.SteamID = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
         /// <summary>
@@ -279,8 +289,8 @@ namespace SteamKit2
         /// </value>
         public override JobID TargetJobID
         {
-            get { return Header.TargetJobID; }
-            set { Header.TargetJobID = value; }
+            get => Header.TargetJobID;
+            set => Header.TargetJobID = value ?? throw new ArgumentNullException( nameof(value) );
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -290,15 +300,15 @@ namespace SteamKit2
         /// </value>
         public override JobID SourceJobID
         {
-            get { return Header.SourceJobID; }
-            set { Header.SourceJobID = value; }
+            get => Header.SourceJobID;
+            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
 
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; private set; }
+        public BodyType Body { get; }
 
 
         /// <summary>
@@ -324,6 +334,11 @@ namespace SteamKit2
         public ClientMsg( MsgBase<ExtendedClientMsgHdr> msg, int payloadReserve = 64 )
             : this( payloadReserve )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             // our target is where the message came from
             Header.TargetJobID = msg.Header.SourceJobID;
         }
@@ -336,6 +351,11 @@ namespace SteamKit2
         public ClientMsg( IPacketMsg msg )
             : this()
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             DebugLog.Assert( !msg.IsProto, "ClientMsg", $"ClientMsg<{typeof(BodyType).FullName}> used for proto message!" );
 
             Deserialize( msg.GetData() );
@@ -364,6 +384,11 @@ namespace SteamKit2
         /// <param name="data">The data representing a client message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
@@ -392,14 +417,14 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsProto { get { return false; } }
+        public override bool IsProto => false;
         /// <summary>
         /// Gets the network message type of this client message.
         /// </summary>
         /// <value>
         /// The network message type.
         /// </value>
-        public override EMsg MsgType { get { return Header.Msg; } }
+        public override EMsg MsgType => Header.Msg;
 
         /// <summary>
         /// Gets or sets the session id for this client message.
@@ -426,8 +451,8 @@ namespace SteamKit2
         /// </value>
         public override JobID TargetJobID
         {
-            get { return Header.TargetJobID; }
-            set { Header.TargetJobID = value; }
+            get => Header.TargetJobID;
+            set => Header.TargetJobID = value ?? throw new ArgumentNullException( nameof(value) );
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -437,15 +462,15 @@ namespace SteamKit2
         /// </value>
         public override JobID SourceJobID
         {
-            get { return Header.SourceJobID; }
-            set { Header.SourceJobID = value; }
+            get => Header.SourceJobID;
+            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
 
         /// <summary>
         /// Gets the structure body of the message.
         /// </summary>
-        public BodyType Body { get; private set; }
+        public BodyType Body { get; }
 
 
         /// <summary>
@@ -471,6 +496,11 @@ namespace SteamKit2
         public Msg( MsgBase<MsgHdr> msg, int payloadReserve = 0 )
             : this( payloadReserve )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             // our target is where the message came from
             Header.TargetJobID = msg.Header.SourceJobID;
         }
@@ -483,6 +513,11 @@ namespace SteamKit2
         public Msg( IPacketMsg msg )
             : this()
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             Deserialize( msg.GetData() );
         }
 
@@ -510,6 +545,11 @@ namespace SteamKit2
         /// <param name="data">The data representing a client message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );

--- a/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
@@ -4,6 +4,7 @@
  */
 
 
+using System;
 using System.IO;
 using ProtoBuf;
 using SteamKit2.Internal;
@@ -27,14 +28,14 @@ namespace SteamKit2.GC
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsProto { get { return true; } }
+        public override bool IsProto => true;
         /// <summary>
         /// Gets the network message type of this gc message.
         /// </summary>
         /// <value>
         /// The network message type.
         /// </value>
-        public override uint MsgType { get { return Header.Msg; } }
+        public override uint MsgType => Header.Msg;
 
         /// <summary>
         /// Gets or sets the target job id for this gc message.
@@ -44,8 +45,8 @@ namespace SteamKit2.GC
         /// </value>
         public override JobID TargetJobID
         {
-            get { return ProtoHeader.job_id_target; }
-            set { ProtoHeader.job_id_target = value; }
+            get => ProtoHeader.job_id_target;
+            set => ProtoHeader.job_id_target = value ?? throw new ArgumentNullException( nameof(value) );
         }
         /// <summary>
         /// Gets or sets the source job id for this gc message.
@@ -55,15 +56,15 @@ namespace SteamKit2.GC
         /// </value>
         public override JobID SourceJobID
         {
-            get { return ProtoHeader.job_id_source; }
-            set { ProtoHeader.job_id_source = value; }
+            get => ProtoHeader.job_id_source;
+            set => ProtoHeader.job_id_source = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
 
         /// <summary>
         /// Shorthand accessor for the protobuf header.
         /// </summary>
-        public CMsgProtoBufHeader ProtoHeader { get { return Header.Proto; } }
+        public CMsgProtoBufHeader ProtoHeader => Header.Proto;
 
         /// <summary>
         /// Gets the body structure of this message.
@@ -96,6 +97,11 @@ namespace SteamKit2.GC
         public ClientGCMsgProtobuf( uint eMsg, GCMsgBase<MsgGCHdrProtoBuf> msg, int payloadReserve = 64 )
             : this( eMsg, payloadReserve )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             // our target is where the message came from
             Header.Proto.job_id_target = msg.Header.Proto.job_id_source;
         }
@@ -106,7 +112,7 @@ namespace SteamKit2.GC
         /// </summary>
         /// <param name="msg">The packet message to build this gc message from.</param>
         public ClientGCMsgProtobuf( IPacketGCMsg msg )
-            : this( msg.MsgType )
+            : this( msg.GetMsgTypeWithNullCheck( nameof(msg) ) )
         {
             DebugLog.Assert( msg.IsProto, "ClientGCMsgProtobuf", "ClientGCMsgProtobuf used for non-proto message!" );
 
@@ -136,6 +142,11 @@ namespace SteamKit2.GC
         /// <param name="data">The data representing a gc message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
@@ -163,16 +174,16 @@ namespace SteamKit2.GC
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public override bool IsProto { get { return false; } }
+        public override bool IsProto => false;
 
-        uint msgType;
+        readonly uint msgType;
         /// <summary>
         /// Gets the network message type of this gc message.
         /// </summary>
         /// <value>
         /// The network message type.
         /// </value>
-        public override uint MsgType { get { return msgType; } }
+        public override uint MsgType => msgType;
 
         /// <summary>
         /// Gets or sets the target job id for this gc message.
@@ -182,8 +193,8 @@ namespace SteamKit2.GC
         /// </value>
         public override JobID TargetJobID
         {
-            get { return Header.TargetJobID; }
-            set { Header.TargetJobID = value; }
+            get => Header.TargetJobID;
+            set => Header.TargetJobID = value = value ?? throw new ArgumentNullException( nameof(value) );
         }
         /// <summary>
         /// Gets or sets the source job id for this gc message.
@@ -193,15 +204,15 @@ namespace SteamKit2.GC
         /// </value>
         public override JobID SourceJobID
         {
-            get { return Header.SourceJobID; }
-            set { Header.SourceJobID = value; }
+            get => Header.SourceJobID;
+            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
         }
 
 
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; private set; }
+        public BodyType Body { get; }
 
 
         /// <summary>
@@ -227,6 +238,11 @@ namespace SteamKit2.GC
         public ClientGCMsg( GCMsgBase<MsgGCHdr> msg, int payloadReserve = 64 )
             : this( payloadReserve )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             // our target is where the message came from
             Header.TargetJobID = msg.Header.SourceJobID;
         }
@@ -239,6 +255,11 @@ namespace SteamKit2.GC
         public ClientGCMsg( IPacketGCMsg msg )
             : this()
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             DebugLog.Assert( !msg.IsProto, "ClientGCMsg", "ClientGCMsg used for proto message!" );
 
             Deserialize( msg.GetData() );
@@ -267,6 +288,11 @@ namespace SteamKit2.GC
         /// <param name="data">The data representing a client message.</param>
         public override void Deserialize( byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );

--- a/SteamKit2/SteamKit2/Base/GC/MsgBaseGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/MsgBaseGC.cs
@@ -96,7 +96,7 @@ namespace SteamKit2.GC
         /// <summary>
         /// Gets the header for this message type. 
         /// </summary>
-        public HdrType Header { get; private set; }
+        public HdrType Header { get; }
 
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/GC/PacketBaseGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/PacketBaseGC.cs
@@ -4,6 +4,7 @@
  */
 
 
+using System;
 using System.IO;
 using SteamKit2.Internal;
 
@@ -54,6 +55,19 @@ namespace SteamKit2.GC
         byte[] GetData();
     }
 
+    static class IPacketGCMsgExtensions
+    {
+        public static uint GetMsgTypeWithNullCheck( this IPacketGCMsg msg, string name )
+        {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( name );
+            }
+
+            return msg.MsgType;
+        }
+    }
+
 
     /// <summary>
     /// Represents a protobuf backed packet message.
@@ -67,14 +81,14 @@ namespace SteamKit2.GC
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public bool IsProto { get { return true; } }
+        public bool IsProto => true;
         /// <summary>
         /// Gets the network message type of this packet message.
         /// </summary>
         /// <value>
         /// The message type.
         /// </value>
-        public uint MsgType { get; private set; }
+        public uint MsgType { get; }
 
         /// <summary>
         /// Gets the target job id for this packet message.
@@ -82,17 +96,17 @@ namespace SteamKit2.GC
         /// <value>
         /// The target job id.
         /// </value>
-        public JobID TargetJobID { get; private set; }
+        public JobID TargetJobID { get; }
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public JobID SourceJobID { get; private set; }
+        public JobID SourceJobID { get; }
 
 
-        byte[] payload;
+        readonly byte[] payload;
 
 
         /// <summary>
@@ -102,6 +116,11 @@ namespace SteamKit2.GC
         /// <param name="data">The data.</param>
         public PacketClientGCMsgProtobuf( uint eMsg, byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             MsgType = eMsg;
             payload = data;
 
@@ -140,14 +159,14 @@ namespace SteamKit2.GC
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public bool IsProto { get { return false; } }
+        public bool IsProto => false;
         /// <summary>
         /// Gets the network message type of this packet message.
         /// </summary>
         /// <value>
         /// The message type.
         /// </value>
-        public uint MsgType { get; private set; }
+        public uint MsgType { get; }
 
         /// <summary>
         /// Gets the target job id for this packet message.
@@ -155,14 +174,14 @@ namespace SteamKit2.GC
         /// <value>
         /// The target job id.
         /// </value>
-        public JobID TargetJobID { get; private set; }
+        public JobID TargetJobID { get; }
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public JobID SourceJobID { get; private set; }
+        public JobID SourceJobID { get; }
 
         byte[] payload;
 
@@ -174,6 +193,11 @@ namespace SteamKit2.GC
         /// <param name="data">The data.</param>
         public PacketClientGCMsg( uint eMsg, byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             MsgType = eMsg;
             payload = data;
 

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -3,6 +3,7 @@
  * file 'license.txt', which is part of this source code package.
  */
 
+using System;
 using System.IO;
 using System.Text;
 using SteamKit2.Internal;
@@ -79,11 +80,11 @@ namespace SteamKit2
         /// <summary>
         /// Returns a <see cref="System.IO.MemoryStream"/> which is the backing stream for client message payload data.
         /// </summary>
-        public MemoryStream Payload { get; private set; }
+        public MemoryStream Payload { get; }
 
 
-        BinaryReader reader;
-        BinaryWriter writer;
+        readonly BinaryReader reader;
+        readonly BinaryWriter writer;
 
 
         /// <summary>
@@ -216,7 +217,14 @@ namespace SteamKit2
         public void Write( string data, Encoding encoding )
         {
             if ( data == null )
+            {
                 return;
+            }
+
+            if ( encoding == null )
+            {
+                throw new ArgumentNullException( nameof(encoding) );
+            }
 
             Write( encoding.GetBytes( data ) );
         }
@@ -417,6 +425,11 @@ namespace SteamKit2
         /// /// <returns>The string.</returns>
         public string ReadNullTermString( Encoding encoding )
         {
+            if ( encoding == null )
+            {
+                throw new ArgumentNullException( nameof(encoding) );
+            }
+
             return Payload.ReadNullTermString( encoding );
         }
 
@@ -479,7 +492,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the header for this message type. 
         /// </summary>
-        public HdrType Header { get; private set; }
+        public HdrType Header { get; }
 
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -4,6 +4,7 @@
  */
 
 
+using System;
 using System.IO;
 using SteamKit2.Internal;
 
@@ -54,6 +55,18 @@ namespace SteamKit2
         byte[] GetData();
     }
 
+    static class IPacketMsgExtensions
+    {
+        public static EMsg GetMsgTypeWithNullCheck( this IPacketMsg msg, string name )
+        {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( name );
+            }
+
+            return msg.MsgType;
+        }
+    }
 
     /// <summary>
     /// Represents a protobuf backed packet message.
@@ -74,7 +87,7 @@ namespace SteamKit2
         /// <value>
         /// The message type.
         /// </value>
-        public EMsg MsgType { get; private set; }
+        public EMsg MsgType { get; }
 
         /// <summary>
         /// Gets the target job id for this packet message.
@@ -82,14 +95,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; private set; }
+        public ulong TargetJobID { get; }
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; private set; }
+        public ulong SourceJobID { get; }
 
 
         byte[] payload;
@@ -102,6 +115,11 @@ namespace SteamKit2
         /// <param name="data">The data.</param>
         public PacketClientMsgProtobuf( EMsg eMsg, byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             MsgType = eMsg;
             payload = data;
 
@@ -140,14 +158,14 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public bool IsProto { get { return false; } }
+        public bool IsProto => false;
         /// <summary>
         /// Gets the network message type of this packet message.
         /// </summary>
         /// <value>
         /// The message type.
         /// </value>
-        public EMsg MsgType { get; private set; }
+        public EMsg MsgType { get; }
 
         /// <summary>
         /// Gets the target job id for this packet message.
@@ -155,14 +173,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; private set; }
+        public ulong TargetJobID { get; }
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; private set; }
+        public ulong SourceJobID { get; }
 
         byte[] payload;
 
@@ -174,6 +192,11 @@ namespace SteamKit2
         /// <param name="data">The data.</param>
         public PacketClientMsg( EMsg eMsg, byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             MsgType = eMsg;
             payload = data;
 
@@ -212,14 +235,14 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public bool IsProto { get { return false; } }
+        public bool IsProto => false;
         /// <summary>
         /// Gets the network message type of this packet message.
         /// </summary>
         /// <value>
         /// The message type.
         /// </value>
-        public EMsg MsgType { get; private set; }
+        public EMsg MsgType { get; }
 
         /// <summary>
         /// Gets the target job id for this packet message.
@@ -227,14 +250,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; private set; }
+        public ulong TargetJobID { get; }
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; private set; }
+        public ulong SourceJobID { get; }
 
         byte[] payload;
 
@@ -246,6 +269,11 @@ namespace SteamKit2
         /// <param name="data">The data.</param>
         public PacketMsg( EMsg eMsg, byte[] data )
         {
+            if ( data == null )
+            {
+                throw new ArgumentNullException( nameof(data) );
+            }
+
             MsgType = eMsg;
             payload = data;
 

--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace SteamKit2
 {

--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
-using System.Threading.Tasks;
 using SteamKit2.Internal;
 
 namespace SteamKit2

--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -135,12 +135,17 @@ namespace SteamKit2
             /// <exception cref="System.IO.InvalidDataException">Thrown if the processed data does not match the expected checksum given in it's chunk information.</exception>
             public void Process( byte[] depotKey )
             {
+                if ( depotKey == null )
+                {
+                    throw new ArgumentNullException( nameof(depotKey) );
+                }
+
                 if ( IsProcessed )
                     return;
 
                 byte[] processedData = CryptoHelper.SymmetricDecrypt( Data, depotKey );
 
-                if ( processedData[0] == 'V' && processedData[1] == 'Z' )
+                if ( processedData.Length > 1 &&  processedData[0] == 'V' && processedData[1] == 'Z' )
                 {
                     processedData = VZipUtil.Decompress( processedData );
                 }
@@ -193,6 +198,11 @@ namespace SteamKit2
         /// </param>
         public CDNClient( SteamClient steamClient, byte[] appTicket = null )
         {
+            if ( steamClient == null )
+            {
+                throw new ArgumentNullException( nameof(steamClient) );
+            }
+
             this.steamClient = steamClient;
             this.httpClient = new HttpClient();
 
@@ -318,7 +328,9 @@ namespace SteamKit2
             DebugLog.Assert( steamClient.IsConnected, "CDNClient", "CMClient is not connected!" );
 
             if ( csServer == null )
-                throw new ArgumentNullException( "csServer" );
+            {
+                throw new ArgumentNullException( nameof(csServer) );
+            }
 
             // Nothing needs to be done to initialize a session to a CDN server
             if ( csServer.Type == "CDN" )
@@ -369,7 +381,9 @@ namespace SteamKit2
         public async Task AuthenticateDepotAsync( uint depotid, byte[] depotKey = null, string cdnAuthToken = null )
         {
             if ( depotIds.ContainsKey( depotid ) )
+            {
                 return;
+            }
 
             string data;
 
@@ -401,11 +415,8 @@ namespace SteamKit2
         /// <returns>A <see cref="DepotManifest"/> instance that contains information about the files present within a depot.</returns>
         public async Task<DepotManifest> DownloadManifestAsync( uint depotId, ulong manifestId )
         {
-            string cdnToken = null;
-            depotCdnAuthKeys.TryGetValue( depotId, out cdnToken );
-
-            byte[] depotKey = null;
-            depotKeys.TryGetValue( depotId, out depotKey );
+            depotCdnAuthKeys.TryGetValue( depotId, out var cdnToken );
+            depotKeys.TryGetValue( depotId, out var depotKey );
 
             return await DownloadManifestCoreAsync( depotId, manifestId, connectedServer, cdnToken, depotKey ).ConfigureAwait(false);
         }
@@ -458,14 +469,18 @@ namespace SteamKit2
 #pragma warning restore 0419
 #pragma warning restore 1574
         {
+            if ( chunk == null )
+            {
+                throw new ArgumentNullException( nameof(chunk) );
+            }
+
             if ( chunk.ChunkID == null )
-                throw new ArgumentNullException( "chunk.ChunkID" );
+            {
+                throw new ArgumentException( "Chunk must have a ChunkID.", nameof(chunk) );
+            }
 
-            string cdnToken = null;
-            depotCdnAuthKeys.TryGetValue( depotId, out cdnToken );
-
-            byte[] depotKey = null;
-            depotKeys.TryGetValue( depotId, out depotKey );
+            depotCdnAuthKeys.TryGetValue( depotId, out var cdnToken );
+            depotKeys.TryGetValue( depotId, out var depotKey );
 
             return await DownloadDepotChunkCoreAsync( depotId, chunk, connectedServer, cdnToken, depotKey ).ConfigureAwait( false );
         }
@@ -501,8 +516,15 @@ namespace SteamKit2
 #pragma warning restore 1574
 #pragma warning restore 0419
         {
-            if (chunk.ChunkID == null)
-                throw new ArgumentNullException( "chunk.ChunkID" );
+            if ( chunk == null )
+            {
+                throw new ArgumentNullException( nameof(chunk) );
+            }
+
+            if ( chunk.ChunkID == null )
+            {
+                throw new ArgumentException( "Chunk must have a ChunkID.", nameof(chunk) );
+            }
 
             var server = new Server
             {

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -209,13 +209,19 @@ namespace SteamKit2.Internal
         public void Send( IClientMsg msg )
         {
             if ( msg == null )
-                throw new ArgumentException( "A value for 'msg' must be supplied" );
+            {
+                throw new ArgumentNullException( nameof(msg), "A value for 'msg' must be supplied" );
+            }
 
             if ( this.SessionID.HasValue )
+            {
                 msg.SessionID = this.SessionID.Value;
+            }
 
             if ( this.SteamID != null )
+            {
                 msg.SteamID = this.SteamID;
+            }
 
             DebugLog.WriteLine( "CMClient", "Sent -> EMsg: {0} (Proto: {1})", msg.MsgType, msg.IsProto );
 

--- a/SteamKit2/SteamKit2/Steam/Discovery/FileStorageServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/FileStorageServerListProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,6 +57,11 @@ namespace SteamKit2.Discovery
         /// <returns>Awaitable task for write completion</returns>
         public Task UpdateServerListAsync(IEnumerable<ServerRecord> endpoints)
         {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
             return Task.Run(() =>
             {
                 try

--- a/SteamKit2/SteamKit2/Steam/Discovery/IsolatedStorageServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/IsolatedStorageServerListProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.IsolatedStorage;

--- a/SteamKit2/SteamKit2/Steam/Discovery/IsolatedStorageServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/IsolatedStorageServerListProvider.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.IsolatedStorage;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using ProtoBuf;
 
@@ -60,6 +59,11 @@ namespace SteamKit2.Discovery
         /// <returns>Awaitable task for write completion</returns>
         public Task UpdateServerListAsync(IEnumerable<ServerRecord> endpoints)
         {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
             return Task.Run(() =>
             {
                 try

--- a/SteamKit2/SteamKit2/Steam/Discovery/NullServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/NullServerListProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace SteamKit2.Discovery

--- a/SteamKit2/SteamKit2/Steam/Discovery/SmartCMServerList.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/SmartCMServerList.cs
@@ -156,6 +156,11 @@ namespace SteamKit2.Discovery
         /// <param name="endpointList">The <see cref="ServerRecord"/>s to use for this <see cref="SmartCMServerList"/>.</param>
         public void ReplaceList( IEnumerable<ServerRecord> endpointList )
         {
+            if ( endpointList == null )
+            {
+                throw new ArgumentNullException( nameof(endpointList) );
+            }
+
             lock ( listLock )
             {
                 var distinctEndPoints = endpointList.Distinct().ToArray();

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/Callbacks.cs
@@ -459,7 +459,7 @@ namespace SteamKit2
 
                     this.KeyValues = new KeyValue();
 
-                    if ( app_info.buffer != null )
+                    if ( app_info.buffer != null && app_info.buffer.Length > 0 )
                     {
                         // we don't want to read the trailing null byte
                         using ( var ms = new MemoryStream( app_info.buffer, 0, app_info.buffer.Length - 1 ) )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -245,6 +245,16 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
         public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( IEnumerable<PICSRequest> apps, IEnumerable<PICSRequest> packages, bool metaDataOnly = false )
         {
+            if ( apps == null )
+            {
+                throw new ArgumentNullException( nameof(apps) );
+            }
+
+            if ( packages == null )
+            {
+                throw new ArgumentNullException( nameof(apps) );
+            }
+
             var request = new ClientMsgProtobuf<CMsgClientPICSProductInfoRequest>( EMsg.ClientPICSProductInfoRequest );
             request.SourceJobID = Client.GetNextJobID();
 
@@ -284,16 +294,16 @@ namespace SteamKit2
         /// <param name="depot">Depot id requested.</param>
         /// <param name="host_name">CDN host name being requested.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="CDNAuthTokenCallback"/>.</returns>
-        public AsyncJob<CDNAuthTokenCallback> GetCDNAuthToken(uint app, uint depot, string host_name)
+        public AsyncJob<CDNAuthTokenCallback> GetCDNAuthToken( uint app, uint depot, string host_name )
         {
-            var request = new ClientMsgProtobuf<CMsgClientGetCDNAuthToken>(EMsg.ClientGetCDNAuthToken);
+            var request = new ClientMsgProtobuf<CMsgClientGetCDNAuthToken>( EMsg.ClientGetCDNAuthToken );
             request.SourceJobID = Client.GetNextJobID();
 
             request.Body.app_id = app;
             request.Body.depot_id = depot;
             request.Body.host_name = host_name;
 
-            this.Client.Send(request);
+            this.Client.Send( request );
 
             return new AsyncJob<CDNAuthTokenCallback>( this.Client, request.SourceJobID );
         }
@@ -318,6 +328,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="FreeLicenseCallback"/>.</returns>
         public AsyncJob<FreeLicenseCallback> RequestFreeLicense( IEnumerable<uint> apps )
         {
+            if ( apps == null )
+            {
+                throw new ArgumentNullException( nameof(apps) );
+            }
+
             var request = new ClientMsgProtobuf<CMsgClientRequestFreeLicense>( EMsg.ClientRequestFreeLicense );
             request.SourceJobID = Client.GetNextJobID();
 
@@ -355,8 +370,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
@@ -82,7 +82,7 @@ namespace SteamKit2
         /// <param name="appid">The app id of the game.</param>
         /// <param name="filename">The path to the file being requested.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="ShareFileCallback"/>.</returns>
-        public AsyncJob<ShareFileCallback> ShareFile(uint appid, string filename)
+        public AsyncJob<ShareFileCallback> ShareFile( uint appid, string filename )
         {
             var request = new ClientMsgProtobuf<CMsgClientUFSShareFile>(EMsg.ClientUFSShareFile);
             request.SourceJobID = Client.GetNextJobID();

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
@@ -38,6 +38,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UGCDetailsCallback"/>.</returns>
         public AsyncJob<UGCDetailsCallback> RequestUGCDetails( UGCHandle ugcId )
         {
+            if ( ugcId == null )
+            {
+                throw new ArgumentNullException( nameof(ugcId) );
+            }
+
             var request = new ClientMsgProtobuf<CMsgClientUFSGetUGCDetails>( EMsg.ClientUFSGetUGCDetails );
             request.SourceJobID = Client.GetNextJobID();
 
@@ -56,9 +61,9 @@ namespace SteamKit2
         /// <param name="appid">The app id of the game.</param>
         /// <param name="filename">The path to the file being requested.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="SingleFileInfoCallback"/>.</returns>
-        public AsyncJob<SingleFileInfoCallback> GetSingleFileInfo(uint appid, string filename)
+        public AsyncJob<SingleFileInfoCallback> GetSingleFileInfo( uint appid, string filename )
         {
-            var request = new ClientMsgProtobuf<CMsgClientUFSGetSingleFileInfo>(EMsg.ClientUFSGetSingleFileInfo);
+            var request = new ClientMsgProtobuf<CMsgClientUFSGetSingleFileInfo> (EMsg.ClientUFSGetSingleFileInfo );
             request.SourceJobID = Client.GetNextJobID();
 
             request.Body.app_id = appid;
@@ -96,8 +101,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+            
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
@@ -735,11 +735,8 @@ namespace SteamKit2
 
                 this.ChatMsgType = msg.ChatMsgType;
 
-                if ( payload != null )
-                {
-                    this.Message = Encoding.UTF8.GetString( payload );
-                    this.Message = this.Message.TrimEnd( new[] { '\0' } ); // trim any extra null chars from the end
-                }
+                this.Message = Encoding.UTF8.GetString( payload );
+                this.Message = this.Message.TrimEnd( new[] { '\0' } ); // trim any extra null chars from the end
             }
         }
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -74,7 +74,7 @@ namespace SteamKit2
         public AsyncJob<PersonaChangeCallback> SetPersonaName( string name )
         {
             // cache the local name right away, so that early calls to SetPersonaState don't reset the set name
-            cache.LocalUser.Name = name;
+            cache.LocalUser.Name = name ?? throw new ArgumentNullException( nameof(name) );
 
             var stateMsg = new ClientMsgProtobuf<CMsgClientChangeStatus>( EMsg.ClientChangeStatus );
             stateMsg.SourceJobID = Client.GetNextJobID();
@@ -151,6 +151,11 @@ namespace SteamKit2
         /// <returns>The name.</returns>
         public string GetFriendPersonaName( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).Name;
         }
         /// <summary>
@@ -160,6 +165,11 @@ namespace SteamKit2
         /// <returns>The persona state.</returns>
         public EPersonaState GetFriendPersonaState( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).PersonaState;
         }
         /// <summary>
@@ -169,6 +179,11 @@ namespace SteamKit2
         /// <returns>The relationship of the friend to the local user.</returns>
         public EFriendRelationship GetFriendRelationship( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).Relationship;
         }
         /// <summary>
@@ -178,6 +193,11 @@ namespace SteamKit2
         /// <returns>The game name of a friend playing a game, or null if they haven't been cached yet.</returns>
         public string GetFriendGamePlayedName( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).GameName;
         }
         /// <summary>
@@ -187,6 +207,11 @@ namespace SteamKit2
         /// <returns>The gameid of a friend playing a game, or 0 if they haven't been cached yet.</returns>
         public GameID GetFriendGamePlayed( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).GameID;
         }
         /// <summary>
@@ -196,6 +221,11 @@ namespace SteamKit2
         /// <returns>A byte array representing a SHA-1 hash of the friend's avatar.</returns>
         public byte[] GetFriendAvatar( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.GetUser( steamId ).AvatarHash;
         }
 
@@ -233,6 +263,11 @@ namespace SteamKit2
         /// <returns>The name.</returns>
         public string GetClanName( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.Clans.GetAccount( steamId ).Name;
         }
         /// <summary>
@@ -242,6 +277,11 @@ namespace SteamKit2
         /// <returns>The relationship of the clan to the local user.</returns>
         public EClanRelationship GetClanRelationship( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.Clans.GetAccount( steamId ).Relationship;
         }
         /// <summary>
@@ -251,6 +291,11 @@ namespace SteamKit2
         /// <returns>A byte array representing a SHA-1 hash of the clan's avatar, or null if the clan could not be found.</returns>
         public byte[] GetClanAvatar( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             return cache.Clans.GetAccount( steamId ).AvatarHash;
         }
 
@@ -262,7 +307,17 @@ namespace SteamKit2
         /// <param name="message">The message to send.</param>
         public void SendChatMessage( SteamID target, EChatEntryType type, string message )
         {
-            var chatMsg = new ClientMsgProtobuf<CMsgClientFriendMsg>( EMsg.ClientFriendMsg );
+            if ( target == null )
+            {
+                throw new ArgumentNullException( nameof(target) );
+			}
+
+			if ( message == null )
+			{
+				throw new ArgumentNullException( nameof(message) );
+			}
+
+			var chatMsg = new ClientMsgProtobuf<CMsgClientFriendMsg>( EMsg.ClientFriendMsg );
 
             chatMsg.Body.steamid = target;
             chatMsg.Body.chat_entry_type = ( int )type;
@@ -277,6 +332,11 @@ namespace SteamKit2
         /// <param name="accountNameOrEmail">The account name or email of the user.</param>
         public void AddFriend( string accountNameOrEmail )
         {
+            if ( accountNameOrEmail == null )
+            {
+                throw new ArgumentNullException( nameof(accountNameOrEmail) );
+            }
+
             var addFriend = new ClientMsgProtobuf<CMsgClientAddFriend>( EMsg.ClientAddFriend );
 
             addFriend.Body.accountname_or_email_to_add = accountNameOrEmail;
@@ -289,6 +349,11 @@ namespace SteamKit2
         /// <param name="steamId">The SteamID of the friend to add.</param>
         public void AddFriend( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             var addFriend = new ClientMsgProtobuf<CMsgClientAddFriend>( EMsg.ClientAddFriend );
 
             addFriend.Body.steamid_to_add = steamId;
@@ -301,6 +366,11 @@ namespace SteamKit2
         /// <param name="steamId">The SteamID of the friend to remove.</param>
         public void RemoveFriend( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             var removeFriend = new ClientMsgProtobuf<CMsgClientRemoveFriend>( EMsg.ClientRemoveFriend );
 
             removeFriend.Body.friendid = steamId;
@@ -315,6 +385,11 @@ namespace SteamKit2
         /// <param name="steamId">The SteamID of the chat room.</param>
         public void JoinChat( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             SteamID chatId = steamId.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             var joinChat = new ClientMsg<MsgClientJoinChat>();
@@ -337,6 +412,11 @@ namespace SteamKit2
         /// <param name="steamId">The SteamID of the chat room.</param>
         public void LeaveChat( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             SteamID chatId = steamId.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             var leaveChat = new ClientMsg<MsgClientChatMemberInfo>();
@@ -366,6 +446,16 @@ namespace SteamKit2
         /// <param name="message">The message.</param>
         public void SendChatRoomMessage( SteamID steamIdChat, EChatEntryType type, string message )
         {
+            if ( steamIdChat == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdChat) );
+            }
+
+            if ( message == null )
+            {
+                throw new ArgumentNullException( nameof(message) );
+            }
+
             SteamID chatId = steamIdChat.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             if ( chatId.IsClanAccount )
@@ -394,6 +484,16 @@ namespace SteamKit2
         /// <param name="steamIdChat">The SteamID of the chat room to invite the user to.</param>
         public void InviteUserToChat( SteamID steamIdUser, SteamID steamIdChat )
         {
+            if ( steamIdUser == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdUser) );
+            }
+
+            if ( steamIdChat == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdChat) );
+            }
+
             SteamID chatId = steamIdChat.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             if ( chatId.IsClanAccount )
@@ -421,6 +521,16 @@ namespace SteamKit2
         /// <param name="steamIdMember">The SteamID of the member to kick from the chat.</param>
         public void KickChatMember( SteamID steamIdChat, SteamID steamIdMember )
         {
+            if ( steamIdChat == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdChat) );
+            }
+
+            if ( steamIdMember == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdMember) );
+            }
+
             SteamID chatId = steamIdChat.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             var kickMember = new ClientMsg<MsgClientChatAction>();
@@ -447,6 +557,16 @@ namespace SteamKit2
         /// <param name="steamIdMember">The SteamID of the member to ban from the chat.</param>
         public void BanChatMember( SteamID steamIdChat, SteamID steamIdMember )
         {
+            if ( steamIdChat == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdChat) );
+            }
+
+            if ( steamIdMember == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdMember) );
+            }
+
             SteamID chatId = steamIdChat.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             var banMember = new ClientMsg<MsgClientChatAction>();
@@ -472,6 +592,16 @@ namespace SteamKit2
         /// <param name="steamIdMember">The SteamID of the member to unban from the chat.</param>
         public void UnbanChatMember( SteamID steamIdChat, SteamID steamIdMember )
         {
+            if ( steamIdChat == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdChat) );
+            }
+
+            if ( steamIdMember == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdMember) );
+            }
+
             SteamID chatId = steamIdChat.ConvertToUInt64(); // copy the steamid so we don't modify it
 
             var unbanMember = new ClientMsg<MsgClientChatAction>();
@@ -499,6 +629,11 @@ namespace SteamKit2
         /// <param name="requestedInfo">The requested info flags. If none specified, this uses <see cref="SteamConfiguration.DefaultPersonaStateFlags"/>.</param>
         public void RequestFriendInfo( IEnumerable<SteamID> steamIdList, EClientPersonaStateFlag requestedInfo = default(EClientPersonaStateFlag) )
         {
+            if ( steamIdList == null )
+            {
+                throw new ArgumentNullException( nameof(steamIdList) );
+            }
+
             if ( requestedInfo == default(EClientPersonaStateFlag) )
             {
                 requestedInfo = Client.Configuration.DefaultPersonaStateFlags;
@@ -519,6 +654,11 @@ namespace SteamKit2
         /// <param name="requestedInfo">The requested info flags. If none specified, this uses <see cref="SteamConfiguration.DefaultPersonaStateFlags"/>.</param>
         public void RequestFriendInfo( SteamID steamId, EClientPersonaStateFlag requestedInfo = 0 )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             RequestFriendInfo( new SteamID[] { steamId }, requestedInfo );
         }
 
@@ -532,6 +672,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="IgnoreFriendCallback"/>.</returns>
         public AsyncJob<IgnoreFriendCallback> IgnoreFriend( SteamID steamId, bool setIgnore = true )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             var ignore = new ClientMsg<MsgClientSetIgnoreFriend>();
             ignore.SourceJobID = Client.GetNextJobID();
 
@@ -554,6 +699,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="ProfileInfoCallback"/>.</returns>
         public AsyncJob<ProfileInfoCallback> RequestProfileInfo( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             var request = new ClientMsgProtobuf<CMsgClientFriendProfileInfo>( EMsg.ClientFriendProfileInfo );
             request.SourceJobID = Client.GetNextJobID();
 
@@ -571,6 +721,11 @@ namespace SteamKit2
         /// <param name="steamId">SteamID of the friend</param>
         public void RequestMessageHistory( SteamID steamId )
         {
+            if ( steamId == null )
+            {
+                throw new ArgumentNullException( nameof(steamId) );
+            }
+
             var request = new ClientMsgProtobuf<CMsgClientChatGetFriendMessageHistory>( EMsg.ClientFSGetFriendMessageHistory );
 
             request.Body.steamid = steamId;
@@ -597,6 +752,11 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
             Action<IPacketMsg> handlerFunc;
             bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -310,14 +310,14 @@ namespace SteamKit2
             if ( target == null )
             {
                 throw new ArgumentNullException( nameof(target) );
-			}
+            }
 
-			if ( message == null )
-			{
-				throw new ArgumentNullException( nameof(message) );
-			}
+            if ( message == null )
+            {
+                throw new ArgumentNullException( nameof(message) );
+            }
 
-			var chatMsg = new ClientMsgProtobuf<CMsgClientFriendMsg>( EMsg.ClientFriendMsg );
+            var chatMsg = new ClientMsgProtobuf<CMsgClientFriendMsg>( EMsg.ClientFriendMsg );
 
             chatMsg.Body.steamid = target;
             chatMsg.Body.chat_entry_type = ( int )type;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -757,8 +757,7 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(packetMsg) );
             }
 
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
@@ -28,6 +28,11 @@ namespace SteamKit2
         /// <param name="appId">The app id of the game coordinator to send to.</param>
         public void Send( IClientGCMsg msg, uint appId )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             var clientMsg = new ClientMsgProtobuf<CMsgGCClient>( EMsg.ClientToGC );
 
             clientMsg.ProtoHeader.routing_appid = appId;
@@ -46,8 +51,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -217,8 +217,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -187,7 +187,7 @@ namespace SteamKit2
         {
             if (details == null)
             {
-                throw new ArgumentNullException("details");
+                throw new ArgumentNullException( nameof(details) );
             }
 
             if (details.Address != null && details.Address.AddressFamily != AddressFamily.InterNetwork)

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
@@ -68,13 +68,20 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="QueryCallback"/>.</returns>
         public AsyncJob<QueryCallback> ServerQuery( QueryDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var query = new ClientMsgProtobuf<CMsgClientGMSServerQuery>( EMsg.ClientGMSServerQuery );
             query.SourceJobID = Client.GetNextJobID();
 
             query.Body.app_id = details.AppID;
 
             if ( details.GeoLocatedIP != null )
+            {
                 query.Body.geo_location_ip = NetHelpers.GetIPAddress( details.GeoLocatedIP );
+            }
 
             query.Body.filter_text = details.Filter;
             query.Body.region_code = ( uint )details.Region;
@@ -93,8 +100,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamScreenshots/SteamScreenshots.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamScreenshots/SteamScreenshots.cs
@@ -101,10 +101,19 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="ScreenshotAddedCallback"/>.</returns>
         public AsyncJob<ScreenshotAddedCallback> AddScreenshot( ScreenshotDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var msg = new ClientMsgProtobuf<CMsgClientUCMAddScreenshot>( EMsg.ClientUCMAddScreenshot );
             msg.SourceJobID = Client.GetNextJobID();
 
-            msg.Body.appid = details.GameID.AppID;
+            if ( details.GameID != null )
+            {
+                msg.Body.appid = details.GameID.AppID;
+            }
+
             msg.Body.caption = details.Caption;
             msg.Body.filename = details.UFSImageFilePath;
             msg.Body.permissions = ( uint )details.Privacy;
@@ -125,8 +134,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamTrading/SteamTrading.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamTrading/SteamTrading.cs
@@ -35,6 +35,11 @@ namespace SteamKit2
         /// <param name="user">The client to trade.</param>
         public void Trade( SteamID user )
         {
+            if ( user == null )
+            {
+                throw new ArgumentNullException( nameof(user) );
+            }
+
             var tradeReq = new ClientMsgProtobuf<CMsgTrading_InitiateTradeRequest>( EMsg.EconTrading_InitiateTradeRequest );
 
             tradeReq.Body.other_steamid = user;
@@ -63,6 +68,11 @@ namespace SteamKit2
         /// <param name="user">The user.</param>
         public void CancelTrade( SteamID user )
         {
+            if ( user == null )
+            {
+                throw new ArgumentNullException( nameof(user) );
+            }
+
             var cancelTrade = new ClientMsgProtobuf<CMsgTrading_CancelTradeRequest>( EMsg.EconTrading_CancelTradeRequest );
 
             cancelTrade.Body.other_steamid = user;
@@ -77,8 +87,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
@@ -111,7 +111,7 @@ namespace SteamKit2
             internal ServiceMethodNotification( Type messageType, IPacketMsg packetMsg )
             {
                 // Bounce into generic-land.
-                var setupMethod = GetType().GetMethod( "Setup", BindingFlags.Instance | BindingFlags.NonPublic ).MakeGenericMethod( messageType );
+                var setupMethod = GetType().GetMethod( nameof(Setup), BindingFlags.Instance | BindingFlags.NonPublic ).MakeGenericMethod( messageType );
                 setupMethod.Invoke( this, new[] { packetMsg } );
             }
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -290,7 +290,7 @@ namespace SteamKit2
         {
             if ( details == null )
             {
-                throw new ArgumentNullException( "details" );
+                throw new ArgumentNullException( nameof(details) );
             }
             if ( string.IsNullOrEmpty( details.Username ) || ( string.IsNullOrEmpty( details.Password ) && string.IsNullOrEmpty( details.LoginKey ) ) )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -372,6 +372,11 @@ namespace SteamKit2
         /// <param name="details">The details to use for logging on.</param>
         public void LogOnAnonymous( AnonymousLogOnDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             if ( !this.Client.IsConnected )
             {
                 this.Client.PostCallback( new LoggedOnCallback( EResult.NoConnection ) );
@@ -414,6 +419,11 @@ namespace SteamKit2
         /// <param name="details">The details pertaining to the response.</param>
         public void SendMachineAuthResponse( MachineAuthDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var response = new ClientMsgProtobuf<CMsgClientUpdateMachineAuthResponse>( EMsg.ClientUpdateMachineAuthResponse );
 
             // so we respond to the correct message
@@ -460,6 +470,11 @@ namespace SteamKit2
         /// <param name="callback">The callback containing the new Login Key.</param>
         public void AcceptNewLoginKey( LoginKeyCallback callback )
         {
+            if ( callback == null )
+            {
+                throw new ArgumentNullException( nameof(callback) );
+            }
+
             var acceptance = new ClientMsgProtobuf<CMsgClientNewLoginKeyAccepted>( EMsg.ClientNewLoginKeyAccepted );
             acceptance.Body.unique_id = callback.UniqueID;
 
@@ -472,8 +487,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
@@ -135,7 +135,7 @@ namespace SteamKit2
         /// <param name="packetMsg">The <see cref="SteamKit2.IPacketMsg"/> instance containing the event data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            if ( packetMsg != null )
+            if ( packetMsg == null )
             {
                 throw new ArgumentNullException( nameof(packetMsg) );
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUserStats/SteamUserStats.cs
@@ -135,8 +135,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The <see cref="SteamKit2.IPacketMsg"/> instance containing the event data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg != null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamWorkshop/SteamWorkshop.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamWorkshop/SteamWorkshop.cs
@@ -77,6 +77,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UserPublishedFilesCallback"/>.</returns>
         public AsyncJob<UserPublishedFilesCallback> EnumerateUserPublishedFiles( EnumerationUserDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var enumRequest = new ClientMsgProtobuf<CMsgClientUCMEnumerateUserPublishedFiles>( EMsg.ClientUCMEnumerateUserPublishedFiles );
             enumRequest.SourceJobID = Client.GetNextJobID();
 
@@ -97,6 +102,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UserSubscribedFilesCallback"/>.</returns>
         public AsyncJob<UserSubscribedFilesCallback> EnumerateUserSubscribedFiles( EnumerationUserDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var enumRequest = new ClientMsgProtobuf<CMsgClientUCMEnumerateUserSubscribedFiles>( EMsg.ClientUCMEnumerateUserSubscribedFiles );
             enumRequest.SourceJobID = Client.GetNextJobID();
 
@@ -117,6 +127,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UserActionPublishedFilesCallback"/>.</returns>
         public AsyncJob<UserActionPublishedFilesCallback> EnumeratePublishedFilesByUserAction( EnumerationUserDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var enumRequest = new ClientMsgProtobuf<CMsgClientUCMEnumeratePublishedFilesByUserAction>( EMsg.ClientUCMEnumeratePublishedFilesByUserAction );
             enumRequest.SourceJobID = Client.GetNextJobID();
 
@@ -202,6 +217,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PublishedFilesCallback"/>.</returns>
         public AsyncJob<PublishedFilesCallback> EnumeratePublishedFiles( EnumerationDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             var enumRequest = new ClientMsgProtobuf<CMsgCREEnumeratePublishedFiles>( EMsg.CREEnumeratePublishedFiles );
             enumRequest.SourceJobID = Client.GetNextJobID();
 
@@ -228,8 +248,12 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            Action<IPacketMsg> handlerFunc;
-            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out handlerFunc );
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            bool haveFunc = dispatchMap.TryGetValue( packetMsg.MsgType, out var handlerFunc );
 
             if ( !haveFunc )
             {

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -31,6 +31,11 @@ namespace SteamKit2
         /// <param name="client">The <see cref="SteamClient"/> instance to handle the callbacks of.</param>
         public CallbackManager( SteamClient client )
         {
+            if ( client == null )
+            {
+                throw new ArgumentNullException( nameof(client) );
+            }
+
             registeredCallbacks = new List<CallbackBase>();
 
             this.client = client;
@@ -97,6 +102,16 @@ namespace SteamKit2
         public IDisposable Subscribe<TCallback>( JobID jobID, Action<TCallback> callbackFunc )
             where TCallback : class, ICallbackMsg
         {
+            if ( jobID == null )
+            {
+                throw new ArgumentNullException( nameof(jobID) );
+            }
+
+            if ( callbackFunc == null )
+            {
+                throw new ArgumentNullException( nameof(callbackFunc) );
+            }
+
             var callback = new Internal.Callback<TCallback>( callbackFunc, this, jobID );
             return new Subscription( callback, this );
         }
@@ -106,13 +121,13 @@ namespace SteamKit2
         /// </summary>
         /// <param name="callbackFunc">The function to invoke with the callback.</param>
         /// <returns>An <see cref="IDisposable"/>. Disposing of the return value will unsubscribe the <paramref name="callbackFunc"/>.</returns>
-        public IDisposable Subscribe<TCallback>( Action<TCallback> callbackFunc)
+        public IDisposable Subscribe<TCallback>( Action<TCallback> callbackFunc )
             where TCallback : class, ICallbackMsg
         {
             return Subscribe( JobID.Invalid, callbackFunc );
         }
 
-        void ICallbackMgrInternals.Register(CallbackBase call )
+        void ICallbackMgrInternals.Register( CallbackBase call )
         {
             if ( registeredCallbacks.Contains( call ) )
                 return;
@@ -127,14 +142,14 @@ namespace SteamKit2
                 .ForEach( callback => callback.Run( call ) ); // run them
         }
 
-        void ICallbackMgrInternals.Unregister(CallbackBase call )
+        void ICallbackMgrInternals.Unregister( CallbackBase call )
         {
             registeredCallbacks.Remove( call );
         }
 
         sealed class Subscription : IDisposable
         {
-            public Subscription(CallbackBase call, ICallbackMgrInternals manager)
+            public Subscription( CallbackBase call, ICallbackMgrInternals manager)
             {
                 this.manager = manager;
                 this.call = call;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -149,7 +149,7 @@ namespace SteamKit2
 
         sealed class Subscription : IDisposable
         {
-            public Subscription( CallbackBase call, ICallbackMgrInternals manager)
+            public Subscription( CallbackBase call, ICallbackMgrInternals manager )
             {
                 this.manager = manager;
                 this.call = call;
@@ -160,7 +160,7 @@ namespace SteamKit2
 
             void IDisposable.Dispose()
             {
-                if (call != null && manager != null)
+                if ( call != null && manager != null )
                 {
                     manager.Unregister( call );
                     call = null;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -110,9 +110,6 @@ namespace SteamKit2
         /// <param name="handler">The handler name to remove.</param>
         public void RemoveHandler( Type handler )
         {
-            if ( !handlers.ContainsKey( handler ) )
-                return;
-
             handlers.Remove( handler );
         }
         /// <summary>
@@ -136,8 +133,10 @@ namespace SteamKit2
         {
             Type type = typeof( T );
 
-            if ( handlers.ContainsKey( type ) )
-                return handlers[ type ] as T;
+            if ( handlers.TryGetValue( type, out var handler ) )
+            {
+                return handler as T;
+            }
 
             return null;
         }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -95,10 +95,13 @@ namespace SteamKit2
         public void AddHandler( ClientMsgHandler handler )
         {
             if ( handlers.ContainsKey( handler.GetType() ) )
+            {
                 throw new InvalidOperationException( string.Format( "A handler of type \"{0}\" is already registered.", handler.GetType() ) );
 
-            handlers[ handler.GetType() ] = handler;
+            }
+
             handler.Setup( this );
+            handlers[ handler.GetType() ] = handler;
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
+++ b/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
@@ -58,7 +58,7 @@ namespace SteamKit2
         /// </param>
         public UFSClient( SteamClient steamClient )
         {
-            this.steamClient = steamClient ?? throw new ArgumentNullException(nameof(steamClient));
+            this.steamClient = steamClient ?? throw new ArgumentNullException( nameof(steamClient) );
 
             // our default timeout
             ConnectionTimeout = TimeSpan.FromSeconds( 5 );

--- a/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
+++ b/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
@@ -58,12 +58,7 @@ namespace SteamKit2
         /// </param>
         public UFSClient( SteamClient steamClient )
         {
-            if ( steamClient != null )
-            {
-                throw new ArgumentNullException( nameof(steamClient) );
-            }
-
-            this.steamClient = steamClient;
+            this.steamClient = steamClient ?? throw new ArgumentNullException(nameof(steamClient));
 
             // our default timeout
             ConnectionTimeout = TimeSpan.FromSeconds( 5 );

--- a/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
+++ b/SteamKit2/SteamKit2/Steam/UFSClient/UFSClient.cs
@@ -58,6 +58,11 @@ namespace SteamKit2
         /// </param>
         public UFSClient( SteamClient steamClient )
         {
+            if ( steamClient != null )
+            {
+                throw new ArgumentNullException( nameof(steamClient) );
+            }
+
             this.steamClient = steamClient;
 
             // our default timeout
@@ -158,6 +163,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="LoggedOnCallback"/>.</returns>
         public JobID Logon( IEnumerable<uint> appIds )
         {
+            if ( appIds == null )
+            {
+                throw new ArgumentNullException( nameof(appIds) );
+            }
+
             var jobId = steamClient.GetNextJobID();
 
             if ( !steamClient.IsConnected )
@@ -188,6 +198,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UploadFileResponseCallback"/>.</returns>
         public JobID RequestFileUpload( UploadDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             byte[] compressedData = ZipUtil.Compress( details.FileData );
 
             var msg = new ClientMsgProtobuf<CMsgClientUFSUploadFileRequest>( EMsg.ClientUFSUploadFileRequest );
@@ -215,6 +230,11 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UploadFileFinishedCallback"/>.</returns>
         public void UploadFile( UploadDetails details )
         {
+            if ( details == null )
+            {
+                throw new ArgumentNullException( nameof(details) );
+            }
+
             const uint MaxBytesPerChunk = 10240;
 
             byte[] compressedData = ZipUtil.Compress( details.FileData );
@@ -256,6 +276,11 @@ namespace SteamKit2
         /// <param name="msg">The client message to send.</param>
         public void Send( IClientMsg msg )
         {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
             msg.SteamID = steamClient.SteamID;
 
             DebugLog.WriteLine( "UFSClient", "Sent -> EMsg: {0} {1}", msg.MsgType, msg.IsProto ? "(Proto)" : "" );
@@ -303,9 +328,10 @@ namespace SteamKit2
                 { EMsg.ClientUFSUploadFileFinished, HandleUploadFileFinished },
             };
 
-            Action<IPacketMsg> handlerFunc;
-            if ( !msgDispatch.TryGetValue( packetMsg.MsgType, out handlerFunc ) )
+            if ( !msgDispatch.TryGetValue( packetMsg.MsgType, out var handlerFunc ) )
+            {
                 return;
+            }
 
             handlerFunc( packetMsg );
         }

--- a/SteamKit2/SteamKit2/Steam/WebAPI/SteamDirectory.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/SteamDirectory.cs
@@ -31,6 +31,11 @@ namespace SteamKit2
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> with the Result set to an enumerable list of <see cref="ServerRecord"/>s.</returns>
         public static Task<IReadOnlyCollection<ServerRecord>> LoadAsync( SteamConfiguration configuration, CancellationToken cancellationToken )
         {
+            if ( configuration == null )
+            {
+                throw new ArgumentNullException( nameof(configuration) );
+            }
+
             var directory = new WebAPI.AsyncInterface( configuration.WebAPIBaseAddress, "ISteamDirectory", null );
             var args = new Dictionary<string, string>
             {

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -232,13 +232,19 @@ namespace SteamKit2
             async Task<KeyValue> CallAsyncCore( HttpMethod method, string func, int version = 1, Dictionary<string, string> args = null )
             {
                 if ( method == null )
+                {
                     throw new ArgumentNullException( nameof(method) );
+                }
 
                 if ( func == null )
+                {
                     throw new ArgumentNullException( nameof(func) );
+                }
 
                 if ( args == null )
+                {
                     args = new Dictionary<string, string>();
+                }
 
 
                 var urlBuilder = new StringBuilder();
@@ -443,6 +449,16 @@ namespace SteamKit2
         /// <returns>A dynamic <see cref="Interface"/> object to interact with the Web API.</returns>
         public static Interface GetInterface( Uri baseAddress, string iface, string apiKey = "" )
         {
+            if ( baseAddress == null )
+            {
+                throw new ArgumentNullException( nameof(baseAddress) );
+            }
+
+            if ( iface == null )
+            {
+                throw new ArgumentNullException( nameof(iface) );
+            }
+
             return new Interface( baseAddress, iface, apiKey );
         }
 
@@ -454,6 +470,11 @@ namespace SteamKit2
         /// <returns>A dynamic <see cref="Interface"/> object to interact with the Web API.</returns>
         public static Interface GetInterface( string iface, string apiKey = "" )
         {
+            if ( iface == null )
+            {
+                throw new ArgumentNullException( nameof(iface) );
+            }
+
             return new Interface( DefaultBaseAddress, iface, apiKey );
         }
 
@@ -465,6 +486,11 @@ namespace SteamKit2
         /// <returns>A dynamic <see cref="AsyncInterface"/> object to interact with the Web API.</returns>
         public static AsyncInterface GetAsyncInterface( string iface, string apiKey = "" )
         {
+            if ( iface == null )
+            {
+                throw new ArgumentNullException( nameof(iface) );
+            }
+
             return new AsyncInterface( DefaultBaseAddress, iface, apiKey );
         }
 
@@ -477,6 +503,16 @@ namespace SteamKit2
         /// <returns>A dynamic <see cref="AsyncInterface"/> object to interact with the Web API.</returns>
         public static AsyncInterface GetAsyncInterface( Uri baseAddress, string iface, string apiKey = "" )
         {
+            if ( baseAddress == null )
+            {
+                throw new ArgumentNullException( nameof(baseAddress) );
+            }
+
+            if ( iface == null )
+            {
+                throw new ArgumentNullException( nameof(iface) );
+            }
+            
             return new AsyncInterface( baseAddress, iface, apiKey );
         }
     }

--- a/SteamKit2/SteamKit2/Types/DepotManifest.cs
+++ b/SteamKit2/SteamKit2/Types/DepotManifest.cs
@@ -103,9 +103,13 @@ namespace SteamKit2
             internal FileData(string filename, EDepotFileFlag flag, ulong size, byte[] hash, bool encrypted, int numChunks)
             {
                 if (encrypted)
+                {
                     this.FileName = filename;
+                }
                 else
+                {
                     this.FileName = filename.Replace(altDirChar, Path.DirectorySeparatorChar);
+                }
 
                 this.Flags = flag;
                 this.TotalSize = size;
@@ -141,7 +145,9 @@ namespace SteamKit2
         public bool DecryptFilenames(byte[] encryptionKey)
         {
             if (!FilenamesEncrypted)
+            {
                 return true;
+            }
 
             foreach (var file in Files)
             {

--- a/SteamKit2/SteamKit2/Types/GameID.cs
+++ b/SteamKit2/SteamKit2/Types/GameID.cs
@@ -92,6 +92,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator string( GameID gid )
         {
+            if ( gid == null )
+            {
+                throw new ArgumentNullException( nameof(gid) );
+            }
+
             return gid.gameid.Data.ToString();
         }
 
@@ -104,6 +109,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator UInt64( GameID gid )
         {
+            if ( gid == null )
+            {
+                throw new ArgumentNullException( nameof(gid) );
+            }
+
             return gid.gameid.Data;
         }
 
@@ -225,11 +235,15 @@ namespace SteamKit2
         public override bool Equals( System.Object obj )
         {
             if ( obj == null )
+            {
                 return false;
+            }
 
             GameID gid = obj as GameID;
             if ( ( System.Object )gid == null )
+            {
                 return false;
+            }
 
             return gameid.Data == gid.gameid.Data;
         }
@@ -244,7 +258,9 @@ namespace SteamKit2
         public bool Equals( GameID gid )
         {
             if ( ( object )gid == null )
+            {
                 return false;
+            }
 
             return gameid.Data == gid.gameid.Data;
         }
@@ -260,10 +276,14 @@ namespace SteamKit2
         public static bool operator ==( GameID a, GameID b )
         {
             if ( System.Object.ReferenceEquals( a, b ) )
+            {
                 return true;
+            }
 
             if ( ( ( object )a == null ) || ( ( object )b == null ) )
+            {
                 return false;
+            }
 
             return a.gameid.Data == b.gameid.Data;
         }

--- a/SteamKit2/SteamKit2/Types/GlobalID.cs
+++ b/SteamKit2/SteamKit2/Types/GlobalID.cs
@@ -48,6 +48,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator ulong( GlobalID gid )
         {
+            if ( gid == null )
+            {
+                throw new ArgumentNullException( nameof(gid) );
+            }
+
             return gid.gidBits.Data;
         }
 
@@ -144,11 +149,15 @@ namespace SteamKit2
         public override bool Equals( object obj )
         {
             if ( obj == null )
+            {
                 return false;
+            }
 
             GlobalID gid = obj as GlobalID;
             if ( ( object )gid == null )
+            {
                 return false;
+            }
 
             return gidBits.Data == gid.gidBits.Data;
         }
@@ -163,7 +172,9 @@ namespace SteamKit2
         public bool Equals( GlobalID gid )
         {
             if ( ( object )gid == null )
+            {
                 return false;
+            }
 
             return gidBits.Data == gid.gidBits.Data;
         }
@@ -179,10 +190,14 @@ namespace SteamKit2
         public static bool operator ==( GlobalID a, GlobalID b )
         {
             if ( System.Object.ReferenceEquals( a, b ) )
+            {
                 return true;
+            }
 
             if ( ( ( object )a == null ) || ( ( object )b == null ) )
+            {
                 return false;
+            }
 
             return a.gidBits.Data == b.gidBits.Data;
         }
@@ -255,6 +270,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator ulong( UGCHandle handle )
         {
+            if ( handle == null )
+            {
+                throw new ArgumentNullException( nameof(handle) );
+            }
+
             return handle.Value;
         }
 

--- a/SteamKit2/SteamKit2/Types/JobID.cs
+++ b/SteamKit2/SteamKit2/Types/JobID.cs
@@ -50,6 +50,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator ulong ( JobID jobId )
         {
+            if ( jobId == null )
+            {
+                throw new ArgumentNullException( nameof(jobId) );
+            }
+
             return jobId.Value;
         }
 
@@ -74,6 +79,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator JobID( AsyncJob asyncJob )
         {
+            if ( asyncJob == null )
+            {
+                throw new ArgumentNullException( nameof(asyncJob) );
+            }
+
             return asyncJob.JobID;
         }
     }
@@ -90,7 +100,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the <see cref="JobID"/> for this job.
         /// </summary>
-        public JobID JobID { get; private set; }
+        public JobID JobID { get; }
 
         /// <summary>
         /// Gets or sets the period of time before this job will be considered timed out and will be canceled. By default this is 10 seconds.
@@ -103,8 +113,18 @@ namespace SteamKit2
         }
 
 
-        internal AsyncJob( SteamClient client, ulong jobId )
+        internal AsyncJob( SteamClient client, JobID jobId )
         {
+            if ( client == null )
+            {
+                throw new ArgumentNullException( nameof(client) );
+            }
+            
+            if ( jobId == null )
+            {
+                throw new ArgumentNullException( nameof(jobId) );
+            }
+
             jobStart = DateTime.UtcNow;
             JobID = jobId;
 
@@ -146,7 +166,7 @@ namespace SteamKit2
     public sealed class AsyncJob<T> : AsyncJob
         where T : CallbackMsg
     {
-        TaskCompletionSource<T> tcs;
+        readonly TaskCompletionSource<T> tcs;
 
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -272,6 +272,11 @@ namespace SteamKit2
         {
             get
             {
+                if ( key == null )
+                {
+                    throw new ArgumentNullException( nameof(key) );
+                }
+
                 var child = this.Children
                     .FirstOrDefault( c => string.Equals( c.Name, key, StringComparison.OrdinalIgnoreCase ) );
 
@@ -284,6 +289,11 @@ namespace SteamKit2
             }
             set
             {
+                if ( key == null )
+                {
+                    throw new ArgumentNullException( nameof(key) );
+                }
+
                 var existingChild = this.Children
                     .FirstOrDefault( c => string.Equals( c.Name, key, StringComparison.OrdinalIgnoreCase ) );
 
@@ -556,6 +566,11 @@ namespace SteamKit2
         /// </remarks>
         public static KeyValue LoadFromString( string input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+
             byte[] bytes = Encoding.UTF8.GetBytes( input );
 
             using ( MemoryStream stream = new MemoryStream( bytes ) )
@@ -583,6 +598,11 @@ namespace SteamKit2
         /// <returns><c>true</c> if the read was successful; otherwise, <c>false</c>.</returns>
         public bool ReadAsText( Stream input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+
             this.Children = new List<KeyValue>();
 
             new KVTextReader( this, input );
@@ -622,7 +642,9 @@ namespace SteamKit2
                 }
 
                 if ( name.StartsWith( "}" ) && !wasQuoted )	// top level closed, stop reading
+                {
                     break;
+                }
 
                 KeyValue dat = new KeyValue( name );
                 dat.Children = new List<KeyValue>();
@@ -638,10 +660,14 @@ namespace SteamKit2
                 }
 
                 if ( value == null )
+                {
                     throw new Exception( "RecursiveLoadFromBuffer:  got NULL key" );
+                }
 
                 if ( value.StartsWith( "}" ) && !wasQuoted )
+                {
                     throw new Exception( "RecursiveLoadFromBuffer:  got } in key" );
+                }
 
                 if ( value.StartsWith( "{" ) && !wasQuoted )
                 {
@@ -680,6 +706,11 @@ namespace SteamKit2
         /// <param name="asBinary">If set to <c>true</c>, saves this instance as binary.</param>
         public void SaveToStream( Stream stream, bool asBinary )
         {
+            if ( stream == null )
+            {
+                throw new ArgumentNullException( nameof(stream) );
+            }
+
             if (asBinary)
             {
                 RecursiveSaveBinaryToStream( stream );
@@ -779,6 +810,11 @@ namespace SteamKit2
         /// <returns><c>true</c> if the read was successful; otherwise, <c>false</c>.</returns>
         public bool TryReadAsBinary( Stream input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
             return TryReadAsBinaryCore( input, this, null );
         }
 

--- a/SteamKit2/SteamKit2/Types/Manifest.cs
+++ b/SteamKit2/SteamKit2/Types/Manifest.cs
@@ -115,6 +115,11 @@ namespace SteamKit2
 
         public Steam3Manifest(byte[] data)
         {
+            if (data ==  null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
             Deserialize(data);
         }
 

--- a/SteamKit2/SteamKit2/Types/Manifest.cs
+++ b/SteamKit2/SteamKit2/Types/Manifest.cs
@@ -115,7 +115,7 @@ namespace SteamKit2
 
         public Steam3Manifest(byte[] data)
         {
-            if (data ==  null)
+            if (data == null)
             {
                 throw new ArgumentNullException(nameof(data));
             }

--- a/SteamKit2/SteamKit2/Types/MessageObject.cs
+++ b/SteamKit2/SteamKit2/Types/MessageObject.cs
@@ -23,6 +23,11 @@ namespace SteamKit2
         /// <param name="keyValues">The KeyValue backing store for this message object.</param>
         public MessageObject( KeyValue keyValues )
         {
+            if ( keyValues == null )
+            {
+                throw new ArgumentNullException( nameof(keyValues) );
+            }
+
             this.KeyValues = keyValues;
         }
         /// <summary>
@@ -41,6 +46,11 @@ namespace SteamKit2
         /// <returns><c>true</c> on success; otherwise, <c>false</c>.</returns>
         public bool ReadFromStream( Stream stream )
         {
+            if ( stream == null )
+            {
+                throw new ArgumentNullException( nameof(stream) );
+            }
+
             return KeyValues.TryReadAsBinary( stream );
         }
 
@@ -50,6 +60,11 @@ namespace SteamKit2
         /// <param name="stream">The stream to write to.</param>
         public void WriteToStream( Stream stream )
         {
+            if ( stream == null )
+            {
+                throw new ArgumentNullException( nameof(stream) );
+            }
+
             KeyValues.SaveToStream( stream, true );
         }
     }

--- a/SteamKit2/SteamKit2/Types/PubFile.cs
+++ b/SteamKit2/SteamKit2/Types/PubFile.cs
@@ -61,12 +61,16 @@ namespace SteamKit2
         public override bool Equals( object obj )
         {
             if ( obj == null )
+            {
                 return false;
+            }
 
             UInt64Handle handle = obj as UInt64Handle;
 
             if ( ( object )handle == null )
+            {
                 return false;
+            }
 
             return handle.Value == Value;
         }
@@ -92,7 +96,9 @@ namespace SteamKit2
         public bool Equals( UInt64Handle other )
         {
             if ( ( object )other == null )
+            {
                 return false;
+            }
 
             return Value == other.Value;
         }
@@ -127,6 +133,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator ulong( PublishedFileID file )
         {
+            if ( file == null )
+            {
+                throw new ArgumentNullException( nameof(file) );
+            }
+
             return file.Value;
         }
         /// <summary>
@@ -152,10 +163,14 @@ namespace SteamKit2
         public static bool operator ==( PublishedFileID a, PublishedFileID b )
         {
             if ( object.ReferenceEquals( a, b ) )
+            {
                 return true;
+            }
 
             if ( ( ( object )a == null ) || ( ( object )b == null ) )
+            {
                 return false;
+            }
 
             return a.Value == b.Value;
         }

--- a/SteamKit2/SteamKit2/Types/SteamID.cs
+++ b/SteamKit2/SteamKit2/Types/SteamID.cs
@@ -238,17 +238,22 @@ namespace SteamKit2
         public bool SetFromString( string steamId, EUniverse eUniverse )
         {
             if ( string.IsNullOrEmpty( steamId ) )
+            {
                 return false;
+            }
 
             Match m = Steam2Regex.Match( steamId );
 
             if ( !m.Success )
+            {
                 return false;
+            }
 
-            uint accId, authServer;
-            if ( !uint.TryParse( m.Groups[ "accountid" ].Value, out accId ) || 
-                 !uint.TryParse( m.Groups[ "authserver" ].Value, out authServer ) )
+            if ( !uint.TryParse( m.Groups[ "accountid" ].Value, out var accId ) || 
+                 !uint.TryParse( m.Groups[ "authserver" ].Value, out var authServer ) )
+            {
                 return false;
+            }
 
             this.AccountUniverse = eUniverse;
             this.AccountInstance = 1;
@@ -266,7 +271,9 @@ namespace SteamKit2
         public bool SetFromSteam3String( string steamId )
         {
             if ( string.IsNullOrEmpty( steamId ) )
+            {
                 return false;
+            }
 
             Match m = Steam3Regex.Match( steamId );
 
@@ -275,22 +282,28 @@ namespace SteamKit2
                 m = Steam3FallbackRegex.Match( steamId );
 
                 if ( !m.Success )
+                {
                     return false;
+                }
             }
 
-            uint accId;
-            if ( !uint.TryParse( m.Groups[ "account" ].Value, out accId ) )
+            if ( !uint.TryParse( m.Groups[ "account" ].Value, out var accId ) )
+            {
                 return false;
+            }
 
-            uint universe;
-            if ( !uint.TryParse( m.Groups[ "universe" ].Value, out universe ) )
+            if ( !uint.TryParse( m.Groups[ "universe" ].Value, out var universe ) )
+            {
                 return false;
+            }
 
-            char type;
             var typeString = m.Groups[ "type" ].Value;
             if ( typeString.Length != 1 )
+            {
                 return false;
-            type = typeString[ 0 ];
+            }
+
+            var type = typeString[ 0 ];
 
             uint instance;
             var instanceGroup = m.Groups[ "instance" ];
@@ -616,7 +629,9 @@ namespace SteamKit2
         public string Render( bool steam3 = false )
         {
             if ( steam3 )
+            {
                 return RenderSteam3();
+            }
 
             return RenderSteam2();
         }
@@ -645,9 +660,13 @@ namespace SteamKit2
             if ( AccountType == EAccountType.Chat )
             {
                 if ( ( ( ChatInstanceFlags )AccountInstance ).HasFlag( ChatInstanceFlags.Clan ) )
+                {
                    accountTypeChar = 'c';
+                }
                 else if ( ( ( ChatInstanceFlags )AccountInstance ).HasFlag( ChatInstanceFlags.Lobby ) )
+                {
                     accountTypeChar = 'L';
+                }
             }
 
             bool renderInstance = false;
@@ -696,6 +715,11 @@ namespace SteamKit2
         /// </returns>
         public static implicit operator UInt64( SteamID sid )
         {
+            if ( sid == null )
+            {
+                throw new ArgumentNullException( nameof(sid) );
+            }
+
             return sid.steamid.Data;
         }
 
@@ -721,11 +745,15 @@ namespace SteamKit2
         public override bool Equals( System.Object obj )
         {
             if ( obj == null )
+            {
                 return false;
+            }
 
             SteamID sid = obj as SteamID;
             if ( ( System.Object )sid == null )
+            {
                 return false;
+            }
 
             return steamid.Data == sid.steamid.Data;
         }
@@ -740,7 +768,9 @@ namespace SteamKit2
         public bool Equals( SteamID sid )
         {
             if ( ( object )sid == null )
+            {
                 return false;
+            }
 
             return steamid.Data == sid.steamid.Data;
         }
@@ -756,10 +786,14 @@ namespace SteamKit2
         public static bool operator ==( SteamID a, SteamID b )
         {
             if ( System.Object.ReferenceEquals( a, b ) )
+            {
                 return true;
+            }
 
             if ( ( ( object )a == null ) || ( ( object )b == null ) )
+            {
                 return false;
+            }
 
             return a.steamid.Data == b.steamid.Data;
         }

--- a/SteamKit2/SteamKit2/Util/CryptoHelper.cs
+++ b/SteamKit2/SteamKit2/Util/CryptoHelper.cs
@@ -30,6 +30,11 @@ namespace SteamKit2
         /// <param name="key">The public key to encrypt with.</param>
         public RSACrypto( byte[] key )
         {
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+
             AsnKeyParser keyParser = new AsnKeyParser( key );
 
             rsa = RSA.Create();
@@ -43,6 +48,11 @@ namespace SteamKit2
         /// <param name="input">The input to encrypt.</param>
         public byte[] Encrypt( byte[] input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+
             return rsa.Encrypt( input, RSAEncryptionPadding.OaepSHA1 );
         }
 
@@ -65,6 +75,11 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SHAHash( byte[] input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+
             using ( var sha = SHA1.Create() )
             {
                 return sha.ComputeHash( input );
@@ -76,6 +91,21 @@ namespace SteamKit2
         /// </summary>
         public static byte[] AESEncrypt( byte[] input, byte[] key, byte[] iv )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            if ( iv == null )
+            {
+                throw new ArgumentNullException( nameof(iv) );
+            }
+
             using ( var aes = Aes.Create() )
             {
                 aes.BlockSize = 128;
@@ -101,6 +131,21 @@ namespace SteamKit2
         /// </summary>
         public static byte[] AESDecrypt( byte[] input, byte[] key, byte[] iv )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            if ( iv == null )
+            {
+                throw new ArgumentNullException( nameof(iv) );
+            }
+
             using ( var aes = Aes.Create() )
             {
                 aes.BlockSize = 128;
@@ -131,6 +176,21 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricEncryptWithIV( byte[] input, byte[] key, byte[] iv )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            if ( iv == null )
+            {
+                throw new ArgumentNullException( nameof(iv) );
+            }
+
             DebugLog.Assert( key.Length == 32, "CryptoHelper", "SymmetricEncrypt used with non 32 byte key!" );
 
             using ( var aes = Aes.Create() )
@@ -178,6 +238,16 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricEncrypt( byte[] input, byte[] key )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+
             var iv = GenerateRandomBlock( 16 );
             return SymmetricEncryptWithIV( input, key, iv );
         }
@@ -187,6 +257,21 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricEncryptWithHMACIV( byte[] input, byte[] key, byte[] hmacSecret )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            if ( hmacSecret == null )
+            {
+                throw new ArgumentNullException( nameof(hmacSecret) );
+            }
+
             // IV is HMAC-SHA1(Random(3) + Plaintext) + Random(3). (Same random values for both)
             var iv = new byte[ 16 ];
             var random = GenerateRandomBlock( 3 );
@@ -211,8 +296,17 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricDecrypt( byte[] input, byte[] key )
         {
-            byte[] iv;
-            return SymmetricDecrypt( input, key, out iv );
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            return SymmetricDecrypt( input, key, out _ );
         }
 
         /// <summary>
@@ -220,12 +314,26 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricDecryptHMACIV( byte[] input, byte[] key, byte[] hmacSecret )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
+            if ( hmacSecret == null )
+            {
+                throw new ArgumentNullException( nameof(hmacSecret) );
+            }
+
             Debug.Assert( key.Length >= 16 );
             var truncatedKeyForHmac = new byte[ 16 ];
             Array.Copy( key, 0, truncatedKeyForHmac, 0, truncatedKeyForHmac.Length );
 
-            byte[] iv;
-            var plaintextData = SymmetricDecrypt( input, key, out iv );
+            var plaintextData = SymmetricDecrypt( input, key, out var iv );
 
             // validate HMAC
             byte[] hmacBytes;
@@ -252,6 +360,16 @@ namespace SteamKit2
         /// </summary>
         static byte[] SymmetricDecrypt( byte[] input, byte[] key, out byte[] iv )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+
             DebugLog.Assert( key.Length == 32, "CryptoHelper", "SymmetricDecrypt used with non 32 byte key!" );
 
             using ( var aes = Aes.Create() )
@@ -303,6 +421,16 @@ namespace SteamKit2
         /// </summary>
         public static byte[] VerifyAndDecryptPassword( byte[] input, string password )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( password == null )
+            {
+                throw new ArgumentNullException( nameof(password) );
+            }
+
             byte[] key, hash;
             using( var sha256 = SHA256.Create() )
             {
@@ -329,6 +457,16 @@ namespace SteamKit2
         /// </summary>
         public static byte[] SymmetricDecryptECB( byte[] input, byte[] key )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
+            if ( key == null )
+            {
+                throw new ArgumentNullException( nameof(key) );
+            }
+            
             DebugLog.Assert( key.Length == 32, "CryptoHelper", "SymmetricDecryptECB used with non 32 byte key!" );
 
             using ( var aes = Aes.Create() )
@@ -352,6 +490,11 @@ namespace SteamKit2
         /// </summary>
         public static byte[] CRCHash( byte[] input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+
             using ( var crc = new Crc32() )
             {
                 byte[] hash = crc.ComputeHash( input );
@@ -366,6 +509,11 @@ namespace SteamKit2
         /// </summary>
         public static byte[] AdlerHash( byte[] input )
         {
+            if ( input == null )
+            {
+                throw new ArgumentNullException( nameof(input) );
+            }
+            
             uint a = 0, b = 0;
             for ( int i = 0 ; i < input.Length ; i++ )
             {

--- a/SteamKit2/SteamKit2/Util/DebugLog.cs
+++ b/SteamKit2/SteamKit2/Util/DebugLog.cs
@@ -75,6 +75,11 @@ namespace SteamKit2
         /// <param name="listener">The listener.</param>
         public static void AddListener( IDebugListener listener )
         {
+            if ( listener == null )
+            {
+                throw new ArgumentNullException( nameof(listener) );
+            }
+            
             listeners.Add( listener );
         }
         /// <summary>
@@ -84,7 +89,9 @@ namespace SteamKit2
         public static void AddListener( Action<string, string> listenerAction )
         {
             if ( listenerAction == null )
+            {
                 return;
+            }
 
             AddListener( new ActionListener( listenerAction ) );
         }
@@ -106,7 +113,9 @@ namespace SteamKit2
             // Just In Case
 
             if ( listenerAction == null )
+            {
                 return;
+            }
 
             var removals = listeners
                  .Where( list => list is ActionListener )
@@ -137,7 +146,9 @@ namespace SteamKit2
         public static void WriteLine( string category, string msg, params object[] args )
         {
             if ( !DebugLog.Enabled )
+            {
                 return;
+            }
 
             string strMsg;
 

--- a/SteamKit2/SteamKit2/Util/KeyDictionary.cs
+++ b/SteamKit2/SteamKit2/Util/KeyDictionary.cs
@@ -83,8 +83,10 @@ namespace SteamKit2
         /// <param name="eUniverse">The universe.</param>
         public static byte[] GetPublicKey( EUniverse eUniverse )
         {
-            if ( keys.ContainsKey( eUniverse ) )
-                return keys[ eUniverse ];
+            if ( keys.TryGetValue( eUniverse, out var key ) )
+            {
+                return key;
+            }
 
             return keys[ EUniverse.Invalid ];
         }


### PR DESCRIPTION
There are a lot of places in SK2 where we can be passed null values and either attempt to operate on them immediately, or store them and fail at a later time.

This PR adds null argument checking to the API surface, so that consumer misuse is exposed immediately at the original call-site, with an explanation of what is wrong.

PR for tracking and discussion at this point in time.

Fixes #412.

Todo:
- [x] Base
- [X] Networking
- [X] Steam
- [x] Types
- [x] Util