### PR TITLE
SteamMatchmaking - creating, retrieving, listing, joining and leaving lobbies.

### DIFF
--- a/Resources/SteamLanguage/enums.steamd
+++ b/Resources/SteamLanguage/enums.steamd
@@ -1473,3 +1473,39 @@ enum ETradeOfferConfirmationMethod
 	Email = 1;
 	MobileApp = 2;
 };
+
+enum ELobbyType
+{
+    Private = 0;
+    FriendsOnly = 1;
+    Public = 2;
+    Invisible = 3;
+    PrivateUnique = 4;
+};
+
+enum ELobbyFilterType
+{
+    String = 0;
+    Numerical = 1;
+    SlotsAvailable = 2;
+    NearValue = 3;
+    Distance = 4;
+};
+
+enum ELobbyComparison
+{
+    EqualToOrLessThan = -2;
+    LessThan = -1;
+    Equal = 0;
+    GreaterThan = 1;
+    EqualToOrGreaterThan = 2;
+    NotEqual = 3;
+};
+
+public enum ELobbyDistanceFilter
+{
+    Close = 0;
+    Default = 1;
+    Far = 2;
+    Worldwide = 3;
+};

--- a/Resources/SteamLanguage/generate.sh
+++ b/Resources/SteamLanguage/generate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+BASEDIR="$(dirname $0)"
+cd "$BASEDIR"
+dotnet ../SteamLanguageParser/bin/Release/netcoreapp2.0/SteamLanguageParser.dll ../..
+

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
@@ -3169,6 +3169,38 @@ namespace SteamKit2
 		Email = 1,
 		MobileApp = 2,
 	}
+	public enum ELobbyType
+	{
+		Private = 0,
+		FriendsOnly = 1,
+		Public = 2,
+		Invisible = 3,
+		PrivateUnique = 4,
+	}
+	public enum ELobbyFilterType
+	{
+		String = 0,
+		Numerical = 1,
+		SlotsAvailable = 2,
+		NearValue = 3,
+		Distance = 4,
+	}
+	public enum ELobbyComparison
+	{
+		EqualToOrLessThan = -2,
+		LessThan = -1,
+		Equal = 0,
+		GreaterThan = 1,
+		EqualToOrGreaterThan = 2,
+		NotEqual = 3,
+	}
+	public enum ELobbyDistanceFilter
+	{
+		Close = 0,
+		Default = 1,
+		Far = 2,
+		Worldwide = 3,
+	}
 	public enum EUdpPacketType : byte
 	{
 		Invalid = 0,

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -41,6 +41,20 @@ namespace SteamKit2.Internal
         public IPAddress LocalIP => connection?.GetLocalIP();
 
         /// <summary>
+        /// Gets the public IP address of this client. This value is assigned after a logon attempt has succeeded.
+        /// This value will be <c>null</c> if the client is logged off of Steam.
+        /// </summary>
+        /// <value>The SteamID.</value>
+        public IPAddress PublicIP { get; private set; }
+
+        /// <summary>
+        /// Gets the country code of our public IP address according to Steam. This value is assigned after a logon attempt has succeeded.
+        /// This value will be <c>null</c> if the client is logged off of Steam.
+        /// </summary>
+        /// <value>The SteamID.</value>
+        public string IPCountryCode { get; private set; }
+
+        /// <summary>
         /// Gets the universe of this client.
         /// </summary>
         /// <value>The universe.</value>
@@ -523,6 +537,8 @@ namespace SteamKit2.Internal
                 SteamID = logonResp.ProtoHeader.steamid;
 
                 CellID = logonResp.Body.cell_id;
+                PublicIP = NetHelpers.GetIPAddress(logonResp.Body.public_ip);
+                IPCountryCode = logonResp.Body.ip_country_code;
 
                 int hbDelay = logonResp.Body.out_of_game_heartbeat_seconds;
 
@@ -538,6 +554,8 @@ namespace SteamKit2.Internal
             SteamID = null;
 
             CellID = null;
+            PublicIP = null;
+            IPCountryCode = null;
 
             heartBeatFunc.Stop();
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/Callbacks.cs
@@ -1,0 +1,260 @@
+using System.Collections.Generic;
+
+namespace SteamKit2
+{
+    public partial class SteamMatchmaking
+    {
+        /// <summary>
+        /// This callback is fired in response to <see cref="GetLobbyList"/>.
+        /// </summary>
+        public sealed class GetLobbyListCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the lobbies belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EResult Result { get; }
+
+            /// <summary>
+            /// The list of lobbies matching the criteria specified with <see cref="GetLobbyList"/>.
+            /// </summary>
+            public List<Lobby> Lobbies { get; }
+
+            internal GetLobbyListCallback( uint appId, EResult res, List<Lobby> lobbies )
+            {
+                AppID = appId;
+                Result = res;
+                Lobbies = lobbies;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="CreateLobby"/>.
+        /// </summary>
+        public sealed class CreateLobbyCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the created lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EResult Result { get; }
+
+            /// <summary>
+            /// The SteamID of the created lobby.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            internal CreateLobbyCallback( JobID jobId, uint appId, EResult res, SteamID lobbySteamId )
+            {
+                JobID = jobId;
+                AppID = appId;
+                Result = res;
+                LobbySteamID = lobbySteamId;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="SetLobbyData"/>.
+        /// </summary>
+        public sealed class SetLobbyDataCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the targeted lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EResult Result { get; }
+
+            /// <summary>
+            /// The SteamID of the targeted Lobby.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            internal SetLobbyDataCallback( JobID jobId, uint appId, EResult res, SteamID lobbySteamId )
+            {
+                JobID = jobId;
+                AppID = appId;
+                Result = res;
+                LobbySteamID = lobbySteamId;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="SetLobbyOwner"/>.
+        /// </summary>
+        public sealed class SetLobbyOwnerCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the targeted lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EResult Result { get; }
+
+            /// <summary>
+            /// The SteamID of the targeted Lobby.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            internal SetLobbyOwnerCallback( JobID jobId, uint appId, EResult res, SteamID lobbySteamId )
+            {
+                JobID = jobId;
+                AppID = appId;
+                Result = res;
+                LobbySteamID = lobbySteamId;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="JoinLobby"/>.
+        /// </summary>
+        public sealed class JoinLobbyCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the targeted lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EChatRoomEnterResponse ChatRoomEnterResponse { get; }
+
+            /// <summary>
+            /// The joined <see cref="Lobby"/>, when <see cref="ChatRoomEnterResponse"/> equals
+            /// <see cref="EChatRoomEnterResponse.Success"/>, otherwise <c>null</c>
+            /// </summary>
+            public Lobby Lobby { get; }
+
+            internal JoinLobbyCallback( JobID jobId, uint appId, EChatRoomEnterResponse res, Lobby lobby )
+            {
+                JobID = jobId;
+                AppID = appId;
+                ChatRoomEnterResponse = res;
+                Lobby = lobby;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="LeaveLobby"/>.
+        /// </summary>
+        public sealed class LeaveLobbyCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the targeted lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The result of the request.
+            /// </summary>
+            public EResult Result { get; }
+
+            /// <summary>
+            /// The SteamID of the targeted Lobby.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            internal LeaveLobbyCallback( JobID jobId, uint appId, EResult res, SteamID lobbySteamId )
+            {
+                JobID = jobId;
+                AppID = appId;
+                Result = res;
+                LobbySteamID = lobbySteamId;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired in response to <see cref="GetLobbyData"/>, as well as whenever Steam sends us updated lobby data.
+        /// </summary>
+        public sealed class LobbyDataCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the updated lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The lobby that was updated.
+            /// </summary>
+            public Lobby Lobby { get; }
+
+            internal LobbyDataCallback( JobID jobId, uint appId, Lobby lobby )
+            {
+                JobID = jobId;
+                AppID = appId;
+                Lobby = lobby;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired whenever Steam informs us a user has joined a lobby.
+        /// </summary>
+        public sealed class UserJoinedLobbyCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The SteamID of the lobby that a member joined.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            /// <summary>
+            /// The lobby member that joined.
+            /// </summary>
+            public Lobby.Member User { get; }
+
+            internal UserJoinedLobbyCallback( uint appId, SteamID lobbySteamId, Lobby.Member user )
+            {
+                AppID = appId;
+                LobbySteamID = lobbySteamId;
+                User = user;
+            }
+        }
+
+        /// <summary>
+        /// This callback is fired whenever Steam informs us a user has left a lobby.
+        /// </summary>
+        public sealed class UserLeftLobbyCallback : CallbackMsg
+        {
+            /// <summary>
+            /// ID of the app the lobby belongs to.
+            /// </summary>
+            public uint AppID { get; }
+
+            /// <summary>
+            /// The SteamID of the lobby that a member left.
+            /// </summary>
+            public SteamID LobbySteamID { get; }
+
+            /// <summary>
+            /// The lobby member that left.
+            /// </summary>
+            public Lobby.Member User { get; }
+
+            internal UserLeftLobbyCallback( uint appId, SteamID lobbySteamId, Lobby.Member user )
+            {
+                AppID = appId;
+                LobbySteamID = lobbySteamId;
+                User = user;
+            }
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/Lobby.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/Lobby.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using SteamKit2.Internal;
+
+namespace SteamKit2
+{
+    public partial class SteamMatchmaking
+    {
+        /// <summary>
+        /// Represents a Steam lobby.
+        /// </summary>
+        public sealed class Lobby
+        {
+            /// <summary>
+            /// The lobby filter base class.
+            /// </summary>
+            public abstract class Filter
+            {
+                /// <summary>
+                /// The type of filter.
+                /// </summary>
+                public ELobbyFilterType FilterType { get; }
+
+                /// <summary>
+                /// The metadata key this filter pertains to. Under certain circumstances e.g. a distance
+                /// filter, this will be an empty string.
+                /// </summary>
+                public string Key { get; }
+
+                /// <summary>
+                /// The comparison method used by this filter.
+                /// </summary>
+                public ELobbyComparison Comparison { get; }
+
+                /// <summary>
+                /// Base constructor for all filter sub-classes.
+                /// </summary>
+                /// <param name="filterType">The type of filter.</param>
+                /// <param name="key">The metadata key this filter pertains to.</param>
+                /// <param name="comparison">The comparison method used by this filter.</param>
+                protected Filter( ELobbyFilterType filterType, string key, ELobbyComparison comparison )
+                {
+                    FilterType = filterType;
+                    Key = key;
+                    Comparison = comparison;
+                }
+
+                /// <summary>
+                /// Serializes the filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public virtual CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = new CMsgClientMMSGetLobbyList.Filter();
+                    filter.filter_type = ( int )FilterType;
+                    filter.key = Key;
+                    filter.comparision = ( int )Comparison;
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Can be used to filter lobbies geographically (based on IP according to Steam's IP database).
+            /// </summary>
+            public sealed class DistanceFilter : Filter
+            {
+                /// <summary>
+                /// Steam distance filter value.
+                /// </summary>
+                public ELobbyDistanceFilter Value { get; }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="DistanceFilter"/> class.
+                /// </summary>
+                /// <param name="value">Steam distance filter value.</param>
+                public DistanceFilter( ELobbyDistanceFilter value ) : base( ELobbyFilterType.Distance, "", ELobbyComparison.Equal )
+                {
+                    Value = value;
+                }
+
+                /// <summary>
+                /// Serializes the distance filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public override CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = base.Serialize();
+                    filter.value = ( ( int )Value ).ToString();
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Can be used to filter lobbies with a metadata value closest to the specified value. Multiple
+            /// near filters can be specified, with former filters taking precedence over latter filters.
+            /// </summary>
+            public sealed class NearValueFilter : Filter
+            {
+                /// <summary>
+                /// Integer value that lobbies' metadata value should be close to.
+                /// </summary>
+                public int Value { get; }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="NearValueFilter"/> class.
+                /// </summary>
+                /// <param name="key">The metadata key this filter pertains to.</param>
+                /// <param name="value">Integer value to compare against.</param>
+                public NearValueFilter( string key, int value ) : base( ELobbyFilterType.NearValue, key, ELobbyComparison.Equal )
+                {
+                    Value = value;
+                }
+
+                /// <summary>
+                /// Serializes the slots available filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public override CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = base.Serialize();
+                    filter.value = Value.ToString();
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Can be used to filter lobbies by comparing an integer against a value in each lobby's metadata.
+            /// </summary>
+            public sealed class NumericalFilter : Filter
+            {
+                /// <summary>
+                /// Integer value to compare against.
+                /// </summary>
+                public int Value { get; }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="NumericalFilter"/> class.
+                /// </summary>
+                /// <param name="key">The metadata key this filter pertains to.</param>
+                /// <param name="comparison">The comparison method used by this filter.</param>
+                /// <param name="value">Integer value to compare against.</param>
+                public NumericalFilter( string key, ELobbyComparison comparison, int value ) : base( ELobbyFilterType.Numerical, key, comparison )
+                {
+                    Value = value;
+                }
+
+                /// <summary>
+                /// Serializes the numerical filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public override CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = base.Serialize();
+                    filter.value = Value.ToString();
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Can be used to filter lobbies by minimum number of slots available.
+            /// </summary>
+            public sealed class SlotsAvailableFilter : Filter
+            {
+                /// <summary>
+                /// Minumum number of slots available in the lobby.
+                /// </summary>
+                public int SlotsAvailable { get; }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="SlotsAvailableFilter"/> class.
+                /// </summary>
+                /// <param name="key">The metadata key this filter pertains to.</param>
+                /// <param name="slotsAvailable">Integer value to compare against.</param>
+                public SlotsAvailableFilter( int slotsAvailable ) : base( ELobbyFilterType.SlotsAvailable, "", ELobbyComparison.Equal )
+                {
+                    SlotsAvailable = slotsAvailable;
+                }
+
+                /// <summary>
+                /// Serializes the slots available filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public override CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = base.Serialize();
+                    filter.value = SlotsAvailable.ToString();
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Can be used to filter lobbies by comparing a string against a value in each lobby's metadata.
+            /// </summary>
+            public sealed class StringFilter : Filter
+            {
+                /// <summary>
+                /// String value to compare against.
+                /// </summary>
+                public string Value { get; }
+
+                /// <summary>
+                /// Initializes a new instance of the <see cref="StringFilter"/> class.
+                /// </summary>
+                /// <param name="key">The metadata key this filter pertains to.</param>
+                /// <param name="comparison">The comparison method used by this filter.</param>
+                /// <param name="value">String value to compare against.</param>
+                public StringFilter( string key, ELobbyComparison comparison, string value ) : base( ELobbyFilterType.String, key, comparison )
+                {
+                    Value = value;
+                }
+
+                /// <summary>
+                /// Serializes the string filter into a representation used internally by SteamMatchmaking.
+                /// </summary>
+                /// <returns>A protobuf serializable representation of this filter.</returns>
+                public override CMsgClientMMSGetLobbyList.Filter Serialize()
+                {
+                    var filter = base.Serialize();
+                    filter.value = Value;
+                    return filter;
+                }
+            }
+
+            /// <summary>
+            /// Represents a Steam user within a lobby.
+            /// </summary>
+            public sealed class Member
+            {
+                /// <summary>
+                /// SteamID of the lobby member.
+                /// </summary>
+                public SteamID SteamID { get; }
+
+                /// <summary>
+                /// Steam persona of the lobby member.
+                /// </summary>
+                public string PersonaName { get; }
+
+                /// <summary>
+                /// Metadata attached to the lobby member.
+                /// </summary>
+                public IReadOnlyDictionary<string, string> Metadata { get; }
+
+                internal Member( SteamID steamId, string personaName, IReadOnlyDictionary<string, string> metadata = null )
+                {
+                    SteamID = steamId;
+                    PersonaName = personaName;
+                    Metadata = metadata ?? EmptyMetadata;
+                }
+
+                /// <summary>
+                /// Checks to see if this lobby member is equal to another. Only the SteamID of the lobby member is taken into account.
+                /// </summary>
+                /// <param name="obj"></param>
+                /// <returns>true, if obj is <see cref="Member"/> with a matching SteamID. Otherwise, false.</returns>
+                public override bool Equals( object obj )
+                {
+                    if ( obj is Member member )
+                    {
+                        return SteamID.Equals( member.SteamID );
+                    }
+
+                    return false;
+                }
+
+                /// <summary>
+                /// Hash code of the lobby member. Only the SteamID of the lobby member is taken into account.
+                /// </summary>
+                /// <returns>The hash code of this lobby member.</returns>
+                public override int GetHashCode()
+                {
+                    return SteamID.GetHashCode();
+                }
+            }
+
+            /// <summary>
+            /// SteamID of the lobby.
+            /// </summary>
+            public SteamID SteamID { get; }
+
+            /// <summary>
+            /// The type of the lobby.
+            /// </summary>
+            public ELobbyType LobbyType { get; }
+
+            /// <summary>
+            /// The lobby's flags.
+            /// </summary>
+            public int LobbyFlags { get; }
+
+            /// <summary>
+            /// The SteamID of the lobby's owner. Please keep in mind that Steam does not provide lobby
+            /// owner details for lobbies returned in a lobby list. As such, lobbies that have been
+            /// obtained/updated as a result of calling <see cref="SteamMatchmaking.GetLobbyList"/>
+            /// may have a null (or non-null but state) owner.
+            /// </summary>
+            public SteamID OwnerSteamID { get; }
+
+            /// <summary>
+            /// The metadata of the lobby; string key-value pairs.
+            /// </summary>
+            public IReadOnlyDictionary<string, string> Metadata { get; }
+
+            /// <summary>
+            /// The maximum number of members that can occupy the lobby.
+            /// </summary>
+            public int MaxMembers { get; }
+
+            /// <summary>
+            /// The number of members that are currently occupying the lobby.
+            /// </summary>
+            public int NumMembers { get; }
+
+            /// <summary>
+            /// A list of lobby members. This will only be populated for the user's current lobby.
+            /// </summary>
+            public IReadOnlyList<Member> Members { get; }
+
+            /// <summary>
+            /// The distance of the lobby.
+            /// </summary>
+            public float? Distance { get; }
+
+            /// <summary>
+            /// The weight of the lobby.
+            /// </summary>
+            public long? Weight { get; }
+
+            static readonly ReadOnlyDictionary<string, string> EmptyMetadata =
+                new ReadOnlyDictionary<string, string>( new Dictionary<string, string>() );
+
+            static readonly IReadOnlyList<Member> EmptyMembers = Array.AsReadOnly(Array.Empty<Member>());
+
+            internal Lobby( SteamID steamId, ELobbyType lobbyType, int lobbyFlags, SteamID ownerSteamId, IReadOnlyDictionary<string, string> metadata,
+                int maxMembers, int numMembers, IReadOnlyList<Member> members, float? distance, long? weight )
+            {
+                SteamID = steamId;
+                LobbyType = lobbyType;
+                LobbyFlags = lobbyFlags;
+                OwnerSteamID = ownerSteamId;
+                Metadata = metadata ?? EmptyMetadata;
+                MaxMembers = maxMembers;
+                NumMembers = numMembers;
+                Members = members ?? EmptyMembers;
+                Distance = distance;
+                Weight = weight;
+            }
+
+            internal static byte[] EncodeMetadata( IReadOnlyDictionary<string, string> metadata )
+            {
+                var keyValue = new KeyValue( "" );
+
+                if ( metadata != null )
+                {
+                    foreach ( var entry in metadata )
+                    {
+                        keyValue[ entry.Key ] = new KeyValue( null, entry.Value );
+                    }
+                }
+
+                using ( var ms = new MemoryStream() )
+                {
+                    keyValue.SaveToStream( ms, true );
+                    return ms.ToArray();
+                }
+            }
+
+            internal static ReadOnlyDictionary<string, string> DecodeMetadata( byte[] buffer )
+            {
+                if ( buffer.Length == 0 )
+                {
+                    return EmptyMetadata;
+                }
+
+                var keyValue = new KeyValue();
+
+                using ( var ms = new MemoryStream( buffer ) )
+                {
+                    if ( !keyValue.TryReadAsBinary( ms ) )
+                    {
+                        throw new FormatException( "Lobby metadata is of an unexpected format" );
+                    }
+                }
+
+                var metadata = new Dictionary<string, string>();
+
+                foreach ( var value in keyValue.Children )
+                {
+                    metadata[ value.Name ] = value.Value;
+                }
+
+                return new ReadOnlyDictionary<string, string>( metadata );
+            }
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/LobbyCache.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/LobbyCache.cs
@@ -1,0 +1,137 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SteamKit2
+{
+    public partial class SteamMatchmaking
+    {
+        class LobbyCache
+        {
+            readonly ConcurrentDictionary<uint, ConcurrentDictionary<SteamID, Lobby>> lobbies =
+                new ConcurrentDictionary<uint, ConcurrentDictionary<SteamID, Lobby>>();
+
+            public Lobby GetLobby( uint appId, SteamID lobbySteamId )
+            {
+                return GetAppLobbies( appId ).TryGetValue( lobbySteamId, out var lobby ) ? lobby : null;
+            }
+
+            public void CacheLobby( uint appId, Lobby lobby )
+            {
+                GetAppLobbies( appId )[ lobby.SteamID ] = lobby;
+            }
+
+            public Lobby.Member AddLobbyMember( uint appId, Lobby lobby, SteamID memberId, string personaName )
+            {
+                var existingMember = lobby.Members.FirstOrDefault( m => m.SteamID == memberId );
+
+                if ( existingMember != null )
+                {
+                    // Already in lobby
+                    return null;
+                }
+
+                var addedMember = new Lobby.Member( memberId, personaName );
+
+                var members = new List<Lobby.Member>( lobby.Members.Count + 1 );
+                members.AddRange( lobby.Members );
+                members.Add( addedMember );
+
+                UpdateLobbyMembers( appId, lobby, members.AsReadOnly() );
+
+                return addedMember;
+            }
+
+            public Lobby.Member RemoveLobbyMember( uint appId, Lobby lobby, SteamID memberId )
+            {
+                var removedMember = lobby.Members.FirstOrDefault( m => m.SteamID.Equals( memberId ) );
+
+                if ( removedMember == null )
+                {
+                    return null;
+                }
+
+                var members = lobby.Members.Where( m => !m.Equals( removedMember ) ).ToList();
+
+                if ( members.Count > 0 )
+                {
+                    UpdateLobbyMembers( appId, lobby, members.AsReadOnly() );
+                }
+                else
+                {
+                    // Steam deletes lobbies that contain no members
+                    DeleteLobby( appId, lobby.SteamID );
+                }
+
+                return removedMember;
+            }
+
+            public void ClearLobbyMembers( uint appId, SteamID lobbySteamId )
+            {
+                var lobby = GetLobby( appId, lobbySteamId );
+
+                if ( lobby != null )
+                {
+                    UpdateLobbyMembers( appId, lobby, null, null );
+                }
+            }
+
+            public void UpdateLobbyOwner( uint appId, SteamID lobbySteamId, SteamID ownerSteamId )
+            {
+                var lobby = GetLobby( appId, lobbySteamId );
+
+                if ( lobby != null )
+                {
+                    UpdateLobbyMembers( appId, lobby, ownerSteamId, lobby.Members );
+                }
+            }
+
+            public void UpdateLobbyMembers( uint appId, Lobby lobby, IReadOnlyList<Lobby.Member> members )
+            {
+                UpdateLobbyMembers( appId, lobby, lobby.OwnerSteamID, members );
+            }
+
+            public void UpdateLobbyMembers( uint appId, Lobby lobby, List<Lobby.Member> members )
+            {
+                UpdateLobbyMembers( appId, lobby, lobby.OwnerSteamID, members.AsReadOnly() );
+            }
+
+            public void Clear()
+            {
+                lobbies.Clear();
+            }
+
+            void UpdateLobbyMembers( uint appId, Lobby lobby, SteamID owner, IReadOnlyList<Lobby.Member> members )
+            {
+                CacheLobby( appId, new Lobby(
+                    lobby.SteamID,
+                    lobby.LobbyType,
+                    lobby.LobbyFlags,
+                    owner,
+                    lobby.Metadata,
+                    lobby.MaxMembers,
+                    lobby.NumMembers,
+                    members,
+                    lobby.Distance,
+                    lobby.Weight
+                ) );
+            }
+
+            ConcurrentDictionary<SteamID, Lobby> GetAppLobbies( uint appId )
+            {
+                return lobbies.GetOrAdd( appId, k => new ConcurrentDictionary<SteamID, Lobby>() );
+            }
+
+            Lobby DeleteLobby( uint appId, SteamID lobbySteamId )
+            {
+                if ( !lobbies.TryGetValue( appId, out var appLobbies ) )
+                {
+                    return null;
+                }
+
+                appLobbies.TryRemove( lobbySteamId, out var lobby );
+                return lobby;
+            }
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
@@ -1,0 +1,667 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using SteamKit2.Internal;
+
+namespace SteamKit2
+{
+    /// <summary>
+    /// This handler is used for creating, joining and obtaining lobby information.
+    /// </summary>
+    public partial class SteamMatchmaking : ClientMsgHandler
+    {
+        readonly Dictionary<EMsg, Action<IPacketMsg>> dispatchMap;
+
+        readonly ConcurrentDictionary<JobID, ProtoBuf.IExtensible> lobbyManipulationRequests = new ConcurrentDictionary<JobID, ProtoBuf.IExtensible>();
+
+        readonly LobbyCache lobbyCache = new LobbyCache();
+
+        internal SteamMatchmaking()
+        {
+            dispatchMap = new Dictionary<EMsg, Action<IPacketMsg>>
+            {
+                { EMsg.ClientMMSCreateLobbyResponse, HandleCreateLobbyResponse },
+                { EMsg.ClientMMSSetLobbyDataResponse, HandleSetLobbyDataResponse },
+                { EMsg.ClientMMSSetLobbyOwnerResponse, HandleSetLobbyOwnerResponse },
+                { EMsg.ClientMMSLobbyData, HandleLobbyData },
+                { EMsg.ClientMMSGetLobbyListResponse, HandleGetLobbyListResponse },
+                { EMsg.ClientMMSJoinLobbyResponse, HandleJoinLobbyResponse },
+                { EMsg.ClientMMSLeaveLobbyResponse, HandleLeaveLobbyResponse },
+                { EMsg.ClientMMSUserJoinedLobby, HandleUserJoinedLobby },
+                { EMsg.ClientMMSUserLeftLobby, HandleUserLeftLobby },
+            };
+        }
+
+        /// <summary>
+        /// Sends a request to create a new lobby.
+        /// </summary>
+        /// <param name="appId">ID of the app the lobby will belong to.</param>
+        /// <param name="lobbyType">The new lobby type.</param>
+        /// <param name="maxMembers">The new maximum number of members that may occupy the lobby.</param>
+        /// <param name="lobbyFlags">The new lobby flags. Defaults to 0.</param>
+        /// <param name="metadata">The new metadata for the lobby. Defaults to <c>null</c> (treated as an empty dictionary).</param>
+        /// <returns><c>null</c>, if the request could not be submitted i.e. not yet logged in. Otherwise, an <see cref="AsyncJob{CreateLobbyCallback}"/>.</returns>
+        public AsyncJob<CreateLobbyCallback> CreateLobby( uint appId, ELobbyType lobbyType, int maxMembers, int lobbyFlags = 0,
+            IReadOnlyDictionary<string, string> metadata = null )
+        {
+            if ( Client.CellID == null )
+            {
+                return null;
+            }
+
+            var personaName = Client.GetHandler<SteamFriends>().GetPersonaName();
+
+            var createLobby = new ClientMsgProtobuf<CMsgClientMMSCreateLobby>( EMsg.ClientMMSCreateLobby )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    lobby_type = ( int )lobbyType,
+                    max_members = maxMembers,
+                    lobby_flags = lobbyFlags,
+                    metadata = Lobby.EncodeMetadata( metadata ),
+                    cell_id = Client.CellID.Value,
+                    public_ip = NetHelpers.GetIPAddress( Client.PublicIP ),
+                    persona_name_owner = personaName
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( createLobby, appId );
+
+            lobbyManipulationRequests[ createLobby.SourceJobID ] = createLobby.Body;
+            return AttachIncompleteManipulationHandler( new AsyncJob<CreateLobbyCallback>( Client, createLobby.SourceJobID ) );
+        }
+
+        /// <summary>
+        /// Sends a request to update a lobby.
+        /// </summary>
+        /// <param name="appId">ID of app the lobby belongs to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should be updated.</param>
+        /// <param name="lobbyType">The new lobby type.</param>
+        /// <param name="maxMembers">The new maximum number of members that may occupy the lobby.</param>
+        /// <param name="lobbyFlags">The new lobby flags. Defaults to 0.</param>
+        /// <param name="metadata">The new metadata for the lobby. Defaults to <c>null</c> (treated as an empty dictionary).</param>
+        /// <returns>An <see cref="AsyncJob{SetLobbyDataCallback}"/>.</returns>
+        public AsyncJob<SetLobbyDataCallback> SetLobbyData( uint appId, SteamID lobbySteamId, ELobbyType lobbyType, int maxMembers, int lobbyFlags = 0,
+            IReadOnlyDictionary<string, string> metadata = null )
+        {
+            var setLobbyData = new ClientMsgProtobuf<CMsgClientMMSSetLobbyData>( EMsg.ClientMMSSetLobbyData )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId,
+                    steam_id_member = 0,
+                    lobby_type = ( int )lobbyType,
+                    max_members = maxMembers,
+                    lobby_flags = lobbyFlags,
+                    metadata = Lobby.EncodeMetadata( metadata ),
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( setLobbyData, appId );
+
+            lobbyManipulationRequests[ setLobbyData.SourceJobID ] = setLobbyData.Body;
+            return AttachIncompleteManipulationHandler( new AsyncJob<SetLobbyDataCallback>( Client, setLobbyData.SourceJobID ) );
+        }
+
+        /// <summary>
+        /// Sends a request to update the current user's lobby metadata.
+        /// </summary>
+        /// <param name="appId">ID of app the lobby belongs to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should be updated.</param>
+        /// <param name="metadata">The new metadata for the lobby.</param>
+        /// <returns><c>null</c>, if the request could not be submitted i.e. not yet logged in. Otherwise, an <see cref="AsyncJob{SetLobbyDataCallback}"/>.</returns>
+        public AsyncJob<SetLobbyDataCallback> SetLobbyMemberData( uint appId, SteamID lobbySteamId, IReadOnlyDictionary<string, string> metadata )
+        {
+            if ( Client.SteamID == null )
+            {
+                return null;
+            }
+
+            var setLobbyData = new ClientMsgProtobuf<CMsgClientMMSSetLobbyData>( EMsg.ClientMMSSetLobbyData )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId,
+                    steam_id_member = Client.SteamID,
+                    metadata = Lobby.EncodeMetadata( metadata )
+                }
+            };
+
+            Send( setLobbyData, appId );
+
+            lobbyManipulationRequests[ setLobbyData.SourceJobID ] = setLobbyData.Body;
+            return AttachIncompleteManipulationHandler( new AsyncJob<SetLobbyDataCallback>( Client, setLobbyData.SourceJobID ) );
+        }
+
+        /// <summary>
+        /// Sends a request to update the owner of a lobby.
+        /// </summary>
+        /// <param name="appId">ID of app the lobby belongs to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should have its owner updated.</param>
+        /// <param name="newOwner">The SteamID of the new owner.</param>
+        /// <returns>An <see cref="AsyncJob{SetLobbyOwnerCallback}"/>.</returns>
+        public AsyncJob<SetLobbyOwnerCallback> SetLobbyOwner( uint appId, SteamID lobbySteamId, SteamID newOwner )
+        {
+            var setLobbyOwner = new ClientMsgProtobuf<CMsgClientMMSSetLobbyOwner>( EMsg.ClientMMSSetLobbyOwner )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId,
+                    steam_id_new_owner = newOwner
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( setLobbyOwner, appId );
+
+            lobbyManipulationRequests[ setLobbyOwner.SourceJobID ] = setLobbyOwner.Body;
+            return AttachIncompleteManipulationHandler( new AsyncJob<SetLobbyOwnerCallback>( Client, setLobbyOwner.SourceJobID ) );
+        }
+
+        /// <summary>
+        /// Sends a request to obtains a list of lobbies matching the specified criteria.
+        /// </summary>
+        /// <param name="appId">The ID of app for which we're requesting a list of lobbies.</param>
+        /// <param name="filters">An optional list of filters.</param>
+        /// <param name="maxLobbies">An optional maximum number of lobbies that will be returned.</param>
+        /// <returns><c>null</c>, if the request could not be submitted i.e. not yet logged in. Otherwise, an <see cref="AsyncJob{GetLobbyListCallback}"/>.</returns>
+        public AsyncJob<GetLobbyListCallback> GetLobbyList( uint appId, List<Lobby.Filter> filters = null, int maxLobbies = -1 )
+        {
+            if ( Client.CellID == null )
+            {
+                return null;
+            }
+
+            var getLobbies = new ClientMsgProtobuf<CMsgClientMMSGetLobbyList>( EMsg.ClientMMSGetLobbyList )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    cell_id = Client.CellID.Value,
+                    public_ip = NetHelpers.GetIPAddress( Client.PublicIP ),
+                    num_lobbies_requested = maxLobbies
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            if ( filters != null )
+            {
+                foreach ( var filter in filters )
+                {
+                    getLobbies.Body.filters.Add( filter.Serialize() );
+                }
+            }
+
+            Send( getLobbies, appId );
+
+            return new AsyncJob<GetLobbyListCallback>( Client, getLobbies.SourceJobID );
+        }
+
+        /// <summary>
+        /// Sends a request to join a lobby.
+        /// </summary>
+        /// <param name="appId">ID of app the lobby belongs to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should be joined.</param>
+        /// <returns><c>null</c>, if the request could not be submitted i.e. not yet logged in. Otherwise, an <see cref="AsyncJob{JoinLobbyCallback}"/>.</returns>
+        public AsyncJob<JoinLobbyCallback> JoinLobby( uint appId, SteamID lobbySteamId )
+        {
+            var personaName = Client.GetHandler<SteamFriends>()?.GetPersonaName();
+
+            if ( personaName == null )
+            {
+                return null;
+            }
+
+            var joinLobby = new ClientMsgProtobuf<CMsgClientMMSJoinLobby>( EMsg.ClientMMSJoinLobby )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    persona_name = personaName,
+                    steam_id_lobby = lobbySteamId
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( joinLobby, appId );
+
+            return new AsyncJob<JoinLobbyCallback>( Client, joinLobby.SourceJobID );
+        }
+
+        /// <summary>
+        /// Sends a request to leave a lobby.
+        /// </summary>
+        /// <param name="appId">ID of app the lobby belongs to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should be left.</param>
+        /// <returns>An <see cref="AsyncJob{LeaveLobbyCallback}"/>.</returns>
+        public AsyncJob<LeaveLobbyCallback> LeaveLobby( uint appId, SteamID lobbySteamId )
+        {
+            var leaveLobby = new ClientMsgProtobuf<CMsgClientMMSLeaveLobby>( EMsg.ClientMMSLeaveLobby )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( leaveLobby, appId );
+
+            return new AsyncJob<LeaveLobbyCallback>( Client, leaveLobby.SourceJobID );
+        }
+
+        /// <summary>
+        /// Sends a request to obtain a lobby's data.
+        /// </summary>
+        /// <param name="appId">The ID of app which we're attempting to obtain lobby data for.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby whose data is being requested.</param>
+        /// <returns>An <see cref="AsyncJob{LobbyDataCallback}"/>.</returns>
+        public AsyncJob<LobbyDataCallback> GetLobbyData( uint appId, SteamID lobbySteamId )
+        {
+            var getLobbyData = new ClientMsgProtobuf<CMsgClientMMSGetLobbyData>( EMsg.ClientMMSGetLobbyData )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId
+                },
+                SourceJobID = Client.GetNextJobID()
+            };
+
+            Send( getLobbyData, appId );
+
+            return new AsyncJob<LobbyDataCallback>( Client, getLobbyData.SourceJobID );
+        }
+
+        /// <summary>
+        /// Sends a lobby invite request.
+        /// NOTE: Steam provides no functionality to determine if the user was successfully invited.
+        /// </summary>
+        /// <param name="appId">The ID of app which owns the lobby we're inviting a user to.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby we're inviting a user to.</param>
+        /// <param name="userSteamId">The SteamID of the user we're inviting.</param>
+        public void InviteToLobby( uint appId, SteamID lobbySteamId, SteamID userSteamId )
+        {
+            var getLobbyData = new ClientMsgProtobuf<CMsgClientMMSInviteToLobby>( EMsg.ClientMMSInviteToLobby )
+            {
+                Body =
+                {
+                    app_id = appId,
+                    steam_id_lobby = lobbySteamId,
+                    steam_id_user_invited = userSteamId
+                }
+            };
+
+            Send( getLobbyData, appId );
+        }
+
+        /// <summary>
+        /// Obtains a <see cref="Lobby"/>, by its SteamID, if the data is cached locally.
+        /// This method does not send a network request.
+        /// </summary>
+        /// <param name="appId">The ID of app which we're attempting to obtain a lobby for.</param>
+        /// <param name="lobbySteamId">The SteamID of the lobby that should be returned.</param>
+        /// <returns>The <see cref="Lobby"/> corresponding with the specified app and lobby ID, if cached. Otherwise, <c>null</c>.</returns>
+        public Lobby GetLobby( uint appId, SteamID lobbySteamId )
+        {
+            return lobbyCache.GetLobby( appId, lobbySteamId );
+        }
+
+        /// <summary>
+        /// Sends a matchmaking message for a specific app.
+        /// </summary>
+        /// <param name="msg">The matchmaking message to send.</param>
+        /// <param name="appId">The ID of the app this message pertains to.</param>
+        public void Send( ClientMsgProtobuf msg, uint appId )
+        {
+            if ( msg == null )
+            {
+                throw new ArgumentNullException( nameof(msg) );
+            }
+
+            msg.ProtoHeader.routing_appid = appId;
+            Client.Send( msg );
+        }
+
+        /// <summary>
+        /// Handles a client message. This should not be called directly.
+        /// </summary>
+        /// <param name="packetMsg">The packet message that contains the data.</param>
+        public override void HandleMsg( IPacketMsg packetMsg )
+        {
+            if ( packetMsg == null )
+            {
+                throw new ArgumentNullException( nameof(packetMsg) );
+            }
+
+            if ( dispatchMap.TryGetValue( packetMsg.MsgType, out var handler ) )
+            {
+                handler( packetMsg );
+            }
+        }
+
+        internal void ClearLobbyCache()
+        {
+            lobbyCache.Clear();
+        }
+
+        AsyncJob<T> AttachIncompleteManipulationHandler<T>( AsyncJob<T> job )
+            where T : CallbackMsg
+        {
+            // Manipulation requests typically complete (and are removed from lobbyManipulationRequests) when
+            // a message is handled. However, jobs can also be faulted, or be cancelled (e.g. when SteamClient
+            // disconnects.) Thus, when a job fails we remove the JobID/request from lobbyManipulationRequests.
+            job.ToTask().ContinueWith( task =>
+            {
+                lobbyManipulationRequests.TryRemove( job.JobID, out _ );
+            }, TaskContinuationOptions.NotOnRanToCompletion );
+            return job;
+        }
+
+        #region ClientMsg Handlers
+
+        void HandleCreateLobbyResponse( IPacketMsg packetMsg )
+        {
+            var lobbyListResponse = new ClientMsgProtobuf<CMsgClientMMSCreateLobbyResponse>( packetMsg );
+            var body = lobbyListResponse.Body;
+
+            if ( lobbyManipulationRequests.TryRemove( lobbyListResponse.TargetJobID, out var request ) )
+            {
+                if ( body.eresult == ( int )EResult.OK && request != null )
+                {
+                    var createLobby = ( CMsgClientMMSCreateLobby )request;
+                    var members = new List<Lobby.Member>( 1 ) { new Lobby.Member( Client.SteamID, createLobby.persona_name_owner ) };
+
+                    lobbyCache.CacheLobby(
+                        createLobby.app_id,
+                        new Lobby(
+                            body.steam_id_lobby,
+                            ( ELobbyType )createLobby.lobby_type,
+                            createLobby.lobby_flags,
+                            Client.SteamID,
+                            Lobby.DecodeMetadata( createLobby.metadata ),
+                            createLobby.max_members,
+                            1,
+                            members.AsReadOnly(),
+                            null,
+                            null
+                        )
+                    );
+                }
+            }
+
+            Client.PostCallback( new CreateLobbyCallback(
+                lobbyListResponse.TargetJobID,
+                body.app_id,
+                ( EResult )body.eresult,
+                body.steam_id_lobby
+            ) );
+        }
+
+        void HandleSetLobbyDataResponse( IPacketMsg packetMsg )
+        {
+            var lobbyListResponse = new ClientMsgProtobuf<CMsgClientMMSSetLobbyDataResponse>( packetMsg );
+            var body = lobbyListResponse.Body;
+
+            if ( lobbyManipulationRequests.TryRemove( lobbyListResponse.TargetJobID, out var request ) )
+            {
+                if ( body.eresult == ( int )EResult.OK && request != null )
+                {
+                    var setLobbyData = ( CMsgClientMMSSetLobbyData )request;
+                    var lobby = lobbyCache.GetLobby( setLobbyData.app_id, setLobbyData.steam_id_lobby );
+
+                    if ( lobby != null )
+                    {
+                        var metadata = Lobby.DecodeMetadata( setLobbyData.metadata );
+
+                        if ( setLobbyData.steam_id_member == 0 )
+                        {
+                            lobbyCache.CacheLobby(
+                                setLobbyData.app_id,
+                                new Lobby(
+                                    lobby.SteamID,
+                                    ( ELobbyType )setLobbyData.lobby_type,
+                                    setLobbyData.lobby_flags,
+                                    lobby.OwnerSteamID,
+                                    metadata,
+                                    setLobbyData.max_members,
+                                    lobby.NumMembers,
+                                    lobby.Members,
+                                    lobby.Distance,
+                                    lobby.Weight
+                                )
+                            );
+                        }
+                        else
+                        {
+                            var members = lobby.Members.Select( m =>
+                                m.SteamID == setLobbyData.steam_id_member ? new Lobby.Member( m.SteamID, m.PersonaName, metadata ) : m
+                            ).ToList();
+
+                            lobbyCache.UpdateLobbyMembers( setLobbyData.app_id, lobby, members );
+                        }
+                    }
+                }
+            }
+
+            Client.PostCallback( new SetLobbyDataCallback(
+                lobbyListResponse.TargetJobID,
+                body.app_id,
+                ( EResult )body.eresult,
+                body.steam_id_lobby
+            ) );
+        }
+
+        void HandleSetLobbyOwnerResponse( IPacketMsg packetMsg )
+        {
+            var setLobbyOwnerResponse = new ClientMsgProtobuf<CMsgClientMMSSetLobbyOwnerResponse>( packetMsg );
+            var body = setLobbyOwnerResponse.Body;
+
+            if ( lobbyManipulationRequests.TryRemove( setLobbyOwnerResponse.TargetJobID, out var request ) )
+            {
+                if ( body.eresult == ( int )EResult.OK && request != null )
+                {
+                    var setLobbyOwner = ( CMsgClientMMSSetLobbyOwner )request;
+                    lobbyCache.UpdateLobbyOwner( body.app_id, body.steam_id_lobby, setLobbyOwner.steam_id_new_owner );
+                }
+            }
+
+            Client.PostCallback( new SetLobbyOwnerCallback(
+                setLobbyOwnerResponse.TargetJobID,
+                body.app_id,
+                ( EResult )body.eresult,
+                body.steam_id_lobby
+            ) );
+        }
+
+        void HandleGetLobbyListResponse( IPacketMsg packetMsg )
+        {
+            var lobbyListResponse = new ClientMsgProtobuf<CMsgClientMMSGetLobbyListResponse>( packetMsg );
+            var body = lobbyListResponse.Body;
+
+            var lobbyList =
+                body.lobbies.ConvertAll( lobby =>
+                {
+                    var existingLobby = lobbyCache.GetLobby( body.app_id, lobby.steam_id );
+                    var members = existingLobby?.Members;
+
+                    return new Lobby(
+                        lobby.steam_id,
+                        ( ELobbyType )lobby.lobby_type,
+                        lobby.lobby_flags,
+                        existingLobby?.OwnerSteamID,
+                        Lobby.DecodeMetadata( lobby.metadata ),
+                        lobby.max_members,
+                        lobby.num_members,
+                        members,
+                        lobby.distance,
+                        lobby.weight
+                    );
+                } );
+
+            foreach ( var lobby in lobbyList )
+            {
+                lobbyCache.CacheLobby( body.app_id, lobby );
+            }
+
+            Client.PostCallback( new GetLobbyListCallback(
+                body.app_id,
+                ( EResult )body.eresult,
+                lobbyList
+            ) );
+        }
+
+        void HandleJoinLobbyResponse( IPacketMsg packetMsg )
+        {
+            var joinLobbyResponse = new ClientMsgProtobuf<CMsgClientMMSJoinLobbyResponse>( packetMsg );
+            var body = joinLobbyResponse.Body;
+
+            Lobby joinedLobby = null;
+
+            if ( body.steam_id_lobbySpecified )
+            {
+                var members =
+                    body.members.ConvertAll( member => new Lobby.Member(
+                        member.steam_id,
+                        member.persona_name,
+                        Lobby.DecodeMetadata( member.metadata )
+                    ) );
+
+                var cachedLobby = lobbyCache.GetLobby( body.app_id, body.steam_id_lobby );
+
+                joinedLobby = new Lobby(
+                    body.steam_id_lobby,
+                    ( ELobbyType )body.lobby_type,
+                    body.lobby_flags,
+                    body.steam_id_owner,
+                    Lobby.DecodeMetadata( body.metadata ),
+                    body.max_members,
+                    members.Count,
+                    members,
+                    cachedLobby?.Distance,
+                    cachedLobby?.Weight
+                );
+
+                lobbyCache.CacheLobby( body.app_id, joinedLobby );
+            }
+
+            Client.PostCallback( new JoinLobbyCallback(
+                joinLobbyResponse.TargetJobID,
+                body.app_id,
+                ( EChatRoomEnterResponse )body.chat_room_enter_response,
+                joinedLobby
+            ) );
+        }
+
+        void HandleLeaveLobbyResponse( IPacketMsg packetMsg )
+        {
+            var leaveLobbyResponse = new ClientMsgProtobuf<CMsgClientMMSLeaveLobbyResponse>( packetMsg );
+            var body = leaveLobbyResponse.Body;
+
+            if ( body.eresult == ( int )EResult.OK )
+            {
+                lobbyCache.ClearLobbyMembers( body.app_id, body.steam_id_lobby );
+            }
+
+            Client.PostCallback( new LeaveLobbyCallback(
+                leaveLobbyResponse.TargetJobID,
+                body.app_id,
+                ( EResult )body.eresult,
+                body.steam_id_lobby
+            ) );
+        }
+
+        void HandleLobbyData( IPacketMsg packetMsg )
+        {
+            var lobbyListResponse = new ClientMsgProtobuf<CMsgClientMMSLobbyData>( packetMsg );
+            var body = lobbyListResponse.Body;
+
+            var cachedLobby = lobbyCache.GetLobby( body.app_id, body.steam_id_lobby );
+            var members = body.members.Count == 0
+                ? cachedLobby.Members
+                : body.members.ConvertAll( member => new Lobby.Member(
+                    member.steam_id,
+                    member.persona_name,
+                    Lobby.DecodeMetadata( member.metadata )
+                ) );
+
+            var updatedLobby = new Lobby(
+                body.steam_id_lobby,
+                ( ELobbyType )body.lobby_type,
+                body.lobby_flags,
+                body.steam_id_owner,
+                Lobby.DecodeMetadata( body.metadata ),
+                body.max_members,
+                body.num_members,
+                members,
+                cachedLobby?.Distance,
+                cachedLobby?.Weight
+            );
+
+            lobbyCache.CacheLobby( body.app_id, updatedLobby );
+
+            Client.PostCallback( new LobbyDataCallback(
+                lobbyListResponse.TargetJobID,
+                body.app_id,
+                updatedLobby
+            ) );
+        }
+
+        void HandleUserJoinedLobby( IPacketMsg packetMsg )
+        {
+            var userJoinedLobby = new ClientMsgProtobuf<CMsgClientMMSUserJoinedLobby>( packetMsg );
+            var body = userJoinedLobby.Body;
+
+            var lobby = lobbyCache.GetLobby( body.app_id, body.steam_id_lobby );
+
+            if ( lobby != null && lobby.Members.Count > 0 )
+            {
+                var joiningMember = lobbyCache.AddLobbyMember( body.app_id, lobby, body.steam_id_user, body.persona_name );
+
+                if ( joiningMember != null )
+                {
+                    Client.PostCallback( new UserJoinedLobbyCallback(
+                        body.app_id,
+                        body.steam_id_lobby,
+                        joiningMember
+                    ) );
+                }
+            }
+        }
+
+        void HandleUserLeftLobby( IPacketMsg packetMsg )
+        {
+            var userLeftLobby = new ClientMsgProtobuf<CMsgClientMMSUserLeftLobby>( packetMsg );
+            var body = userLeftLobby.Body;
+
+            var lobby = lobbyCache.GetLobby( body.app_id, body.steam_id_lobby );
+
+            if ( lobby != null && lobby.Members.Count > 0 )
+            {
+                var leavingMember = lobbyCache.RemoveLobbyMember( body.app_id, lobby, body.steam_id_user );
+
+                if ( leavingMember?.SteamID == Client.SteamID )
+                {
+                    lobbyCache.ClearLobbyMembers( body.app_id, body.steam_id_lobby );
+                }
+
+                Client.PostCallback( new UserLeftLobbyCallback(
+                    body.app_id,
+                    body.steam_id_lobby,
+                    leavingMember
+                ) );
+            }
+        }
+
+        #endregion
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -69,6 +69,7 @@ namespace SteamKit2
             this.AddHandler( new SteamTrading() );
             this.AddHandler( new SteamUnifiedMessages() );
             this.AddHandler( new SteamScreenshots() );
+            this.AddHandler( new SteamMatchmaking() );
 
             using ( var process = Process.GetCurrentProcess() )
             {
@@ -390,9 +391,16 @@ namespace SteamKit2
 
             jobManager.SetTimeoutsEnabled( false );
 
+            ClearHandlerCaches();
+
             PostCallback( new DisconnectedCallback( userInitiated ) );
         }
 
+
+        void ClearHandlerCaches()
+        {
+            GetHandler<SteamMatchmaking>()?.ClearLobbyCache();
+        }
 
         void HandleCMList( IPacketMsg packetMsg )
         {


### PR DESCRIPTION
An implementation of SteamMatchmaking.

### Currently supported

- [x] `CreateLobby` (Sending of `CMsgClientMMSCreateLobby`)
- [x] `CreateLobbyCallback` (Receiving of `CMsgClientMMSCreateLobbyResponse`)
- [x] `SetLobbyData` (Sending of `CMsgClientMMSSetLobbyData`)
- [x] `SetLobbyDataCallback` (Receiving of `CMsgClientMMSSetLobbyDataResponse`)
- [x] `SetLobbyOwner` (Sending of `CMsgClientMMSSetLobbyOwner`)
- [x] `SetLobbyOwnerCallback` (Receiving of `CMsgClientMMSSetLobbyOwnerResponse`)
- [x] `GetLobbyList` (Sending of `CMsgClientMMSGetLobbyList`) i.e. Searching for lobbies.
- [x] `LobbyListCallback` (Receiving of `CMsgClientMMSGetLobbyListResponse`)
   - [x] `DistanceFilter`
   - [x] `NearValueFilter`
   - [x] `NumericalFilter`
   - [x] `SlotsAvailableFilter`
   - [x] `StringFilter`
- [x] `GetLobby` (Equivalent to functionality offered by https://partner.steamgames.com/doc/api/ISteamMatchmaking i.e. non-blocking synchronous access to lobbies we already "know about" .
- [x] `LobbyDataCallback` (Receiving of `CMsgClientMMSLobbyData`) i.e. Lobby change tracking.
- [x] `UserJoinedLobbyCallback` (Receiving of `CMsgClientMMSUserJoinedLobby`)
- [x] `UserLeftLobbyCallback` (Receiving of `CMsgClientMMSUserLeftLobby`).

Since originally opening the PR, the following has been added:

- [x] Joining lobbies.
- [x] Leaving lobbies.
- [x] Inviting another user to a lobby.
- [x] Getting data for a specific lobby rather than from a lobby list (probably only useful if you were invited to a lobby).

### What's not implemented in this PR

- [ ] Assigning a game server to a lobby.
- [ ] Lobby chat.
- [ ] Steam's "frenemy" stuff, which is officially deprecated and according to ISteamNetworking documentation doesn't actually do anything 🤷‍♂

### Related Issues

Closes https://github.com/SteamRE/SteamKit/issues/656

Closes https://github.com/SteamRE/SteamKit/issues/487 ... as the requested functionality is necessary to implement Matchmaking. Specifically, when we create a lobby we need to submit our public IP, so we require persistent access to it. Same is true of `IPCountryCode`.

Ping https://github.com/SteamRE/SteamKit/issues/131 (only partially implemented, so not closing).