### PR TITLE
WebAPI: Treat the args dictionary as immutable

### DIFF
--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -222,20 +222,13 @@ namespace SteamKit2
                     throw new ArgumentNullException( nameof(func) );
                 }
 
-
-                if ( args == null )
-                {
-                    args = new Dictionary<string, object>();
-                }
-                else if ( args.TryGetValue( "format", out var format ) )
+                if ( args != null && args.TryGetValue( "format", out var format ) )
                 {
                     if ( !( format is string formatText ) || formatText != "vdf" )
                     {
                         throw new ArgumentException( $"{nameof( args )} include unsupported {nameof( format )}: {format}" );
                     }
                 }
-
-                args ??= new Dictionary<string, object>();
 
                 var paramBuilder = new StringBuilder();
 
@@ -249,7 +242,7 @@ namespace SteamKit2
                     urlBuilder.Append( "/?" );
                 }
 
-                if ( !string.IsNullOrEmpty( apiKey ) && !args.ContainsKey( "key" ) )
+                if ( !string.IsNullOrEmpty( apiKey ) && args != null && !args.ContainsKey( "key" ) )
                 {
                     paramBuilder.Append( "key=" );
                     paramBuilder.Append( Uri.EscapeDataString( apiKey ) );
@@ -257,24 +250,27 @@ namespace SteamKit2
 
                 paramBuilder.Append( "format=vdf" );
 
-                foreach (var (key, value) in args)
+                if ( args != null )
                 {
-                    paramBuilder.Append( '&' );
-                    paramBuilder.Append( Uri.EscapeDataString( key ) );
-                    paramBuilder.Append( '=' );
-
-                    switch (value)
+                    foreach ( var (key, value) in args )
                     {
-                        case null:
-                            break;
+                        paramBuilder.Append( '&' );
+                        paramBuilder.Append( Uri.EscapeDataString( key ) );
+                        paramBuilder.Append( '=' );
 
-                        case byte[] byteArrayValue:
-                            paramBuilder.Append( HttpUtility.UrlEncode( byteArrayValue ) );
-                            break;
+                        switch ( value )
+                        {
+                            case null:
+                                break;
 
-                        default:
-                            paramBuilder.Append( Uri.EscapeDataString( value.ToString() ) );
-                            break;
+                            case byte[] byteArrayValue:
+                                paramBuilder.Append( HttpUtility.UrlEncode( byteArrayValue ) );
+                                break;
+
+                            default:
+                                paramBuilder.Append( Uri.EscapeDataString( value.ToString() ) );
+                                break;
+                        }
                     }
                 }
                 

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -226,7 +226,7 @@ namespace SteamKit2
                 {
                     if ( !( format is string formatText ) || formatText != "vdf" )
                     {
-                        throw new ArgumentException( $"{nameof( args )} include unsupported {nameof( format )}: {format}" );
+                        throw new ArgumentException( $"Unsupported 'format' value '{format}'. Format must either be 'vdf' or omitted.", nameof(args) );
                     }
                 }
 
@@ -246,6 +246,7 @@ namespace SteamKit2
                 {
                     paramBuilder.Append( "key=" );
                     paramBuilder.Append( Uri.EscapeDataString( apiKey ) );
+                    paramBuilder.Append( "&" );
                 }
 
                 paramBuilder.Append( "format=vdf" );

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -153,6 +153,27 @@ namespace Tests
         }
 
         [Fact]
+        public async Task SupportsNullArgsDictionary()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = default( Dictionary<string, object> );
+            var response = await iface.CallAsync( HttpMethod.Get, "PerformFooOperation", 2, args );
+
+            var request = capturingHandler.MostRecentRequest;
+            Assert.NotNull( request );
+            Assert.Equal( HttpMethod.Get, request.Method );
+            Assert.Equal( "/IFooService/PerformFooOperation/v2/", request.RequestUri.AbsolutePath );
+
+            var values = request.RequestUri.ParseQueryString();
+            Assert.Single( values);
+            Assert.Equal( "vdf", values[ "format" ] );
+        }
+
+        [Fact]
         public async Task UsesSingleParameterArgumentsDictionary()
         {
             var capturingHandler = new CaturingHttpMessageHandler();

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -202,6 +202,37 @@ namespace Tests
             Assert.Equal( "vdf", formData[ "format" ] );
         }
 
+        [Fact]
+        public async Task IncludesApiKeyInParams()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c
+                .WithHttpClientFactory( () => new HttpClient( capturingHandler ) )
+                .WithWebAPIKey("MySecretApiKey") );
+
+            dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar",
+            };
+
+            var response = await iface.PerformFooOperation2( args );
+
+            var request = capturingHandler.MostRecentRequest;
+            Assert.NotNull( request );
+            Assert.Equal( HttpMethod.Get, request.Method );
+            Assert.Equal( "/IFooService/PerformFooOperation/v2/", request.RequestUri.AbsolutePath );
+
+            var values = request.RequestUri.ParseQueryString();
+            Assert.Equal( 4, values.Count );
+            Assert.Equal( "MySecretApiKey", values[ "key" ] );
+            Assert.Equal( "foo", values[ "f" ] );
+            Assert.Equal( "bar", values[ "b" ] );
+            Assert.Equal( "vdf", values[ "format" ] );
+        }
+
         sealed class ServiceUnavailableHttpMessageHandler : HttpMessageHandler
         {
             protected override Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -125,6 +125,34 @@ namespace Tests
         }
 
         [Fact]
+        public async Task UsesArgsAsQueryStringParams()
+        {
+            var capturingHandler = new CaturingHttpMessageHandler();
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( capturingHandler ) ) );
+
+            dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
+
+            var args = new Dictionary<string, object>
+            {
+                [ "f" ] = "foo",
+                [ "b" ] = "bar",
+            };
+
+            var response = await iface.PerformFooOperation2( args );
+
+            var request = capturingHandler.MostRecentRequest;
+            Assert.NotNull( request );
+            Assert.Equal( HttpMethod.Get, request.Method );
+            Assert.Equal( "/IFooService/PerformFooOperation/v2/", request.RequestUri.AbsolutePath );
+
+            var values =  request.RequestUri.ParseQueryString();
+            Assert.Equal( 3, values.Count );
+            Assert.Equal( "foo", values[ "f" ] );
+            Assert.Equal( "bar", values[ "b" ] );
+            Assert.Equal( "vdf", values[ "format" ] );
+        }
+
+        [Fact]
         public async Task UsesSingleParameterArgumentsDictionary()
         {
             var capturingHandler = new CaturingHttpMessageHandler();


### PR DESCRIPTION
This PR follows on from #992 by avoiding making any changes to the arguments dictionary in the first place.

I've rewritten the flow of the HTTP request builder function so that instead of updating the dictionary and then transforming the dictionary into text, we write out the text values directly, and then copy over the existing dictionary values.

cc/ @JustArchi @xPaw 