### PR TITLE
Fix null warnings

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -565,7 +565,10 @@ namespace SteamKit2.Internal
             }
             else if ( logonResult == EResult.TryAnotherCM || logonResult == EResult.ServiceUnavailable )
             {
-                Servers.TryMark( connection.CurrentEndPoint, connection.ProtocolTypes, ServerQuality.Bad );
+                if ( connection?.CurrentEndPoint != null )
+                {
+                    Servers.TryMark( connection.CurrentEndPoint, connection.ProtocolTypes, ServerQuality.Bad );
+                }
             }
         }
         void HandleLoggedOff( IPacketMsg packetMsg )

--- a/SteamKit2/SteamKit2/Util/DebugNetworkListener.cs
+++ b/SteamKit2/SteamKit2/Util/DebugNetworkListener.cs
@@ -63,7 +63,7 @@ namespace SteamKit2
             );
             Directory.CreateDirectory( LogDirectory );
 
-            log.LogDebug( CategoryName, $"Created nethook directory: {LogDirectory}" );
+            this.log.LogDebug( CategoryName, $"Created nethook directory: {LogDirectory}" );
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace SteamKit2
         /// <param name="log">An optional logging context for log messages.</param>
         public NetHookNetworkListener( string path, ILogContext? log = null )
         {
-            this.log = log;
+            this.log = log ?? DebugLogContext.Instance;
 
             if ( !Directory.Exists( path ) )
             {


### PR DESCRIPTION
```
Util\DebugNetworkListener.cs(66,13): warning CS8602: Dereference of a possibly null reference. 
Util\DebugNetworkListener.cs(76,24): warning CS8601: Possible null reference assignment. 
Steam\CMClient.cs(568,34): warning CS8602: Dereference of a possibly null reference. 
Steam\CMClient.cs(568,34): warning CS8604: Possible null reference argument for parameter 'endPoint' in 'bool SmartCMServerList.TryMark(EndPoint endPoint, ProtocolTypes protocolTypes, ServerQuality quality)'. 
```