### PR TITLE
Make StreamHelpers thread-safe.

### DIFF
--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -6,53 +6,68 @@ namespace SteamKit2
 {
     internal static class StreamHelpers
     {
-        static byte[] data = new byte[8];
+        [ThreadStatic]
+        static byte[] data;
+
+        static void EnsureInitialized()
+        {
+            if ( data == null )
+                data = new byte[ 8 ];
+        }
+
         public static Int16 ReadInt16(this Stream stream)
         {
-            stream.Read( data, 0, 2 );
+            EnsureInitialized();
 
+            stream.Read( data, 0, 2 );
             return BitConverter.ToInt16( data, 0 );
         }
 
         public static UInt16 ReadUInt16(this Stream stream)
         {
-            stream.Read(data, 0, 2);
+            EnsureInitialized();
 
-            return BitConverter.ToUInt16(data, 0);
+            stream.Read( data, 0, 2 );
+            return BitConverter.ToUInt16( data, 0);
         }
 
         public static Int32 ReadInt32(this Stream stream)
         {
-            stream.Read( data, 0, 4 );
+            EnsureInitialized();
 
+            stream.Read( data, 0, 4 );
             return BitConverter.ToInt32( data, 0 );
         }
 
         public static Int64 ReadInt64(this Stream stream)
         {
-            stream.Read( data, 0, 8 );
+            EnsureInitialized();
 
+            stream.Read( data, 0, 8 );
             return BitConverter.ToInt64( data, 0 );
         }
 
         public static UInt32 ReadUInt32(this Stream stream)
         {
-            stream.Read(data, 0, 4);
+            EnsureInitialized();
 
-            return BitConverter.ToUInt32(data, 0);
+            stream.Read(data, 0, 4);
+            return BitConverter.ToUInt32( data, 0);
         }
 
         public static UInt64 ReadUInt64(this Stream stream)
         {
-            stream.Read( data, 0, 8 );
+            EnsureInitialized();
 
+            stream.Read( data, 0, 8 );
             return BitConverter.ToUInt64( data, 0 );
         }
 
         public static float ReadFloat( this Stream stream )
         {
-            stream.Read( data, 0, 4 );
+            EnsureInitialized();
 
+            stream.Read( data, 0, 4 );
             return BitConverter.ToSingle( data, 0 );
         }
 
@@ -76,7 +91,7 @@ namespace SteamKit2
                     ms.Write( data, 0, data.Length );
                 }
 
-                return encoding.GetString( ms.ToArray() );
+                return encoding.GetString( ms.GetBuffer(), 0, ( int )ms.Length );
             }
         }
 
@@ -88,19 +103,6 @@ namespace SteamKit2
             data[ dataLength ] = 0x00; // '\0'
 
             stream.Write( data, 0, data.Length );
-        }
-
-        static byte[] discardBuffer = new byte[2 << 12];
-
-        public static void ReadAndDiscard(this Stream stream, int len)
-        {
-            while (len > discardBuffer.Length)
-            {
-                stream.Read(discardBuffer, 0, discardBuffer.Length);
-                len -= discardBuffer.Length;
-            }
-
-            stream.Read(discardBuffer, 0, len);
         }
     }
 }

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using SteamKit2;
+using Xunit;
+
+namespace Tests
+{
+    public class StreamHelpersFacts
+    {
+        [Fact]
+        public void IsThreadSafe()
+        {
+            const int NumConcurrentThreads = 200;
+            var threads = new Thread[NumConcurrentThreads];
+            
+            for ( var i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(ThreadStart);
+                threads[i].Start(i);
+            }
+
+            for (var i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            if (!threadExceptions.IsEmpty)
+            {
+                throw new AggregateException(threadExceptions);
+            }
+        }
+
+        ConcurrentBag<Exception> threadExceptions = new ConcurrentBag<Exception>();
+
+        void ThreadStart(object o)
+        {
+            try
+            {
+                var threadNumber = (int)o;
+
+                using (var ms = new MemoryStream())
+                {
+                    var bytes = BitConverter.GetBytes(threadNumber);
+                    ms.Write(bytes, 0, bytes.Length);
+
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        ms.Seek(0, SeekOrigin.Begin);
+
+                        var value = ReadValue(threadNumber, ms).ToString(CultureInfo.InvariantCulture);
+                        Assert.Equal(threadNumber.ToString(CultureInfo.InvariantCulture), value);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                threadExceptions.Add(ex);
+            }
+
+            IConvertible ReadValue(int threadNumber, Stream s)
+            {
+                switch (threadNumber % 7)
+                {
+                    case 0: return s.ReadByte();
+                    case 1: return s.ReadInt64();
+                    case 2: return s.ReadUInt16();
+                    case 3: return s.ReadInt32();
+                    case 4: return s.ReadUInt32();
+                    case 5: return s.ReadInt64();
+                    case 6: return s.ReadUInt64();
+                    default: throw new Exception("Unreachable");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #553.

I'd have preferred to use `ArrayPool<T>` but it's probably not worth roping in another dependency for this.