### PR TITLE
Restore response status code in exception messages

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -497,7 +497,7 @@ namespace SteamKit2
 
                     if ( !response.IsSuccessStatusCode )
                     {
-                        throw new SteamKitWebRequestException( $"Response status code does not indicate success: {response.StatusCode} ({response.ReasonPhrase}).", response );
+                        throw new SteamKitWebRequestException( $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).", response );
                     }
 
                     var responseData = await response.Content.ReadAsByteArrayAsync().ConfigureAwait( false );

--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -497,7 +497,7 @@ namespace SteamKit2
 
                     if ( !response.IsSuccessStatusCode )
                     {
-                        throw new SteamKitWebRequestException( $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).", response );
+                        throw new SteamKitWebRequestException( $"Response status code does not indicate success: {response.StatusCode:D} ({response.ReasonPhrase}).", response );
                     }
 
                     var responseData = await response.Content.ReadAsByteArrayAsync().ConfigureAwait( false );

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -300,7 +300,7 @@ namespace SteamKit2
 
                 if ( !response.IsSuccessStatusCode )
                 {
-                    throw new WebAPIRequestException( $"Response status code does not indicate success: {response.StatusCode} ({response.ReasonPhrase}).", response );
+                    throw new WebAPIRequestException( $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).", response );
                 }
 
                 var kv = new KeyValue();

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -300,7 +300,7 @@ namespace SteamKit2
 
                 if ( !response.IsSuccessStatusCode )
                 {
-                    throw new WebAPIRequestException( $"Response status code does not indicate success: {(int)response.StatusCode} ({response.ReasonPhrase}).", response );
+                    throw new WebAPIRequestException( $"Response status code does not indicate success: {response.StatusCode:D} ({response.ReasonPhrase}).", response );
                 }
 
                 var kv = new KeyValue();


### PR DESCRIPTION
After updating my SteamKit dependency from 2.1.0 to 2.2.0, I noticed the exception messages from Web API requests were slightly different. Before 2.2.0, an example exception message looked like this:

> Response status code does not indicate success: 403 (Forbidden).

But now after updating to 2.2.0, the same message looks like this:

> Response status code does not indicate success: Forbidden (Forbidden).

This change was caused by #603 and is most likely unintentional. My pull requests restores the original exception messages.