### PR TITLE
Fix running tests in CI

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run Tests
       if: matrix.configuration == 'Debug'
-      run: dotnet test --no-restore --verbosity normal SteamKit2/Tests/Tests.csproj
+      run: dotnet test --verbosity normal SteamKit2/Tests/Tests.csproj
 
   steamkit2-artifacts:
     name: Create NuGet Package

--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Configure Dependencies
       run: Resources/NetHook2/SetupDependencies.cmd

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -6,6 +6,7 @@
     <ProjectGuid>{5BF6D076-399B-41CA-BAE7-37CE1C40CA67}</ProjectGuid>
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # SteamKit2
 [![Build Status (CI/CD)](https://github.com/SteamRE/SteamKit/workflows/CI/CD/badge.svg?branch=master&event=push)](https://github.com/SteamRE/SteamKit/actions?query=workflow%3ACI%2FCD)
 [![NuGet](https://img.shields.io/nuget/v/SteamKit2.svg)](https://www.nuget.org/packages/SteamKit2/)
-[![Code Coverage](https://img.shields.io/badge/Code-Coverage-007ec6.svg)](https://codecov.io/github/SteamRE/SteamKit)
 
 
 SteamKit2 is a .NET library designed to interoperate with Valve's [Steam network](http://store.steampowered.com/about). It aims to provide a simple, yet extensible, interface to perform various actions on the network.


### PR DESCRIPTION
First I ran with diagnostic verbosity, and it complained about `IsTestProject` not matching.

