### PR TITLE
Prefer stable release of Microsoft.Win32.Registry

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -48,7 +48,7 @@
 
   <ItemGroup>
     <PackageReference Include="protobuf-net" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Side note: should we keep bumping `protobuf-net` to latest released version after confirming that it works fine, or we're keeping it at `2.1.0` as a minimum requirement?