### PR TITLE
Fix race condition in CMClient.Send

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -271,14 +271,18 @@ namespace SteamKit2.Internal
                 throw new ArgumentNullException( nameof(msg), "A value for 'msg' must be supplied" );
             }
 
-            if ( this.SessionID.HasValue )
+            var sessionID = this.SessionID;
+
+            if ( sessionID.HasValue )
             {
-                msg.SessionID = this.SessionID.Value;
+                msg.SessionID = sessionID.Value;
             }
 
-            if ( this.SteamID != null )
+            var steamID = this.SteamID;
+
+            if ( steamID != null )
             {
-                msg.SteamID = this.SteamID;
+                msg.SteamID = steamID;
             }
 
             try


### PR DESCRIPTION
My cm monitor app managed to crash there with `msg.SteamID` being set to null.

Logged out and disconnected callback set it to null, so I assume it can race with that, although I'm not sure why.

While this isn't the most correct fix, there's no reason to access these properties twice.