### PR TITLE
Prep for 2.2.0 Beta

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>
     <Description>.NET library that aims to interoperate with the Steam network.</Description>
-    <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.0.0-Beta.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.2.0-Beta.1</PackageReleaseNotes>
     <PackageIconUrl>https://raw.github.com/SteamRE/SteamKit/master/Resources/Misc/steamkit_logo_128.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/SteamRE/SteamKit</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/license.txt</PackageLicenseUrl>

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -1,4 +1,25 @@
 ------------------------------------------------------------------------------
+v 2.2.0 (Beta) 	Feb 9, 2019
+------------------------------------------------------------------------------
+* Added an overload of `SteamDirectory.LoadAsync` that accepts a maximum number of servers to return.
+* Added `ServerRecord.TryCreateSocketServer` to try parse a record from a string.
+* Added support for initializing a `GameID` for mods and shortcuts.
+* Added response details for some failed WebAPI responses. WebAPI can now throw a `WebAPIRequestException` with further details.
+* Added customization options to SteamKit's underlying HTTP stack.
+* Added `WalletInfoCallback.Balance64` for large Steam Wallet balances.
+* Added more details to `DepotManifest`.
+* Added SteamKit version to default HTTP user agent.
+* Fixed concurrency issues with UDP connections.
+* Fixed final fallback connection to Steam when server list is unavailable.
+* Fixed thread safety issues in message deserialization.
+* Fixed a crash on logon when network adapter information is not available from the underlying runtime.
+* Fixed downloaded content silently ignoring a length mismatch. An exception will now be thrown in this case.
+* Fixed WebSocket CM servers not being marked as bad by the server list, and thus not being ignored on subsequent connection attempts.
+* Updated Steam protocol version.
+* Updated Steam enums and protobufs.
+
+
+------------------------------------------------------------------------------
 v 2.1.0			Jun 13, 2018
 ------------------------------------------------------------------------------
 * Added `SimpleConsoleDebugListener`.


### PR DESCRIPTION
* Adds release notes for 2.2.0 beta
* Updates release notes in NuGet package to point to where the GitHub release will be.