### PR TITLE
Fix AsyncJob for GameCoordinator.MessageCallback

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/Callbacks.cs
@@ -41,6 +41,7 @@ namespace SteamKit2
                 this.eMsg = gcMsg.msgtype;
                 this.AppID = gcMsg.appid;
                 this.Message = GetPacketGCMsg( gcMsg.msgtype, gcMsg.payload );
+                this.JobID = this.Message.TargetJobID;
             }
 
 


### PR DESCRIPTION
Fixes JobID for MessageCallback in order to use value from GC message header.

Related: #824