### PR TITLE
NetHookAnalyzer2 fixes

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/App.config
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NetHookAnalyzer2</RootNamespace>
     <AssemblyName>NetHookAnalyzer2</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItem.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItem.cs
@@ -125,13 +125,13 @@ namespace NetHookAnalyzer2
 					return hdr.Proto.target_job_name;
 				}
 
-				case SteamKit2.EMsg.ClientServiceMethod:
+				case SteamKit2.EMsg.ClientServiceMethodLegacy:
 				{
 					var proto = ReadAsProtobufMsg<CMsgClientServiceMethod>();
 					return proto.Body.method_name;
 				}
 
-				case SteamKit2.EMsg.ClientServiceMethodResponse:
+				case SteamKit2.EMsg.ClientServiceMethodLegacyResponse:
 				{
 					var proto = ReadAsProtobufMsg<CMsgClientServiceMethodResponse>();
 					return proto.Body.method_name;

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Properties/Resources.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NetHookAnalyzer2.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Properties/Settings.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace NetHookAnalyzer2.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.0.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
- Fixes assembly binding conflict by updating to .NET Framework 4.7.2, the only Framework runtime will full support for .NET Standard 2.0
- Fixes warnings from obsolete EMsg values in SteamKit