### PR TITLE
KeyValue: Handle (ignore) conditionals

### DIFF
--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -486,6 +486,112 @@ namespace Tests
                 }
             };
 
+            var text = SaveToText( kv );
+
+            Assert.Equal( expected, text );
+        }
+
+        [Fact]
+        public void CanLoadUnicodeTextDocument()
+        {
+            var expected = "\"RootNode\"\n{\n\t\"key1\"\t\t\"value1\"\n\t\"key2\"\n\t{\n\t\t\"ChildKey\"\t\t\"ChildValue\"\n\t}\n}\n";
+            var kv = new KeyValue();
+
+            var temporaryFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText( temporaryFile, expected, Encoding.Unicode );
+                kv.ReadFileAsText( temporaryFile );
+            }
+            finally
+            {
+                File.Delete( temporaryFile );
+            }
+
+            Assert.Equal( "RootNode", kv.Name );
+            Assert.Equal( 2, kv.Children.Count );
+            Assert.Equal( "key1", kv.Children[0].Name );
+            Assert.Equal( "value1", kv.Children[0].Value );
+            Assert.Equal( "key2", kv.Children[1].Name );
+            Assert.Equal( 1, kv.Children[1].Children.Count );
+            Assert.Equal( "ChildKey", kv.Children[1].Children[0].Name );
+            Assert.Equal( "ChildValue", kv.Children[1].Children[0].Value );
+        }
+
+        [Fact]
+        public void CanLoadUnicodeTextStream()
+        {
+            var expected = "\"RootNode\"\n{\n\t\"key1\"\t\t\"value1\"\n\t\"key2\"\n\t{\n\t\t\"ChildKey\"\t\t\"ChildValue\"\n\t}\n}\n";
+            var kv = new KeyValue();
+
+            var temporaryFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText( temporaryFile, expected, Encoding.Unicode );
+
+                using ( var fs = File.OpenRead( temporaryFile ) )
+                { 
+                    kv.ReadAsText( fs );
+                }
+            }
+            finally
+            {
+                File.Delete( temporaryFile );
+            }
+
+            Assert.Equal( "RootNode", kv.Name );
+            Assert.Equal( 2, kv.Children.Count );
+            Assert.Equal( "key1", kv.Children[0].Name );
+            Assert.Equal( "value1", kv.Children[0].Value );
+            Assert.Equal( "key2", kv.Children[1].Name );
+            Assert.Equal( 1, kv.Children[1].Children.Count );
+            Assert.Equal( "ChildKey", kv.Children[1].Children[0].Name );
+            Assert.Equal( "ChildValue", kv.Children[1].Children[0].Value );
+        }
+
+        [Fact]
+        public void CanReadAndIgnoreConditionals()
+        {
+            var text = @"
+""Repro""
+{
+""Conditional""    ""You're not running Windows.""  [$!WIN32]          // DEPRECATED
+""EmptyThing""	""""
+}
+".Trim();
+
+            var kv = new KeyValue();
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(text)))
+            {
+                kv.ReadAsText(ms);
+            }
+
+            Assert.Equal( "Repro", kv.Name );
+            Assert.Equal( 2, kv.Children.Count );
+            Assert.Equal( "Conditional", kv.Children[0].Name );
+            Assert.Equal( "You're not running Windows.", kv.Children[0].Value );
+            Assert.Equal( "EmptyThing", kv.Children[1].Name );
+            Assert.Equal( "", kv.Children[1].Value );
+        }
+
+        [Fact]
+        public void WritesNewLineAsSlashN()
+        {
+            var kv = new KeyValue( "abc" );
+            kv.Children.Add( new KeyValue( "def", "ghi\njkl" ) );
+            var text = SaveToText( kv );
+            var expected = (@"
+""abc""
+{
+" + "\t" + @"""def""		""ghi\njkl""
+}
+").Trim().Replace("\r\n", "\n") + "\n";
+
+            Assert.Equal(expected, text);
+        }
+
+        static string SaveToText( KeyValue kv )
+        {
             string text;
             using ( var ms = new MemoryStream() )
             {
@@ -496,8 +602,7 @@ namespace Tests
                     text = reader.ReadToEnd();
                 }
             }
-
-            Assert.Equal( expected, text );
+            return text;
         }
 
         const string TestObjectHex = "00546573744F626A65637400016B65790076616C7565000808";


### PR DESCRIPTION
As pointed out by @xPaw, we crash when reading `tf_english.txt`.

I narrowed this down to our handling of conditionals - it's completely broken. We count the conditional as a key, then read the next key as a value, etc. until our keys and values are swapped.

Therefore, an empty **value** after a conditional will trigger the exception that fails a parse on an empty **key**.

I don't think this is necessarily the best way to handle them, but at least it doesn't crash :smile: 

Do not merge (yet), I'm only posting this for discussion. How do we want to handle conditionals, and is this the best way?

I think I can see some implementation flaws in this code (i.e. the green part of the diff) but it's getting late and I need to go to bed so I'm stopping for tonight. I know it's not perfect.

Previous PR and discussion at #232.
