### PR TITLE
NH2: Display build info when initializing

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -15,6 +15,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
         sdk: [5.0.x]
         configuration: [Debug, Release]
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
@@ -99,6 +100,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
+      fail-fast: false
 
     runs-on: windows-latest
 

--- a/Resources/NetHook2/GenerateVersionInfo.ps1
+++ b/Resources/NetHook2/GenerateVersionInfo.ps1
@@ -7,8 +7,8 @@ Function Test-GitAvailable {
         }
     }
     Catch {
-        return $false
     }
+    return $false
 }
 
 $buildDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss K"
@@ -19,6 +19,8 @@ if (Test-GitAvailable) {
 
     git diff --quiet
     $dirty = [bool]($LASTEXITCODE)
+} else {
+    $dirty = $false
 }
 
 $versionFile = 'version.cpp'

--- a/Resources/NetHook2/GenerateVersionInfo.ps1
+++ b/Resources/NetHook2/GenerateVersionInfo.ps1
@@ -1,0 +1,34 @@
+﻿$ErrorActionPreference = 'stop'
+
+Function Test-GitAvailable {
+    Try {
+        If (Get-Command git) {
+            return $true
+        }
+    }
+    Catch {
+        return $false
+    }
+}
+
+$buildDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss K"
+
+if (Test-GitAvailable) {
+    $commitDate = [string](git show -s --format="%ci" HEAD)
+    $sha = [string](git rev-parse --short HEAD)
+
+    git diff --quiet
+    $dirty = [bool]($LASTEXITCODE)
+}
+
+$versionFile = 'version.cpp'
+
+$sb = New-Object Text.StringBuilder
+[void]$sb.AppendLine("#include `"version.h`"")
+[void]$sb.AppendLine()
+[void]$sb.AppendLine("const char *g_szBuildDate = `"$($buildDate)`";")
+[void]$sb.AppendLine("const char *g_szBuiltFromCommitSha = `"$($sha)`";")
+[void]$sb.AppendLine("const char *g_szBuiltFromCommitDate = `"$($commitDate)`";")
+[void]$sb.AppendLine("const BOOL g_bBuiltFromDirty = $($dirty.ToString().ToLower());")
+
+Set-Content -Path $versionFile -Value $sb.ToString()

--- a/Resources/NetHook2/NetHook2/.gitignore
+++ b/Resources/NetHook2/NetHook2/.gitignore
@@ -1,0 +1,2 @@
+# Auto-generated at build time
+version.cpp

--- a/Resources/NetHook2/NetHook2/NetHook2.vcxproj
+++ b/Resources/NetHook2/NetHook2/NetHook2.vcxproj
@@ -77,6 +77,9 @@
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions>/SAFESEH:NO /ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -ExecutionPolicy Unrestricted ..\GenerateVersionInfo.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -110,6 +113,7 @@
     <ClCompile Include="sigscan.cpp" />
     <ClCompile Include="steammessages_base.pb.cc" />
     <ClCompile Include="string.cpp" />
+    <ClCompile Include="version.cpp" />
     <ClCompile Include="zip.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -130,6 +134,7 @@
     <ClInclude Include="steam\steamtypes.h" />
     <ClInclude Include="steam\udppkt.h" />
     <ClInclude Include="nh2_string.h" />
+    <ClInclude Include="version.h" />
     <ClInclude Include="zip.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Resources/NetHook2/NetHook2/NetHook2.vcxproj
+++ b/Resources/NetHook2/NetHook2/NetHook2.vcxproj
@@ -99,6 +99,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
+    <PreBuildEvent>
+      <Command>powershell.exe -ExecutionPolicy Unrestricted ..\GenerateVersionInfo.ps1</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="binaryreader.cpp" />

--- a/Resources/NetHook2/NetHook2/NetHook2.vcxproj.filters
+++ b/Resources/NetHook2/NetHook2/NetHook2.vcxproj.filters
@@ -53,6 +53,9 @@
     <ClCompile Include="net.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="version.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="binaryreader.h">
@@ -109,9 +112,11 @@
     <ClInclude Include="net.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Library Include="detours.lib" />
-    <Library Include="zlib.lib" />
   </ItemGroup>
 </Project>

--- a/Resources/NetHook2/NetHook2/nethook.cpp
+++ b/Resources/NetHook2/NetHook2/nethook.cpp
@@ -26,15 +26,15 @@ BOOL IsRunDll32()
 
 void PrintVersionInfo()
 {
-    g_pLogger->LogConsole("Initializing NetHook2...\n");
-    g_pLogger->LogConsole("Built at %s from %s", g_szBuildDate, g_szBuiltFromCommitSha);
+	g_pLogger->LogConsole("Initializing NetHook2...\n");
+	g_pLogger->LogConsole("Built at %s from %s", g_szBuildDate, g_szBuiltFromCommitSha);
 
-    if (g_bBuiltFromDirty)
-    {
-        g_pLogger->LogConsole("/dirty");
-    }
+	if (g_bBuiltFromDirty)
+	{
+		g_pLogger->LogConsole("/dirty");
+	}
 
-    g_pLogger->LogConsole(" (%s)\n", g_szBuiltFromCommitDate);
+	g_pLogger->LogConsole(" (%s)\n", g_szBuiltFromCommitDate);
 }
 
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )

--- a/Resources/NetHook2/NetHook2/nethook.cpp
+++ b/Resources/NetHook2/NetHook2/nethook.cpp
@@ -8,6 +8,7 @@
 #include "nh2_string.h"
 
 #include "steammessages_base.pb.h"
+#include "version.h"
 
 CLogger *g_pLogger = NULL;
 CCrypto* g_pCrypto = NULL;
@@ -21,6 +22,19 @@ BOOL IsRunDll32()
 	DWORD dwMainModulePathLength = GetModuleFileNameA(NULL, szMainModulePath, sizeof(szMainModulePath));
 
 	return stringCaseInsensitiveEndsWith(szMainModulePath, "\\rundll32.exe");
+}
+
+void PrintVersionInfo()
+{
+    g_pLogger->LogConsole("Initializing NetHook2...\n");
+    g_pLogger->LogConsole("Built at %s from %s", g_szBuildDate, g_szBuiltFromCommitSha);
+
+    if (g_bBuiltFromDirty)
+    {
+        g_pLogger->LogConsole("/dirty");
+    }
+
+    g_pLogger->LogConsole(" (%s)\n", g_szBuiltFromCommitDate);
 }
 
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )
@@ -39,6 +53,8 @@ BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )
 		LoadLibrary( "steamclient.dll" );
 
 		g_pLogger = new CLogger();
+
+		PrintVersionInfo();
 
 		g_pCrypto = new CCrypto();
 		g_pNet = new NetHook::CNet();

--- a/Resources/NetHook2/NetHook2/nethook.cpp
+++ b/Resources/NetHook2/NetHook2/nethook.cpp
@@ -27,14 +27,22 @@ BOOL IsRunDll32()
 void PrintVersionInfo()
 {
 	g_pLogger->LogConsole("Initializing NetHook2...\n");
-	g_pLogger->LogConsole("Built at %s from %s", g_szBuildDate, g_szBuiltFromCommitSha);
 
-	if (g_bBuiltFromDirty)
+	if (*g_szBuiltFromCommitSha == '\0')
 	{
-		g_pLogger->LogConsole("/dirty");
+		g_pLogger->LogConsole("Built at %s. No further build information available.\n", g_szBuildDate);
 	}
+	else
+	{
+		g_pLogger->LogConsole("Built at %s from %s", g_szBuildDate, g_szBuiltFromCommitSha);
 
-	g_pLogger->LogConsole(" (%s)\n", g_szBuiltFromCommitDate);
+		if (g_bBuiltFromDirty)
+		{
+			g_pLogger->LogConsole("/dirty");
+		}
+
+		g_pLogger->LogConsole(" (%s)\n", g_szBuiltFromCommitDate);
+	}
 }
 
 BOOL WINAPI DllMain( HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved )

--- a/Resources/NetHook2/NetHook2/version.h
+++ b/Resources/NetHook2/NetHook2/version.h
@@ -1,0 +1,12 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+extern const char *g_szBuildDate;
+extern const char *g_szBuiltFromCommitSha;
+extern const char *g_szBuiltFromCommitDate;
+extern const BOOL g_bBuiltFromDirty;
+
+#endif


### PR DESCRIPTION
Example (dirty working tree):

![image](https://user-images.githubusercontent.com/426009/114301244-64041e80-9b07-11eb-9e47-c5051caa4c80.png)

Example (clean working tree):

![image](https://user-images.githubusercontent.com/426009/114301268-7ed69300-9b07-11eb-9cba-48371856fa8d.png)

Format is:

> Built at \<build time\> from \<commit sha\>[/dirty] (\<commit date\>)

Resolves #979.