### PR TITLE
Handle exception when creating connection.

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -138,8 +138,8 @@ namespace SteamKit2.Internal
 
             var cancellation = new CancellationTokenSource();
             var token = cancellation.Token;
-            var oldCancellation = Interlocked.Exchange(ref connectionCancellation, cancellation);
-            Debug.Assert(oldCancellation == null);
+            var oldCancellation = Interlocked.Exchange( ref connectionCancellation, cancellation );
+            Debug.Assert( oldCancellation == null );
 
             ExpectDisconnection = false;
 
@@ -154,7 +154,7 @@ namespace SteamKit2.Internal
                 recordTask = Task.FromResult( cmServer );
             }
 
-            connectionSetupTask = recordTask.ContinueWith(t =>
+            connectionSetupTask = recordTask.ContinueWith( t =>
             {
                 if ( token.IsCancellationRequested )
                 {
@@ -176,7 +176,11 @@ namespace SteamKit2.Internal
                 connection.Connected += Connected;
                 connection.Disconnected += Disconnected;
                 connection.Connect( record.EndPoint, ( int )ConnectionTimeout.TotalMilliseconds );
-            });
+            } ).ContinueWith( t =>
+            {
+                DebugLog.WriteLine( nameof(CMClient), "Unhandled exception when attempting to connect to Steam: {0}", t.Exception );
+                OnClientDisconnected( userInitiated: false );
+            }, TaskContinuationOptions.OnlyOnFaulted );
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #455.

@JustArchi Want to do a quick review, considering you raised the issue?

This doesn't prevent users from getting themselves into a toxic situation (e.g. setting `ProtocolTypes` to WebSocket-only on Windows 7) but does trigger a disconnected callback, same as when the connection fails for any other reason.