### PR TITLE
WebAPI: Do not render null/empty parameters

### DIFF
--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -269,7 +269,7 @@ namespace SteamKit2
                 }
 
                 // append any args
-                paramBuilder.Append( string.Join( "&", args.Select( kvp =>
+                paramBuilder.Append( string.Join( "&", args.Where( kvp => !string.IsNullOrEmpty( kvp.Value ) ).Select( kvp =>
                 {
                     // TODO: the WebAPI is a special snowflake that needs to appropriately handle url encoding
                     // this is in contrast to the steam3 content server APIs which use an entirely different scheme of encoding

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -269,7 +269,7 @@ namespace SteamKit2
                 }
 
                 // append any args
-                paramBuilder.Append( string.Join( "&", args.Where( kvp => !string.IsNullOrEmpty( kvp.Value ) ).Select( kvp =>
+                paramBuilder.Append( string.Join( "&", args.Select( kvp =>
                 {
                     // TODO: the WebAPI is a special snowflake that needs to appropriately handle url encoding
                     // this is in contrast to the steam3 content server APIs which use an entirely different scheme of encoding
@@ -374,6 +374,12 @@ namespace SteamKit2
                     string argName = binder.CallInfo.ArgumentNames[ x ];
                     object argValue = args[ x ];
 
+                    if ( argValue == null )
+                    {
+                        // null value is not valid for any of below methods
+                        continue;
+                    }
+
                     // method is a reserved param for selecting the http request method
                     if ( argName.Equals( "method", StringComparison.OrdinalIgnoreCase ) )
                     {
@@ -408,8 +414,15 @@ namespace SteamKit2
                         continue;
                     }
 
+                    string stringValue = argValue.ToString();
 
-                    apiArgs.Add( argName, argValue.ToString() );
+                    if ( stringValue.Length == 0 )
+                    {
+                        // empty value serves no purpose in URL query string
+                        continue;
+                    }
+
+                    apiArgs.Add( argName, stringValue );
                 }
 
                 Match match = funcNameRegex.Match( binder.Name );


### PR DESCRIPTION
Consider following code:

```c#
using (dynamic iEconService = WebAPI.GetAsyncInterface(IEconService, steamApiKey)) {
	iEconService.Timeout = WebBrowser.Timeout;

	response = await iEconService.GetTradeHoldDurations(
		secure: true,
		steamid_target: steamID,
		trade_offer_access_token: tradeToken
	);
}
```

`tradeToken` comes from function argument where it's optional argument set to `null` by default. This API endpoint can be called with `trade_offer_access_token`, or without.

My guess would be that if I provide argument with `null` value then it won't be encoded into resulting URL at all. Instead, I got NRE directly in SK2. This has to be fixed, depending how we want to handle this scenario:

- Just ignore `null` and empty arguments. They do not add anything at all, only pollute URL (at best), or cause NRE (at worst, when `null` is passed). This is my PR.
- Just ignore `null` arguments. Like above, but allow empty ones for some reason. This would be non-breaking behaviour, even though I can't see how encoding empty arguments in the URL can affect anything apart from how request looks like, so I don't consider this PR breaking in the first place, unless I'm wrong.
- Throw appropriate `ArgumentException` on null arguments. IMHO this makes things worse, since I'll need to either split my above function into conditional `if`, or use `trade_offer_access_token: tradeToken ?? ""` which is silly. This is current behaviour, but with (unintentional) NRE instead.