### PR TITLE
Remove sent/recv debug messages

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -263,8 +263,6 @@ namespace SteamKit2.Internal
                 msg.SteamID = this.SteamID;
             }
 
-            DebugLog.WriteLine( "CMClient", "Sent -> EMsg: {0} (Proto: {1})", msg.MsgType, msg.IsProto );
-
             try
             {
                 DebugNetworkListener?.OnOutgoingNetworkMessage(msg.MsgType, msg.Serialize());
@@ -303,8 +301,6 @@ namespace SteamKit2.Internal
                 Disconnect();
                 return false;
             }
-
-            DebugLog.WriteLine( "CMClient", "<- Recv'd EMsg: {0} ({1}) (Proto: {2})", packetMsg.MsgType, ( int )packetMsg.MsgType, packetMsg.IsProto );
 
             // Multi message gets logged down the line after it's decompressed
             if ( packetMsg.MsgType != EMsg.Multi )

--- a/SteamKit2/SteamKit2/Util/DebugNetworkListener.cs
+++ b/SteamKit2/SteamKit2/Util/DebugNetworkListener.cs
@@ -82,6 +82,8 @@ namespace SteamKit2
         /// <param name="data">Raw packet data that was received.</param>
         public void OnIncomingNetworkMessage( EMsg msgType, byte[] data )
         {
+            DebugLog.WriteLine( "NetHook", $"<- Recv'd EMsg: {msgType} ({( int )msgType})" );
+
             LogNetMessage( "in", msgType, data );
         }
 
@@ -92,6 +94,8 @@ namespace SteamKit2
         /// <param name="data">Raw packet data that will be sent.</param>
         public void OnOutgoingNetworkMessage( EMsg msgType, byte[] data )
         {
+            DebugLog.WriteLine( "NetHook", $"Sent -> EMsg: {msgType} ({( int )msgType})" );
+
             LogNetMessage( "out", msgType, data );
         }
 


### PR DESCRIPTION
DebugNetworkListener can be used for this purpose.

This will actually make DebugLog easier to enable without having to worry about the packet spam.