### PR TITLE
Fix websocket servers not being marked as bad by the server list

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
@@ -14,8 +14,7 @@ namespace SteamKit2
 
         public event EventHandler<DisconnectedEventArgs> Disconnected;
 
-        public EndPoint CurrentEndPoint => currentContext?.EndPoint;
-
+        public EndPoint CurrentEndPoint { get; set; }
         public ProtocolTypes ProtocolTypes => ProtocolTypes.WebSocket;
 
         public void Connect(EndPoint endPoint, int timeout = 5000)
@@ -29,6 +28,7 @@ namespace SteamKit2
                 Disconnected?.Invoke(this, new DisconnectedEventArgs(false));
             }
 
+            CurrentEndPoint = newContext.EndPoint;
             newContext.Start(TimeSpan.FromMilliseconds(timeout));
         }
 
@@ -58,6 +58,7 @@ namespace SteamKit2
                 oldContext.Dispose();
 
                 Disconnected?.Invoke(this, new DisconnectedEventArgs(userInitiated));
+                CurrentEndPoint = null;
             }
             else
             {


### PR DESCRIPTION
Fixes #626.

Refactoring the callback looks to be more complex and involved than I expected, so the simplest solution is just to cache the value between `Connect()` and the end of `Disconnected`.