### PR TITLE
Remove only_public from pics requests

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -24,7 +24,7 @@ namespace SteamKit2
         /// <summary>
         /// Represents a PICS request used for <see cref="SteamApps.PICSGetProductInfo"/>
         /// </summary>
-        public sealed class PICSRequest
+        public struct PICSRequest
 #pragma warning restore 0419
         {
             /// <summary>
@@ -37,38 +37,16 @@ namespace SteamKit2
             /// </summary>
             /// <value>The access token</value>
             public ulong AccessToken { get; set; }
-            /// <summary>
-            /// Requests only public app info
-            /// </summary>
-            /// <value>The flag specifying if only public data is requested</value>
-            public bool Public { get; set; }
-
-            /// <summary>
-            /// Instantiate an empty PICS product info request
-            /// </summary>
-            public PICSRequest() : this( 0, 0, true )
-            {
-            }
-
-            /// <summary>
-            ///  Instantiate a PICS product info request for a given app or package id
-            /// </summary>
-            /// <param name="id">App or package ID</param>
-            public PICSRequest( uint id ) : this( id, 0, true )
-            {
-            }
 
             /// <summary>
             /// Instantiate a PICS product info request for a given app or package id and an access token
             /// </summary>
             /// <param name="id">App or package ID</param>
             /// <param name="access_token">PICS access token</param>
-            /// <param name="only_public">Get only public info</param>
-            public PICSRequest( uint id, ulong access_token, bool only_public )
+            public PICSRequest( uint id = 0, ulong access_token = 0 )
             {
                 ID = id;
                 AccessToken = access_token;
-                Public = only_public;
             }
         }
 
@@ -205,10 +183,9 @@ namespace SteamKit2
         /// </summary>
         /// <param name="app">App id requested.</param>
         /// <param name="package">Package id requested.</param>
-        /// <param name="onlyPublic">Whether to send only public information.</param>
         /// <param name="metaDataOnly">Whether to send only meta data.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
-        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo(uint? app, uint? package, bool onlyPublic = true, bool metaDataOnly = false)
+        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo(uint? app, uint? package, bool metaDataOnly = false)
         {
             List<uint> apps = new List<uint>();
             List<uint> packages = new List<uint>();
@@ -216,7 +193,7 @@ namespace SteamKit2
             if ( app.HasValue ) apps.Add( app.Value );
             if ( package.HasValue ) packages.Add( package.Value );
 
-            return PICSGetProductInfo( apps, packages, onlyPublic, metaDataOnly );
+            return PICSGetProductInfo( apps, packages, metaDataOnly );
         }
 
         /// <summary>
@@ -226,12 +203,11 @@ namespace SteamKit2
         /// </summary>
         /// <param name="apps">List of app ids requested.</param>
         /// <param name="packages">List of package ids requested.</param>
-        /// <param name="onlyPublic">Whether to send only public information.</param>
         /// <param name="metaDataOnly">Whether to send only meta data.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
-        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( IEnumerable<uint> apps, IEnumerable<uint> packages, bool onlyPublic = true, bool metaDataOnly = false )
+        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( IEnumerable<uint> apps, IEnumerable<uint> packages, bool metaDataOnly = false )
         {
-            return PICSGetProductInfo( apps.Select( app => new PICSRequest( app, 0, onlyPublic ) ), packages.Select( package => new PICSRequest( package ) ), metaDataOnly );
+            return PICSGetProductInfo( apps.Select( app => new PICSRequest( app ) ), packages.Select( package => new PICSRequest( package ) ), metaDataOnly );
         }
 
         /// <summary>
@@ -263,7 +239,7 @@ namespace SteamKit2
                 var appinfo = new CMsgClientPICSProductInfoRequest.AppInfo();
                 appinfo.access_token = app_request.AccessToken;
                 appinfo.appid = app_request.ID;
-                appinfo.only_public_obsolete = app_request.Public;
+                appinfo.only_public_obsolete = false;
 
                 request.Body.apps.Add( appinfo );
             }


### PR DESCRIPTION
See #910 

It was renamed to `only_public_obsolete` in protos, and I believe it has no effect.

Question: Is it a good idea to make `PICSRequest` a struct?