### PR TITLE
Add sonarqube analysis as part of CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,33 @@ dist: trusty
 
 language: csharp
 mono: none
-dotnet: 2.0.0
+dotnet: 2.1
+
+git:
+    depth: false
+
+addons:
+    sonarcloud:
+        organization: "steamre"
 
 solution: SteamKit2/SteamKit2.sln
 
 install:
+    - dotnet tool install --global dotnet-sonarscanner
     - dotnet restore SteamKit2/SteamKit2.sln
     - dotnet restore Samples/Samples.sln
 
+before_script:
+    - export PATH="$PATH:/home/travis/.dotnet/tools"
+
 script:
+    - dotnet sonarscanner begin /k:"SteamKit" /d:sonar.host.url="https://sonarcloud.io"
     - dotnet build SteamKit2/SteamKit2/SteamKit2.csproj
     - dotnet build SteamKit2/Tests/Tests.csproj
     - dotnet build Resources/SteamLanguageParser/SteamLanguageParser.csproj
     - dotnet build Samples/Samples.sln
     - dotnet test SteamKit2/Tests/Tests.csproj
+    - dotnet sonarscanner end
 
 notifications:
     irc:
@@ -28,3 +41,4 @@ notifications:
 cache:
     directories:
         - "~/.local/share/NuGet/Cache"
+        - "~/.sonar/cache"

--- a/Resources/SteamLanguageParser/SteamLanguageParser.csproj
+++ b/Resources/SteamLanguageParser/SteamLanguageParser.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <ProjectGuid>{CCAB4961-4C59-4400-978B-7D9552AE2296}</ProjectGuid>
   </PropertyGroup>
 
 </Project>

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -11,6 +11,7 @@
     <PackageLicenseUrl>https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/license.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/SteamRE/SteamKit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <ProjectGuid>{4B2B0365-DE37-4B65-B614-3E4E7C05147D}</ProjectGuid>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <ProjectGuid>{5BF6D076-399B-41CA-BAE7-37CE1C40CA67}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,0 @@
-sonar.projectKey=SteamKit
-sonar.sources=./SteamKit2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=SteamKit
+sonar.sources=./SteamKit2


### PR DESCRIPTION
Add sonarqube scanning and analysis as part of CI. A peek at what this gives us: https://sonarcloud.io/project/issues?branch=experiment%2Fsonarqube&id=SteamKit&resolved=false

Supposedly this will also decorate PRs, but we'll see - the GitHub integration isn't all there yet.

Phase two will probably be trimming down which files get analyzed, cause we probably don't want autogenerated code running through it. Or maybe we do. We'll see!