### PR TITLE
Fix CA2101: Specify marshaling for P/Invoke string arguments

### DIFF
--- a/SteamKit2/SteamKit2/Util/MacHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/MacHelpers.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace SteamKit2.Util.MacHelpers
 {
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments. All the APIs in this file deal with regular UTF-8 strings (char *). With CharSet.Unicode, SK2 just crashes.
     class CFTypeRef : SafeHandle
     {
         CFTypeRef()
@@ -71,7 +72,7 @@ namespace SteamKit2.Util.MacHelpers
     {
         const string LibraryName = "libc";
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int statfs64(string path, ref statfs buf);
     }
 
@@ -91,10 +92,10 @@ namespace SteamKit2.Util.MacHelpers
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool CFDictionaryGetValueIfPresent(CFTypeRef theDict, CFTypeRef key, out IntPtr value);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern CFTypeRef CFStringCreateWithCString(CFTypeRef allocator, string cStr, CFStringEncoding encoding);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         [return:MarshalAs(UnmanagedType.U1)]
         public static extern bool CFStringGetCString(CFTypeRef theString, StringBuilder buffer, long bufferSize, CFStringEncoding encoding);
 
@@ -110,7 +111,7 @@ namespace SteamKit2.Util.MacHelpers
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern CFTypeRef DASessionCreate(CFTypeRef allocator);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern CFTypeRef DADiskCreateFromBSDName(CFTypeRef allocator, CFTypeRef session, string name);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -130,11 +131,12 @@ namespace SteamKit2.Util.MacHelpers
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr IOServiceMatching(string name);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int IOObjectRelease(uint @object);
     }
+#pragma warning restore CA2101 // Specify marshaling for P/Invoke string arguments
 }
 

--- a/SteamKit2/SteamKit2/Util/MacHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/MacHelpers.cs
@@ -71,7 +71,7 @@ namespace SteamKit2.Util.MacHelpers
     {
         const string LibraryName = "libc";
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern int statfs64(string path, ref statfs buf);
     }
 
@@ -91,10 +91,10 @@ namespace SteamKit2.Util.MacHelpers
         [return: MarshalAs(UnmanagedType.I1)]
         public static extern bool CFDictionaryGetValueIfPresent(CFTypeRef theDict, CFTypeRef key, out IntPtr value);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern CFTypeRef CFStringCreateWithCString(CFTypeRef allocator, string cStr, CFStringEncoding encoding);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         [return:MarshalAs(UnmanagedType.U1)]
         public static extern bool CFStringGetCString(CFTypeRef theString, StringBuilder buffer, long bufferSize, CFStringEncoding encoding);
 
@@ -110,7 +110,7 @@ namespace SteamKit2.Util.MacHelpers
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern CFTypeRef DASessionCreate(CFTypeRef allocator);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern CFTypeRef DADiskCreateFromBSDName(CFTypeRef allocator, CFTypeRef session, string name);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
@@ -130,7 +130,7 @@ namespace SteamKit2.Util.MacHelpers
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
 
-        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern IntPtr IOServiceMatching(string name);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]

--- a/SteamKit2/SteamKit2/Util/Win32Helpers.cs
+++ b/SteamKit2/SteamKit2/Util/Win32Helpers.cs
@@ -168,7 +168,7 @@ namespace SteamKit2.Util
 			public static uint FILE_SHARE_WRITE = 2;
 			public static uint OPEN_EXISTING = 3;
 
-			[DllImport( "kernel32.dll", SetLastError = true )]
+			[DllImport( "kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode )]
 			public static extern FileSafeHandle CreateFile( string lpFileName, uint dwDesiredAccess, uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, IntPtr hTemplateFile );
 
 			#endregion


### PR DESCRIPTION
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2101-specify-marshaling-for-p-invoke-string-arguments?view=vs-2019