### PR TITLE
Make SteamConfiguration immutable

### DIFF
--- a/Samples/4.Friends/Program.cs
+++ b/Samples/4.Friends/Program.cs
@@ -37,7 +37,7 @@ namespace Sample4_Friends
             pass = args[ 1 ];
 
             // create our steamclient instance
-            var configuration = new SteamConfiguration { ProtocolTypes = ProtocolTypes.Tcp };
+            var configuration = SteamConfiguration.Create(b => b.WithProtocolTypes( ProtocolTypes.Tcp ) );
             steamClient = new SteamClient( configuration );
             // create the callback manager which will route callbacks to function calls
             manager = new CallbackManager( steamClient );

--- a/Samples/4.Friends/Program.cs
+++ b/Samples/4.Friends/Program.cs
@@ -37,7 +37,7 @@ namespace Sample4_Friends
             pass = args[ 1 ];
 
             // create our steamclient instance
-            var configuration = SteamConfiguration.Create(b => b.WithProtocolTypes( ProtocolTypes.Tcp ) );
+            var configuration = SteamConfiguration.Create( b => b.WithProtocolTypes( ProtocolTypes.Tcp ) );
             steamClient = new SteamClient( configuration );
             // create the callback manager which will route callbacks to function calls
             manager = new CallbackManager( steamClient );

--- a/Samples/7.ServerList/Program.cs
+++ b/Samples/7.ServerList/Program.cs
@@ -35,8 +35,6 @@ namespace Sample7_ServerList
             user = args[ 0 ];
             pass = args[ 1 ];
 
-            var configuration = new SteamConfiguration();
-
             var cellid = 0u;
 
             // if we've previously connected and saved our cellid, load it.
@@ -45,15 +43,17 @@ namespace Sample7_ServerList
                 if ( !uint.TryParse( File.ReadAllText( "cellid.txt"), out cellid ) )
                 {
                     Console.WriteLine( "Error parsing cellid from cellid.txt. Continuing with cellid 0." );
+                    cellid = 0;
                 }
                 else
                 {
                     Console.WriteLine( $"Using persisted cell ID {cellid}" );
-                    configuration.CellID = cellid;
                 }
             }
 
-            configuration.ServerListProvider = new FileStorageServerListProvider("servers_list.bin");
+            var configuration = SteamConfiguration.Create( b =>
+                b.WithCellID( cellid )
+                 .WithServerListProvider( new FileStorageServerListProvider("servers_list.bin") ) );
 
             // create our steamclient instance
             steamClient = new SteamClient( configuration );

--- a/SteamKit2/SteamKit2/Steam/Discovery/FileStorageServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/FileStorageServerListProvider.cs
@@ -12,14 +12,14 @@ namespace SteamKit2.Discovery
     /// </summary>
     public class FileStorageServerListProvider : IServerListProvider
     {
-        string filename;
+        readonly string filename;
 
         /// <summary>
         /// Initialize a new instance of FileStorageServerListProvider
         /// </summary>
         public FileStorageServerListProvider(string filename)
         {
-            this.filename = filename;
+            this.filename = filename ?? throw new ArgumentNullException(nameof(filename));
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+
+using System;
+using SteamKit2.Discovery;
+
+namespace SteamKit2
+{
+    /// <summary>
+    /// Interface to configure a <see cref="SteamConfiguration" /> before it is created.
+    /// A reference to the underlying object should not be live beyond the configurator function's scope.
+    /// </summary>
+    public interface ISteamConfigurationBuilder
+    {
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> to discover available servers.
+        /// </summary>
+        /// <param name="allowDirectoryFetch">Whether or not to use the Steam Directory to discover available servers.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithDirectoryFetch(bool allowDirectoryFetch);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> for a particular Steam cell.
+        /// </summary>
+        /// <param name="cellID">The Steam Cell ID to prioritize when connecting.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithCellID(uint cellID);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> with a connection timeout.
+        /// </summary>
+        /// <param name="connectionTimeout">The connection timeout used when connecting to Steam serves.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithConnectionTimeout(TimeSpan connectionTimeout);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> with the default <see cref="EClientPersonaStateFlag"/>s to request from Steam.
+        /// </summary>
+        /// <param name="personaStateFlags">The default persona state flags used when requesting information for a new friend, or
+        /// when calling <c>SteamFriends.RequestFriendInfo</c> without specifying flags.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithDefaultPersonaStateFlags(EClientPersonaStateFlag personaStateFlags);
+
+        /// <summary>
+        /// Configures how this <see cref="SteamConfiguration" /> will be used to connect to Steam.
+        /// </summary>
+        /// <param name="protocolTypes">The supported protocol types to use when attempting to connect to Steam.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithProtocolTypes(ProtocolTypes protocolTypes);
+
+        /// <summary>
+        /// Configures the server list provider for this <see cref="SteamConfiguration" />.
+        /// </summary>
+        /// <param name="provider">The server list provider to use..</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithServerListProvider(IServerListProvider provider);
+
+        /// <summary>
+        /// Configures the Universe that this <see cref="SteamConfiguration" /> belongs to.
+        /// </summary>
+        /// <param name="universe">The Universe to connect to. This should always be <see cref="EUniverse.Public"/> unless
+        /// you work at Valve and are using this internally. If this is you, hello there.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithUniverse(EUniverse universe);
+
+        /// <summary>
+        /// Configures the Steam Web API address for this <see cref="SteamConfiguration" />.
+        /// </summary>
+        /// <param name="baseAddress">The base address of the Steam Web API to connect to.
+        /// Use of "partner.steam-api.com" requires a Partner API Key.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithWebAPIBaseAddress(Uri baseAddress);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> to discover available servers.
+        /// </summary>
+        /// <param name="webApiKey">An API key to be used for authorized requests.
+        /// Keys can be obtained from https://steamcommunity.com/dev or the Steamworks Partner site.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithWebAPIKey(string webApiKey);
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -75,7 +75,7 @@ namespace SteamKit2
         ISteamConfigurationBuilder WithWebAPIBaseAddress(Uri baseAddress);
 
         /// <summary>
-        /// Configures this <see cref="SteamConfiguration" /> to discover available servers.
+        /// Configures this <see cref="SteamConfiguration" /> with a Web API key to attach to requests.
         /// </summary>
         /// <param name="webApiKey">An API key to be used for authorized requests.
         /// Keys can be obtained from https://steamcommunity.com/dev or the Steamworks Partner site.</param>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -16,13 +16,6 @@ namespace SteamKit2
     public interface ISteamConfigurationBuilder
     {
         /// <summary>
-        /// Configures this <see cref="SteamConfiguration" /> to discover available servers.
-        /// </summary>
-        /// <param name="allowDirectoryFetch">Whether or not to use the Steam Directory to discover available servers.</param>
-        /// <returns>A builder with modified configuration.</returns>
-        ISteamConfigurationBuilder WithDirectoryFetch(bool allowDirectoryFetch);
-
-        /// <summary>
         /// Configures this <see cref="SteamConfiguration" /> for a particular Steam cell.
         /// </summary>
         /// <param name="cellID">The Steam Cell ID to prioritize when connecting.</param>
@@ -43,6 +36,13 @@ namespace SteamKit2
         /// when calling <c>SteamFriends.RequestFriendInfo</c> without specifying flags.</param>
         /// <returns>A builder with modified configuration.</returns>
         ISteamConfigurationBuilder WithDefaultPersonaStateFlags(EClientPersonaStateFlag personaStateFlags);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> to discover available servers.
+        /// </summary>
+        /// <param name="allowDirectoryFetch">Whether or not to use the Steam Directory to discover available servers.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithDirectoryFetch(bool allowDirectoryFetch);
 
         /// <summary>
         /// Configures how this <see cref="SteamConfiguration" /> will be used to connect to Steam.

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -16,83 +16,88 @@ namespace SteamKit2
     public sealed class SteamConfiguration
     {
         /// <summary>
-        /// Creates a <see cref="SteamConfiguration"/> object.
+        /// Do not use directly - create a SteamConfiguration object by using a builder or helper method.
         /// </summary>
-        public SteamConfiguration()
+        internal SteamConfiguration(SteamConfigurationState state)
         {
-            serverListProvider = new NullServerListProvider();
-            webAPIBaseAddress = WebAPI.DefaultBaseAddress;
+            this.state = state;
             ServerList = new SmartCMServerList(this);
         }
 
-        IServerListProvider serverListProvider;
-        Uri webAPIBaseAddress;
+        /// <summary>
+        /// Creates a <see cref="SteamConfiguration" />, allowing for configuration.
+        /// </summary>
+        /// <param name="configurator">A method which is used to configure the configuration.</param>
+        /// <returns>A configuration object.</returns>
+        public static SteamConfiguration Create(Action<ISteamConfigurationBuilder> configurator)
+        {
+            if (configurator == null)
+            {
+                throw new ArgumentNullException(nameof(configurator));
+            }
+
+            var builder = new SteamConfigurationBuilder();
+            configurator(builder);
+            return builder.Build();
+        }
+
+        internal static SteamConfiguration CreateDefault()
+            => new SteamConfigurationBuilder().Build();
+
+        readonly SteamConfigurationState state;
 
         /// <summary>
         /// Whether or not to use the Steam Directory to discover available servers.
         /// </summary>
-        public bool AllowDirectoryFetch { get; set; } = true;
+        public bool AllowDirectoryFetch => state.AllowDirectoryFetch;
 
         /// <summary>
         /// The Steam Cell ID to prioritize when connecting.
         /// </summary>
-        public uint CellID { get; set; } = 0;
+        public uint CellID => state.CellID;
 
         /// <summary>
         /// The connection timeout used when connecting to Steam serves.
         /// </summary>
-        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(5);
+        public TimeSpan ConnectionTimeout => state.ConnectionTimeout;
 
         /// <summary>
         /// The default persona state flags used when requesting information for a new friend, or
         /// when calling <c>SteamFriends.RequestFriendInfo</c> without specifying flags.
         /// </summary>
-        public EClientPersonaStateFlag DefaultPersonaStateFlags { get; set; } =
-            EClientPersonaStateFlag.PlayerName | EClientPersonaStateFlag.Presence |
-            EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo |
-            EClientPersonaStateFlag.LastSeen;
-
+        public EClientPersonaStateFlag DefaultPersonaStateFlags => state.DefaultPersonaStateFlags;
         /// <summary>
         /// The supported protocol types to use when attempting to connect to Steam.
         /// </summary>
-        public ProtocolTypes ProtocolTypes { get; set; } = ProtocolTypes.Tcp;
+        public ProtocolTypes ProtocolTypes => state.ProtocolTypes;
 
         /// <summary>
         /// The server list provider to use.
         /// </summary>
-        public IServerListProvider ServerListProvider
-        {
-            get => serverListProvider;
-            set => serverListProvider = value ?? throw new ArgumentNullException(nameof(value));
-        }
+        public IServerListProvider ServerListProvider => state.ServerListProvider;
 
         /// <summary>
         /// The Universe to connect to. This should always be <see cref="EUniverse.Public"/> unless
         /// you work at Valve and are using this internally. If this is you, hello there.
         /// </summary>
-        public EUniverse Universe { get; set; } = EUniverse.Public;
+        public EUniverse Universe => state.Universe;
 
         /// <summary>
         /// The base address of the Steam Web API to connect to.
-        /// Using "partner.steam-api.com" base address always requires a partner api key.
+        /// Use of "partner.steam-api.com" requires a Partner API key.
         /// </summary>
-        public Uri WebAPIBaseAddress
-        {
-            get => webAPIBaseAddress;
-            set => webAPIBaseAddress = value ?? throw new ArgumentNullException(nameof(value));
-        }
+        public Uri WebAPIBaseAddress => state.WebAPIBaseAddress;
 
         /// <summary>
-        /// An optional API key to be used for authorized requests.
-        /// Keys can be obtained from https://steamcommunity.com/dev
+        /// An  API key to be used for authorized requests.
+        /// Keys can be obtained from https://steamcommunity.com/dev or the Steamworks Partner site.
         /// </summary>
-        public string WebAPIKey { get; set; }
+        public string WebAPIKey => state.WebAPIKey;
 
         /// <summary>
         /// The server list used for this configuration.
         /// If this configuration is used by multiple <see cref="SteamClient"/> instances, they all share the server list.
         /// </summary>
         public SmartCMServerList ServerList { get; }
-
     }
 }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -42,7 +42,7 @@ namespace SteamKit2
         }
 
         internal static SteamConfiguration CreateDefault()
-            => new SteamConfigurationBuilder().Build();
+            => new SteamConfiguration(SteamConfigurationBuilder.CreateDefaultState());
 
         readonly SteamConfigurationState state;
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -1,0 +1,97 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+
+using System;
+using SteamKit2.Discovery;
+
+namespace SteamKit2
+{
+    sealed class SteamConfigurationBuilder : ISteamConfigurationBuilder
+    {
+        public SteamConfigurationBuilder()
+        {
+            // Defaults are specified here.
+            state = new SteamConfigurationState
+            {
+                AllowDirectoryFetch = true,
+
+                ConnectionTimeout = TimeSpan.FromSeconds(5),
+
+                DefaultPersonaStateFlags =
+                    EClientPersonaStateFlag.PlayerName | EClientPersonaStateFlag.Presence |
+                    EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo |
+                    EClientPersonaStateFlag.LastSeen,
+
+                ProtocolTypes = ProtocolTypes.Tcp,
+
+                ServerListProvider = new NullServerListProvider(),
+
+                Universe = EUniverse.Public,
+
+                WebAPIBaseAddress = WebAPI.DefaultBaseAddress
+            };
+        }
+
+        SteamConfigurationState state;
+
+        public SteamConfiguration Build()
+            => new SteamConfiguration(state);
+
+        public ISteamConfigurationBuilder WithCellID(uint cellID)
+        {
+            state.CellID = cellID;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithConnectionTimeout(TimeSpan connectionTimeout)
+        {
+            state.ConnectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithDefaultPersonaStateFlags(EClientPersonaStateFlag personaStateFlags)
+        {
+            state.DefaultPersonaStateFlags = personaStateFlags;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithDirectoryFetch(bool allowDirectoryFetch)
+        {
+            state.AllowDirectoryFetch = allowDirectoryFetch;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithProtocolTypes(ProtocolTypes protocolTypes)
+        {
+            state.ProtocolTypes = protocolTypes;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithServerListProvider(IServerListProvider provider)
+        {
+            state.ServerListProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithUniverse(EUniverse universe)
+        {
+            state.Universe = universe;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithWebAPIBaseAddress(Uri baseAddress)
+        {
+            state.WebAPIBaseAddress = baseAddress ?? throw new ArgumentNullException(nameof(baseAddress));
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithWebAPIKey(string webApiKey)
+        {
+            state.WebAPIKey = webApiKey ?? throw new ArgumentNullException(nameof(webApiKey));
+            return this;
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -13,8 +13,12 @@ namespace SteamKit2
     {
         public SteamConfigurationBuilder()
         {
-            // Defaults are specified here.
-            state = new SteamConfigurationState
+            state = CreateDefaultState();
+        }
+
+        public static SteamConfigurationState CreateDefaultState()
+        {
+            return new SteamConfigurationState
             {
                 AllowDirectoryFetch = true,
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
@@ -1,0 +1,24 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+
+using System;
+using SteamKit2.Discovery;
+
+namespace SteamKit2
+{
+    struct SteamConfigurationState
+    {
+        public bool AllowDirectoryFetch;
+        public uint CellID;
+        public TimeSpan ConnectionTimeout;
+        public EClientPersonaStateFlag DefaultPersonaStateFlags;
+        public ProtocolTypes ProtocolTypes;
+        public IServerListProvider ServerListProvider;
+        public EUniverse Universe;
+        public Uri WebAPIBaseAddress;
+        public string WebAPIKey;
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -39,7 +39,7 @@ namespace SteamKit2
         /// Initializes a new instance of the <see cref="SteamClient"/> class with the default configuration.
         /// </summary>
         public SteamClient()
-            : this( new SteamConfiguration () )
+            : this( SteamConfiguration.CreateDefault() )
         {
         }
 

--- a/SteamKit2/Tests/AsyncJobFacts.cs
+++ b/SteamKit2/Tests/AsyncJobFacts.cs
@@ -55,7 +55,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobClearsOnTimeout()
+        public async Task AsyncJobClearsOnTimeout()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -70,7 +70,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobCancelsOnSetFailedTimeout()
+        public async Task AsyncJobCancelsOnSetFailedTimeout()
         {
             SteamClient client = new SteamClient();
 
@@ -102,7 +102,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobTimesout()
+        public async Task AsyncJobTimesout()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -132,7 +132,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobThrowsFailureExceptionOnFailure()
+        public async Task AsyncJobThrowsFailureExceptionOnFailure()
         {
             SteamClient client = new SteamClient();
 
@@ -201,7 +201,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobMultipleClearsOnTimeout()
+        public async Task AsyncJobMultipleClearsOnTimeout()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -216,7 +216,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobMultipleExtendsTimeoutOnMessage()
+        public async Task AsyncJobMultipleExtendsTimeoutOnMessage()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -254,7 +254,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobMultipleTimesout()
+        public async Task AsyncJobMultipleTimesout()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -274,7 +274,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobMultipleCompletesOnIncompleteResult()
+        public async Task AsyncJobMultipleCompletesOnIncompleteResult()
         {
             SteamClient client = new SteamClient();
             client.jobManager.SetTimeoutsEnabled( true );
@@ -345,7 +345,7 @@ namespace Tests
         }
 
         [Fact]
-        public async void AsyncJobMultipleThrowsFailureExceptionOnFailure()
+        public async Task AsyncJobMultipleThrowsFailureExceptionOnFailure()
         {
             SteamClient client = new SteamClient();
 

--- a/SteamKit2/Tests/CMClientFacts.cs
+++ b/SteamKit2/Tests/CMClientFacts.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using SteamKit2;
 using SteamKit2.Internal;
 using Xunit;
@@ -19,7 +18,7 @@ namespace Tests
                 EMsg.ChannelEncryptResult
             };
 
-            foreach(var emsg in messages)
+            foreach (var emsg in messages)
             {
                 var msgHdr = new MsgHdr { Msg = emsg };
 
@@ -123,7 +122,7 @@ namespace Tests
         class DummyCMClient : CMClient
         {
             public DummyCMClient()
-                : base( new SteamConfiguration() )
+                : base( SteamConfiguration.CreateDefault() )
             {
             }
 

--- a/SteamKit2/Tests/ClientMsgFacts.cs
+++ b/SteamKit2/Tests/ClientMsgFacts.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using SteamKit2;
+﻿using SteamKit2;
 using SteamKit2.Internal;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Tests
 {
@@ -40,18 +34,6 @@ namespace Tests
             0x00,
         };
 
-#if NET46
-        public ClientMsgFacts()
-        {
-            // Debug.Assert's default behavior is to display a dialog if the default trace listener is still installed
-            // xunit prior to 2.0 would disable the default trace listener and prevent the assert dialog
-            // since we're now on 2.0, we need to restore this behavior ourselves
-
-            Debug.Listeners.Clear();
-            Debug.Listeners.Add( new TraceAssertListener() );
-    }
-#endif
-
         [Fact]
         public void PayloadReaderReadsNullTermString()
         {
@@ -79,41 +61,6 @@ namespace Tests
             // and the one after should be the beginning of a MessageObject
             Assert.Equal( mByte, 'M' );
         }
-
-#if NET46
-        [Fact]
-        public void ClientMsgAssertsInitializedWithNonProtoMsg()
-        {
-            var packetMsgData = new ClientMsgProtobuf<CMsgClientLogon>( EMsg.ClientLogon ).Serialize();
-            var packetMsg = new PacketClientMsgProtobuf( MsgUtil.MakeMsg( EMsg.ClientLogon, protobuf: true ), packetMsgData );
-
-
-            var exception = Record.Exception( () => new ClientMsg<MsgClientLogon>( packetMsg ) );
-            Assert.NotNull( exception );
-            Assert.IsType<TraceAssertException>( exception );
-
-            var tae = (TraceAssertException)exception;
-
-            // Can't nameof(ClientMsg) - nameof doesn't support open generic types (yet).
-            Assert.Contains( $"ClientMsg<{typeof( MsgClientLogon ).FullName}>", tae.AssertMessage );
-        }
-
-        [Fact]
-        public void ClientMsgProtobufAssertsInitializedWithProtoMsg()
-        {
-            var packetMsgData = new ClientMsg<MsgClientLogon>().Serialize();
-            var packetMsg = new PacketClientMsg( MsgUtil.MakeMsg( EMsg.ClientLogon, protobuf: false ), packetMsgData );
-
-            var exception = Record.Exception( () => new ClientMsgProtobuf<CMsgClientLogon>( packetMsg ) );
-            Assert.NotNull( exception );
-            Assert.IsType<TraceAssertException>( exception );
-
-            var tae = (TraceAssertException)exception;
-
-            // Can't nameof(ClientMsgProtobuf) - nameof doesn't support open generic types (yet).
-            Assert.Contains( $"ClientMsgProtobuf<{typeof( CMsgClientLogon ).FullName}>", tae.AssertMessage );
-        }
-#endif
 
         static IPacketMsg BuildStructMsg()
         {

--- a/SteamKit2/Tests/FileStorageServerListProviderFacts.cs
+++ b/SteamKit2/Tests/FileStorageServerListProviderFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using SteamKit2;
 using SteamKit2.Discovery;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Tests
         readonly FileStorageServerListProvider fileStorageProvider;
 
         [Fact]
-        public async void ReadsUpdatedServerList()
+        public async Task ReadsUpdatedServerList()
         {
             var initialServers = await fileStorageProvider.FetchServerListAsync();
 

--- a/SteamKit2/Tests/IsolatedStorageServerListProviderFacts.cs
+++ b/SteamKit2/Tests/IsolatedStorageServerListProviderFacts.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using SteamKit2;
 using SteamKit2.Discovery;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Tests
         readonly IsolatedStorageServerListProvider isolatedStorageProvider;
 
         [Fact]
-        public async void ReadsUpdatedServerList()
+        public async Task ReadsUpdatedServerList()
         {
             await isolatedStorageProvider.UpdateServerListAsync(new List<ServerRecord>()
             {

--- a/SteamKit2/Tests/SmartCMServerListFacts.cs
+++ b/SteamKit2/Tests/SmartCMServerListFacts.cs
@@ -10,7 +10,7 @@ namespace Tests
     {
         public SmartCMServerListFacts()
         {
-            var configuration = new SteamConfiguration { AllowDirectoryFetch = false };
+            var configuration = SteamConfiguration.Create(b => b.WithDirectoryFetch(false));
             serverList = new SmartCMServerList(configuration);
         }
 

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SteamKit2;
+using SteamKit2.Discovery;
+using Xunit;
+
+namespace Tests
+{
+    public class SteamConfigurationDefaultFacts
+    {
+        public SteamConfigurationDefaultFacts()
+        {
+            configuration = SteamConfiguration.Create(_ => { });
+        }
+
+        readonly SteamConfiguration configuration;
+
+        [Fact]
+        public void AllowsDirectoryFetch()
+        {
+            Assert.Equal(true, configuration.AllowDirectoryFetch);
+        }
+
+        [Fact]
+        public void CellIDIsZero()
+        {
+            Assert.Equal(0u, configuration.CellID);
+        }
+
+        [Fact]
+        public void ConnectionTimeoutIsFiveSeconds()
+        {
+            Assert.Equal(TimeSpan.FromSeconds(5), configuration.ConnectionTimeout);
+        }
+
+        [Fact]
+        public void DefaultPersonaStateFlags()
+        {
+            var expected = EClientPersonaStateFlag.PlayerName | EClientPersonaStateFlag.Presence |
+                    EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo |
+                    EClientPersonaStateFlag.LastSeen;
+
+            Assert.Equal(expected, configuration.DefaultPersonaStateFlags);
+        }
+
+        [Fact]
+        public void ServerListProviderIsNothingFancy()
+        {
+            Assert.IsType<NullServerListProvider>(configuration.ServerListProvider);
+        }
+
+        [Fact]
+        public void ServerListIsNotNull()
+        {
+            Assert.NotNull(configuration.ServerList);
+        }
+
+        [Fact]
+        public void DefaultProtocols()
+        {
+            Assert.Equal(ProtocolTypes.Tcp, configuration.ProtocolTypes);
+        }
+
+        [Fact]
+        public void PublicUniverse()
+        {
+            Assert.Equal(EUniverse.Public, configuration.Universe);
+        }
+
+        [Fact]
+        public void WebAPIAddress()
+        {
+            Assert.Equal("https://api.steampowered.com/", configuration.WebAPIBaseAddress?.AbsoluteUri);
+        }
+
+        [Fact]
+        public void NoWebAPIKey()
+        {
+            Assert.Null(configuration.WebAPIKey);
+        }
+    }
+
+    public class SteamConfigurationConfiguredObjectFacts
+    {
+        public SteamConfigurationConfiguredObjectFacts()
+        {
+            configuration = SteamConfiguration.Create(b =>
+                b.WithDirectoryFetch(false)
+                 .WithCellID(123)
+                 .WithConnectionTimeout(TimeSpan.FromMinutes(1))
+                 .WithDefaultPersonaStateFlags(EClientPersonaStateFlag.SourceID)
+                 .WithProtocolTypes(ProtocolTypes.WebSocket | ProtocolTypes.Udp)
+                 .WithServerListProvider(new CustomServerListProvider())
+                 .WithUniverse(EUniverse.Internal)
+                 .WithWebAPIBaseAddress(new Uri("http://foo.bar.com/api/"))
+                 .WithWebAPIKey("T0PS3kR1t"));
+        }
+
+        readonly SteamConfiguration configuration;
+
+        [Fact]
+        public void DirectoryFetchIsConfigured()
+        {
+            Assert.Equal(false, configuration.AllowDirectoryFetch);
+        }
+
+        [Fact]
+        public void CellIDIsConfigured()
+        {
+            Assert.Equal(123u, configuration.CellID);
+        }
+
+        [Fact]
+        public void ConnectionTimeoutIsConfigured()
+        {
+            Assert.Equal(TimeSpan.FromMinutes(1), configuration.ConnectionTimeout);
+        }
+
+        [Fact]
+        public void PersonaStateFlagsIsConfigured()
+        {
+            Assert.Equal(EClientPersonaStateFlag.SourceID, configuration.DefaultPersonaStateFlags);
+        }
+
+        [Fact]
+        public void ServerListProviderIsConfigured()
+        {
+            Assert.IsType<CustomServerListProvider>(configuration.ServerListProvider);
+        }
+
+        [Fact]
+        public void ServerListIsNotNull()
+        {
+            Assert.NotNull(configuration.ServerList);
+        }
+
+        [Fact]
+        public void ProtocolsAreConfigured()
+        {
+            Assert.Equal(ProtocolTypes.WebSocket | ProtocolTypes.Udp, configuration.ProtocolTypes);
+        }
+
+        [Fact]
+        public void UniverseIsConfigured()
+        {
+            Assert.Equal(EUniverse.Internal, configuration.Universe);
+        }
+
+        [Fact]
+        public void WebAPIAddress()
+        {
+            Assert.Equal("http://foo.bar.com/api/", configuration.WebAPIBaseAddress?.AbsoluteUri);
+        }
+
+        [Fact]
+        public void NoWebAPIKey()
+        {
+            Assert.Equal("T0PS3kR1t", configuration.WebAPIKey);
+        }
+
+        class CustomServerListProvider : IServerListProvider
+        {
+            Task<IEnumerable<ServerRecord>> IServerListProvider.FetchServerListAsync()
+                => throw new NotImplementedException();
+
+            Task IServerListProvider.UpdateServerListAsync(IEnumerable<ServerRecord> endpoints)
+                => throw new NotImplementedException();
+        }
+    }
+}

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -30,11 +30,9 @@ namespace Tests
         [Fact]
         public void SteamConfigWebAPIInterface()
         {
-            var config = new SteamConfiguration
-            {
-                WebAPIBaseAddress = new Uri("http://example.com"),
-                WebAPIKey = "hello world"
-            };
+            var config = SteamConfiguration.Create(b =>
+                b.WithWebAPIBaseAddress(new Uri("http://example.com"))
+                 .WithWebAPIKey("hello world"));
 
             var iface = config.GetAsyncWebAPIInterface("TestInterface");
 


### PR DESCRIPTION
Fixes #415.

This is my first stab at it.

I figured we should make the way to construct a `SteamConfiguration` instance easily discoverable on the type itself, so `SteamConfiguration.Create` is the only way for external code and the canonical way for internal code to create a configuration object.

Internal code can also use `SteamConfiguration.CreateDefault` as a reasonable default where a consumer has not passed in a configuration.

The factory method approach here is somewhat similar to ASP.NET WebAPI's `GlobalConfiguration.Configure` method.

Splitting HTTP/WebAPI has been left for later as per #450.

Thoughts, feedback and [constructive] criticism welcome.