### PR TITLE
Add a per-SteamClient unique identifier message to DebugLog messages

### DIFF
--- a/Samples/3.DebugLog/Program.cs
+++ b/Samples/3.DebugLog/Program.cs
@@ -29,12 +29,19 @@ namespace Sample3_DebugLog
     // define our debuglog listener
     class MyListener : IDebugListener
     {
-        public void WriteLine( string category, string msg )
+        public void WriteLine( LoggerToken token, string category, string msg )
         {
             // this function will be called when internal steamkit components write to the debuglog
 
             // for this example, we'll print the output to the console
-            Console.WriteLine( "MyListener - {0}: {1}", category, msg );
+            if ( token.IsDefault )
+            {
+                Console.WriteLine( "MyListener - {0}: {1}", category, msg );
+            }
+            else
+            {
+                Console.WriteLine( "MyListener - {0}/{1}: {2}", token.Identifier, category, msg );
+            }
         }
     }
 

--- a/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryption.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryption.cs
@@ -12,12 +12,14 @@ namespace SteamKit2
     class NetFilterEncryption : INetFilterEncryption
     {
         readonly byte[] sessionKey;
+        readonly LoggerToken loggerToken;
 
-        public NetFilterEncryption( byte[] sessionKey )
+        public NetFilterEncryption( byte[] sessionKey ,LoggerToken loggerToken )
         {
-            DebugLog.Assert( sessionKey.Length == 32, nameof(NetFilterEncryption), "AES session key was not 32 bytes!" );
+            DebugLog.Assert( sessionKey.Length == 32, loggerToken, nameof( NetFilterEncryption), "AES session key was not 32 bytes!" );
 
             this.sessionKey = sessionKey;
+            this.loggerToken = loggerToken;
         }
 
         public byte[] ProcessIncoming( byte[] data )
@@ -28,7 +30,7 @@ namespace SteamKit2
             }
             catch ( CryptographicException ex )
             {
-                DebugLog.WriteLine( nameof(NetFilterEncryption), "Unable to decrypt incoming packet: " + ex.Message );
+                DebugLog.WriteLine( loggerToken, nameof( NetFilterEncryption), "Unable to decrypt incoming packet: " + ex.Message );
 
                 // rethrow as an IO exception so it's handled in the network thread
                 throw new IOException( "Unable to decrypt incoming packet", ex );

--- a/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryptionWithHMAC.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/NetFilterEncryptionWithHMAC.cs
@@ -14,12 +14,15 @@ namespace SteamKit2
     {
         readonly byte[] sessionKey;
         readonly byte[] hmacSecret;
+        readonly LoggerToken loggerToken;
 
-        public NetFilterEncryptionWithHMAC( byte[] sessionKey )
+        public NetFilterEncryptionWithHMAC( byte[] sessionKey, LoggerToken loggerToken )
         {
-            DebugLog.Assert( sessionKey.Length == 32, nameof(NetFilterEncryption), "AES session key was not 32 bytes!" );
+            DebugLog.Assert( sessionKey.Length == 32, loggerToken, nameof(NetFilterEncryption), "AES session key was not 32 bytes!" );
 
             this.sessionKey = sessionKey;
+            this.loggerToken = loggerToken;
+
             this.hmacSecret = new byte[ 16 ];
             Array.Copy( sessionKey, 0, hmacSecret, 0, hmacSecret.Length );
         }
@@ -32,7 +35,7 @@ namespace SteamKit2
             }
             catch ( CryptographicException ex )
             {
-                DebugLog.WriteLine( nameof(NetFilterEncryptionWithHMAC), "Unable to decrypt incoming packet: " + ex.Message );
+                DebugLog.WriteLine( loggerToken, nameof(NetFilterEncryptionWithHMAC), "Unable to decrypt incoming packet: " + ex.Message );
 
                 // rethrow as an IO exception so it's handled in the network thread
                 throw new IOException( "Unable to decrypt incoming packet", ex );

--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -16,6 +16,7 @@ namespace SteamKit2
     {
         const uint MAGIC = 0x31305456; // "VT01"
 
+        private LoggerToken loggerToken;
         private Socket? socket;
         private Thread? netThread;
         private NetworkStream? netStream;
@@ -25,8 +26,9 @@ namespace SteamKit2
         private CancellationTokenSource? cancellationToken;
         private object netLock;
 
-        public TcpConnection()
+        public TcpConnection(LoggerToken loggerToken)
         {
+            this.loggerToken = loggerToken;
             netLock = new object();
         }
 
@@ -102,19 +104,19 @@ namespace SteamKit2
             // If we have no cancellation token source, we were already Release()'ed
             if (cancellationToken?.IsCancellationRequested ?? true)
             {
-                DebugLog.WriteLine("TcpConnection", "Connection request to {0} was cancelled", CurrentEndPoint);
+                DebugLog.WriteLine(loggerToken, "TcpConnection", "Connection request to {0} was cancelled", CurrentEndPoint);
                 if (success) Shutdown();
                 Release( userRequestedDisconnect: true );
                 return;
             }
             else if (!success)
             {
-                DebugLog.WriteLine("TcpConnection", "Timed out while connecting to {0}", CurrentEndPoint);
+                DebugLog.WriteLine( loggerToken, "TcpConnection", "Timed out while connecting to {0}", CurrentEndPoint);
                 Release( userRequestedDisconnect: false );
                 return;
             }
 
-            DebugLog.WriteLine("TcpConnection", "Connected to {0}", CurrentEndPoint);
+            DebugLog.WriteLine( loggerToken, "TcpConnection", "Connected to {0}", CurrentEndPoint);
 
             try
             {
@@ -136,19 +138,19 @@ namespace SteamKit2
             }
             catch (Exception ex)
             {
-                DebugLog.WriteLine("TcpConnection", "Exception while setting up connection to {0}: {1}", CurrentEndPoint, ex);
+                DebugLog.WriteLine( loggerToken, "TcpConnection", "Exception while setting up connection to {0}: {1}", CurrentEndPoint, ex);
                 Release( userRequestedDisconnect: false );
             }
         }
 
         private void TryConnect(object sender)
         {
-            DebugLog.Assert( cancellationToken != null, nameof( TcpConnection ), "null CancellationToken in TryConnect" );
+            DebugLog.Assert( cancellationToken != null, loggerToken, nameof( TcpConnection ), "null CancellationToken in TryConnect" );
 
             int timeout = (int)sender;
             if (cancellationToken.IsCancellationRequested)
             {
-                DebugLog.WriteLine("TcpConnection", "Connection to {0} cancelled by user", CurrentEndPoint);
+                DebugLog.WriteLine( loggerToken, "TcpConnection", "Connection to {0} cancelled by user", CurrentEndPoint);
                 Release( userRequestedDisconnect: true );
                 return;
             }
@@ -163,7 +165,7 @@ namespace SteamKit2
                 }
                 catch ( Exception ex )
                 {
-                    DebugLog.WriteLine( "TcpConnection", "Socket exception while completing connection request to {0}: {1}", CurrentEndPoint, ex );
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Socket exception while completing connection request to {0}: {1}", CurrentEndPoint, ex );
                     ConnectCompleted( false );
                 }
             }
@@ -190,7 +192,7 @@ namespace SteamKit2
                 socket.SendTimeout = timeout;
 
                 CurrentEndPoint = endPoint;
-                DebugLog.WriteLine( "TcpConnection", "Connecting to {0}...", CurrentEndPoint);
+                DebugLog.WriteLine( loggerToken, "TcpConnection", "Connecting to {0}...", CurrentEndPoint);
                 TryConnect( timeout );
             }
 
@@ -215,7 +217,7 @@ namespace SteamKit2
             // poll for readable data every 100ms
             const int POLL_MS = 100;
 
-            DebugLog.Assert( cancellationToken != null, nameof( TcpConnection ), "null cancellationToken in NetLoop" );
+            DebugLog.Assert( cancellationToken != null, loggerToken, nameof( TcpConnection ), "null cancellationToken in NetLoop" );
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -227,7 +229,7 @@ namespace SteamKit2
                 }
                 catch (SocketException ex)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception while polling: {0}", ex);
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Socket exception while polling: {0}", ex);
                     break;
                 }
 
@@ -246,7 +248,7 @@ namespace SteamKit2
                 }
                 catch (IOException ex)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception occurred while reading packet: {0}", ex);
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Socket exception occurred while reading packet: {0}", ex);
                     break;
                 }
 
@@ -256,7 +258,7 @@ namespace SteamKit2
                 }
                 catch (Exception ex)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Unexpected exception propogated back to NetLoop: {0}", ex);
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Unexpected exception propogated back to NetLoop: {0}", ex);
                 }
             }
 
@@ -309,7 +311,7 @@ namespace SteamKit2
             {
                 if (socket == null || netStream == null)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Attempting to send client data when not connected.");
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Attempting to send client data when not connected.");
                     return;
                 }
 
@@ -321,7 +323,7 @@ namespace SteamKit2
                 }
                 catch (IOException ex)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception while writing data: {0}", ex);
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Socket exception while writing data: {0}", ex);
                 }
             }
         }
@@ -341,7 +343,7 @@ namespace SteamKit2
                 }
                 catch (Exception ex)
                 {
-                    DebugLog.WriteLine("TcpConnection", "Socket exception trying to read bound IP: {0}", ex);
+                    DebugLog.WriteLine( loggerToken, "TcpConnection", "Socket exception trying to read bound IP: {0}", ex);
                     return IPAddress.None;
                 }
             }

--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
@@ -51,6 +51,8 @@ namespace SteamKit2
         /// </summary>
         private volatile int state;
 
+        private LoggerToken loggerToken;
+
         private Thread? netThread;
         private Socket sock;
 
@@ -90,9 +92,11 @@ namespace SteamKit2
         [NotNull] private List<UdpPacket>? outPackets;
         [NotNull] private Dictionary<uint, UdpPacket>? inPackets;
 
-        public UdpConnection()
+        public UdpConnection(LoggerToken loggerToken)
         {
-            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Any, 0);
+            this.loggerToken = loggerToken;
+
+            var localEndPoint = new IPEndPoint(IPAddress.Any, 0);
 
             sock = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
             sock.Bind(localEndPoint);
@@ -245,7 +249,7 @@ namespace SteamKit2
             packet.Header.DestConnID = remoteConnId;
             packet.Header.SeqAck = inSeqAcked = inSeq;
 
-            DebugLog.WriteLine("UdpConnection", "Sent -> {0} Seq {1} Ack {2}; {3} bytes; Message: {4} bytes {5} packets",
+            DebugLog.WriteLine( loggerToken, "UdpConnection", "Sent -> {0} Seq {1} Ack {2}; {3} bytes; Message: {4} bytes {5} packets",
                 packet.Header.PacketType, packet.Header.SeqThis, packet.Header.SeqAck,
                 packet.Header.PayloadSize, packet.Header.MsgSize, packet.Header.PacketsInMsg);
 
@@ -257,7 +261,7 @@ namespace SteamKit2
             }
             catch ( SocketException e )
             {
-                DebugLog.WriteLine( "UdpConnection", "Critical socket failure: " + e.SocketErrorCode );
+                DebugLog.WriteLine( loggerToken, "UdpConnection", "Critical socket failure: " + e.SocketErrorCode );
 
                 state = ( int )State.Disconnected;
                 return;
@@ -298,7 +302,7 @@ namespace SteamKit2
                         outPackets.Clear();
                     }
 
-                    DebugLog.WriteLine( "UdpConnection", "Sequenced packet resend required" );
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Sequenced packet resend required" );
 
                     // Don't send more than 3 (Steam behavior?)
                     for ( int i = 0; i < RESEND_COUNT && i < outPackets.Count; i++ )
@@ -360,7 +364,7 @@ namespace SteamKit2
 
             byte[] data = payload.ToArray();
 
-            DebugLog.WriteLine("UdpConnection", "Dispatching message; {0} bytes", data.Length);
+            DebugLog.WriteLine( loggerToken, "UdpConnection", "Dispatching message; {0} bytes", data.Length);
 
             NetMsgReceived?.Invoke( this, new NetMsgEventArgs( data, CurrentEndPoint! ) );
 
@@ -405,7 +409,7 @@ namespace SteamKit2
                     if ( !sock.Poll(150000, SelectMode.SelectRead)
                         && DateTime.Now > timeOut )
                     {
-                        DebugLog.WriteLine("UdpConnection", "Connection timed out");
+                        DebugLog.WriteLine( loggerToken, "UdpConnection", "Connection timed out");
 
                         state = (int)State.Disconnected;
                         break;
@@ -432,14 +436,14 @@ namespace SteamKit2
                 }
                 catch ( IOException ex )
                 {
-                    DebugLog.WriteLine( "UdpConnection", "Exception occurred while reading packet: {0}", ex );
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Exception occurred while reading packet: {0}", ex );
 
                     state = ( int )State.Disconnected;
                     break;
                 }
                 catch ( SocketException e )
                 {
-                    DebugLog.WriteLine( "UdpConnection", "Critical socket failure: " + e.SocketErrorCode );
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Critical socket failure: " + e.SocketErrorCode );
 
                     state = ( int )State.Disconnected;
                     break;
@@ -459,7 +463,7 @@ namespace SteamKit2
                 // Once it's empty, we exit, since the last packet was our disconnect notification.
                 if ( state == ( int )State.Disconnecting && outPackets.Count == 0 )
                 {
-                    DebugLog.WriteLine( "UdpConnection", "Graceful disconnect completed" );
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Graceful disconnect completed" );
 
                     state = ( int )State.Disconnected;
                     userRequestedDisconnect = true;
@@ -472,7 +476,7 @@ namespace SteamKit2
                 sock.Dispose();
             }
 
-            DebugLog.WriteLine("UdpConnection", "Calling OnDisconnected");
+            DebugLog.WriteLine( loggerToken, "UdpConnection", "Calling OnDisconnected");
             Disconnected?.Invoke( this, new DisconnectedEventArgs( userRequestedDisconnect ) );
         }
 
@@ -488,7 +492,7 @@ namespace SteamKit2
             else if ( remoteConnId > 0 && packet.Header.SourceConnID != remoteConnId )
                 return;
 
-            DebugLog.WriteLine("UdpConnection", "<- Recv'd {0} Seq {1} Ack {2}; {3} bytes; Message: {4} bytes {5} packets",
+            DebugLog.WriteLine( loggerToken, "UdpConnection", "<- Recv'd {0} Seq {1} Ack {2}; {3} bytes; Message: {4} bytes {5} packets",
                 packet.Header.PacketType, packet.Header.SeqThis, packet.Header.SeqAck,
                 packet.Header.PayloadSize, packet.Header.MsgSize, packet.Header.PacketsInMsg);
 
@@ -535,7 +539,7 @@ namespace SteamKit2
                     break;
 
                 case EUdpPacketType.Disconnect:
-                    DebugLog.WriteLine("UdpConnection", "Disconnected by server");
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Disconnected by server");
                     state = (int)State.Disconnected;
                     return;
 
@@ -543,7 +547,7 @@ namespace SteamKit2
                     break;
 
                 default:
-                    DebugLog.WriteLine("UdpConnection", "Received unexpected packet type " + packet.Header.PacketType);
+                    DebugLog.WriteLine( loggerToken, "UdpConnection", "Received unexpected packet type " + packet.Header.PacketType);
                     break;
             }
         }
@@ -582,7 +586,7 @@ namespace SteamKit2
             if ( Interlocked.CompareExchange( ref state, (int)State.Connected, (int)State.ConnectSent ) != (int)State.ConnectSent )
                 return;
 
-            DebugLog.WriteLine( "UdpConnection", "Connection established" );
+            DebugLog.WriteLine( loggerToken, "UdpConnection", "Connection established" );
             remoteConnId = packet.Header.SourceConnID;
             inSeqHandled = packet.Header.SeqThis;
 

--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
@@ -6,6 +6,13 @@ namespace SteamKit2
 {
     partial class WebSocketConnection : IConnection
     {
+        public WebSocketConnection(LoggerToken loggerToken)
+        {
+            this.loggerToken = loggerToken;
+        }
+
+        readonly LoggerToken loggerToken;
+
         WebSocketContext? currentContext;
 
         public event EventHandler<NetMsgEventArgs>? NetMsgReceived;
@@ -19,11 +26,11 @@ namespace SteamKit2
 
         public void Connect(EndPoint endPoint, int timeout = 5000)
         {
-            var newContext = new WebSocketContext(this, endPoint);
+            var newContext = new WebSocketContext(this, endPoint, loggerToken);
             var oldContext = Interlocked.Exchange(ref currentContext, newContext);
             if (oldContext != null)
             {
-                DebugLog.WriteLine(nameof(WebSocketConnection), "Attempted to connect while already connected. Closing old connection...");
+                DebugLog.WriteLine(loggerToken, nameof(WebSocketConnection), "Attempted to connect while already connected. Closing old connection...");
                 oldContext.Dispose();
                 Disconnected?.Invoke(this, new DisconnectedEventArgs(false));
             }
@@ -45,7 +52,7 @@ namespace SteamKit2
             }
             catch (Exception ex)
             {
-                DebugLog.WriteLine(nameof(WebSocketConnection), "Exception while sending data: {0} - {1}", ex.GetType().FullName, ex.Message);
+                DebugLog.WriteLine( loggerToken, nameof( WebSocketConnection), "Exception while sending data: {0} - {1}", ex.GetType().FullName, ex.Message);
                 DisconnectCore(userInitiated: false, specificContext: null);
             }
         }

--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
@@ -14,16 +14,18 @@ namespace SteamKit2
     {
         class WebSocketContext : IDisposable
         {
-            public WebSocketContext(WebSocketConnection connection, EndPoint endPoint)
+            public WebSocketContext(WebSocketConnection connection, EndPoint endPoint, LoggerToken loggerToken)
             {
                 this.connection = connection;
                 EndPoint = endPoint;
+                this.loggerToken = loggerToken;
 
                 cts = new CancellationTokenSource();
                 socket = new ClientWebSocket();
                 hostAndPort = GetHostAndPort(endPoint);
             }
 
+            readonly LoggerToken loggerToken;
             readonly WebSocketConnection connection;
             readonly CancellationTokenSource cts;
             readonly ClientWebSocket socket;
@@ -53,19 +55,19 @@ namespace SteamKit2
                     }
                     catch (TaskCanceledException) when (timeout.IsCancellationRequested)
                     {
-                        DebugLog.WriteLine(nameof(WebSocketContext), "Time out connecting websocket {0} after {1}", uri, connectionTimeout);
+                        DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Time out connecting websocket {0} after {1}", uri, connectionTimeout);
                         connection.DisconnectCore(userInitiated: false, specificContext: this);
                         return;
                     }
                     catch (Exception ex)
                     {
-                        DebugLog.WriteLine(nameof(WebSocketContext), "Exception connecting websocket: {0} - {1}", ex.GetType().FullName, ex.Message);
+                        DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Exception connecting websocket: {0} - {1}", ex.GetType().FullName, ex.Message);
                         connection.DisconnectCore(userInitiated: false, specificContext: this);
                         return;
                     }
                 }
 
-                DebugLog.WriteLine(nameof(WebSocketContext), "Connected to {0}", uri);
+                DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Connected to {0}", uri);
                 connection.Connected?.Invoke(connection, EventArgs.Empty);
 
                 while (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
@@ -79,14 +81,14 @@ namespace SteamKit2
 
                 if (socket.State == WebSocketState.Open)
                 {
-                    DebugLog.WriteLine(nameof(WebSocketContext), "Closing connection...");
+                    DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Closing connection...");
                     try
                     {
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, default(CancellationToken)).ConfigureAwait(false);
                     }
                     catch (Win32Exception ex)
                     {
-                        DebugLog.WriteLine(nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
+                        DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Error closing connection: {0}", ex.Message);
                     }
                 }
             }
@@ -100,11 +102,11 @@ namespace SteamKit2
                 }
                 catch (WebSocketException ex)
                 {
-                    DebugLog.WriteLine(nameof(WebSocketContext), "{0} exception when sending message: {1}", ex.GetType().FullName, ex.Message);
+                    DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "{0} exception when sending message: {1}", ex.GetType().FullName, ex.Message);
                     connection.DisconnectCore(userInitiated: false, specificContext: this);
                     return;
                 }
-                DebugLog.WriteLine(nameof(WebSocketContext), "Sent {0} bytes.", data.Length);
+                DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Sent {0} bytes.", data.Length);
             }
 
             public void Dispose()
@@ -155,21 +157,21 @@ namespace SteamKit2
                         {
                             case WebSocketMessageType.Binary:
                                 ms.Write(buffer, 0, result.Count);
-                                DebugLog.WriteLine(nameof(WebSocketContext), "Recieved {0} bytes.", result.Count);
+                                DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Recieved {0} bytes.", result.Count);
                                 break;
 
                             case WebSocketMessageType.Text:
                                 try
                                 {
                                     var message = Encoding.UTF8.GetString(buffer, 0, result.Count);
-                                    DebugLog.WriteLine(nameof(WebSocketContext), "Recieved websocket text message: \"{0}\"", message);
+                                    DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Recieved websocket text message: \"{0}\"", message);
                                 }
                                 catch
                                 {
                                     var frameBytes = new byte[result.Count];
                                     Array.Copy(buffer, 0, frameBytes, 0, result.Count);
                                     var frameHexBytes = BitConverter.ToString(frameBytes).Replace("-", string.Empty);
-                                    DebugLog.WriteLine(nameof(WebSocketContext), "Recieved websocket text message: 0x{0}", frameHexBytes);
+                                    DebugLog.WriteLine( loggerToken, nameof( WebSocketContext), "Recieved websocket text message: 0x{0}", frameHexBytes);
                                 }
                                 break;
 

--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -287,8 +287,8 @@ namespace SteamKit2
         /// <exception cref="SteamKitWebRequestException">A network error occurred when performing the request.</exception>
         public async Task<IList<Server>> FetchServerListAsync( IPEndPoint? csServer = null, uint? cellId = null, int maxServers = 20 )
         {
-            DebugLog.Assert( steamClient.IsConnected, "CDNClient", "CMClient is not connected!" );
-            DebugLog.Assert( steamClient.CellID != null, "CDNClient", "CMClient is not logged on!" );
+            DebugLog.Assert( steamClient.IsConnected, steamClient.LoggerToken, "CDNClient", "CMClient is not connected!" );
+            DebugLog.Assert( steamClient.CellID != null, steamClient.LoggerToken, "CDNClient", "CMClient is not logged on!" );
 
             if ( csServer == null )
             {
@@ -331,7 +331,7 @@ namespace SteamKit2
 
                 if ( host is null )
                 {
-                    DebugLog.WriteLine( nameof( CDNClient ), "Encountered server list entry with no 'host' property." );
+                    DebugLog.WriteLine( steamClient.LoggerToken, nameof( CDNClient ), "Encountered server list entry with no 'host' property." );
                     continue;
                 }
 
@@ -393,8 +393,8 @@ namespace SteamKit2
         /// <exception cref="SteamKitWebRequestException">A network error occurred when performing the request.</exception>
         public async Task ConnectAsync( Server csServer )
         {
-            DebugLog.Assert( steamClient.IsConnected, nameof(CDNClient), "CMClient is not connected!" );
-            DebugLog.Assert( steamClient.SteamID != null, nameof(CDNClient), "CMClient has no SteamID!" );
+            DebugLog.Assert( steamClient.IsConnected, steamClient.LoggerToken, nameof( CDNClient), "CMClient is not connected!" );
+            DebugLog.Assert( steamClient.SteamID != null, steamClient.LoggerToken, nameof( CDNClient), "CMClient has no SteamID!" );
 
             if ( csServer == null )
             {
@@ -409,7 +409,7 @@ namespace SteamKit2
             }
 
             var pubKey = KeyDictionary.GetPublicKey( steamClient.Universe );
-            DebugLog.Assert( pubKey != null, nameof( CDNClient ), "Unable to load public key for Steam Universe that we're already connected to!" );
+            DebugLog.Assert( pubKey != null, steamClient.LoggerToken, nameof( CDNClient ), "Unable to load public key for Steam Universe that we're already connected to!" );
 
             sessionKey = CryptoHelper.GenerateRandomBlock( 32 );
 
@@ -462,7 +462,7 @@ namespace SteamKit2
                 throw new InvalidOperationException( "Cannot perform CDN operations before connecting to CDN server." );
             }
 
-            DebugLog.Assert( sessionKey != null, nameof( CDNClient ), "Inconsistent state - connected to CDN without a session key." );
+            DebugLog.Assert( sessionKey != null, steamClient.LoggerToken, nameof( CDNClient ), "Inconsistent state - connected to CDN without a session key." );
 
             string data;
 
@@ -765,7 +765,7 @@ namespace SteamKit2
                 }
                 catch ( Exception ex )
                 {
-                    DebugLog.WriteLine( "CDNClient", "Failed to complete web request to {0}: {1}", url, ex.Message );
+                    DebugLog.WriteLine( steamClient.LoggerToken, "CDNClient", "Failed to complete web request to {0}: {1}", url, ex.Message );
                     throw;
                 }
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
@@ -588,7 +588,7 @@ namespace SteamKit2
             var body = lobbyListResponse.Body;
 
             var cachedLobby = lobbyCache.GetLobby( body.app_id, body.steam_id_lobby );
-            DebugLog.Assert( cachedLobby != null, nameof( SteamMatchmaking ), "Got LobbyData without corresponding object in cache." );
+            DebugLog.Assert( cachedLobby != null, Client.LoggerToken, nameof( SteamMatchmaking ), "Got LobbyData without corresponding object in cache." );
 
             var members = body.members.Count == 0
                 ? cachedLobby.Members

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -354,13 +354,13 @@ namespace SteamKit2
                 }
                 catch ( ProtoException ex )
                 {
-                    DebugLog.WriteLine( "SteamClient", "'{0}' handler failed to (de)serialize a protobuf: '{1}'", key.Name, ex.Message );
+                    DebugLog.WriteLine( LoggerToken, "SteamClient", "'{0}' handler failed to (de)serialize a protobuf: '{1}'", key.Name, ex.Message );
                     Disconnect();
                     return false;
                 }
                 catch ( Exception ex )
                 {
-                    DebugLog.WriteLine( "SteamClient", "Unhandled '{0}' exception from '{1}' handler: '{2}'", ex.GetType().Name, key.Name, ex.Message );
+                    DebugLog.WriteLine( LoggerToken, "SteamClient", "Unhandled '{0}' exception from '{1}' handler: '{2}'", ex.GetType().Name, key.Name, ex.Message );
                     Disconnect();
                     return false;
                 }

--- a/SteamKit2/SteamKit2/Util/DebugLog.cs
+++ b/SteamKit2/SteamKit2/Util/DebugLog.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace SteamKit2
 {
@@ -21,25 +22,58 @@ namespace SteamKit2
         /// <summary>
         /// Called when the DebugLog wishes to inform listeners of debug spew.
         /// </summary>
+        /// <param name="token">A token that can be used to uniquely identify the SteamClient that triggered this message.</param>
         /// <param name="category">The category of the message.</param>
         /// <param name="msg">The message to log.</param>
-        void WriteLine( string category, string msg );
+        void WriteLine( LoggerToken token, string category, string msg );
     }
 
     class ActionListener : IDebugListener
     {
-        public Action<string, string> Action;
+        public Action<LoggerToken, string, string> Action;
 
-        public ActionListener( Action<string, string> action )
+        public ActionListener( Action<LoggerToken, string, string> action )
         {
             this.Action = action;
         }
 
-        public void WriteLine( string category, string msg )
+        public void WriteLine( LoggerToken token, string category, string msg )
         {
-            Action( category, msg );
+            Action( token, category, msg );
         }
 
+    }
+
+    /// <summary>
+    /// Represents a trackable token used to associated log events with a particular client instance.
+    /// </summary>
+    public readonly struct LoggerToken
+    {
+        LoggerToken(Guid identifier)
+        {
+            this.Identifier = identifier;
+        }
+
+        /// <summary>
+        /// The unique identifier for this token.
+        /// </summary>
+        public Guid Identifier { get; }
+
+        /// <summary>
+        /// Creates a token with a new unique identifier.
+        /// </summary>
+        /// <returns>The new token.</returns>
+        public static LoggerToken Create() => new LoggerToken( Guid.NewGuid() );
+
+        /// <summary>
+        /// Determines whether this is the default token or not.
+        /// </summary>
+        public bool IsDefault => Identifier == Guid.Empty;
+
+        /// <summary>
+        /// Returns a default token with no unique identifier.
+        /// </summary>
+        public static LoggerToken Default { get; } = default( LoggerToken );
     }
 
     /// <summary>
@@ -87,7 +121,7 @@ namespace SteamKit2
         /// Adds an action listener.
         /// </summary>
         /// <param name="listenerAction">The listener action.</param>
-        public static void AddListener( Action<string, string> listenerAction )
+        public static void AddListener( Action<LoggerToken, string, string> listenerAction )
         {
             if ( listenerAction == null )
             {
@@ -108,7 +142,7 @@ namespace SteamKit2
         /// Removes a listener.
         /// </summary>
         /// <param name="listenerAction">The previously registered listener action.</param>
-        public static void RemoveListener( Action<string, string> listenerAction )
+        public static void RemoveListener( Action<LoggerToken, string, string> listenerAction )
         {
             // probably don't need this function at all, since actions are designed to be anonymous methods
             // Just In Case
@@ -145,6 +179,16 @@ namespace SteamKit2
         /// <param name="msg">A composite format string.</param>
         /// <param name="args">An System.Object array containing zero or more objects to format.</param>
         public static void WriteLine( string category, string msg, params object?[]? args )
+            => WriteLine( LoggerToken.Default, category, msg, args );
+
+        /// <summary>
+        /// Writes a line to the debug log, informing all listeners.
+        /// </summary>
+        /// <param name="token">A token used to identify the source of the log event.</param>
+        /// <param name="category">The category of the message.</param>
+        /// <param name="msg">A composite format string.</param>
+        /// <param name="args">An System.Object array containing zero or more objects to format.</param>
+        public static void WriteLine( LoggerToken token, string category, string msg, params object?[]? args )
         {
             if ( !DebugLog.Enabled )
             {
@@ -164,7 +208,7 @@ namespace SteamKit2
 
             foreach ( IDebugListener debugListener in listeners )
             {
-                debugListener.WriteLine( category, strMsg );
+                debugListener.WriteLine( token, category, strMsg );
             }
         }
 
@@ -176,14 +220,26 @@ namespace SteamKit2
         /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, the specified message is not sent and the message box is not displayed.</param>
         /// <param name="category">The category of the message.</param>
         /// <param name="message">The message to display if the assertion fails.</param>
-        public static void Assert( [DoesNotReturnIf(false)] bool condition, string category, string message )
+        public static void Assert( [DoesNotReturnIf( false )] bool condition, string category, string message )
+            => DebugLog.Assert( condition, LoggerToken.Default, category, message );
+
+
+        /// <summary>
+        /// Checks for a condition; if the condition is <c>false</c>, outputs a specified message and displays a message box that shows the call stack.
+        /// This method is equivalent to System.Diagnostics.Debug.Assert, however, it is tailored to spew failed assertions into the SteamKit debug log.
+        /// </summary>
+        /// <param name="condition">The conditional expression to evaluate. If the condition is <c>true</c>, the specified message is not sent and the message box is not displayed.</param>
+        /// <param name="token">A token used to identify the source of the log event.</param>
+        /// <param name="category">The category of the message.</param>
+        /// <param name="message">The message to display if the assertion fails.</param>
+        public static void Assert( [DoesNotReturnIf( false )] bool condition, LoggerToken token, string category, string message )
         {
             // make use of .NET's assert facility first
             Debug.Assert( condition, string.Format( "{0}: {1}", category, message ) );
 
             // then spew to our debuglog, so we can get info in release builds
             if ( !condition )
-                WriteLine( category, "Assertion Failed! " + message );
+                WriteLine( token, category, "Assertion Failed! " + message );
         }
     }
 }

--- a/SteamKit2/SteamKit2/Util/SimpleConsoleDebugListener.cs
+++ b/SteamKit2/SteamKit2/Util/SimpleConsoleDebugListener.cs
@@ -10,11 +10,19 @@ namespace SteamKit2
         /// <summary>
         /// Called when the DebugLog wishes to inform listeners of debug spew.
         /// </summary>
+        /// <param name="token">A token to uniquely identify the source of the message.</param>
         /// <param name="category">The category of the message.</param>
         /// <param name="msg">The message to log.</param>
-        public void WriteLine(string category, string msg)
+        public void WriteLine(LoggerToken token, string category, string msg)
         {
-            Console.WriteLine("[{0}]: {1}", category, msg);
+            if ( token.IsDefault )
+            {
+                Console.WriteLine( "[{0}]: {1}", category, msg );
+            }
+            else
+            {
+                Console.WriteLine( "[{0}/{1}]: {2}", token.Identifier, category, msg );
+            }
         }
     }
 }


### PR DESCRIPTION
One approach to solving https://github.com/SteamRE/SteamKit/issues/503.

Thoughts?

Personally I don't like having to pass it everywhere - though I think that I would rather pass just a unique ID around than a whole `ILogger` object or similar.

I have considered storing it in an `AsyncLocal<T>` but that could get messy quite quickly.

(cc @JustArchi)