### PR TITLE
Add Balance64 to WalletInfoCallback

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -305,7 +305,7 @@ namespace SteamKit2
             /// <summary>
             /// Gets the balance of the wallet as a 64-bit integer, in cents.
             /// </summary>
-            public long Balance64 { get; private set; }
+            public long LongBalance { get; private set; }
 
 
             internal WalletInfoCallback( CMsgClientWalletInfoUpdate wallet )
@@ -314,7 +314,7 @@ namespace SteamKit2
 
                 Currency = ( ECurrencyCode )wallet.currency;
                 Balance = wallet.balance;
-                Balance64 = wallet.balance64;
+                LongBalance = wallet.balance64;
             }
         }
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -296,10 +296,16 @@ namespace SteamKit2
             /// Gets the currency code for this wallet.
             /// </summary>
             public ECurrencyCode Currency { get; private set; }
+
             /// <summary>
-            /// Gets the balance of the wallet, in cents.
+            /// Gets the balance of the wallet as a 32-bit integer, in cents.
             /// </summary>
             public int Balance { get; private set; }
+
+            /// <summary>
+            /// Gets the balance of the wallet as a 64-bit integer, in cents.
+            /// </summary>
+            public long Balance64 { get; private set; }
 
 
             internal WalletInfoCallback( CMsgClientWalletInfoUpdate wallet )
@@ -308,6 +314,7 @@ namespace SteamKit2
 
                 Currency = ( ECurrencyCode )wallet.currency;
                 Balance = wallet.balance;
+                Balance64 = wallet.balance64;
             }
         }
 


### PR DESCRIPTION
This can be needed if `int` won't be enough to display the account balance, i.e. when balance reaches more than `21474836.47` in local currency.

Unlikely to happen, but won't hurt to add considering Steam provides this.