### PR TITLE
Pass WebAPI args as generic objects. Encode with correct HttpUtility.UrlEncode override

### DIFF
--- a/Samples/6.WebAPI/Program.cs
+++ b/Samples/6.WebAPI/Program.cs
@@ -92,7 +92,7 @@ namespace Sample6_WebAPI
             // you can call interface functions through a Call method
             using ( WebAPI.Interface steamNews = WebAPI.GetInterface( "ISteamNews" ) )
             {
-                Dictionary<string, object> newsArgs = new Dictionary<string,object>();
+                Dictionary<string, object> newsArgs = new Dictionary<string, object>();
                 newsArgs[ "appid" ] = "440";
 
                 KeyValue results = steamNews.Call( "GetNewsForApp", /* version */ 1, newsArgs );

--- a/Samples/6.WebAPI/Program.cs
+++ b/Samples/6.WebAPI/Program.cs
@@ -92,10 +92,15 @@ namespace Sample6_WebAPI
             // you can call interface functions through a Call method
             using ( WebAPI.Interface steamNews = WebAPI.GetInterface( "ISteamNews" ) )
             {
-                Dictionary<string, string> newsArgs = new Dictionary<string,string>();
+                Dictionary<string, object> newsArgs = new Dictionary<string,object>();
                 newsArgs[ "appid" ] = "440";
 
                 KeyValue results = steamNews.Call( "GetNewsForApp", /* version */ 1, newsArgs );
+
+                foreach ( KeyValue news in results[ "newsitems" ][ "newsitem" ].Children )
+                {
+                    Console.WriteLine( "News: {0}", news[ "title" ].AsString() );
+                }
             }
         }
     }

--- a/SteamKit2/SteamKit2/Steam/WebAPI/SteamDirectory.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/SteamDirectory.cs
@@ -48,7 +48,7 @@ namespace SteamKit2
             }
 
             var directory = configuration.GetAsyncWebAPIInterface( "ISteamDirectory" );
-            var args = new Dictionary<string, string>
+            var args = new Dictionary<string, object>
             {
                 ["cellid"] = configuration.CellID.ToString( CultureInfo.InvariantCulture )
             };

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -272,9 +272,13 @@ namespace SteamKit2
                     string key = HttpUtility.UrlEncode( kvp.Key );
                     string value;
 
-                    if ( kvp.Value is byte[] )
+                    if ( kvp.Value == null )
                     {
-                        value = HttpUtility.UrlEncode( kvp.Value as byte[] );
+                        value = string.Empty;
+                    }
+                    else if ( kvp.Value is byte[] buffer )
+                    {
+                        value = HttpUtility.UrlEncode( buffer );
                     }
                     else
                     {

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -11,6 +11,7 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace SteamKit2
 {
@@ -67,7 +68,7 @@ namespace SteamKit2
             /// <exception cref="HttpRequestException">An network error occurred when performing the request.</exception>
             /// <exception cref="WebAPIRequestException">A network error occurred when performing the request.</exception>
             /// <exception cref="InvalidDataException">An error occured when parsing the response from the WebAPI.</exception>
-            public KeyValue Call( string func, int version = 1, Dictionary<string, string> args = null )
+            public KeyValue Call( string func, int version = 1, Dictionary<string, object> args = null )
                 => Call( HttpMethod.Get, func, version, args );
 
 
@@ -83,7 +84,7 @@ namespace SteamKit2
             /// <exception cref="HttpRequestException">An network error occurred when performing the request.</exception>
             /// <exception cref="WebAPIRequestException">A network error occurred when performing the request.</exception>
             /// <exception cref="InvalidDataException">An error occured when parsing the response from the WebAPI.</exception>
-            public KeyValue Call( HttpMethod method, string func, int version = 1, Dictionary<string, string> args = null )
+            public KeyValue Call( HttpMethod method, string func, int version = 1, Dictionary<string, object> args = null )
             {
                 var callTask = asyncInterface.CallAsync( method, func, version, args );
 
@@ -209,7 +210,7 @@ namespace SteamKit2
             /// <exception cref="HttpRequestException">An network error occurred when performing the request.</exception>
             /// <exception cref="WebAPIRequestException">A network error occurred when performing the request.</exception>
             /// <exception cref="InvalidDataException">An error occured when parsing the response from the WebAPI.</exception>
-            public Task<KeyValue> CallAsync( HttpMethod method, string func, int version = 1, Dictionary<string, string> args = null )
+            public Task<KeyValue> CallAsync( HttpMethod method, string func, int version = 1, Dictionary<string, object> args = null )
             {
                 var task = CallAsyncCore( method, func, version, args );
 
@@ -226,7 +227,7 @@ namespace SteamKit2
                 return task;
             }
                 
-            async Task<KeyValue> CallAsyncCore( HttpMethod method, string func, int version = 1, Dictionary<string, string> args = null )
+            async Task<KeyValue> CallAsyncCore( HttpMethod method, string func, int version = 1, Dictionary<string, object> args = null )
             {
                 if ( method == null )
                 {
@@ -240,7 +241,7 @@ namespace SteamKit2
 
                 if ( args == null )
                 {
-                    args = new Dictionary<string, string>();
+                    args = new Dictionary<string, object>();
                 }
 
 
@@ -268,11 +269,17 @@ namespace SteamKit2
                 // append any args
                 paramBuilder.Append( string.Join( "&", args.Select( kvp =>
                 {
-                    // TODO: the WebAPI is a special snowflake that needs to appropriately handle url encoding
-                    // this is in contrast to the steam3 content server APIs which use an entirely different scheme of encoding
+                    string key = HttpUtility.UrlEncode( kvp.Key );
+                    string value;
 
-                    string key = WebHelpers.UrlEncode( kvp.Key );
-                    string value = kvp.Value; // WebHelpers.UrlEncode( kvp.Value );
+                    if ( kvp.Value is byte[] )
+                    {
+                        value = HttpUtility.UrlEncode( kvp.Value as byte[] );
+                    }
+                    else
+                    {
+                        value = HttpUtility.UrlEncode( kvp.Value.ToString() );
+                    }
 
                     return string.Format( "{0}={1}", key, value );
                 } ) ) );
@@ -360,7 +367,7 @@ namespace SteamKit2
                     throw new InvalidOperationException( "Argument mismatch in API call. All parameters must be passed as named arguments." );
                 }
 
-                var apiArgs = new Dictionary<string, string>();
+                var apiArgs = new Dictionary<string, object>();
 
                 var requestMethod = HttpMethod.Get;
 
@@ -384,14 +391,14 @@ namespace SteamKit2
 
                         foreach ( object value in enumerable )
                         {
-                            apiArgs.Add( String.Format( "{0}[{1}]", argName, index++ ), value.ToString() );
+                            apiArgs.Add( String.Format( "{0}[{1}]", argName, index++ ), value );
                         }
 
                         continue;
                     }
 
 
-                    apiArgs.Add( argName, argValue.ToString() );
+                    apiArgs.Add( argName, argValue );
                 }
 
                 Match match = funcNameRegex.Match( binder.Name );


### PR DESCRIPTION
Breaking change. Rather than forcing everything into a string up front, keep them as generic objects. See #641 

These comments need clarification:

```
// TODO: the WebAPI is a special snowflake that needs to appropriately handle url encoding
// this is in contrast to the steam3 content server APIs which use an entirely different scheme of encoding```