### PR TITLE
Read all available data in CryptoStream.Read()

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpPacket.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpPacket.cs
@@ -135,7 +135,7 @@ namespace SteamKit2
                 throw new ArgumentException( "Payload length exceeds 0x4DC maximum" );
 
             byte[] buf = new byte[ length ];
-            ms.Read( buf, 0, buf.Length );
+            ms.ReadAll( buf );
 
             var payload = new MemoryStream( buf );
             header.PayloadSize = ( ushort )payload.Length;

--- a/SteamKit2/SteamKit2/Util/CryptoHelper.cs
+++ b/SteamKit2/SteamKit2/Util/CryptoHelper.cs
@@ -161,7 +161,7 @@ namespace SteamKit2
                 using ( var ms = new MemoryStream( input ) )
                 using ( var cs = new CryptoStream( ms, aesTransform, CryptoStreamMode.Read ) )
                 {
-                    outLen = ReadAll( cs, plainText );
+                    outLen = cs.ReadAll( plainText );
                 }
 
                 byte[] output = new byte[ outLen ];
@@ -406,7 +406,7 @@ namespace SteamKit2
                     // plaintext is never longer than ciphertext
                     byte[] plaintext = new byte[ cipherText.Length ];
 
-                    int len = ReadAll( cs, plaintext );
+                    int len = cs.ReadAll( plaintext );
 
                     byte[] output = new byte[ len ];
                     Array.Copy( plaintext, 0, output, 0, len );
@@ -536,17 +536,6 @@ namespace SteamKit2
 
                 return block;
             }
-        }
-
-        private static int ReadAll( Stream stream, byte[] buffer )
-        {
-            int bytesRead;
-            int totalRead = 0;
-            while ( ( bytesRead = stream.Read( buffer, totalRead, buffer.Length - totalRead ) ) != 0 )
-            {
-                totalRead += bytesRead;
-            }
-            return totalRead;
         }
     }
 }

--- a/SteamKit2/SteamKit2/Util/CryptoHelper.cs
+++ b/SteamKit2/SteamKit2/Util/CryptoHelper.cs
@@ -161,7 +161,7 @@ namespace SteamKit2
                 using ( var ms = new MemoryStream( input ) )
                 using ( var cs = new CryptoStream( ms, aesTransform, CryptoStreamMode.Read ) )
                 {
-                    outLen = cs.Read( plainText, 0, plainText.Length );
+                    outLen = ReadAll( cs, plainText );
                 }
 
                 byte[] output = new byte[ outLen ];
@@ -406,7 +406,7 @@ namespace SteamKit2
                     // plaintext is never longer than ciphertext
                     byte[] plaintext = new byte[ cipherText.Length ];
 
-                    int len = cs.Read( plaintext, 0, plaintext.Length );
+                    int len = ReadAll( cs, plaintext );
 
                     byte[] output = new byte[ len ];
                     Array.Copy( plaintext, 0, output, 0, len );
@@ -538,5 +538,15 @@ namespace SteamKit2
             }
         }
 
+        private static int ReadAll( Stream stream, byte[] buffer )
+        {
+            int bytesRead;
+            int totalRead = 0;
+            while ( ( bytesRead = stream.Read( buffer, totalRead, buffer.Length - totalRead ) ) != 0 )
+            {
+                totalRead += bytesRead;
+            }
+            return totalRead;
+        }
     }
 }

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -104,5 +104,16 @@ namespace SteamKit2
 
             stream.Write( data, 0, data.Length );
         }
+
+        public static int ReadAll( this Stream stream, byte[] buffer )
+        {
+            int bytesRead;
+            int totalRead = 0;
+            while ( ( bytesRead = stream.Read( buffer, totalRead, buffer.Length - totalRead ) ) != 0 )
+            {
+                totalRead += bytesRead;
+            }
+            return totalRead;
+        }
     }
 }

--- a/SteamKit2/SteamKit2/Util/ZipUtil.cs
+++ b/SteamKit2/SteamKit2/Util/ZipUtil.cs
@@ -265,7 +265,13 @@ namespace SteamKit2
             using ( DeflateStream deflateStream = new DeflateStream( ms, CompressionMode.Decompress ) )
             {
                 byte[] inflated = new byte[ decompressedSize ];
-                deflateStream.Read( inflated, 0, inflated.Length );
+
+                int bytesRead;
+                int totalRead = 0;
+                while ( ( bytesRead = deflateStream.Read( inflated, totalRead, inflated.Length - totalRead ) ) != 0 )
+                {
+                    totalRead += bytesRead;
+                }
 
                 return inflated;
             }

--- a/SteamKit2/SteamKit2/Util/ZipUtil.cs
+++ b/SteamKit2/SteamKit2/Util/ZipUtil.cs
@@ -265,13 +265,7 @@ namespace SteamKit2
             using ( DeflateStream deflateStream = new DeflateStream( ms, CompressionMode.Decompress ) )
             {
                 byte[] inflated = new byte[ decompressedSize ];
-
-                int bytesRead;
-                int totalRead = 0;
-                while ( ( bytesRead = deflateStream.Read( inflated, totalRead, inflated.Length - totalRead ) ) != 0 )
-                {
-                    totalRead += bytesRead;
-                }
+                deflateStream.ReadAll( inflated );
 
                 return inflated;
             }

--- a/SteamKit2/Tests/CryptoHelperFacts.cs
+++ b/SteamKit2/Tests/CryptoHelperFacts.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using SteamKit2;
+using Xunit;
+
+namespace Tests
+{
+    public class CryptoHelperFacts
+    {
+        [Fact]
+        public void TestSymmetricEncryption()
+        {
+            const string decryptedExpected = "this is a 24 byte string";
+            const string encryptionKey = "encryption key";
+
+            using var sha256 = SHA256.Create();
+            var key = sha256.ComputeHash( Encoding.UTF8.GetBytes( encryptionKey ) );
+
+            var encryptedData = Encoding.UTF8.GetBytes( decryptedExpected );
+            encryptedData = CryptoHelper.SymmetricEncrypt( encryptedData, key );
+            var encryptedString = Convert.ToBase64String( encryptedData );
+
+            var decryptedData = Convert.FromBase64String( encryptedString );
+            decryptedData = CryptoHelper.SymmetricDecrypt( decryptedData, key );
+            var decryptedString = Encoding.UTF8.GetString( decryptedData );
+
+            Assert.Equal( decryptedExpected, decryptedString );
+        }
+    }
+}


### PR DESCRIPTION
This appears to be a breaking change in .NET 6 caused by https://github.com/dotnet/runtime/pull/53644

https://github.com/dotnet/runtime/issues/55527#issuecomment-878555536