### PR TITLE
AppVeyor: Skip branches with an open PR

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ configuration:
   - Debug
   - Release
 
+skip_branch_with_pr: true
+
 init:
   - git config --global core.autocrlf true
 


### PR DESCRIPTION
This should build just the PR (merge commit) and not the branch itself, in the same manner as though the PR came from a forked repo.