### PR TITLE
ClientServiceMethodLegacy/Response fixes for NHA2

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder_MessageReading.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder_MessageReading.cs
@@ -59,14 +59,14 @@ namespace NetHookAnalyzer2
 					body = UnifiedMessagingHelpers.ReadServiceMethodBody(targetJobName.Value, stream, x => x.ReturnType);
 					break;
                 
-                case EMsg.ClientServiceMethodLegacy:
-                    var tempBody = (CMsgClientServiceMethodLegacy) RuntimeTypeModel.Default.Deserialize( stream, null, typeof(CMsgClientServiceMethodLegacy) );
-                    using ( var ms = new MemoryStream( tempBody.serialized_method ) )
-                    {
-                        body = UnifiedMessagingHelpers.ReadServiceMethodBody( tempBody.method_name, ms, x => x.GetParameters().First().ParameterType );
-                    }
+				case EMsg.ClientServiceMethodLegacy:
+					var tempBody = (CMsgClientServiceMethodLegacy) RuntimeTypeModel.Default.Deserialize( stream, null, typeof(CMsgClientServiceMethodLegacy) );
+					using ( var ms = new MemoryStream( tempBody.serialized_method ) )
+					{
+						body = UnifiedMessagingHelpers.ReadServiceMethodBody( tempBody.method_name, ms, x => x.GetParameters().First().ParameterType );
+					}
  
-                    break;
+					break;
 
 				default:
 					body = ReadMessageBody(rawEMsg, stream);

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder_MessageReading.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder_MessageReading.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using NetHookAnalyzer2.Specializations;
 using ProtoBuf;
 using ProtoBuf.Meta;
@@ -59,6 +58,15 @@ namespace NetHookAnalyzer2
 				case EMsg.ServiceMethodResponse:
 					body = UnifiedMessagingHelpers.ReadServiceMethodBody(targetJobName.Value, stream, x => x.ReturnType);
 					break;
+                
+                case EMsg.ClientServiceMethodLegacy:
+                    var tempBody = (CMsgClientServiceMethodLegacy) RuntimeTypeModel.Default.Deserialize( stream, null, typeof(CMsgClientServiceMethodLegacy) );
+                    using ( var ms = new MemoryStream( tempBody.serialized_method ) )
+                    {
+                        body = UnifiedMessagingHelpers.ReadServiceMethodBody( tempBody.method_name, ms, x => x.GetParameters().First().ParameterType );
+                    }
+ 
+                    break;
 
 				default:
 					body = ReadMessageBody(rawEMsg, stream);

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/ClientServiceMethodResponseSpecialization.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/Specializations/ClientServiceMethodResponseSpecialization.cs
@@ -17,11 +17,11 @@ namespace NetHookAnalyzer2.Specializations
 			var name = serviceMethodBody.method_name;
 			object innerBody = null;
 
-            if ( serviceMethodBody.serialized_method_response != null )
-            {
-                using var ms = new MemoryStream(serviceMethodBody.serialized_method_response);
-                innerBody = UnifiedMessagingHelpers.ReadServiceMethodBody(name, ms, x => x.ReturnType);
-            }
+			if ( serviceMethodBody.serialized_method_response != null )
+			{
+				using var ms = new MemoryStream(serviceMethodBody.serialized_method_response);
+				innerBody = UnifiedMessagingHelpers.ReadServiceMethodBody(name, ms, x => x.ReturnType);
+			}
 
 			yield return new KeyValuePair<string, object>("Service Method Response", innerBody);
 		}


### PR DESCRIPTION
1. Fixes deserializing `ClientServiceMethodLegacy` message (earlier it was parsed as Dictionary, because `ClientServiceMethodResponseSpecialization` did not have support for this type).
2. Fixes `ArgumentNullException` when NHA2 tries to display `CMsgClientServiceMethodLegacyResponse` with underlying response being `null` (e.g. `NoResponse` type in protobufs).