### PR TITLE
Add ParentalSettings to LoggedOnCallback

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -158,7 +158,7 @@ namespace SteamKit2
                 {
                     using ( var ms = new MemoryStream( resp.parental_settings ) )
                     {
-                        ParentalSettings = Serializer.Deserialize<ParentalSettings>( ms );
+                        this.ParentalSettings = Serializer.Deserialize<ParentalSettings>( ms );
                     }
                 }
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -10,7 +10,9 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Collections.Generic;
 using System.Text;
+using ProtoBuf;
 using SteamKit2.Internal;
+using SteamKit2.Unified.Internal;
 
 namespace SteamKit2
 {
@@ -113,6 +115,10 @@ namespace SteamKit2
             /// </summary>
             public int NumDisconnectsToMigrate { get; private set; }
 
+            /// <summary>
+            /// Gets the Steam parental settings.
+            /// </summary>
+            public ParentalSettings ParentalSettings { get; private set; }
 
             internal LoggedOnCallback( CMsgClientLogonResponse resp )
             {
@@ -147,6 +153,14 @@ namespace SteamKit2
 
                 this.NumLoginFailuresToMigrate = resp.count_loginfailures_to_migrate;
                 this.NumDisconnectsToMigrate = resp.count_disconnects_to_migrate;
+
+                if ( resp.parental_settings != null )
+                {
+                    using ( var ms = new MemoryStream( resp.parental_settings ) )
+                    {
+                        ParentalSettings = Serializer.Deserialize<ParentalSettings>( ms );
+                    }
+                }
             }
 
 


### PR DESCRIPTION
I've verified that this works properly, and it's a big help for those apps that want/need to interpret those settings, for example in order to determine if `ParentalSettings.is_enabled`.

I could expose `resp.parental_settings` alone and expect from the consumer to do the deserialization himself, but I believe that we can aid him a little since there is nothing else he should be doing with that data anyway. Let me know if there is anything you'd change in this implementation.

Thank you in advance for considering this PR.