### PR TITLE
WIP: Initial implementation of content delta patches

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -20,7 +20,7 @@ namespace SteamKit2
     /// <summary>
     /// The CDNClient class is used for downloading game content from the Steam servers.
     /// </summary>
-    public sealed class CDNClient : IDisposable
+    public sealed partial class CDNClient : IDisposable
     {
         /// <summary>
         /// Represents a single Steam3 'Steampipe' content server.

--- a/SteamKit2/SteamKit2/Steam/CDNClient_Patch.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient_Patch.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SteamKit2
+{
+    public sealed partial class CDNClient : IDisposable
+    {
+        const uint MAGIC_PATCH_HEADER = 0x502F15E5;
+        const uint MAGIC_PATCH_FOOTER = 0xF3DEA982;
+
+        /// <summary>
+        /// Downloads the depot delta patch specified by the given manifest IDs.
+        /// </summary>
+        /// <param name="depotId">The id of the depot being accessed.</param>
+        /// <param name="sourceManifestId">The unique identifier of the manifest to diff from.</param>
+        /// <param name="targetManifestId">The unique identifier of the manifest to diff to.</param>
+        /// <returns>A <see cref="DepotDeltaChunks"/> instance that contains information about the delta chunk patches present</returns>
+        public async Task<DepotDeltaChunks> DownloadPatchAsync( uint depotId, ulong sourceManifestId, ulong targetManifestId )
+        {
+            depotCdnAuthKeys.TryGetValue( depotId, out var cdnToken );
+            depotKeys.TryGetValue( depotId, out var depotKey );
+
+            return await DownloadPatchCoreAsync( depotId, sourceManifestId, targetManifestId, connectedServer, cdnToken, depotKey ).ConfigureAwait( false );
+        }
+
+        /// <summary>
+        /// Downloads the depot delta patch specified by the given manifest IDs.
+        /// </summary>
+        /// <param name="depotId">The id of the depot being accessed.</param>
+        /// <param name="sourceManifestId">The unique identifier of the manifest to diff from.</param>
+        /// <param name="targetManifestId">The unique identifier of the manifest to diff to.</param>
+        /// <param name="host">CDN hostname.</param>
+        /// <param name="cdnAuthToken">CDN auth token for CDN content server endpoints.</param>
+        /// <param name="depotKey">
+        /// The depot decryption key for the depot that will be downloaded.
+        /// This is used for decrypting filenames (if needed) in depot manifests, and processing depot chunks.
+        /// </param>
+        /// <returns>A <see cref="DepotDeltaChunks"/> instance that contains information about the delta chunk patches present</returns>
+        public async Task<DepotDeltaChunks> DownloadPatchAsync( uint depotId, ulong sourceManifestId, ulong targetManifestId, string host, string cdnAuthToken, byte[] depotKey )
+        {
+            var server = new Server
+            {
+                Protocol = Server.ConnectionProtocol.HTTP,
+                Host = host,
+                VHost = host,
+                Port = 80
+            };
+
+            return await DownloadPatchCoreAsync( depotId, sourceManifestId, targetManifestId, server, cdnAuthToken, depotKey ).ConfigureAwait( false );
+        }
+
+        async Task<DepotDeltaChunks> DownloadPatchCoreAsync( uint depotId, ulong sourceManifestId, ulong targetManifestId, Server server, string cdnAuthToken, byte[] depotKey )
+        {
+            if ( depotKey == null )
+            {
+                throw new ArgumentNullException( nameof( depotKey ) );
+            }
+
+            if ( sourceManifestId == targetManifestId )
+            {
+                throw new ArgumentException( "Source manifest cannot equal target manifest" );
+            }
+
+            // TODO: This request can return 404 with html content, need to account for that
+            var patchData = await DoRawCommandAsync( server, HttpMethod.Get, "depot", doAuth: true, args: $"{depotId}/patch/{sourceManifestId}/{targetManifestId}", authtoken: cdnAuthToken ).ConfigureAwait( false );
+            
+            // Steam client reference is CContentDeltaChunks::BDeserializeProtobuf
+            patchData = CryptoHelper.SymmetricDecrypt( patchData, depotKey );
+
+            using ( var ms = new MemoryStream( patchData ) )
+            using ( var br = new BinaryReader( ms ) )
+            {
+                var headerMagic = br.ReadUInt32();
+
+                if ( headerMagic != MAGIC_PATCH_HEADER )
+                {
+                    throw new InvalidDataException( "Didn't recognize header of content delta patch" );
+                }
+
+                var payloadLength = br.ReadUInt32();
+                var payload = br.ReadBytes( ( int )payloadLength );
+
+                var footerMagic = br.ReadUInt32();
+
+                if ( footerMagic != MAGIC_PATCH_FOOTER )
+                {
+                    throw new InvalidDataException( "Didn't recognize trailer of content delta patch" );
+                }
+
+                return new DepotDeltaChunks( payload );
+            }
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Types/DepotDeltaChunks.cs
+++ b/SteamKit2/SteamKit2/Types/DepotDeltaChunks.cs
@@ -1,0 +1,104 @@
+﻿/*
+ * This file is subject to the terms and conditions defined in
+ * file 'license.txt', which is part of this source code package.
+ */
+
+using ProtoBuf;
+using SteamKit2.Internal;
+using System.Collections.Generic;
+using System.IO;
+
+namespace SteamKit2
+{
+    /// <summary>
+    /// Represents a depot delta patch.
+    /// </summary>
+    public sealed class DepotDeltaChunks
+    {
+        /// <summary>
+        /// Represents a single delta chunk.
+        /// </summary>
+        public class DeltaChunkData
+        {
+            /// <summary>
+            /// Gets or sets the chunk content.
+            /// </summary>
+            public byte[] Chunk { get; set; }
+            /// <summary>
+            /// Gets or sets the expected SHA-1 hash of the original chunk.
+            /// </summary>
+            public byte[] SourceSHA { get; set; }
+            /// <summary>
+            /// Gets or sets the expected SHA-1 hash of the target chunk.
+            /// </summary>
+            public byte[] TargetSHA { get; set; }
+            /// <summary>
+            /// Gets or sets the length of this chunk.
+            /// </summary>
+            public uint Length { get; set; }
+            /// <summary>
+            /// Gets or sets the patch method.
+            /// </summary>
+            public uint PatchMethod { get; set; }
+
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DeltaChunkData"/> class.
+            /// </summary>
+            public DeltaChunkData()
+            {
+            }
+
+            // TODO: Figure out patch_method and make it an enum
+            internal DeltaChunkData( byte[] chunk, uint patchMethod, uint length, byte[] sourceSHA, byte[] targetSHA )
+            {
+                this.Chunk = chunk;
+                this.Length = length;
+                this.SourceSHA = sourceSHA;
+                this.TargetSHA = targetSHA;
+                this.PatchMethod = patchMethod;
+            }
+        }
+
+        /// <summary>
+        /// Gets the list of chunk patches.
+        /// </summary>
+        public List<DeltaChunkData> Chunks { get; private set; }
+        /// <summary>
+        /// Gets the depot id.
+        /// </summary>
+        public uint DepotID { get; private set; }
+        /// <summary>
+        /// Gets the original manifest id.
+        /// </summary>
+        public ulong SourceManifestGID { get; private set; }
+        /// <summary>
+        /// Gets the target manifest id.
+        /// </summary>
+        public ulong TargetManifestGID { get; private set; }
+
+        internal DepotDeltaChunks( byte[] payload )
+        {
+            Deserialize( payload );
+        }
+
+        void Deserialize( byte[] payload )
+        {
+            ContentDeltaChunks patch;
+
+            using ( var ms_payload = new MemoryStream( payload ) )
+            {
+                patch = Serializer.Deserialize<ContentDeltaChunks>( ms_payload );
+            }
+
+            this.DepotID = patch.depot_id;
+            this.SourceManifestGID = patch.manifest_id_source;
+            this.TargetManifestGID = patch.manifest_id_target;
+
+            foreach ( var chunk in patch.deltaChunks )
+            {
+                this.Chunks.Add( new DeltaChunkData( chunk.chunk, chunk.patch_method, chunk.size_original, chunk.sha_source, chunk.sha_target ) );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Opening a PR for tracking and discussion.

All the code is in steamclient, reference functions:
- ContentDeltaChunks proto
- CDepotReconstructCtx::BInitializeDeltaChunks
- CContentDeltaChunks::BDeserializeProtobuf

I haven't looked into what `patch_method` is yet.

Example: `DownloadPatchAsync( 441, 1210411661116720898, 6498161485441060059 );` (with depot key, and cdn auth set)