### PR TITLE
CurrentProtocol bump

### DIFF
--- a/Resources/SteamLanguage/steammsg.steamd
+++ b/Resources/SteamLanguage/steammsg.steamd
@@ -44,7 +44,7 @@ class MsgClientNewLoginKeyAccepted<EMsg::ClientNewLoginKeyAccepted>
 class MsgClientLogon<EMsg::ClientLogon>
 {
 	const uint ObfuscationMask = 0xBAADF00D;
-	const uint CurrentProtocol = 65579;
+	const uint CurrentProtocol = 65580;
 
 	const uint ProtocolVerMajorMask = 0xFFFF0000;
 	const uint ProtocolVerMinorMask = 0xFFFF;

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
@@ -662,7 +662,7 @@ namespace SteamKit2.Internal
 		public EMsg GetEMsg() { return EMsg.ClientLogon; }
 
 		public static readonly uint ObfuscationMask = 0xBAADF00D;
-		public static readonly uint CurrentProtocol = 65579;
+		public static readonly uint CurrentProtocol = 65580;
 		public static readonly uint ProtocolVerMajorMask = 0xFFFF0000;
 		public static readonly uint ProtocolVerMinorMask = 0xFFFF;
 		public static readonly ushort ProtocolVerMinorMinGameServers = 4;


### PR DESCRIPTION
#567 retargetted against master branch with recommended fixes.

@VoiDeD @yaakov-h Any particular reason what issues package version bump can bring and why we should stick to that initial version?