### PR TITLE
Switch from PackageIconUrl to PackageIcon as per deprecation

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>
     <Description>.NET library that aims to interoperate with the Steam network.</Description>
     <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.2.0</PackageReleaseNotes>
-    <PackageIconUrl>https://raw.github.com/SteamRE/SteamKit/master/Resources/Misc/steamkit_logo_128.png</PackageIconUrl>
+    <PackageIcon>steamkit_logo_128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/SteamRE/SteamKit</PackageProjectUrl>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <PackageTags>steamkit;sk2;steam;valve;dota;dota2;csgo</PackageTags>
@@ -47,6 +47,7 @@
         <Pack>true</Pack>
         <PackagePath />
     </Content>
+    <None Include="..\..\Resources\Misc\steamkit_logo_128.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #736.

Between this and the licence it seems that NuGet wants everything to be contained in the nupkg rather than just external references.