### PR TITLE
High DPI support for NHA2

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Program.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Program.cs
@@ -10,9 +10,9 @@ namespace NetHookAnalyzer2
 		/// </summary>
 		[STAThread]
 		static void Main()
-		{
-            // See https://github.com/dotnet/winforms/issues/4397#issuecomment-749782104
-			// Application.EnableVisualStyles();
+        {
+            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 			Application.Run(new MainForm());
 		}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Program.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Program.cs
@@ -10,8 +10,8 @@ namespace NetHookAnalyzer2
 		/// </summary>
 		[STAThread]
 		static void Main()
-        {
-            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+		{
+			Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 			Application.Run(new MainForm());


### PR DESCRIPTION
Enables using high DPI support for NHA2 and removes old workaround disabling `EnableVisualStyles` since it's fixed with .NET runtime 5.0.4.