### PR TITLE
Add ELauncherType

### DIFF
--- a/Resources/SteamLanguage/enums.steamd
+++ b/Resources/SteamLanguage/enums.steamd
@@ -1540,3 +1540,16 @@ public enum ESteamRealm
 	SteamGlobal = 1;
 	SteamChina = 2;
 };
+
+enum ELauncherType
+{
+	Default = 0;
+	PerfectWorld = 1;
+	Nexon = 2;
+	CmdLine = 3;
+	CSGO = 4;
+	ClientUI = 5;
+	Headless = 6;
+	SteamChina = 7;
+	SingleApp = 8;
+}

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
@@ -3256,6 +3256,18 @@ namespace SteamKit2
 		SteamGlobal = 1,
 		SteamChina = 2,
 	}
+	public enum ELauncherType
+	{
+		Default = 0,
+		PerfectWorld = 1,
+		Nexon = 2,
+		CmdLine = 3,
+		CSGO = 4,
+		ClientUI = 5,
+		Headless = 6,
+		SteamChina = 7,
+		SingleApp = 8,
+	}
 	public enum EUdpPacketType : byte
 	{
 		Invalid = 0,


### PR DESCRIPTION
```
export const enum ELauncherType
{
	k_ELauncherTypeDefault = 0,			// Traditional Steam launcher

	k_ELauncherTypePerfectWorld = 1,	// Perfect World launcher for Dota 2 (dota2launcher.exe)
	k_ELauncherTypeNexon = 2,			// Nexon launcher for Dota 2
	k_ELauncherTypeCmdLine = 3,			// Steam command line interface steamcmd.exe
	k_ELauncherTypeCSGO = 4,			// Perfect World launcher for CS:GO (csgolauncher.exe)
	k_ELauncherTypeClientUI = 5,		// client web ui launcher for steam (clientui.exe)
	k_ELauncherTypeHeadless = 6,		// Headless services for in-proc SteamWorks
	k_ELauncherTypeSteamChina = 7,		// SteamChina
	k_ELauncherTypeSingleApp = 8,		// SteamChina game govt review launcher, minimal UI to launch one app

	k_ELauncherTypeMax = 9,
}
```