### PR TITLE
Fix System.ArgumentException with WebAPI args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TestResults
 *.user
 *.userprefs
 *.sln.docstates
+.idea/
 .vs/
 
 # Build results

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -242,11 +242,11 @@ namespace SteamKit2
                     paramBuilder.Append( "/?" ); // start our GET params
                 }
 
-                args.Add( "format", "vdf" );
+                args[ "format" ] = "vdf";
 
                 if ( !string.IsNullOrEmpty( apiKey ) )
                 {
-                    args.Add( "key", apiKey );
+                    args[ "key" ] = apiKey;
                 }
 
                 // append any args

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -242,11 +242,21 @@ namespace SteamKit2
                     paramBuilder.Append( "/?" ); // start our GET params
                 }
 
-                args[ "format" ] = "vdf";
-
-                if ( !string.IsNullOrEmpty( apiKey ) )
+                if ( args.TryGetValue( "format", out var format ) )
                 {
-                    args[ "key" ] = apiKey;
+                    if ( !(format is string formatText) || formatText != "vdf" )
+                    {
+                        throw new ArgumentException( $"{nameof(args)} include unsupported {nameof(format)}: {format}" );
+                    }
+                }
+                else
+                {
+                    args.Add( "format", "vdf" );
+                }
+
+                if ( !string.IsNullOrEmpty( apiKey ) && !args.ContainsKey( "key" ) )
+                {
+                    args.Add( "key", apiKey );
                 }
 
                 // append any args

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -49,6 +49,80 @@ namespace Tests
 
            await Assert.ThrowsAsync<WebAPIRequestException>(() => (Task)iface.PerformFooOperation());
         }
+        
+        [Fact]
+        public async Task ThrowsOnIncorrectFormatInArgsProvided()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar",
+                [ "format" ] = "json"
+            };
+            
+            await Assert.ThrowsAsync<ArgumentException>(() => iface.CallAsync( HttpMethod.Get, "GetFoo", args: args ));
+        }
+        
+        [Fact]
+        public async Task DoesntThrowWhenCorrectFormatInArgsProvided()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar",
+                [ "format" ] = "vdf"
+            };
+
+            await iface.CallAsync( HttpMethod.Get, "GetFoo", args: args );
+        }
+        
+        [Fact]
+        public async Task DoesntThrowWhenKeyInArgsProvided()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithWebAPIKey( "test1" ).WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar",
+                [ "key" ] = "test2"
+            };
+
+            await iface.CallAsync( HttpMethod.Get, "GetFoo", args: args );
+            
+            Assert.Equal( "test2", args["key"] );
+        }
+        
+        [Fact]
+        public async Task DoesntThrowOnArgumentsReuse()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar"
+            };
+
+            await iface.CallAsync( HttpMethod.Get, "GetFoo", args: args );
+            await iface.CallAsync( HttpMethod.Get, "GetFoo", args: args );
+        }
 
         [Fact]
         public async Task UsesSingleParameterArgumentsDictionary()


### PR DESCRIPTION
`args` in this function can either be provided by the consumer, or is initialized by the function.

When it's initialized by the function (no args provided by the consumer), everything is fine since it's not possible for the `args` to have duplicate elements in this local scope.

When `args` is provided by the consumer, it is possible for the dictionary to already have the same elements in it, and therefore clash with the two we set in the lib.

This can happen as a genuine mistake, for example when user set `format: json` himself and the function throws an exception now because it tries to add `format: vdf`, but it can also happen in a more "expected" manner, for example in my use case, where I retry the request (with the same collection) upon failure. This means that if the first request fails, the dictionary that I've provided now has additional entries **already added** by previous SK2 call, and in result it now fails upon second try, as if I provided them myself (but I did not).

If by any chance you decide that this solution is not appropriate (for example due to first scenario above), it will be required for us to actually copy the dictionary over first and **then** append the entries, in order to still correct the consumer in invalid usage of providing format/key himself, while not throwing on the same dictionary used twice which was modified and returned to the consumer, and then called again. If we go this route it makes sense to mark the dictionary in the input as `IReadOnlyDictionary` to signalize that we're not modifying it. As it is right now, it's signalized we do.

Third option is to tell consumer "you can't re-use the same dictionary twice", but I find this argument very silly in regards to what this function really does (no reason to not go the way I suggest right now).

I believe that we don't really have to throw on the consumer in the first case. If he already provided format and/or key in the args, then we'll simply correct it as we had to anyway in order for the call to succeed. This is why I've decided to fix the code for the second scenario above, rather than re-writing the logic for dictionary cloning.

Edit: I improved the logic upon @xPaw initial thought and as it is right now we *do* throw on format that is not `vdf`, so the first use case should be met in addition to the original fix.