### PR TITLE
Target all projects to NET5.0

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: NetHookAnalyzer2
-        path: 'Resources/NetHookAnalyzer2/NetHookAnalyzer2/bin/Release/netcoreapp3.0/win-x64/publish/*'
+        path: 'Resources/NetHookAnalyzer2/NetHookAnalyzer2/bin/Release/win-x64/publish/*'
 
   nethook2:
     name: NetHook2 - ${{ matrix.configuration }}

--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -35,6 +35,9 @@ jobs:
     - name: Build ProtobufGen
       run: dotnet build --configuration ${{ matrix.configuration }} Resources/ProtobufGen/ProtobufGen.sln
 
+    - name: Build ProtobufDumper
+      run: dotnet build --configuration ${{ matrix.configuration }} Resources/ProtobufDumper/ProtobufDumper.sln
+
     - name: Build Samples
       run: dotnet build --configuration ${{ matrix.configuration }} Samples/Samples.sln
 

--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -8,24 +8,24 @@ on:
 
 jobs:
   steamkit2:
-    name: SteamKit2 on ${{ matrix.os }} - ${{ matrix.configuration }} (SDK ${{ matrix.sdk }}) 
+    name: SteamKit2 on ${{ matrix.os }} - ${{ matrix.configuration }} (SDK ${{ matrix.sdk }})
 
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        sdk: [3.1.301, 5.0.100-preview.8.20417.9]
+        sdk: [5.0.x]
         configuration: [Debug, Release]
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ matrix.sdk }}
-      
+
     - name: Build SteamKit2
       run: dotnet build --configuration ${{ matrix.configuration }} SteamKit2/SteamKit2/SteamKit2.csproj
 
@@ -51,17 +51,17 @@ jobs:
 
   steamkit2-artifacts:
     name: Create NuGet Package
-      
+
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
-        
+        dotnet-version: 5.0.x
+
     - name: Create NuGet Package
       run: dotnet pack --configuration Release SteamKit2/SteamKit2/SteamKit2.csproj
 
@@ -78,12 +78,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
-        
+        dotnet-version: 5.0.x
+
     - name: Publish NetHookAnalyzer2
       run: dotnet publish --configuration Release --runtime win-x64 Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj /p:PublishSingleFile=True /p:PublishTrimmed=True
 
@@ -95,13 +95,13 @@ jobs:
 
   nethook2:
     name: NetHook2 - ${{ matrix.configuration }}
-    
+
     strategy:
       matrix:
         configuration: [Debug, Release]
 
     runs-on: windows-latest
-      
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/steamkit2-release.yaml
+++ b/.github/workflows/steamkit2-release.yaml
@@ -7,17 +7,17 @@ on:
 jobs:
   publish-nupkg:
     name: Publish NuGet Package
-      
+
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
-        
+        dotnet-version: 5.0.x
+
     - name: Create NuGet Package
       run: dotnet pack --configuration Release SteamKit2/SteamKit2/SteamKit2.csproj /p:Version=${{ github.event.release.tag_name }}
 
@@ -38,6 +38,6 @@ jobs:
         asset_content_type: application/zip
 
     - name: Publish NuGet Package to NuGet Gallery
-      run: | 
+      run: |
         nuget setapikey ${{ secrets.NUGET_API_KEY }}
         nuget push SteamKit2/SteamKit2/bin/Release/SteamKit2.${{ github.event.release.tag_name }}.nupkg -Source https://api.nuget.org/v3/index.json

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>..\..\Misc\steamkit.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookAnalyzer2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>..\..\Misc\steamkit.ico</ApplicationIcon>
   </PropertyGroup>

--- a/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
+++ b/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
@@ -8,6 +8,7 @@
     <RepositoryUrl>https://github.com/SteamRE/SteamKit</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <OutputType>Exe</OutputType>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>..\..\Misc\steamkit.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
+++ b/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageProjectUrl>https://github.com/SteamRE/SteamKit/tree/master/Resources/ProtobufDumper</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/license.txt</PackageLicenseUrl>

--- a/Resources/ProtobufGen/ProtobufGen/ProtobufGen.csproj
+++ b/Resources/ProtobufGen/ProtobufGen/ProtobufGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ApplicationIcon>..\..\Misc\steamkit.ico</ApplicationIcon>

--- a/Resources/SteamLanguage/generate.bat
+++ b/Resources/SteamLanguage/generate.bat
@@ -1,3 +1,4 @@
 @echo off
 
-dotnet ..\SteamLanguageParser\bin\Release\SteamLanguageParser.dll ..\..\
+cd ..\SteamLanguageParser
+dotnet run ..\..\

--- a/Resources/SteamLanguage/generate.sh
+++ b/Resources/SteamLanguage/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 BASEDIR="$(dirname $0)"
 cd "$BASEDIR"
-cd ..\SteamLanguageParser
-dotnet run ..\..\
+cd ../SteamLanguageParser
+dotnet run ../../

--- a/Resources/SteamLanguage/generate.sh
+++ b/Resources/SteamLanguage/generate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 BASEDIR="$(dirname $0)"
 cd "$BASEDIR"
-dotnet ../SteamLanguageParser/bin/Release/SteamLanguageParser.dll ../..
-
+cd ..\SteamLanguageParser
+dotnet run ..\..\

--- a/Resources/SteamLanguageParser/SteamLanguageParser.csproj
+++ b/Resources/SteamLanguageParser/SteamLanguageParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ProjectGuid>{CCAB4961-4C59-4400-978B-7D9552AE2296}</ProjectGuid>

--- a/Resources/SteamLanguageParser/SteamLanguageParser.sln
+++ b/Resources/SteamLanguageParser/SteamLanguageParser.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SteamLanguageParser", "SteamLanguageParser.csproj", "{CCAB4961-4C59-4400-978B-7D9552AE2296}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CCAB4961-4C59-4400-978B-7D9552AE2296}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCAB4961-4C59-4400-978B-7D9552AE2296}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCAB4961-4C59-4400-978B-7D9552AE2296}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCAB4961-4C59-4400-978B-7D9552AE2296}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7FD992FD-0EF5-41F2-9CCA-552E4D1D4393}
+	EndGlobalSection
+EndGlobal

--- a/Samples/1.Logon/Sample1_Logon.csproj
+++ b/Samples/1.Logon/Sample1_Logon.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Company>SteamRE</Company>
     <Product>Sample1_Logon</Product>
     <Authors />

--- a/Samples/10.DotaMatchRequest/Sample10_DotaMatchRequest.csproj
+++ b/Samples/10.DotaMatchRequest/Sample10_DotaMatchRequest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 10: Dota 2 Coordinator</Description>

--- a/Samples/2.Extending/Sample2_Extending.csproj
+++ b/Samples/2.Extending/Sample2_Extending.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 2: Extending</Description>

--- a/Samples/3.DebugLog/Sample3_DebugLog.csproj
+++ b/Samples/3.DebugLog/Sample3_DebugLog.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKite Sample 3: DebugLog</Description>

--- a/Samples/4.Friends/Sample4_Friends.csproj
+++ b/Samples/4.Friends/Sample4_Friends.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 4: Friends</Description>

--- a/Samples/5.SteamGuard/Sample5_SteamGuard.csproj
+++ b/Samples/5.SteamGuard/Sample5_SteamGuard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 5: SteamGuard</Description>

--- a/Samples/6.WebAPI/Sample6_WebAPI.csproj
+++ b/Samples/6.WebAPI/Sample6_WebAPI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 6: WebAPI</Description>

--- a/Samples/7.ServerList/Sample7_ServerList.csproj
+++ b/Samples/7.ServerList/Sample7_ServerList.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 7: ServerList</Description>

--- a/Samples/8.UnifiedMessages/Sample8_UnifiedMessages.csproj
+++ b/Samples/8.UnifiedMessages/Sample8_UnifiedMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 8: UnifiedMessages</Description>

--- a/Samples/9.AsyncJobs/Sample9_AsyncJobs.csproj
+++ b/Samples/9.AsyncJobs/Sample9_AsyncJobs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors />
     <Company>SteamRE Team</Company>
     <Description>SteamKit Sample 9: AsyncJobs</Description>

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <ProjectGuid>{5BF6D076-399B-41CA-BAE7-37CE1C40CA67}</ProjectGuid>
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This omits changing steamkit2 itself.

I also did a few minor changes like creating missing SteamLanguageParser.sln, making SteamLanguage generate script not require a manual build, and added ProtobufDumper building to github action.