### PR TITLE
Implement CMsgIPAddress

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -553,7 +553,7 @@ namespace SteamKit2.Internal
                 SteamID = logonResp.ProtoHeader.steamid;
 
                 CellID = logonResp.Body.cell_id;
-                PublicIP = NetHelpers.GetIPAddress( logonResp.Body.deprecated_public_ip );
+                PublicIP = NetHelpers.GetIPAddress( logonResp.Body.public_ip );
                 IPCountryCode = logonResp.Body.ip_country_code;
 
                 int hbDelay = logonResp.Body.out_of_game_heartbeat_seconds;

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -553,7 +553,7 @@ namespace SteamKit2.Internal
                 SteamID = logonResp.ProtoHeader.steamid;
 
                 CellID = logonResp.Body.cell_id;
-                PublicIP = NetHelpers.GetIPAddress( logonResp.Body.public_ip );
+                PublicIP = logonResp.Body.public_ip.GetIPAddress();
                 IPCountryCode = logonResp.Body.ip_country_code;
 
                 int hbDelay = logonResp.Body.out_of_game_heartbeat_seconds;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -119,8 +119,7 @@ namespace SteamKit2
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = gsId.ConvertToUInt64();
 
-            uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP! );
-            logon.Body.deprecated_obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+            logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
 
             logon.Body.protocol_version = MsgClientLogon.CurrentProtocol;
 
@@ -154,8 +153,7 @@ namespace SteamKit2
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = gsId.ConvertToUInt64();
 
-            uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP! );
-            logon.Body.deprecated_obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+            logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
 
             logon.Body.protocol_version = MsgClientLogon.CurrentProtocol;
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -119,7 +119,7 @@ namespace SteamKit2
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = gsId.ConvertToUInt64();
 
-            logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
+            logon.Body.obfuscated_private_ip = NetHelpers.GetMsgIPAddress( this.Client.LocalIP! ).ObfuscatePrivateIP();
 
             logon.Body.protocol_version = MsgClientLogon.CurrentProtocol;
 
@@ -153,7 +153,7 @@ namespace SteamKit2
             logon.ProtoHeader.client_sessionid = 0;
             logon.ProtoHeader.steamid = gsId.ConvertToUInt64();
 
-            logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
+            logon.Body.obfuscated_private_ip = NetHelpers.GetMsgIPAddress( this.Client.LocalIP! ).ObfuscatePrivateIP();
 
             logon.Body.protocol_version = MsgClientLogon.CurrentProtocol;
 
@@ -203,7 +203,7 @@ namespace SteamKit2
 
             if (details.Address != null)
             {
-                status.Body.deprecated_game_ip_address = NetHelpers.GetIPAddress( details.Address );
+                status.Body.deprecated_game_ip_address = NetHelpers.GetIPAddressAsUInt( details.Address );
             }
 
             this.Client.Send( status );

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/Callbacks.cs
@@ -36,7 +36,7 @@ namespace SteamKit2
                 internal Server( CMsgGMSClientServerQueryResponse.Server server )
                 {
                     EndPoint = new IPEndPoint(
-                        NetHelpers.GetIPAddress( server.server_ip ),
+                        server.server_ip.GetIPAddress(),
                         ( int )server.server_port );
 
                     AuthedPlayers = server.auth_players;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/Callbacks.cs
@@ -36,7 +36,7 @@ namespace SteamKit2
                 internal Server( CMsgGMSClientServerQueryResponse.Server server )
                 {
                     EndPoint = new IPEndPoint(
-                        NetHelpers.GetIPAddress( server.deprecated_server_ip ),
+                        NetHelpers.GetIPAddress( server.server_ip ),
                         ( int )server.server_port );
 
                     AuthedPlayers = server.auth_players;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMasterServer/SteamMasterServer.cs
@@ -80,7 +80,7 @@ namespace SteamKit2
 
             if ( details.GeoLocatedIP != null )
             {
-                query.Body.geo_location_ip = NetHelpers.GetIPAddress( details.GeoLocatedIP );
+                query.Body.geo_location_ip = NetHelpers.GetIPAddressAsUInt( details.GeoLocatedIP );
             }
 
             query.Body.filter_text = details.Filter;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamMatchmaking/SteamMatchmaking.cs
@@ -63,7 +63,7 @@ namespace SteamKit2
                     lobby_flags = lobbyFlags,
                     metadata = Lobby.EncodeMetadata( metadata ),
                     cell_id = Client.CellID.Value,
-                    deprecated_public_ip = NetHelpers.GetIPAddress( Client.PublicIP! ),
+                    public_ip = NetHelpers.GetMsgIPAddress( Client.PublicIP! ),
                     persona_name_owner = personaName
                 },
                 SourceJobID = Client.GetNextJobID()
@@ -187,7 +187,7 @@ namespace SteamKit2
                 {
                     app_id = appId,
                     cell_id = Client.CellID.Value,
-                    deprecated_public_ip = NetHelpers.GetIPAddress( Client.PublicIP! ),
+                    public_ip = NetHelpers.GetMsgIPAddress( Client.PublicIP! ),
                     num_lobbies_requested = maxLobbies
                 },
                 SourceJobID = Client.GetNextJobID()

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -127,7 +127,7 @@ namespace SteamKit2
                 this.OutOfGameSecsPerHeartbeat = resp.out_of_game_heartbeat_seconds;
                 this.InGameSecsPerHeartbeat = resp.in_game_heartbeat_seconds;
 
-                this.PublicIP = NetHelpers.GetIPAddress( resp.public_ip );
+                this.PublicIP = resp.public_ip.GetIPAddress();
 
                 this.ServerTime = DateUtils.DateTimeFromUnixTime( resp.rtime32_server_time );
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -127,7 +127,7 @@ namespace SteamKit2
                 this.OutOfGameSecsPerHeartbeat = resp.out_of_game_heartbeat_seconds;
                 this.InGameSecsPerHeartbeat = resp.in_game_heartbeat_seconds;
 
-                this.PublicIP = resp.public_ip.GetIPAddress();
+                this.PublicIP = resp.public_ip?.GetIPAddress();
 
                 this.ServerTime = DateUtils.DateTimeFromUnixTime( resp.rtime32_server_time );
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -127,7 +127,7 @@ namespace SteamKit2
                 this.OutOfGameSecsPerHeartbeat = resp.out_of_game_heartbeat_seconds;
                 this.InGameSecsPerHeartbeat = resp.in_game_heartbeat_seconds;
 
-                this.PublicIP = NetHelpers.GetIPAddress( resp.deprecated_public_ip );
+                this.PublicIP = NetHelpers.GetIPAddress( resp.public_ip );
 
                 this.ServerTime = DateUtils.DateTimeFromUnixTime( resp.rtime32_server_time );
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -320,7 +320,7 @@ namespace SteamKit2
             }
             else
             {
-                logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
+                logon.Body.obfuscated_private_ip = NetHelpers.GetMsgIPAddress( this.Client.LocalIP! ).ObfuscatePrivateIP();
             }
 
             // Legacy field, Steam client still sets it

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -316,12 +316,17 @@ namespace SteamKit2
 
             if ( details.LoginID.HasValue )
             {
-                logon.Body.deprecated_obfustucated_private_ip = details.LoginID.Value;
+                logon.Body.obfuscated_private_ip.v4 = details.LoginID.Value;
             }
             else
             {
-                uint localIp = NetHelpers.GetIPAddress( this.Client.LocalIP! );
-                logon.Body.deprecated_obfustucated_private_ip = localIp ^ MsgClientLogon.ObfuscationMask;
+                logon.Body.obfuscated_private_ip = NetHelpers.ObfuscatePrivateIP( this.Client.LocalIP! );
+            }
+
+            // Legacy field, Steam client still sets it
+            if ( logon.Body.obfuscated_private_ip.ShouldSerializev4() )
+            {
+                logon.Body.deprecated_obfustucated_private_ip = logon.Body.obfuscated_private_ip.v4;
             }
 
             logon.ProtoHeader.client_sessionid = 0;

--- a/SteamKit2/SteamKit2/Util/Utils.cs
+++ b/SteamKit2/SteamKit2/Util/Utils.cs
@@ -402,8 +402,26 @@ namespace SteamKit2
 
             if ( ipAddr.AddressFamily == AddressFamily.InterNetworkV6 )
             {
-                // TODO: Implement ipv6 obfuscation, it uses MsgClientLogon.ObfuscationMask too
-                // See ObfuscatePrivateIP in steamclient
+                // TODO: See ObfuscatePrivateIP in steamclient, unsure if applied correctly
+                localIp.v6[ 0 ] ^= 0xBA;
+                localIp.v6[ 1 ] ^= 0xAD;
+                localIp.v6[ 2 ] ^= 0xF0;
+                localIp.v6[ 3 ] ^= 0x0D;
+
+                localIp.v6[ 4 ] ^= 0xBA;
+                localIp.v6[ 5 ] ^= 0xAD;
+                localIp.v6[ 6 ] ^= 0xF0;
+                localIp.v6[ 7 ] ^= 0x0D;
+
+                localIp.v6[ 8 ] ^= 0xBA;
+                localIp.v6[ 9 ] ^= 0xAD;
+                localIp.v6[ 10 ] ^= 0xF0;
+                localIp.v6[ 11 ] ^= 0x0D;
+
+                localIp.v6[ 12 ] ^= 0xBA;
+                localIp.v6[ 13 ] ^= 0xAD;
+                localIp.v6[ 14 ] ^= 0xF0;
+                localIp.v6[ 15 ] ^= 0x0D;
             }
             else
             {

--- a/SteamKit2/SteamKit2/Util/Utils.cs
+++ b/SteamKit2/SteamKit2/Util/Utils.cs
@@ -357,7 +357,7 @@ namespace SteamKit2
             return new IPAddress( addrBytes );
         }
 
-        public static uint GetIPAddress( IPAddress ipAddr )
+        public static uint GetIPAddressAsUInt( IPAddress ipAddr )
         {
             byte[] addrBytes = ipAddr.GetAddressBytes();
             Array.Reverse( addrBytes );
@@ -365,7 +365,7 @@ namespace SteamKit2
             return BitConverter.ToUInt32( addrBytes, 0 );
         }
 
-        public static IPAddress GetIPAddress( CMsgIPAddress ipAddr )
+        public static IPAddress GetIPAddress( this CMsgIPAddress ipAddr )
         {
             if ( ipAddr.ShouldSerializev6() )
             {
@@ -396,32 +396,31 @@ namespace SteamKit2
             return msgIpAddress;
         }
 
-        public static CMsgIPAddress ObfuscatePrivateIP( IPAddress ipAddr )
+        public static CMsgIPAddress ObfuscatePrivateIP( this CMsgIPAddress msgIpAddress )
         {
-            var localIp = GetMsgIPAddress( ipAddr );
+            var localIp = msgIpAddress;
 
-            if ( ipAddr.AddressFamily == AddressFamily.InterNetworkV6 )
+            if ( localIp.ShouldSerializev6() )
             {
-                // TODO: See ObfuscatePrivateIP in steamclient, unsure if applied correctly
-                localIp.v6[ 0 ] ^= 0xBA;
-                localIp.v6[ 1 ] ^= 0xAD;
-                localIp.v6[ 2 ] ^= 0xF0;
-                localIp.v6[ 3 ] ^= 0x0D;
+                localIp.v6[ 0 ] ^= 0x0D;
+                localIp.v6[ 1 ] ^= 0xF0;
+                localIp.v6[ 2 ] ^= 0xAD;
+                localIp.v6[ 3 ] ^= 0xBA;
 
-                localIp.v6[ 4 ] ^= 0xBA;
-                localIp.v6[ 5 ] ^= 0xAD;
-                localIp.v6[ 6 ] ^= 0xF0;
-                localIp.v6[ 7 ] ^= 0x0D;
+                localIp.v6[ 4 ] ^= 0x0D;
+                localIp.v6[ 5 ] ^= 0xF0;
+                localIp.v6[ 6 ] ^= 0xAD;
+                localIp.v6[ 7 ] ^= 0xBA;
 
-                localIp.v6[ 8 ] ^= 0xBA;
-                localIp.v6[ 9 ] ^= 0xAD;
-                localIp.v6[ 10 ] ^= 0xF0;
-                localIp.v6[ 11 ] ^= 0x0D;
+                localIp.v6[ 8 ] ^= 0x0D;
+                localIp.v6[ 9 ] ^= 0xF0;
+                localIp.v6[ 10 ] ^= 0xAD;
+                localIp.v6[ 11 ] ^= 0xBA;
 
-                localIp.v6[ 12 ] ^= 0xBA;
-                localIp.v6[ 13 ] ^= 0xAD;
-                localIp.v6[ 14 ] ^= 0xF0;
-                localIp.v6[ 15 ] ^= 0x0D;
+                localIp.v6[ 12 ] ^= 0x0D;
+                localIp.v6[ 13 ] ^= 0xF0;
+                localIp.v6[ 14 ] ^= 0xAD;
+                localIp.v6[ 15 ] ^= 0xBA;
             }
             else
             {

--- a/SteamKit2/SteamKit2/Util/Utils.cs
+++ b/SteamKit2/SteamKit2/Util/Utils.cs
@@ -13,6 +13,7 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using SteamKit2.Internal;
 
 namespace SteamKit2
 {
@@ -355,6 +356,7 @@ namespace SteamKit2
 
             return new IPAddress( addrBytes );
         }
+
         public static uint GetIPAddress( IPAddress ipAddr )
         {
             byte[] addrBytes = ipAddr.GetAddressBytes();
@@ -363,42 +365,77 @@ namespace SteamKit2
             return BitConverter.ToUInt32( addrBytes, 0 );
         }
 
-
-        public static uint EndianSwap( uint input )
+        public static IPAddress GetIPAddress( CMsgIPAddress ipAddr )
         {
-            return ( uint )IPAddress.NetworkToHostOrder( ( int )input );
-        }
-        public static ulong EndianSwap( ulong input )
-        {
-            return ( ulong )IPAddress.NetworkToHostOrder( ( long )input );
-        }
-        public static ushort EndianSwap( ushort input )
-        {
-            return ( ushort )IPAddress.NetworkToHostOrder( ( short )input );
+            if ( ipAddr.ShouldSerializev6() )
+            {
+                return new IPAddress( ipAddr.v6 );
+            }
+            else
+            {
+                return GetIPAddress( ipAddr.v4 );
+            }
         }
 
-        public static bool TryParseIPEndPoint(string stringValue, [NotNullWhen(true)] out IPEndPoint? endPoint)
+        public static CMsgIPAddress GetMsgIPAddress( IPAddress ipAddr )
         {
-            var endpointParts = stringValue.Split(':');
-            if (endpointParts.Length != 2)
+            var msgIpAddress = new CMsgIPAddress();
+            byte[] addrBytes = ipAddr.GetAddressBytes();
+
+            if ( ipAddr.AddressFamily == AddressFamily.InterNetworkV6 )
+            {
+                msgIpAddress.v6 = addrBytes;
+            }
+            else
+            {
+                Array.Reverse( addrBytes );
+
+                msgIpAddress.v4 = BitConverter.ToUInt32( addrBytes, 0 );
+            }
+
+            return msgIpAddress;
+        }
+
+        public static CMsgIPAddress ObfuscatePrivateIP( IPAddress ipAddr )
+        {
+            var localIp = GetMsgIPAddress( ipAddr );
+
+            if ( ipAddr.AddressFamily == AddressFamily.InterNetworkV6 )
+            {
+                // TODO: Implement ipv6 obfuscation, it uses MsgClientLogon.ObfuscationMask too
+                // See ObfuscatePrivateIP in steamclient
+            }
+            else
+            {
+                localIp.v4 ^= MsgClientLogon.ObfuscationMask;
+            }
+
+            return localIp;
+        }
+
+        public static bool TryParseIPEndPoint( string stringValue, [NotNullWhen( true )] out IPEndPoint? endPoint )
+        {
+            var colonPosition = stringValue.LastIndexOf( ':' );
+
+            if ( colonPosition == -1 )
             {
                 endPoint = null;
                 return false;
             }
 
-            if (!IPAddress.TryParse(endpointParts[0], out var address))
+            if ( !IPAddress.TryParse( stringValue.Substring( 0, colonPosition ), out var address ) )
             {
                 endPoint = null;
                 return false;
             }
 
-            if (!ushort.TryParse(endpointParts[1], out var port))
+            if ( !ushort.TryParse( stringValue.Substring( colonPosition + 1 ), out var port ) )
             {
                 endPoint = null;
                 return false;
             }
 
-            endPoint = new IPEndPoint(address, port);
+            endPoint = new IPEndPoint( address, port );
             return true;
         }
     }

--- a/SteamKit2/Tests/NetHelpersFacts.cs
+++ b/SteamKit2/Tests/NetHelpersFacts.cs
@@ -22,21 +22,21 @@ namespace Tests
         [Fact]
         public void GetIPAddressFromMsg()
         {
-            Assert.Equal( IPAddress.Loopback, NetHelpers.GetIPAddress( NetHelpers.GetMsgIPAddress( IPAddress.Loopback ) ) );
-            Assert.Equal( IPAddress.IPv6Loopback, NetHelpers.GetIPAddress( NetHelpers.GetMsgIPAddress( IPAddress.IPv6Loopback ) ) );
+            Assert.Equal( IPAddress.Loopback, NetHelpers.GetMsgIPAddress( IPAddress.Loopback ).GetIPAddress() );
+            Assert.Equal( IPAddress.IPv6Loopback, NetHelpers.GetMsgIPAddress( IPAddress.IPv6Loopback ).GetIPAddress() );
         }
 
         [Fact]
         public void GetIPAddress()
         {
             Assert.Equal( IPAddress.Loopback, NetHelpers.GetIPAddress( 2130706433 ) );
-            Assert.Equal( 2130706433u, NetHelpers.GetIPAddress( IPAddress.Loopback ) );
+            Assert.Equal( 2130706433u, NetHelpers.GetIPAddressAsUInt( IPAddress.Loopback ) );
         }
 
         [Fact]
         public void ObfuscatePrivateIP()
         {
-            Assert.Equal( 3316510732u, NetHelpers.ObfuscatePrivateIP( IPAddress.Loopback ).v4 );
+            Assert.Equal( 3316510732u, NetHelpers.GetMsgIPAddress( IPAddress.Loopback ).ObfuscatePrivateIP().v4 );
         }
 
         [Fact]

--- a/SteamKit2/Tests/NetHelpersFacts.cs
+++ b/SteamKit2/Tests/NetHelpersFacts.cs
@@ -37,6 +37,12 @@ namespace Tests
         public void ObfuscatePrivateIP()
         {
             Assert.Equal( 3316510732u, NetHelpers.GetMsgIPAddress( IPAddress.Loopback ).ObfuscatePrivateIP().v4 );
+            Assert.Equal( new byte[] {
+                0x0D, 0xF0, 0xAD, 0xBA,
+                0x0D, 0xF0, 0xAD, 0xBA,
+                0x0D, 0xF0, 0xAD, 0xBA,
+                0x0D, 0xF0, 0xAD, 1 ^ 0xBA
+            }, NetHelpers.GetMsgIPAddress( IPAddress.IPv6Loopback ).ObfuscatePrivateIP().v6 );
         }
 
         [Fact]

--- a/SteamKit2/Tests/NetHelpersFacts.cs
+++ b/SteamKit2/Tests/NetHelpersFacts.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Net;
+using SteamKit2;
+using Xunit;
+
+namespace Tests
+{
+    public class NetHelpersFacts
+    {
+        [Fact]
+        public void GetMsgIPAddress()
+        {
+            Assert.Equal( 2130706433u, NetHelpers.GetMsgIPAddress( IPAddress.Loopback ).v4 );
+            Assert.Equal( new byte[] {
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 1
+            }, NetHelpers.GetMsgIPAddress( IPAddress.IPv6Loopback ).v6 );
+        }
+
+        [Fact]
+        public void GetIPAddressFromMsg()
+        {
+            Assert.Equal( IPAddress.Loopback, NetHelpers.GetIPAddress( NetHelpers.GetMsgIPAddress( IPAddress.Loopback ) ) );
+            Assert.Equal( IPAddress.IPv6Loopback, NetHelpers.GetIPAddress( NetHelpers.GetMsgIPAddress( IPAddress.IPv6Loopback ) ) );
+        }
+
+        [Fact]
+        public void GetIPAddress()
+        {
+            Assert.Equal( IPAddress.Loopback, NetHelpers.GetIPAddress( 2130706433 ) );
+            Assert.Equal( 2130706433u, NetHelpers.GetIPAddress( IPAddress.Loopback ) );
+        }
+
+        [Fact]
+        public void ObfuscatePrivateIP()
+        {
+            Assert.Equal( 3316510732u, NetHelpers.ObfuscatePrivateIP( IPAddress.Loopback ).v4 );
+        }
+
+        [Fact]
+        public void TryParseIPEndPoint()
+        {
+            Assert.True( NetHelpers.TryParseIPEndPoint( "127.0.0.1:1337", out var parsedIp ) );
+            Assert.Equal( new IPEndPoint( IPAddress.Loopback, 1337 ), parsedIp );
+
+            Assert.True( NetHelpers.TryParseIPEndPoint( "[::1]:1337", out var parsedIpv6 ) );
+            Assert.Equal( new IPEndPoint( IPAddress.IPv6Loopback, 1337 ), parsedIpv6 );
+        }
+    }
+}

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <ProjectGuid>{5BF6D076-399B-41CA-BAE7-37CE1C40CA67}</ProjectGuid>
   </PropertyGroup>
 


### PR DESCRIPTION
- [x] Obfuscation for ipv6 is implemented
- [x] `NetHelpers.TryParseIPEndPoint` doesn't support IPv6 bracket notation
- [ ] `LoginID` in logon just sets v4 - i don't think this a big of an issue
- [ ] `CMsgGSServerType` has `deprecated_game_ip_address`, but there are no other fields for IP

I can't test any of this because there's no way of getting ipv6 cm servers anywhere yet.