### PR TITLE
Use TLS 1.2 in Nethook's SetupDependencies.ps1

### DIFF
--- a/Resources/NetHook2/SetupDependencies.ps1
+++ b/Resources/NetHook2/SetupDependencies.ps1
@@ -6,7 +6,9 @@ $ProtobufSourceZipUrl = "https://github.com/google/protobuf/releases/download/v2
 $ProtobufSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "protobuf.zip")
 $ProtobufSourceInnerFolderName = "protobuf-2.5.0"
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+if ([Net.ServicePointManager]::SecurityProtocol -notcontains 'Tls12') {
+    [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+}
 
 Set-Location $PSScriptRoot
 

--- a/Resources/NetHook2/SetupDependencies.ps1
+++ b/Resources/NetHook2/SetupDependencies.ps1
@@ -6,6 +6,8 @@ $ProtobufSourceZipUrl = "https://github.com/google/protobuf/releases/download/v2
 $ProtobufSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "protobuf.zip")
 $ProtobufSourceInnerFolderName = "protobuf-2.5.0"
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 Set-Location $PSScriptRoot
 
 if (-Not (Test-Path $NetHook2DependenciesTemporaryDirectory))


### PR DESCRIPTION
Powershell uses TLS 1.0 which is not supported by github.com anymore.