### PR TITLE
Expose HTTP timeout on WebAPI

### DIFF
--- a/Samples/6.WebAPI/Program.cs
+++ b/Samples/6.WebAPI/Program.cs
@@ -64,9 +64,9 @@ namespace Sample6_WebAPI
                 {
                     kvNews = steamNews.GetNewsForApp002( appid: 730, maxlength: 100, count: 5 );
                 }
-                catch ( WebException ex )
+                catch ( Exception ex )
                 {
-                    Console.WriteLine( "Unable to make API request: {0}", ex.Message );
+                    Console.WriteLine( "Unable to make GetNewsForApp API request: {0}", ex.Message );
                 }
             }
 
@@ -74,11 +74,18 @@ namespace Sample6_WebAPI
             using ( dynamic steamUserAuth = WebAPI.GetInterface( "ISteamUserAuth", "APIKEYGOESHERE" ) )
             {
                 // as the interface functions are synchronous, it may be beneficial to specify a timeout for calls
-                steamUserAuth.Timeout = ( int )TimeSpan.FromSeconds( 5 ).TotalMilliseconds;
+                steamUserAuth.Timeout = TimeSpan.FromSeconds( 5 );
 
                 // additionally, if the API you are using requires you to POST or use an SSL connection, you may specify
                 // these settings with the "method" and "secure" reserved parameters
-                steamUserAuth.AuthenticateUser( someParam: "someValue", method: HttpMethod.Get, secure: true );
+                try
+                {
+                    steamUserAuth.AuthenticateUser( someParam: "someValue", method: HttpMethod.Post, secure: true );
+                }
+                catch ( Exception ex )
+                {
+                    Console.WriteLine( "Unable to make AuthenticateUser API Request: {0}", ex.Message );
+                }
             }
 
             // if you are using a language that does not have dynamic object support, or you otherwise don't wish to use it

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -31,22 +31,24 @@ namespace SteamKit2
         /// </summary>
         public sealed class Interface : DynamicObject, IDisposable
         {
-            AsyncInterface asyncInterface;
+            readonly AsyncInterface asyncInterface;
 
 
             /// <summary>
             /// Gets or sets the timeout value in milliseconds for any web requests made to the WebAPI.
             /// </summary>
             /// <value>
-            /// The timeout value in milliseconds. The default value is 100,000 milliseconds (100 seconds).
+            /// The timeout value in milliseconds. The default value is 100 seconds.
             /// </value>
-            public int Timeout { get; set; }
+            public TimeSpan Timeout
+            {
+                get => asyncInterface.Timeout;
+                set => asyncInterface.Timeout = value;
+            }
 
 
             internal Interface( Uri baseAddress, string iface, string apiKey )
             {
-                Timeout = 1000 * 100; // 100 sec
-
                 asyncInterface = new AsyncInterface( baseAddress, iface, apiKey );
             }
 
@@ -147,28 +149,11 @@ namespace SteamKit2
             {
                 bool success = asyncInterface.TryInvokeMember( binder, args, out result );
 
-                // the async interface's return of TryInvokeMember will be a Task<KeyValue>, but users of this interface class
-                // expect a non-future KeyValue, so we need to duplicate the timeout handling logic here
-                // to return a KeyValue, or throw an exception
-
-                Task<KeyValue> resultTask = result as Task<KeyValue>;
-
-                try
+                if ( success )
                 {
-                    bool completed = resultTask.Wait( Timeout );
-
-                    if ( !completed )
-                        throw new TimeoutException( "The WebAPI call timed out" );
+                    var resultTask = ( Task<KeyValue> )result;
+                    result = resultTask.GetAwaiter().GetResult();
                 }
-                catch ( AggregateException ex ) when ( ex.InnerException != null )
-                {
-                    // because we're internally using the async interface, any WebExceptions thrown will
-                    // be wrapped inside an AggregateException.
-                    // since callers don't expect this, we need to unwrap and rethrow the inner exception
-                    ExceptionDispatchInfo.Capture( ex.InnerException ).Throw();
-                }
-
-                result = resultTask.Result;
 
                 return success;
             }
@@ -186,6 +171,18 @@ namespace SteamKit2
             internal readonly string iface;
             internal readonly string apiKey;
 
+            /// <summary>
+            /// Gets or sets the timeout value in milliseconds for any web requests made to the WebAPI.
+            /// </summary>
+            /// <value>
+            /// The timeout value in milliseconds. The default value is 100 seconds.
+            /// </value>
+            public TimeSpan Timeout
+            {
+                    get => httpClient.Timeout;
+                    set => httpClient.Timeout = value;
+            }
+
             static Regex funcNameRegex = new Regex(
                 @"(?<name>[a-zA-Z]+)(?<version>\d*)",
                 RegexOptions.Compiled | RegexOptions.IgnoreCase
@@ -193,7 +190,11 @@ namespace SteamKit2
 
             internal AsyncInterface( Uri baseAddress, string iface, string apiKey )
             {
-                httpClient = new HttpClient { BaseAddress = baseAddress };
+                httpClient = new HttpClient
+                {
+                    BaseAddress = baseAddress,
+                    Timeout = TimeSpan.FromSeconds(100)
+                };
 
                 this.iface = iface;
                 this.apiKey = apiKey;

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -11,7 +11,15 @@ namespace Tests
         {
             var iface = WebAPI.GetInterface( new Uri("https://whatever/"), "ISteamWhatever" );
 
-            Assert.Equal( iface.Timeout, 1000 * 100 );
+            Assert.Equal( iface.Timeout, TimeSpan.FromSeconds( 100 ) );
+        }
+
+        [Fact]
+        public void WebAPIAsyncHasDefaultTimeout()
+        {
+            var iface = WebAPI.GetAsyncInterface( new Uri("https://whatever/"), "ISteamWhatever" );
+
+            Assert.Equal( iface.Timeout, TimeSpan.FromSeconds( 100 ) );
         }
 
         [Fact]


### PR DESCRIPTION
- Use `HttpClient.Timeout` as the implementation of our timeout mechanism.
- This will throw a `TaskCanceledException` (subclass of `OperationCanceledException`) on timeout now, instead of `TimeoutException`.
- Add `Timeout` property to `AsyncInterface`
- Change `Timeout` property from `int` to `TimeSpan`

Fixes #381.

@JustArchi: mind reviewing?