### PR TITLE
[WIP] Change all int wrappers from class to struct

### DIFF
--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -57,7 +57,7 @@ namespace SteamKit2
         public override SteamID SteamID
         {
             get => ProtoHeader.steamid;
-            set => ProtoHeader.steamid = value ?? throw new ArgumentNullException( nameof(value) );
+            set => ProtoHeader.steamid = value;
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace SteamKit2
         public override JobID TargetJobID
         {
             get => ProtoHeader.jobid_target;
-            set => ProtoHeader.jobid_target = value ?? throw new ArgumentNullException( nameof(value) );
+            set => ProtoHeader.jobid_target = value;
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -80,7 +80,7 @@ namespace SteamKit2
         public override JobID SourceJobID
         {
             get => ProtoHeader.jobid_source;
-            set => ProtoHeader.jobid_source = value ?? throw new ArgumentNullException( nameof(value) );
+            set => ProtoHeader.jobid_source = value;
         }
 
 
@@ -278,7 +278,7 @@ namespace SteamKit2
         public override SteamID SteamID
         {
             get => Header.SteamID;
-            set => Header.SteamID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.SteamID = value;
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace SteamKit2
         public override JobID TargetJobID
         {
             get => Header.TargetJobID;
-            set => Header.TargetJobID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.TargetJobID = value;
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -301,7 +301,7 @@ namespace SteamKit2
         public override JobID SourceJobID
         {
             get => Header.SourceJobID;
-            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.SourceJobID = value;
         }
 
 
@@ -452,7 +452,7 @@ namespace SteamKit2
         public override JobID TargetJobID
         {
             get => Header.TargetJobID;
-            set => Header.TargetJobID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.TargetJobID = value;
         }
         /// <summary>
         /// Gets or sets the source job id for this client message.
@@ -463,7 +463,7 @@ namespace SteamKit2
         public override JobID SourceJobID
         {
             get => Header.SourceJobID;
-            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.SourceJobID = value;
         }
 
 

--- a/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
@@ -46,7 +46,7 @@ namespace SteamKit2.GC
         public override JobID TargetJobID
         {
             get => ProtoHeader.job_id_target;
-            set => ProtoHeader.job_id_target = value ?? throw new ArgumentNullException( nameof(value) );
+            set => ProtoHeader.job_id_target = value;
         }
         /// <summary>
         /// Gets or sets the source job id for this gc message.
@@ -57,7 +57,7 @@ namespace SteamKit2.GC
         public override JobID SourceJobID
         {
             get => ProtoHeader.job_id_source;
-            set => ProtoHeader.job_id_source = value ?? throw new ArgumentNullException( nameof(value) );
+            set => ProtoHeader.job_id_source = value;
         }
 
 
@@ -194,7 +194,7 @@ namespace SteamKit2.GC
         public override JobID TargetJobID
         {
             get => Header.TargetJobID;
-            set => Header.TargetJobID = value = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.TargetJobID = value;
         }
         /// <summary>
         /// Gets or sets the source job id for this gc message.
@@ -205,7 +205,7 @@ namespace SteamKit2.GC
         public override JobID SourceJobID
         {
             get => Header.SourceJobID;
-            set => Header.SourceJobID = value ?? throw new ArgumentNullException( nameof(value) );
+            set => Header.SourceJobID = value;
         }
 
 

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -76,7 +76,7 @@ namespace SteamKit2.Internal
         /// This value will be <c>null</c> if the client is logged off of Steam.
         /// </summary>
         /// <value>The SteamID.</value>
-        public SteamID SteamID { get; private set; }
+        public SteamID SteamID { get; private set; } = 0;
 
         /// <summary>
         /// Gets or sets the connection timeout used when connecting to the Steam server.
@@ -405,7 +405,7 @@ namespace SteamKit2.Internal
             }
 
             SessionID = null;
-            SteamID = null;
+            SteamID = 0;
 
             connectionRelease.NetMsgReceived -= NetMsgReceived;
             connectionRelease.Connected -= Connected;
@@ -535,7 +535,7 @@ namespace SteamKit2.Internal
         void HandleLoggedOff( IPacketMsg packetMsg )
         {
             SessionID = null;
-            SteamID = null;
+            SteamID = 0;
 
             CellID = null;
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamCloud/SteamCloud.cs
@@ -38,11 +38,6 @@ namespace SteamKit2
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="UGCDetailsCallback"/>.</returns>
         public AsyncJob<UGCDetailsCallback> RequestUGCDetails( UGCHandle ugcId )
         {
-            if ( ugcId == null )
-            {
-                throw new ArgumentNullException( nameof(ugcId) );
-            }
-
             var request = new ClientMsgProtobuf<CMsgClientUFSGetUGCDetails>( EMsg.ClientUFSGetUGCDetails );
             request.SourceJobID = Client.GetNextJobID();
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -102,11 +102,6 @@ namespace SteamKit2
         public IDisposable Subscribe<TCallback>( JobID jobID, Action<TCallback> callbackFunc )
             where TCallback : class, ICallbackMsg
         {
-            if ( jobID == null )
-            {
-                throw new ArgumentNullException( nameof(jobID) );
-            }
-
             if ( callbackFunc == null )
             {
                 throw new ArgumentNullException( nameof(callbackFunc) );

--- a/SteamKit2/SteamKit2/Types/GameID.cs
+++ b/SteamKit2/SteamKit2/Types/GameID.cs
@@ -14,7 +14,7 @@ namespace SteamKit2
     /// This 64bit structure represents an app, mod, shortcut, or p2p file on the Steam network.
     /// </summary>
     [DebuggerDisplay( "{ToUInt64()}" )]
-    public class GameID
+    public struct GameID
     {
         /// <summary>
         /// Represents various types of games.
@@ -41,13 +41,6 @@ namespace SteamKit2
 
         BitVector64 gameid;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GameID"/> class.
-        /// </summary>
-        public GameID()
-            : this( 0 )
-        {
-        }
         /// <summary>
         /// Initializes a new instance of the <see cref="GameID"/> class.
         /// </summary>
@@ -91,14 +84,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator string( GameID gid )
-        {
-            if ( gid == null )
-            {
-                throw new ArgumentNullException( nameof(gid) );
-            }
-
-            return gid.gameid.Data.ToString();
-        }
+            => gid.gameid.Data.ToString();
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="SteamKit2.GameID"/> to <see cref="System.UInt64"/>.
@@ -108,14 +94,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator UInt64( GameID gid )
-        {
-            if ( gid == null )
-            {
-                throw new ArgumentNullException( nameof(gid) );
-            }
-
-            return gid.gameid.Data;
-        }
+            => gid.gameid.Data;
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="System.UInt64"/> to <see cref="SteamKit2.GameID"/>.
@@ -234,13 +213,7 @@ namespace SteamKit2
         /// </returns>
         public override bool Equals( System.Object obj )
         {
-            if ( obj == null )
-            {
-                return false;
-            }
-
-            GameID gid = obj as GameID;
-            if ( ( System.Object )gid == null )
+            if ( !( obj is GameID gid ))
             {
                 return false;
             }
@@ -256,14 +229,7 @@ namespace SteamKit2
         ///   <c>true</c> if the specified <see cref="GameID"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals( GameID gid )
-        {
-            if ( ( object )gid == null )
-            {
-                return false;
-            }
-
-            return gameid.Data == gid.gameid.Data;
-        }
+            => gameid.Data == gid.gameid.Data;
 
         /// <summary>
         /// Implements the operator ==.
@@ -274,19 +240,7 @@ namespace SteamKit2
         /// The result of the operator.
         /// </returns>
         public static bool operator ==( GameID a, GameID b )
-        {
-            if ( System.Object.ReferenceEquals( a, b ) )
-            {
-                return true;
-            }
-
-            if ( ( ( object )a == null ) || ( ( object )b == null ) )
-            {
-                return false;
-            }
-
-            return a.gameid.Data == b.gameid.Data;
-        }
+            => a.gameid.Data == b.gameid.Data;
 
         /// <summary>
         /// Implements the operator !=.

--- a/SteamKit2/SteamKit2/Types/GlobalID.cs
+++ b/SteamKit2/SteamKit2/Types/GlobalID.cs
@@ -5,9 +5,6 @@
 
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Diagnostics;
 
 namespace SteamKit2
@@ -17,18 +14,10 @@ namespace SteamKit2
     /// Guaranteed to be unique across all racks and servers for a given Steam universe.
     /// </summary>
     [DebuggerDisplay( "{Value}" )]
-    public class GlobalID : IEquatable<GlobalID>
+    public struct GlobalID : IEquatable<GlobalID>
     {
         BitVector64 gidBits;
 
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GlobalID"/> class.
-        /// </summary>
-        public GlobalID()
-            : this( ulong.MaxValue )
-        {
-        }
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalID"/> class.
         /// </summary>
@@ -47,14 +36,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator ulong( GlobalID gid )
-        {
-            if ( gid == null )
-            {
-                throw new ArgumentNullException( nameof(gid) );
-            }
-
-            return gid.gidBits.Data;
-        }
+            => gid.gidBits.Data;
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="System.UInt64"/> to <see cref="SteamKit2.GlobalID"/>.
@@ -64,9 +46,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator GlobalID( ulong gid )
-        {
-            return new GlobalID( gid );
-        }
+            => new GlobalID( gid );
 
 
         /// <summary>
@@ -148,13 +128,7 @@ namespace SteamKit2
         /// </returns>
         public override bool Equals( object obj )
         {
-            if ( obj == null )
-            {
-                return false;
-            }
-
-            GlobalID gid = obj as GlobalID;
-            if ( ( object )gid == null )
+            if ( !( obj is GlobalID gid ))
             {
                 return false;
             }
@@ -170,14 +144,7 @@ namespace SteamKit2
         ///   <c>true</c> if the specified <see cref="GlobalID"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
         public bool Equals( GlobalID gid )
-        {
-            if ( ( object )gid == null )
-            {
-                return false;
-            }
-
-            return gidBits.Data == gid.gidBits.Data;
-        }
+            => gidBits.Data == gid.gidBits.Data;
 
         /// <summary>
         /// Implements the operator ==.
@@ -188,19 +155,7 @@ namespace SteamKit2
         /// The result of the operator.
         /// </returns>
         public static bool operator ==( GlobalID a, GlobalID b )
-        {
-            if ( System.Object.ReferenceEquals( a, b ) )
-            {
-                return true;
-            }
-
-            if ( ( ( object )a == null ) || ( ( object )b == null ) )
-            {
-                return false;
-            }
-
-            return a.gidBits.Data == b.gidBits.Data;
-        }
+            => a.gidBits.Data == b.gidBits.Data;
 
         /// <summary>
         /// Implements the operator !=.
@@ -242,23 +197,21 @@ namespace SteamKit2
     /// <summary>
     /// Represents a single unique handle to a piece of User Generated Content.
     /// </summary>
-    public sealed class UGCHandle : GlobalID
+    public struct UGCHandle
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UGCHandle"/> class.
-        /// </summary>
-        public UGCHandle()
-            : base()
-        {
-        }
         /// <summary>
         /// Initializes a new instance of the <see cref="UGCHandle"/> class.
         /// </summary>
         /// <param name="ugcId">The UGC ID.</param>
         public UGCHandle( ulong ugcId )
-            : base( ugcId )
         {
+            UCGID = ugcId;
         }
+
+        /// <summary>
+        /// Handle ID details.
+        /// </summary>
+        public GlobalID UCGID { get; }
 
 
         /// <summary>
@@ -269,14 +222,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator ulong( UGCHandle handle )
-        {
-            if ( handle == null )
-            {
-                throw new ArgumentNullException( nameof(handle) );
-            }
-
-            return handle.Value;
-        }
+            => handle.UCGID.Value;
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="System.UInt64"/> to <see cref="SteamKit2.UGCHandle"/>.

--- a/SteamKit2/SteamKit2/Types/JobID.cs
+++ b/SteamKit2/SteamKit2/Types/JobID.cs
@@ -16,28 +16,70 @@ namespace SteamKit2
     /// <summary>
     /// Represents an identifier of a network task known as a job.
     /// </summary>
-    public class JobID : GlobalID
+    public struct JobID
     {
         /// <summary>
         /// Represents an invalid JobID.
         /// </summary>
         public static readonly JobID Invalid = new JobID();
 
+        GlobalID gid;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JobID"/> class.
-        /// </summary>
-        public JobID()
-            : base()
-        {
-        }
         /// <summary>
         /// Initializes a new instance of the <see cref="JobID"/> class.
         /// </summary>
         /// <param name="jobId">The Job ID to initialize this instance with.</param>
         public JobID( ulong jobId )
-            : base( jobId )
         {
+            gid = jobId;
+        }
+
+        /// <summary>
+        /// Gets or sets the sequential count for this GID.
+        /// </summary>
+        /// <value>
+        /// The sequential count.
+        /// </value>
+        public uint SequentialCount
+        {
+            get => gid.SequentialCount;
+            set => gid.SequentialCount = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the start time of the server that generated this GID.
+        /// </summary>
+        /// <value>
+        /// The start time.
+        /// </value>
+        public DateTime StartTime
+        {
+            get => gid.StartTime;
+            set => gid.StartTime = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the process ID of the server that generated this GID.
+        /// </summary>
+        /// <value>
+        /// The process ID.
+        /// </value>
+        public uint ProcessID
+        {
+            get => gid.ProcessID;
+            set => gid.ProcessID = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the box ID of the server that generated this GID.
+        /// </summary>
+        /// <value>
+        /// The box ID.
+        /// </value>
+        public uint BoxID
+        {
+            get => gid.BoxID;
+            set => gid.BoxID = value;
         }
 
 
@@ -49,14 +91,7 @@ namespace SteamKit2
         /// The result of the conversion.
         /// </returns>
         public static implicit operator ulong ( JobID jobId )
-        {
-            if ( jobId == null )
-            {
-                throw new ArgumentNullException( nameof(jobId) );
-            }
-
-            return jobId.Value;
-        }
+            => jobId.gid.Value;
 
         /// <summary>
         /// Performs an implicit conversion from <see cref="System.UInt64"/> to <see cref="SteamKit2.JobID"/>.
@@ -118,11 +153,6 @@ namespace SteamKit2
             if ( client == null )
             {
                 throw new ArgumentNullException( nameof(client) );
-            }
-            
-            if ( jobId == null )
-            {
-                throw new ArgumentNullException( nameof(jobId) );
             }
 
             jobStart = DateTime.UtcNow;

--- a/SteamKit2/SteamKit2/Types/SteamID.cs
+++ b/SteamKit2/SteamKit2/Types/SteamID.cs
@@ -13,13 +13,25 @@ using System.Text.RegularExpressions;
 
 namespace SteamKit2
 {
-    class BitVector64
+    struct BitVector64
     {
-        public ulong Data { get; set; }
+        bool initialized;
+        ulong data;
+
+        public ulong Data
+        {
+            get => initialized ? data : ulong.MaxValue;
+            set
+            {
+                data = value;
+                initialized = true;
+            }
+        }
 
         public BitVector64( ulong value )
         {
-            Data = value;
+            data = value;
+            initialized = true;
         }
 
         public ulong this[ uint bitoffset, ulong valuemask ]
@@ -33,9 +45,9 @@ namespace SteamKit2
     /// This 64-bit structure is used for identifying various objects on the Steam network.
     /// </summary>
     [DebuggerDisplay( "{Render()}, {ConvertToUInt64()}" )]
-    public class SteamID
+    public struct SteamID
     {
-        readonly BitVector64 steamid;
+        BitVector64 steamid;
 
         static readonly Regex Steam2Regex = new Regex(
             @"STEAM_(?<universe>[0-4]):(?<authserver>[0-1]):(?<accountid>\d+)",
@@ -110,15 +122,6 @@ namespace SteamKit2
             /// This flag is set for matchmaking lobby based chat <see cref="SteamID">SteamIDs</see>.
             /// </summary>
             MMSLobby = ( AccountInstanceMask + 1 ) >> 3,
-        }
-
-        /// <inheritdoc />
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SteamID"/> class.
-        /// </summary>
-        public SteamID()
-            : this( 0 )
-        {
         }
 
         /// <inheritdoc />
@@ -570,8 +573,8 @@ namespace SteamKit2
         /// Converts this chat ID to a clan ID.
         /// This can be used to get the group that a group chat is associated with.
         /// </summary>
-        /// <returns><c>true</c> if this chat ID represents a group chat, <c>false</c> otherwise.</returns>\
-        /// <param name="groupID">If the method returned <c>true</c>, then this is the group that this chat is associated with. Otherwise, this is <c>null</c>.</param>
+        /// <returns><c>true</c> if this chat ID represents a group chat, <c>false</c> otherwise.</returns>
+        /// <param name="groupID">If the method returned <c>true</c>, then this is the group that this chat is associated with. Otherwise, this is <c>default</c>.</param>
         public bool TryGetClanID( out SteamID groupID )
         {
             if ( IsChatAccount && AccountInstance == (uint)ChatInstanceFlags.Clan )

--- a/SteamKit2/Tests/SteamIDFacts.cs
+++ b/SteamKit2/Tests/SteamIDFacts.cs
@@ -260,7 +260,7 @@ namespace Tests
             Assert.True( sid.Equals( ( object )sid2 ) );
 
             Assert.False( sid.Equals( new object() ) );
-            Assert.False( sid.Equals( ( SteamID )null ) );
+            Assert.False( sid.Equals( default(SteamID) ) );
             Assert.False( sid.Equals( ( object )null ) );
 
             SteamID sid3 = 12345;
@@ -375,8 +375,8 @@ namespace Tests
         public void TryGetClanIDReturnsFalseForAdHocChatRoom()
         {
             var chatID = new SteamID( 108093571196988453 );
-            Assert.False( chatID.TryGetClanID( out var groupID ), groupID?.Render() );
-            Assert.Null( groupID );
+            Assert.False( chatID.TryGetClanID( out var groupID ), groupID.Render() );
+            Assert.Equal( default(SteamID), groupID );
         }
 
         [InlineData(EAccountType.AnonGameServer)]
@@ -391,7 +391,7 @@ namespace Tests
         public void TryGetClanIDOnlySupportsClanChatRooms( EAccountType type )
         {
             var id = new SteamID( 4, ( uint )SteamID.ChatInstanceFlags.Clan, EUniverse.Public, type );
-            Assert.False( id.TryGetClanID( out var groupID ), groupID?.Render() );
+            Assert.False( id.TryGetClanID( out var groupID ), groupID.Render() );
             Assert.Null( groupID );
         }
     }


### PR DESCRIPTION
Would close #559.

Seems we have a discrepancy:

- `default(JobID)` and all derivates should be `0xFFFFFFFFFFFFFFFF`.
- `default(SteamID)` should be `0x0000000000000000`.

We might need two definitions of `BitVector` with different defaults.