### PR TITLE
[WIP] Improve crypto performance

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryptionWithHMAC.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryptionWithHMAC.cs
@@ -5,30 +5,37 @@
 
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Security.Cryptography;
+using SteamKit2.Util;
 
 namespace SteamKit2
 {
     class NetFilterEncryptionWithHMAC : INetFilterEncryption
     {
-        readonly byte[] sessionKey;
-        readonly byte[] hmacSecret;
+        readonly CryptographicContext context;
 
         public NetFilterEncryptionWithHMAC( byte[] sessionKey )
         {
             DebugLog.Assert( sessionKey.Length == 32, nameof(NetFilterEncryption), "AES session key was not 32 bytes!" );
 
-            this.sessionKey = sessionKey;
-            this.hmacSecret = new byte[ 16 ];
+            var hmacSecret = new byte[ 16 ];
             Array.Copy( sessionKey, 0, hmacSecret, 0, hmacSecret.Length );
+
+            this.context = new CryptographicContext(sessionKey, hmacSecret);
         }
 
         public byte[] ProcessIncoming( byte[] data )
         {
+            var buffer = ArrayPool<byte>.Shared.Rent(data.Length);
             try
             {
-                return CryptoHelper.SymmetricDecryptHMACIV( data, sessionKey, hmacSecret );
+                var segment = context.SymmetricDecryptWithIVHMAC(data, buffer);
+
+                var incoming = new byte[segment.Count];
+                Array.Copy(segment.Array, segment.Offset, incoming, 0, incoming.Length);
+                return incoming;
             }
             catch ( CryptographicException ex )
             {
@@ -37,11 +44,27 @@ namespace SteamKit2
                 // rethrow as an IO exception so it's handled in the network thread
                 throw new IOException( "Unable to decrypt incoming packet", ex );
             }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
 
         public byte[] ProcessOutgoing( byte[] data )
         {
-            return CryptoHelper.SymmetricEncryptWithHMACIV( data, sessionKey, hmacSecret );
+            var buffer = ArrayPool<byte>.Shared.Rent(context.CalculateMaxEncryptedDataLength(data.Length));
+            try
+            {
+                var segment = context.SymmetricEncryptWithIVHMAC(data, buffer);
+
+                var outgoing = new byte[segment.Count];
+                Array.Copy(segment.Array, segment.Offset, outgoing, 0, outgoing.Length);
+                return outgoing;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
     }
 }

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="protobuf-net" Version="2.1.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/SteamKit2/SteamKit2/Util/CryptographicContext.cs
+++ b/SteamKit2/SteamKit2/Util/CryptographicContext.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace SteamKit2.Util
+{
+    sealed class CryptographicContext : IDisposable
+    {
+        public CryptographicContext(byte[] key, byte[] hmacSecret)
+        {
+            this.key = key;
+            this.hmacSecret = hmacSecret;
+
+            rng = RandomNumberGenerator.Create();
+
+            hmac = new HMACSHA1(hmacSecret);
+
+            ivAes = Aes.Create();
+            ivAes.BlockSize = 128;
+            ivAes.KeySize = 256;
+            ivAes.Mode = CipherMode.ECB;
+            ivAes.Padding = PaddingMode.None;
+
+            ivEncryptor = ivAes.CreateEncryptor(key, null);
+            ivDecryptor = ivAes.CreateDecryptor(key, null);
+
+            cipherAes = Aes.Create();
+            cipherAes.BlockSize = 128;
+            cipherAes.KeySize = 256;
+
+            cipherAes.Mode = CipherMode.CBC;
+            cipherAes.Padding = PaddingMode.PKCS7;
+        }
+
+        const int InitializationVectorLength = 16;
+        const int InitializationVectorRandomLength = 3;
+
+        readonly byte[] key;
+        readonly byte[] hmacSecret;
+
+        readonly RandomNumberGenerator rng;
+        readonly HMACSHA1 hmac;
+
+        readonly Aes ivAes;
+        readonly ICryptoTransform ivEncryptor;
+        readonly ICryptoTransform ivDecryptor;
+
+        readonly Aes cipherAes;
+
+        public ArraySegment<byte> SymmetricEncryptWithIVHMAC(byte[] plainText, byte[] cipherTextBuffer)
+        {
+            var iv = new byte[InitializationVectorLength];
+            GenerateInitializationVector(plainText, new ArraySegment<byte>(iv, 0, iv.Length));
+            return SymmetricEncryptWithIV(plainText, iv, cipherTextBuffer);
+        }
+
+        public ArraySegment<byte> SymmetricDecryptWithIVHMAC(byte[] cipherText, byte[] plainTextBuffer)
+        {
+            var iv = ivDecryptor.TransformFinalBlock(cipherText, 0, InitializationVectorLength);
+
+            using (var aesTransform = cipherAes.CreateDecryptor(key, iv))
+            using (var ms = new MemoryStream(cipherText, iv.Length, cipherText.Length - iv.Length))
+            using (var cs = new CryptoStream(ms, aesTransform, CryptoStreamMode.Read))
+            {
+                // plaintext is never longer than ciphertext
+                int len = cs.Read(plainTextBuffer, 0, plainTextBuffer.Length);
+                var plainText = new ArraySegment<byte>(plainTextBuffer, 0, len);
+                ValidateInitializationVector(plainText, new ArraySegment<byte>(iv, 0, iv.Length));
+                return plainText;
+            }
+        }
+
+        void GenerateInitializationVector(byte[] plainText, ArraySegment<byte> iv)
+        {
+            var ivRandom = new ArraySegment<byte>(iv.Array, iv.Offset + iv.Count - InitializationVectorRandomLength, InitializationVectorRandomLength);
+            rng.GetBytes(ivRandom.Array, ivRandom.Offset, ivRandom.Count);
+
+            var hmacBufferLength = ivRandom.Count + plainText.Length;
+            var hmacBuffer = ArrayPool<byte>.Shared.Rent(hmacBufferLength);
+            try
+            {
+                Array.Copy(ivRandom.Array, ivRandom.Offset, hmacBuffer, 0, ivRandom.Count);
+                plainText.CopyTo(hmacBuffer, ivRandom.Count);
+
+                var hmacValue = hmac.ComputeHash(hmacBuffer, 0, hmacBufferLength);
+                Array.Copy(hmacValue, 0, iv.Array, iv.Offset, iv.Count - ivRandom.Count);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(hmacBuffer);
+            }
+        }
+
+        void ValidateInitializationVector(ArraySegment<byte> plainText, ArraySegment<byte> iv)
+        {
+            var ivRandom = new ArraySegment<byte>(iv.Array, iv.Offset + iv.Count - InitializationVectorRandomLength, InitializationVectorRandomLength);
+            var hmacBufferLength = ivRandom.Count + plainText.Count;
+            var hmacBuffer = ArrayPool<byte>.Shared.Rent(hmacBufferLength);
+
+            try
+            {
+                Array.Copy(ivRandom.Array, ivRandom.Offset, hmacBuffer, 0, ivRandom.Count);
+                Array.Copy(plainText.Array, plainText.Offset, hmacBuffer, ivRandom.Count, plainText.Count);
+
+                var hmacValue = hmac.ComputeHash(hmacBuffer, 0, hmacBufferLength);
+
+                var hmacIsOkSoFar = true;
+
+                for (var i = 0; i < InitializationVectorLength - InitializationVectorRandomLength; i++)
+                {
+                    hmacIsOkSoFar &= (hmacValue[i] == iv.Array[iv.Offset + i]);
+                }
+
+                if (!hmacIsOkSoFar)
+                {
+                    throw new Exception("HMAC did not validate.");
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(hmacBuffer);
+            }
+        }
+
+        ArraySegment<byte> SymmetricEncryptWithIV(byte[] plaintext, byte[] iv, byte[] cipherTextBuffer)
+        {
+            var encryptedIv = ivEncryptor.TransformFinalBlock(iv, 0, iv.Length);
+
+            var cipherTextSize = CalculateMaxEncryptedDataLength(plaintext.Length + encryptedIv.Length);
+
+            using (var aesTransform = cipherAes.CreateEncryptor(key, iv))
+            using (var ms = new MemoryStream(cipherTextBuffer))
+            using (var cs = new CryptoStream(ms, aesTransform, CryptoStreamMode.Write))
+            {
+                ms.Write(encryptedIv, 0, encryptedIv.Length);
+
+                cs.Write(plaintext, 0, plaintext.Length);
+                cs.FlushFinalBlock();
+
+                return new ArraySegment<byte>(cipherTextBuffer, 0, (int)ms.Position);
+            }
+        }
+
+        public int CalculateMaxEncryptedDataLength(int plaintextDataLength)
+            => CalculateMaxEncryptedDataLengthRaw(16) + CalculateMaxEncryptedDataLengthRaw(plaintextDataLength);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        int CalculateMaxEncryptedDataLengthRaw(int plaintextDataLength)
+        {
+            var numberOfBlocksRequired = (int)Math.Ceiling((double)plaintextDataLength / (cipherAes.BlockSize / 8));
+            var cipherTextSize = cipherAes.BlockSize * numberOfBlocksRequired / 8;
+            return cipherTextSize;
+        }
+
+        public void Dispose()
+        {
+            rng.Dispose();
+
+            hmac.Dispose();
+
+            ivEncryptor.Dispose();
+            ivDecryptor.Dispose();
+            ivAes.Dispose();
+
+            cipherAes.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
### Benchmark:
Benchmark run against a packet about 670 bytes long.

**Current code:**

- Time to encrypt an outgoing packet: 6.464us
- Memory allocations to encrypt an outgoing packet: 6320B
- Time to decrypt an incoming packet: 6.524us
- Memory allocations to decrypt an incoming packet: 5208B

**This branch:**

- Time to encrypt an outgoing packet: 4.054us
- Memory allocations to encrypt an outgoing packet: 848B +size of packet
- Time to decrypt an incoming packet: 3.688us
- Memory allocations to decrypt an incoming packet: 1008B + size of packet

Unfortunately it seems that about 2/3rds of the CPU time is spent computing the HMAC. I don't think we can do anything about that at the moment.

See also: #552 
