### PR TITLE
SteamID: Add helper methods to convert between Chat IDs and Clan IDs

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -384,16 +384,14 @@ namespace SteamKit2
 
             if ( chatId.IsClanAccount )
             {
-                // this steamid is incorrect, so we'll fix it up
-                chatId.AccountInstance = ( uint )SteamID.ChatInstanceFlags.Clan;
-                chatId.AccountType = EAccountType.Chat;
+                chatId = chatId.ToChatID();
             }
 
             joinChat.Body.SteamIdChat = chatId;
 
             Client.Send( joinChat );
-
         }
+
         /// <summary>
         /// Attempts to leave a chat room.
         /// </summary>

--- a/SteamKit2/SteamKit2/Types/SteamID.cs
+++ b/SteamKit2/SteamKit2/Types/SteamID.cs
@@ -552,6 +552,7 @@ namespace SteamKit2
         /// Converts this clan ID to a chat ID.
         /// </summary>
         /// <returns>The Chat ID for this clan's group chat.</returns>
+        /// <exception cref="InvalidOperationException">This SteamID is not a clan ID.</exception>
         public SteamID ToChatID()
         {
             if ( !IsClanAccount )

--- a/SteamKit2/SteamKit2/Types/SteamID.cs
+++ b/SteamKit2/SteamKit2/Types/SteamID.cs
@@ -548,6 +548,45 @@ namespace SteamKit2
             return RenderSteam2();
         }
 
+        /// <summary>
+        /// Converts this clan ID to a chat ID.
+        /// </summary>
+        /// <returns>The Chat ID for this clan's group chat.</returns>
+        public SteamID ToChatID()
+        {
+            if ( !IsClanAccount )
+            {
+                throw new InvalidOperationException( "Only Clan IDs can be converted to Chat IDs." );
+            }
+
+            SteamID chatID = ConvertToUInt64();
+            chatID.AccountInstance = ( uint )ChatInstanceFlags.Clan;
+            chatID.AccountType = EAccountType.Chat;
+            return chatID;
+        }
+
+        /// <summary>
+        /// Converts this chat ID to a clan ID.
+        /// This can be used to get the group that a group chat is associated with.
+        /// </summary>
+        /// <returns><c>true</c> if this chat ID represents a group chat, <c>false</c> otherwise.</returns>\
+        /// <param name="groupID">If the method returned <c>true</c>, then this is the group that this chat is associated with. Otherwise, this is <c>null</c>.</param>
+        public bool TryGetClanID( out SteamID groupID )
+        {
+            if ( IsChatAccount && AccountInstance == (uint)ChatInstanceFlags.Clan )
+            {
+                groupID = ConvertToUInt64();
+                groupID.AccountType = EAccountType.Clan;
+                groupID.AccountInstance = 0;
+                return true;
+            }
+            else
+            {
+                groupID = default( SteamID );
+                return false;
+            }
+        }
+
         string RenderSteam2()
         {
             switch ( AccountType )

--- a/SteamKit2/SteamKit2/Types/SteamID.cs
+++ b/SteamKit2/SteamKit2/Types/SteamID.cs
@@ -689,8 +689,7 @@ namespace SteamKit2
                 return false;
             }
 
-            SteamID sid = obj as SteamID;
-            if ( ( object )sid == null )
+            if ( !( obj is SteamID sid ) )
             {
                 return false;
             }


### PR DESCRIPTION
Resolves #453.

The idea here between the two different types of methods:

`ToChatID` should only be called when you know what kind of SteamID you have. It makes absolutely no sense to go calling this on arbitrary Steam IDs.

`TryGetClanID` can be called on any kind of chat ID, but it will only work on persistent group chats. I don't feel it makes any sense to have a`TryXXX` method that handles some failure conditions but not others, so this one fails gracefully both on ad-hoc group chats and on totally-the-wrong-`EAccountType` IDs.