### PR TITLE
Fix build failure due to Codecov

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -17,7 +17,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SteamKit2.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -16,6 +16,11 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SteamKit2.xml</DocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   
   <ItemGroup>
     <None Remove="3rd party.txt" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ test_script:
       if ($env:CONFIGURATION -eq 'Debug')
       {
           & nuget install OpenCover -Version 4.6.519 -OutputDirectory SteamKit2\packages
-          & SteamKit2\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user "-target:%ProgramFiles%\dotnet\dotnet.exe" "-targetargs:test SteamKit2\Tests\Tests.csproj" -returntargetcode "-filter:+[SteamKit2]* -[SteamKit2]SteamKit2.Internal.* -[SteamKit2]SteamKit2.*.Internal.* -[SteamKit2]SevenZip*" "-excludebyattribute:*.ProtoContract*" -hideskipped:All -output:SteamKit2-code-coverage.xml
+          & SteamKit2\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user "-target:%ProgramFiles%\dotnet\dotnet.exe" "-targetargs:test SteamKit2\Tests\Tests.csproj" -returntargetcode "-filter:+[SteamKit2]* -[SteamKit2]SteamKit2.Internal.* -[SteamKit2]SteamKit2.*.Internal.* -[SteamKit2]SevenZip*" "-excludebyattribute:*.ProtoContract*" -hideskipped:All -output:SteamKit2-code-coverage.xml -oldStyle
           $env:Path = "C:\Python34;C:\Python34\Scripts;" + $env:Path
           & pip install codecov
           & codecov -f "SteamKit2-code-coverage.xml" -X gcov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,9 +55,8 @@ test_script:
       {
           & nuget install OpenCover -Version 4.6.519 -OutputDirectory SteamKit2\packages
           & SteamKit2\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user "-target:%ProgramFiles%\dotnet\dotnet.exe" "-targetargs:test SteamKit2\Tests\Tests.csproj" -returntargetcode "-filter:+[SteamKit2]* -[SteamKit2]SteamKit2.Internal.* -[SteamKit2]SteamKit2.*.Internal.* -[SteamKit2]SevenZip*" "-excludebyattribute:*.ProtoContract*" -hideskipped:All -output:SteamKit2-code-coverage.xml -oldStyle
-          $env:Path = "C:\Python34;C:\Python34\Scripts;" + $env:Path
-          & pip install codecov
-          & codecov -f "SteamKit2-code-coverage.xml" -X gcov
+          & nuget install Codecov -Version 1.0.3 -OutputDirectory SteamKit2\packages
+          & SteamKit2\packages\Codecov.1.0.3\tools\codecov.exe -f "SteamKit2-code-coverage.xml"
       }
 
 artifacts:


### PR DESCRIPTION
Fixes #512 

The Python version of Codecov is causing the build to fail despite succeeding. It's replaced with the .NET version which doesn't have this issue.

This also fixes support for generating code coverage results. OpenCover cannot generate code coverage results for portable PDBs (https://github.com/OpenCover/opencover/issues/610) so the Debug build now produces Windows PDBs. In addition, OpenCover requires `mscorlib.dll` to be named `mscorlib` but that's not the case for .NET Standard (https://github.com/OpenCover/opencover/issues/595). The `-oldStyle` switch is used to work around this.