### PR TITLE
Write empty values (null and no children) as an object when saving to binary

### DIFF
--- a/SteamKit2/SteamKit2/Types/KeyValue.cs
+++ b/SteamKit2/SteamKit2/Types/KeyValue.cs
@@ -733,7 +733,7 @@ namespace SteamKit2
             // Only supported types ATM:
             // 1. KeyValue with children (no value itself)
             // 2. String KeyValue
-            if ( Children.Any() )
+            if ( Value == null )
             {
                 f.WriteByte( ( byte )Type.None );
                 f.WriteNullTermString( GetNameForSerialization(), Encoding.UTF8 );
@@ -747,7 +747,7 @@ namespace SteamKit2
             {
                 f.WriteByte( ( byte )Type.String );
                 f.WriteNullTermString( GetNameForSerialization(), Encoding.UTF8 );
-                f.WriteNullTermString( Value ?? string.Empty, Encoding.UTF8 );
+                f.WriteNullTermString( Value, Encoding.UTF8 );
             }
         }
 

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -479,6 +479,55 @@ namespace Tests
         }
 
         [Fact]
+        public void KeyValuesTextPreserveEmptyObjects()
+        {
+            var kv = new KeyValue( "key" );
+            kv.Children.Add( new KeyValue( "emptyObj" ) );
+            kv.Children.Add( new KeyValue( "emptyString", string.Empty ) );
+
+            string text;
+            using ( var ms = new MemoryStream() )
+            {
+                kv.SaveToStream( ms, asBinary: false );
+                ms.Seek( 0, SeekOrigin.Begin );
+                using ( var reader = new StreamReader( ms ) )
+                {
+                    text = reader.ReadToEnd();
+                }
+            }
+
+            var expectedValue = "\"key\"\n{\n\t\"emptyObj\"\n\t{\n\t}\n\t\"emptyString\"\t\t\"\"\n}\n";
+            Assert.Equal( expectedValue, text );
+        }
+
+        [Fact]
+        public void KeyValuesBinaryPreserveEmptyObjects()
+        {
+            var expectedHexString = "006B65790000656D7074794F626A000801656D707479537472696E6700000808";
+
+            var kv = new KeyValue( "key" );
+            kv.Children.Add( new KeyValue( "emptyObj" ) );
+            kv.Children.Add( new KeyValue( "emptyString", string.Empty ) );
+            
+            var deserializedKv = new KeyValue();
+            byte[] binaryValue;
+            using ( var ms = new MemoryStream() )
+            {
+                kv.SaveToStream( ms, asBinary: true );
+                ms.Seek( 0, SeekOrigin.Begin );
+                binaryValue = ms.ToArray();
+                deserializedKv.TryReadAsBinary( ms );
+            }
+
+            var hexValue = BitConverter.ToString( binaryValue ).Replace( "-", "" );
+
+            Assert.Equal( expectedHexString, hexValue );
+            Assert.Null( deserializedKv["emptyObj"].Value );
+            Assert.Empty( deserializedKv["emptyObj"].Children );
+            Assert.Equal( string.Empty, deserializedKv["emptyString"].Value );
+        }
+
+        [Fact]
         public void DecodesBinaryWithFieldType10()
         {
             var hex = "00546573744F626A656374000A6B65790001020304050607080808";


### PR DESCRIPTION
This will match the behaviour of text saving. And looking at Valve's code, they default to type none, so when serializing it should be saved as an object as well.

I believe right now deserializing an empty object, and then serializing back into binary would not be roundtrip in Steamkit.

https://github.com/SteamRE/SteamKit/blob/df7f30f0d2880d8d9ceaf0d6b1e3c5d8f04bf7a7/SteamKit2/SteamKit2/Types/KeyValue.cs#L766-L769