### PR TITLE
Fix dependabot (I hope), and just whats needed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,18 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
+  directory: "/SteamKit2"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: nuget
+  directory: "/Resources/ProtobufGen"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: nuget
+  directory: "/Resources/ProtobufDumper"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  


### PR DESCRIPTION
@xPaw you were right on IRC, Samples and NHA2 aren't needed anymore as they pull in their dependencies implicitly through SteamKit2.csproj, but ProtobufDumper and ProtobufGen are both standalone.

Think its worth adding them like here, or not?

It means that we'll get 3 PRs if protobuf-net has an update, but should only get 1 PR if any other package (e.g. XUnit) has an update.