### PR TITLE
Create default MemoryServerListProvider

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Discovery/MemoryServerListProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/Discovery/MemoryServerListProvider.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SteamKit2.Discovery
+{
+    /// <summary>
+    /// A server list provider that uses an in-memory list
+    /// </summary>
+    public class MemoryServerListProvider : IServerListProvider
+    {
+        private IEnumerable<ServerRecord> _servers = Enumerable.Empty<ServerRecord>();
+
+        /// <summary>
+        /// Returns the stored server list in memory
+        /// </summary>
+        /// <returns>List of servers if persisted, otherwise an empty list</returns>
+        public Task<IEnumerable<ServerRecord>> FetchServerListAsync()
+            => Task.FromResult( _servers );
+
+        /// <summary>
+        /// Stores the supplied list of servers in memory
+        /// </summary>
+        /// <param name="endpoints">Server list</param>
+        /// <returns>Completed task</returns>
+        public Task UpdateServerListAsync( IEnumerable<ServerRecord> endpoints )
+        {
+            _servers = endpoints;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -35,7 +35,7 @@ namespace SteamKit2
 
                 ProtocolTypes = ProtocolTypes.Tcp,
 
-                ServerListProvider = new NullServerListProvider(),
+                ServerListProvider = new MemoryServerListProvider(),
 
                 Universe = EUniverse.Public,
 

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -65,7 +65,7 @@ namespace Tests
         [Fact]
         public void ServerListProviderIsNothingFancy()
         {
-            Assert.IsType<NullServerListProvider>(configuration.ServerListProvider);
+            Assert.IsType<MemoryServerListProvider>(configuration.ServerListProvider);
         }
 
         [Fact]


### PR DESCRIPTION
This is more useful than the null storage which would request it from the api any time it is requested.