### PR TITLE
Update SourceLink

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
     <PackageReference Include="protobuf-net" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes a crash when loading an older version of `libgit2` when the build environment is a Docker container without OpenSSL 1.0.0 libraries.