### PR TITLE
Comply with CA1715

### DIFF
--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -143,14 +143,14 @@ namespace SteamKit2
     /// <summary>
     /// Represents a protobuf backed client message.
     /// </summary>
-    /// <typeparam name="BodyType">The body type of this message.</typeparam>
-    public sealed class ClientMsgProtobuf<BodyType> : ClientMsgProtobuf
-        where BodyType : IExtensible, new()
+    /// <typeparam name="TBody">The body type of this message.</typeparam>
+    public sealed class ClientMsgProtobuf<TBody> : ClientMsgProtobuf
+        where TBody : IExtensible, new()
     {
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; private set; }
+        public TBody Body { get; private set; }
 
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace SteamKit2
         public ClientMsgProtobuf( EMsg eMsg, int payloadReserve = 64 )
             : base( payloadReserve )
         {
-            Body = new BodyType();
+            Body = new TBody();
 
             // set our emsg
             Header.Msg = eMsg;
@@ -190,7 +190,7 @@ namespace SteamKit2
         public ClientMsgProtobuf( IPacketMsg msg )
             : this( msg.GetMsgTypeWithNullCheck( nameof(msg) ) )
         {
-            DebugLog.Assert( msg.IsProto, "ClientMsgProtobuf<>", $"ClientMsgProtobuf<{typeof(BodyType).FullName}> used for non-proto message!" );
+            DebugLog.Assert( msg.IsProto, "ClientMsgProtobuf<>", $"ClientMsgProtobuf<{typeof(TBody).FullName}> used for non-proto message!" );
 
             Deserialize( msg.GetData() );
         }
@@ -226,7 +226,7 @@ namespace SteamKit2
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
-                Body = Serializer.Deserialize<BodyType>( ms );
+                Body = Serializer.Deserialize<TBody>( ms );
 
                 // the rest of the data is the payload
                 int payloadOffset = ( int )ms.Position;
@@ -241,9 +241,9 @@ namespace SteamKit2
     /// <summary>
     /// Represents a struct backed client message.
     /// </summary>
-    /// <typeparam name="BodyType">The body type of this message.</typeparam>
-    public sealed class ClientMsg<BodyType> : MsgBase<ExtendedClientMsgHdr>
-        where BodyType : ISteamSerializableMessage, new()
+    /// <typeparam name="TBody">The body type of this message.</typeparam>
+    public sealed class ClientMsg<TBody> : MsgBase<ExtendedClientMsgHdr>
+        where TBody : ISteamSerializableMessage, new()
     {
         /// <summary>
         /// Gets a value indicating whether this client message is protobuf backed.
@@ -311,7 +311,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; }
+        public TBody Body { get; }
 
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace SteamKit2
         public ClientMsg( int payloadReserve = 64 )
             : base( payloadReserve )
         {
-            Body = new BodyType();
+            Body = new TBody();
 
             // assign our emsg
             Header.SetEMsg( Body.GetEMsg() );
@@ -359,7 +359,7 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(msg) );
             }
 
-            DebugLog.Assert( !msg.IsProto, "ClientMsg", $"ClientMsg<{typeof(BodyType).FullName}> used for proto message!" );
+            DebugLog.Assert( !msg.IsProto, "ClientMsg", $"ClientMsg<{typeof(TBody).FullName}> used for proto message!" );
 
             Deserialize( msg.GetData() );
         }
@@ -410,9 +410,9 @@ namespace SteamKit2
     /// <summary>
     /// Represents a struct backed message without session or client info.
     /// </summary>
-    /// <typeparam name="BodyType">The body type of this message.</typeparam>
-    public sealed class Msg<BodyType> : MsgBase<MsgHdr>
-        where BodyType : ISteamSerializableMessage, new()
+    /// <typeparam name="TBody">The body type of this message.</typeparam>
+    public sealed class Msg<TBody> : MsgBase<MsgHdr>
+        where TBody : ISteamSerializableMessage, new()
     {
         /// <summary>
         /// Gets a value indicating whether this client message is protobuf backed.
@@ -473,7 +473,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the structure body of the message.
         /// </summary>
-        public BodyType Body { get; }
+        public TBody Body { get; }
 
 
         /// <summary>
@@ -484,7 +484,7 @@ namespace SteamKit2
         public Msg( int payloadReserve = 0 )
             : base( payloadReserve )
         {
-            Body = new BodyType();
+            Body = new TBody();
 
             // assign our emsg
             Header.SetEMsg( Body.GetEMsg() );

--- a/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/ClientMsgGC.cs
@@ -17,9 +17,9 @@ namespace SteamKit2.GC
     /// <summary>
     /// Represents a protobuf backed game coordinator message.
     /// </summary>
-    /// <typeparam name="BodyType">The body type of this message.</typeparam>
-    public sealed class ClientGCMsgProtobuf<BodyType> : GCMsgBase<MsgGCHdrProtoBuf>
-        where BodyType : IExtensible, new()
+    /// <typeparam name="TBody">The body type of this message.</typeparam>
+    public sealed class ClientGCMsgProtobuf<TBody> : GCMsgBase<MsgGCHdrProtoBuf>
+        where TBody : IExtensible, new()
     {
         /// <summary>
         /// Gets a value indicating whether this gc message is protobuf backed.
@@ -69,7 +69,7 @@ namespace SteamKit2.GC
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; private set; }
+        public TBody Body { get; private set; }
 
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace SteamKit2.GC
         public ClientGCMsgProtobuf( uint eMsg, int payloadReserve = 64 )
             : base( payloadReserve )
         {
-            Body = new BodyType();
+            Body = new TBody();
 
             // set our emsg
             Header.Msg = eMsg;
@@ -150,7 +150,7 @@ namespace SteamKit2.GC
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
                 Header.Deserialize( ms );
-                Body = Serializer.Deserialize<BodyType>( ms );
+                Body = Serializer.Deserialize<TBody>( ms );
 
                 // the rest of the data is the payload
                 int payloadOffset = ( int )ms.Position;
@@ -164,9 +164,9 @@ namespace SteamKit2.GC
     /// <summary>
     /// Represents a struct backed game coordinator message.
     /// </summary>
-    /// <typeparam name="BodyType">The body type of this message.</typeparam>
-    public sealed class ClientGCMsg<BodyType> : GCMsgBase<MsgGCHdr>
-        where BodyType : IGCSerializableMessage, new()
+    /// <typeparam name="TBody">The body type of this message.</typeparam>
+    public sealed class ClientGCMsg<TBody> : GCMsgBase<MsgGCHdr>
+        where TBody : IGCSerializableMessage, new()
     {
         /// <summary>
         /// Gets a value indicating whether this gc message is protobuf backed.
@@ -212,7 +212,7 @@ namespace SteamKit2.GC
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public BodyType Body { get; }
+        public TBody Body { get; }
 
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace SteamKit2.GC
         public ClientGCMsg( int payloadReserve = 64 )
             : base( payloadReserve )
         {
-            Body = new BodyType();
+            Body = new TBody();
 
             // assign our emsg
             msgType = Body.GetEMsg();

--- a/SteamKit2/SteamKit2/Base/GC/MsgBaseGC.cs
+++ b/SteamKit2/SteamKit2/Base/GC/MsgBaseGC.cs
@@ -58,9 +58,9 @@ namespace SteamKit2.GC
     /// This is the abstract base class for all available game coordinator messages.
     /// It's used to maintain packet payloads and provide a header for all gc messages.
     /// </summary>
-    /// <typeparam name="HdrType">The header type for this gc message.</typeparam>
-    public abstract class GCMsgBase<HdrType> : MsgBase, IClientGCMsg
-        where HdrType : IGCSerializableHeader, new()
+    /// <typeparam name="THeader">The header type for this gc message.</typeparam>
+    public abstract class GCMsgBase<THeader> : MsgBase, IClientGCMsg
+        where THeader : IGCSerializableHeader, new()
     {
         /// <summary>
         /// Gets a value indicating whether this gc message is protobuf backed.
@@ -96,7 +96,7 @@ namespace SteamKit2.GC
         /// <summary>
         /// Gets the header for this message type. 
         /// </summary>
-        public HdrType Header { get; }
+        public THeader Header { get; }
 
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace SteamKit2.GC
         public GCMsgBase( int payloadReserve = 0 )
             : base( payloadReserve )
         {
-            Header = new HdrType();
+            Header = new THeader();
         }
 
 

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -439,9 +439,9 @@ namespace SteamKit2
     /// This is the abstract base class for all available client messages.
     /// It's used to maintain packet payloads and provide a header for all client messages.
     /// </summary>
-    /// <typeparam name="HdrType">The header type for this client message.</typeparam>
-    public abstract class MsgBase<HdrType> : MsgBase, IClientMsg
-        where HdrType : ISteamSerializableHeader, new()
+    /// <typeparam name="THeader">The header type for this client message.</typeparam>
+    public abstract class MsgBase<THeader> : MsgBase, IClientMsg
+        where THeader : ISteamSerializableHeader, new()
     {
         /// <summary>
         /// Gets a value indicating whether this client message is protobuf backed.
@@ -492,7 +492,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the header for this message type. 
         /// </summary>
-        public HdrType Header { get; }
+        public THeader Header { get; }
 
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace SteamKit2
         public MsgBase( int payloadReserve = 0 )
             : base( payloadReserve )
         {
-            Header = new HdrType();
+            Header = new THeader();
         }
 
 


### PR DESCRIPTION
The name of a generic type parameter on a type or method should start with an uppercase 'T'.

https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1715-identifiers-should-have-correct-prefix?view=vs-2019