### PR TITLE
Fix unsupported registry on netstandard2.0

### DIFF
--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -85,9 +85,18 @@ namespace SteamKit2
     {
         public override byte[] GetMachineGuid()
         {
-            RegistryKey localKey = RegistryKey
-                .OpenBaseKey( Microsoft.Win32.RegistryHive.LocalMachine, RegistryView.Registry64 )
-                .OpenSubKey( @"SOFTWARE\Microsoft\Cryptography" );
+            RegistryKey? localKey;
+
+            try
+            {
+                localKey = RegistryKey
+                    .OpenBaseKey( RegistryHive.LocalMachine, RegistryView.Registry64 )
+                    .OpenSubKey( @"SOFTWARE\Microsoft\Cryptography" );
+            }
+            catch ( PlatformNotSupportedException )
+            {
+                return base.GetMachineGuid();
+            }
 
             if ( localKey == null )
             {


### PR DESCRIPTION
Fixes `PlatformNotSupportedException` on Windows and netstandard2.0

Without these changes following exception was thrown
```
 System.AggregateException: One or more errors occurred. (Registry is not supported on this platform.)
  ---> System.PlatformNotSupportedException: Registry is not supported on this platform.
     at Microsoft.Win32.RegistryKey.OpenBaseKey(RegistryHive hKey, RegistryView view)
	 at SteamKit2.WindowsInfoProvider.GetMachineGuid()
     at SteamKit2.HardwareUtils.GenerateMachineID()     at System.Threading.Tasks.Task`1.InnerInvoke()
     at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
     at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
```