### PR TITLE
Add steamid symmetric render test for multiseat type

### DIFF
--- a/SteamKit2/Tests/SteamIDFacts.cs
+++ b/SteamKit2/Tests/SteamIDFacts.cs
@@ -143,6 +143,7 @@ namespace Tests
                 "[U:1:123:2]",
                 "[G:1:626]",
                 "[A:2:165:1234]",
+                "[M:2:165:1234]",
             };
 
             foreach ( var steamId in steamIds )


### PR DESCRIPTION
This hopefully removes partial coverage for `switch ( AccountType )`