### PR TITLE
Add GitHub Action - Mark Stale Issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. This issue will be closed in 5 days unless the stale label is removed or there are new comments.'
-        stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. This issue will be closed in 5 days unless the stale label is removed or there are new comments.'
+        stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. This pull request will be closed in 5 days unless the stale label is removed, or there are new commits or comments.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         days-before-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 19 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. This issue will be closed in 5 days unless the stale label is removed or there are new comments.'
+        stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. This issue will be closed in 5 days unless the stale label is removed or there are new comments.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 30
+        days-before-close: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. This issue will be closed in 5 days unless the stale label is removed or there are new comments.'
-        stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. This pull request will be closed in 5 days unless the stale label is removed, or there are new commits or comments.'
+        stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity. This issue will be closed in 7 days unless the stale label is removed or there are new comments.'
+        stale-pr-message: 'This pull request is stale because it has been open for 60 days with no activity. This pull request will be closed in 7 days unless the stale label is removed, or there are new commits or comments.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        days-before-stale: 30
-        days-before-close: 5
+        days-before-stale: 60
+        days-before-close: 7


### PR DESCRIPTION
Adds a GitHub Action to mark stale issues/PRs.

Time chosen is 7PM UTC, which is currently 6AM Sydney, 3PM US East and midday US West.