### PR TITLE
Make HTTP components configurable

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -231,7 +231,7 @@ namespace SteamKit2
             }
 
             this.steamClient = steamClient;
-            this.httpClient = steamClient.Configuration.GetHttpClient();
+            this.httpClient = steamClient.Configuration.HttpClientFactory();
 
             this.depotIds = new ConcurrentDictionary<uint, bool>();
             this.appTicket = appTicket;

--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -231,7 +231,7 @@ namespace SteamKit2
             }
 
             this.steamClient = steamClient;
-            this.httpClient = new HttpClient();
+            this.httpClient = steamClient.Configuration.GetHttpClient();
 
             this.depotIds = new ConcurrentDictionary<uint, bool>();
             this.appTicket = appTicket;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -53,15 +53,6 @@ namespace SteamKit2
         ISteamConfigurationBuilder WithHttpClientFactory(HttpClientFactory factoryFunction);
 
         /// <summary>
-        /// Configures this <see cref="SteamConfiguration" /> to with custom HTTP behaviour.
-        /// </summary>
-        /// <param name="factoryFunction">A function to return a new or existing HttpMessageHandler.
-        /// If multiple invocations will return the same instance, then you must also configure <see cref="WithHttpClientFactory(HttpClientFactory)"/> to return
-        /// a <see cref="HttpClient"/> that will not dispose of the inner handler.</param>
-        /// <returns>A builder with modified configuration.</returns>
-        ISteamConfigurationBuilder WithHttpMessageHandlerFactory(HttpMessageHandlerFactory factoryFunction);
-
-        /// <summary>
         /// Configures how this <see cref="SteamConfiguration" /> will be used to connect to Steam.
         /// </summary>
         /// <param name="protocolTypes">The supported protocol types to use when attempting to connect to Steam.</param>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -5,6 +5,7 @@
 
 
 using System;
+using System.Net.Http;
 using SteamKit2.Discovery;
 
 namespace SteamKit2
@@ -43,6 +44,22 @@ namespace SteamKit2
         /// <param name="allowDirectoryFetch">Whether or not to use the Steam Directory to discover available servers.</param>
         /// <returns>A builder with modified configuration.</returns>
         ISteamConfigurationBuilder WithDirectoryFetch(bool allowDirectoryFetch);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> with custom HTTP behaviour.
+        /// </summary>
+        /// <param name="factoryFunction">A function to create and configure a new HttpClient.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithHttpClientFactory(HttpClientFactory factoryFunction);
+
+        /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> to with custom HTTP behaviour.
+        /// </summary>
+        /// <param name="factoryFunction">A function to return a new or existing HttpMessageHandler.
+        /// If multiple invocations will return the same instance, then you must also configure <see cref="WithHttpClientFactory(HttpClientFactory)"/> to return
+        /// a <see cref="HttpClient"/> that will not dispose of the inner handler.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithHttpMessageHandlerFactory(HttpMessageHandlerFactory factoryFunction);
 
         /// <summary>
         /// Configures how this <see cref="SteamConfiguration" /> will be used to connect to Steam.

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -11,18 +11,11 @@ using SteamKit2.Discovery;
 namespace SteamKit2
 {
     /// <summary>
-    /// Factory function to create a user-configured HttpMessageHandler.
-    /// </summary>
-    /// <returns>A <see cref="HttpMessageHandler"/> to be used to send HTTP requests.</returns>
-    public delegate HttpMessageHandler HttpMessageHandlerFactory();
-
-    /// <summary>
     /// Factory function to create a user-configured HttpClient.
     /// The HttpClient will be disposed of after use.
     /// </summary>
-    /// <param name="handler">The inner <see cref="HttpMessageHandler"/> to be used.</param>
     /// <returns>A new <see cref="HttpClient"/> to be used to send HTTP requests.</returns>
-    public delegate HttpClient HttpClientFactory(HttpMessageHandler handler);
+    public delegate HttpClient HttpClientFactory();
 
     /// <summary>
     /// Configuration object to use.
@@ -86,13 +79,6 @@ namespace SteamKit2
         /// Factory function to create a user-configured HttpClient.
         /// </summary>
         public HttpClientFactory HttpClientFactory => state.HttpClientFactory;
-
-        /// <summary>
-        /// Factory function to be used to create a user-configured HttpMessageHandler.
-        /// If this is to be re-used, then you must also implement a <see cref="HttpClientFactory"/> to ensure
-        /// that it is not disposed of too early.
-        /// </summary>
-        public HttpMessageHandlerFactory HttpMessageHandlerFactory => state.HttpMessageHandlerFactory;
 
         /// <summary>
         /// The supported protocol types to use when attempting to connect to Steam.

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -16,7 +16,6 @@ namespace SteamKit2
     /// <returns>A <see cref="HttpMessageHandler"/> to be used to send HTTP requests.</returns>
     public delegate HttpMessageHandler HttpMessageHandlerFactory();
 
-
     /// <summary>
     /// Factory function to create a user-configured HttpClient.
     /// The HttpClient will be disposed of after use.

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -5,10 +5,26 @@
 
 
 using System;
+using System.Net.Http;
 using SteamKit2.Discovery;
 
 namespace SteamKit2
 {
+    /// <summary>
+    /// Factory function to create a user-configured HttpMessageHandler.
+    /// </summary>
+    /// <returns>A <see cref="HttpMessageHandler"/> to be used to send HTTP requests.</returns>
+    public delegate HttpMessageHandler HttpMessageHandlerFactory();
+
+
+    /// <summary>
+    /// Factory function to create a user-configured HttpClient.
+    /// The HttpClient will be disposed of after use.
+    /// </summary>
+    /// <param name="handler">The inner <see cref="HttpMessageHandler"/> to be used.</param>
+    /// <returns>A new <see cref="HttpClient"/> to be used to send HTTP requests.</returns>
+    public delegate HttpClient HttpClientFactory(HttpMessageHandler handler);
+
     /// <summary>
     /// Configuration object to use.
     /// This object should not be mutated after it is passed to one or more <see cref="SteamClient"/> objects.
@@ -66,6 +82,19 @@ namespace SteamKit2
         /// when calling <c>SteamFriends.RequestFriendInfo</c> without specifying flags.
         /// </summary>
         public EClientPersonaStateFlag DefaultPersonaStateFlags => state.DefaultPersonaStateFlags;
+
+        /// <summary>
+        /// Factory function to create a user-configured HttpClient.
+        /// </summary>
+        public HttpClientFactory HttpClientFactory => state.HttpClientFactory;
+
+        /// <summary>
+        /// Factory function to be used to create a user-configured HttpMessageHandler.
+        /// If this is to be re-used, then you must also implement a <see cref="HttpClientFactory"/> to ensure
+        /// that it is not disposed of too early.
+        /// </summary>
+        public HttpMessageHandlerFactory HttpMessageHandlerFactory => state.HttpMessageHandlerFactory;
+
         /// <summary>
         /// The supported protocol types to use when attempting to connect to Steam.
         /// </summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -32,8 +32,6 @@ namespace SteamKit2
 
                 HttpClientFactory = DefaultHttpClientFactory,
 
-                HttpMessageHandlerFactory = DefaultMessageHandlerFactory,
-
                 ProtocolTypes = ProtocolTypes.Tcp,
 
                 ServerListProvider = new NullServerListProvider(),
@@ -79,13 +77,6 @@ namespace SteamKit2
             return this;
         }
 
-
-        public ISteamConfigurationBuilder WithHttpMessageHandlerFactory(HttpMessageHandlerFactory factoryFunction)
-        {
-            state.HttpMessageHandlerFactory = factoryFunction;
-            return this;
-        }
-
         public ISteamConfigurationBuilder WithProtocolTypes(ProtocolTypes protocolTypes)
         {
             state.ProtocolTypes = protocolTypes;
@@ -118,6 +109,6 @@ namespace SteamKit2
 
         static HttpMessageHandler DefaultMessageHandlerFactory() => new HttpClientHandler();
 
-        static HttpClient DefaultHttpClientFactory(HttpMessageHandler handler) => new HttpClient(handler, disposeHandler: true);
+        static HttpClient DefaultHttpClientFactory() => new HttpClient();
     }
 }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -107,8 +107,6 @@ namespace SteamKit2
             return this;
         }
 
-        static HttpMessageHandler DefaultMessageHandlerFactory() => new HttpClientHandler();
-
         static HttpClient DefaultHttpClientFactory() => new HttpClient();
     }
 }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -5,6 +5,7 @@
 
 
 using System;
+using System.Net.Http;
 using SteamKit2.Discovery;
 
 namespace SteamKit2
@@ -28,6 +29,10 @@ namespace SteamKit2
                     EClientPersonaStateFlag.PlayerName | EClientPersonaStateFlag.Presence |
                     EClientPersonaStateFlag.SourceID | EClientPersonaStateFlag.GameExtraInfo |
                     EClientPersonaStateFlag.LastSeen,
+
+                HttpClientFactory = DefaultHttpClientFactory,
+
+                HttpMessageHandlerFactory = DefaultMessageHandlerFactory,
 
                 ProtocolTypes = ProtocolTypes.Tcp,
 
@@ -68,6 +73,19 @@ namespace SteamKit2
             return this;
         }
 
+        public ISteamConfigurationBuilder WithHttpClientFactory(HttpClientFactory factoryFunction)
+        {
+            state.HttpClientFactory = factoryFunction;
+            return this;
+        }
+
+
+        public ISteamConfigurationBuilder WithHttpMessageHandlerFactory(HttpMessageHandlerFactory factoryFunction)
+        {
+            state.HttpMessageHandlerFactory = factoryFunction;
+            return this;
+        }
+
         public ISteamConfigurationBuilder WithProtocolTypes(ProtocolTypes protocolTypes)
         {
             state.ProtocolTypes = protocolTypes;
@@ -97,5 +115,9 @@ namespace SteamKit2
             state.WebAPIKey = webApiKey ?? throw new ArgumentNullException(nameof(webApiKey));
             return this;
         }
+
+        static HttpMessageHandler DefaultMessageHandlerFactory() => new HttpClientHandler();
+
+        static HttpClient DefaultHttpClientFactory(HttpMessageHandler handler) => new HttpClient(handler, disposeHandler: true);
     }
 }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
@@ -15,6 +15,8 @@ namespace SteamKit2
         public uint CellID;
         public TimeSpan ConnectionTimeout;
         public EClientPersonaStateFlag DefaultPersonaStateFlags;
+        public HttpClientFactory HttpClientFactory;
+        public HttpMessageHandlerFactory HttpMessageHandlerFactory;
         public ProtocolTypes ProtocolTypes;
         public IServerListProvider ServerListProvider;
         public EUniverse Universe;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
@@ -16,7 +16,6 @@ namespace SteamKit2
         public TimeSpan ConnectionTimeout;
         public EClientPersonaStateFlag DefaultPersonaStateFlags;
         public HttpClientFactory HttpClientFactory;
-        public HttpMessageHandlerFactory HttpMessageHandlerFactory;
         public ProtocolTypes ProtocolTypes;
         public IServerListProvider ServerListProvider;
         public EUniverse Universe;

--- a/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
@@ -42,23 +42,11 @@ namespace SteamKit2
 
         internal static HttpClient GetHttpClientForWebAPI(this SteamConfiguration config)
         {
-            var client = config.GetHttpClient();
+            var client = config.HttpClientFactory();
 
             client.BaseAddress = config.WebAPIBaseAddress;
             client.Timeout = WebAPI.DefaultTimeout;
 
-            return client;
-        }
-
-        internal static HttpClient GetHttpClient(this SteamConfiguration config)
-        {
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-
-            var handler = config.HttpMessageHandlerFactory();
-            var client = config.HttpClientFactory(handler);
             return client;
         }
     }

--- a/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 
 namespace SteamKit2
 {
@@ -20,7 +21,7 @@ namespace SteamKit2
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return new WebAPI.Interface(config.WebAPIBaseAddress, iface, config.WebAPIKey);
+            return new WebAPI.Interface(config.GetHttpClientForWebAPI(), iface, config.WebAPIKey);
         }
 
         /// <summary>
@@ -36,7 +37,29 @@ namespace SteamKit2
                 throw new ArgumentNullException(nameof(config));
             }
 
-            return new WebAPI.AsyncInterface(config.WebAPIBaseAddress, iface, config.WebAPIKey);
+            return new WebAPI.AsyncInterface(config.GetHttpClientForWebAPI(), iface, config.WebAPIKey);
+        }
+
+        internal static HttpClient GetHttpClientForWebAPI(this SteamConfiguration config)
+        {
+            var client = config.GetHttpClient();
+
+            client.BaseAddress = config.WebAPIBaseAddress;
+            client.Timeout = WebAPI.DefaultTimeout;
+
+            return client;
+        }
+
+        internal static HttpClient GetHttpClient(this SteamConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            var handler = config.HttpMessageHandlerFactory();
+            var client = config.HttpClientFactory(handler);
+            return client;
         }
     }
 }

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -26,6 +26,8 @@ namespace SteamKit2
         /// </summary>
         public static Uri DefaultBaseAddress { get; } = new Uri("https://api.steampowered.com/", UriKind.Absolute);
 
+        internal static TimeSpan DefaultTimeout { get; } = TimeSpan.FromSeconds(100);
+
         /// <summary>
         /// Represents a single interface that exists within the Web API.
         /// This is a dynamic object that allows function calls to interfaces with minimal code.
@@ -48,9 +50,9 @@ namespace SteamKit2
             }
 
 
-            internal Interface( Uri baseAddress, string iface, string apiKey )
+            internal Interface( HttpClient httpClient, string iface, string apiKey )
             {
-                asyncInterface = new AsyncInterface( baseAddress, iface, apiKey );
+                asyncInterface = new AsyncInterface( httpClient, iface, apiKey );
             }
 
 
@@ -187,14 +189,9 @@ namespace SteamKit2
                 RegexOptions.Compiled | RegexOptions.IgnoreCase
             );
 
-            internal AsyncInterface( Uri baseAddress, string iface, string apiKey )
+            internal AsyncInterface( HttpClient httpClient, string iface, string apiKey )
             {
-                httpClient = new HttpClient
-                {
-                    BaseAddress = baseAddress,
-                    Timeout = TimeSpan.FromSeconds(100)
-                };
-
+                this.httpClient = httpClient;
                 this.iface = iface;
                 this.apiKey = apiKey;
             }
@@ -445,7 +442,7 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(iface) );
             }
 
-            return new Interface( baseAddress, iface, apiKey );
+            return new Interface( CreateDefaultHttpClient( baseAddress ), iface, apiKey );
         }
 
         /// <summary>
@@ -461,7 +458,7 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(iface) );
             }
 
-            return new Interface( DefaultBaseAddress, iface, apiKey );
+            return new Interface( CreateDefaultHttpClient( DefaultBaseAddress ), iface, apiKey );
         }
 
         /// <summary>
@@ -477,7 +474,7 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(iface) );
             }
 
-            return new AsyncInterface( DefaultBaseAddress, iface, apiKey );
+            return new AsyncInterface( CreateDefaultHttpClient( DefaultBaseAddress ), iface, apiKey );
         }
 
         /// <summary>
@@ -499,7 +496,18 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(iface) );
             }
             
-            return new AsyncInterface( baseAddress, iface, apiKey );
+            return new AsyncInterface( CreateDefaultHttpClient( baseAddress ), iface, apiKey );
+        }
+
+        static HttpClient CreateDefaultHttpClient( Uri baseAddress )
+        {
+            var client = new HttpClient
+            {
+                BaseAddress = baseAddress,
+                Timeout = DefaultTimeout
+            };
+
+            return client;
         }
     }
 

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -81,9 +81,6 @@ namespace Tests
                     Assert.False(task.IsCompleted);
 
                     handler.Completion.SetResult(new HttpResponseMessage(HttpStatusCode.OK));
-                    await Task.Yield();
-
-                    Assert.True(task.IsCompleted);
 
                     var result = await task;
                     Assert.Equal(HttpStatusCode.OK, result.StatusCode);


### PR DESCRIPTION
Users can provide one or two new factory functions to `SteamConfiguration`:

- A `HttpMessageHandler` factory function, which is the inner part of the pipeline that actually executes HTTP requests, and
- A `HttpClient` factory function, which is a nice wrapper class that the rest of the .NET HTTP stack is built around.

Users can use these two injection points to, for example:

- Configure credentials
- Configure proxy settings
- Do something instead of HTTP requests
- Inspect and log outgoing requests
- Inspect and log incoming responses
- Mutate requests and responses (though any errors caused from this are their own fault)
- Use a single underlying HTTP connection pool to increase performance
- Use a single underlying HTTP connection pool to avoid connection exhaustion

Note that this only affects WebAPI, it has no bearing on Websocket CM connections. We could expose `ClientWebSocketOptions` some day, but that's another PR for another issue, if/when it's ever needed.

This resolves #450 and #541.

For now I've simply attached them to `SteamConfiguration`, but as the configuration gets bigger we might want to split it up - for example, these two factory methods could be put on an interface, we provide a default implementation, and `SteamConfiguration` would only have one HTTP-related method/property to get/replace the HTTP configuration object.