### PR TITLE
Improve SK2 versioning for CI and non-CI builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,30 @@
+<Project>
+    <PropertyGroup>
+        <SteamKitRootDir>$(MSBuildThisFileDirectory)</SteamKitRootDir>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(APPVEYOR_BUILD_VERSION)' == ''">
+        <AppVeyorConfigPath>$(SteamKitRootDir)appveyor.yml</AppVeyorConfigPath>
+        <AppVeyorConfigText>$([System.IO.File]::ReadAllText($(AppVeyorConfigPath)))</AppVeyorConfigText>
+        <AppVeyorVersionExpression>CoreVersion: (\d+\.\d+\.\d+)</AppVeyorVersionExpression>
+        <SteamKitCoreVersion>$([System.Text.RegularExpressions.Regex]::Match($(AppVeyorConfigText), $(AppVeyorVersionExpression)).Groups[1].Value)</SteamKitCoreVersion>
+        <SteamKitVersion>$(SteamKitCoreVersion).0</SteamKitVersion>
+        <AssemblyVersion>$(SteamKitVersion)</AssemblyVersion>
+        <FileVersion>$(SteamKitVersion)</FileVersion>
+        <InformationalVersion>$(SteamKitVersion) - Development</InformationalVersion>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(APPVEYOR_BUILD_VERSION)' != ''">
+        <AssemblyVersion>$(APPVEYOR_BUILD_VERSION)</AssemblyVersion>
+        <FileVersion>$(APPVEYOR_BUILD_VERSION)</FileVersion>
+        <SteamKitBranch Condition=" '$(APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH)' != '' ">$(APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH)</SteamKitBranch>
+        <SteamKitBranch Condition=" '$(SteamKitBranch)' == '' ">$(APPVEYOR_REPO_BRANCH)</SteamKitBranch>
+        <InformationalVersion>$(APPVEYOR_BUILD_VERSION) - CI (AppVeyor, branch: $(SteamKitBranch))</InformationalVersion>
+    </PropertyGroup>
+    <PropertyGroup>
+        <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+        <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    </PropertyGroup>
+</Project>

--- a/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
+++ b/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
@@ -29,11 +29,6 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid( "cd42d0bc-72e4-451e-bcd0-5d09c4bca2a9" )]
 
-// These are automatically modified by AppVeyor for CI builds and automated deployment, but you should still try to keep them up-to-date for non-CI builds.
-[assembly: AssemblyVersion( "2.2.0" )]
-[assembly: AssemblyFileVersion( "2.2.0.0" )]
-[assembly: AssemblyInformationalVersion( "2.2.0.0 - Development" )]
-
 #if DEBUG
 [assembly: InternalsVisibleTo( "Tests" )]
 #endif

--- a/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
+++ b/SteamKit2/SteamKit2/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "SteamRE Team" )]
 [assembly: AssemblyProduct( "SteamKit2" )]
-[assembly: AssemblyCopyright( "Copyright © SteamRE Team 2018" )]
+[assembly: AssemblyCopyright( "Copyright © SteamRE Team 2019" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -29,10 +29,10 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid( "cd42d0bc-72e4-451e-bcd0-5d09c4bca2a9" )]
 
-// These are automatically modified by AppVeyor for CI builds and automated deployment.
-[assembly: AssemblyVersion( "2.0.0.0" )]
-[assembly: AssemblyFileVersion( "2.0.0.0" )]
-[assembly: AssemblyInformationalVersion( "2.0.0 - Development" )]
+// These are automatically modified by AppVeyor for CI builds and automated deployment, but you should still try to keep them up-to-date for non-CI builds.
+[assembly: AssemblyVersion( "2.2.0" )]
+[assembly: AssemblyFileVersion( "2.2.0.0" )]
+[assembly: AssemblyInformationalVersion( "2.2.0.0 - Development" )]
 
 #if DEBUG
 [assembly: InternalsVisibleTo( "Tests" )]

--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>
     <Description>.NET library that aims to interoperate with the Steam network.</Description>
     <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.2.0</PackageReleaseNotes>

--- a/SteamKit2/Tests/Properties/AssemblyInfo.cs
+++ b/SteamKit2/Tests/Properties/AssemblyInfo.cs
@@ -22,17 +22,4 @@ using Xunit;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("dcef76fb-0139-4e17-a8cd-973a7d9bd856")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ProjectGuid>{5BF6D076-399B-41CA-BAE7-37CE1C40CA67}</ProjectGuid>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-# When modifying version here, consider updating AssemblyInfo.cs manually as well for non-CI builds
 environment:
+  # When modifying version here, consider updating AssemblyInfo.cs manually as well for non-CI builds
   CoreVersion: 2.2.0
 
 version: $(CoreVersion).{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 environment:
-  # When modifying version here, consider updating AssemblyInfo.cs manually as well for non-CI builds
   CoreVersion: 2.2.0
 
 version: $(CoreVersion).{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
-version: 2.2.0.{build}
+# When modifying version here, consider updating AssemblyInfo.cs manually as well for non-CI builds
+environment:
+  CoreVersion: 2.2.0
+
+version: $(CoreVersion).{build}
 os: Visual Studio 2017
 
 cache:
@@ -8,7 +12,7 @@ cache:
 assembly_info:
   patch: true
   file: AssemblyInfo.cs
-  assembly_version: "2.2.0"
+  assembly_version: "$(CoreVersion)"
   assembly_file_version: "{version}"
   assembly_informational_version: "{version} - CI (AppVeyor, branch: {branch})"
 


### PR DESCRIPTION
Developers building/publishing in non-CI environments shouldn't be expected to correct the versioning, at least in regards to the static part of SK2 versioning, such as "2.2.0". This is required for assembly compatibility, developer targetting 2.2.0+, self-compiling SK2 before this PR produced `2.0.0.0` assembly, which is incorrect (we've built `master` which is 2.2.0 as of today). Assembly patching done in AppVeyor CI is OK for automating publishing procedure, and the build number can be very helpful for verification, but self-compiled builds lacking that info should be compatible with static SK2 versioning.

I've also killed duplicate definition in `appveyor.yml` to hopefully make up for the extra hassle caused 😅.

Thanks for considering.