### PR TITLE
Remove PICSGetProductInfo overloads that takes uint

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -185,6 +185,7 @@ namespace SteamKit2
         /// <param name="package">Package id requested.</param>
         /// <param name="metaDataOnly">Whether to send only meta data.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
+        [Obsolete( "Use an overload that takes PICSRequest instead of uint. In SteamKit 2.3, this overload had four parameters, but onlyPublic was removed. Audit your code." )]
         public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo(uint? app, uint? package, bool metaDataOnly = false)
         {
             List<uint> apps = new List<uint>();
@@ -225,6 +226,7 @@ namespace SteamKit2
         /// <param name="packages">List of package ids requested.</param>
         /// <param name="metaDataOnly">Whether to send only meta data.</param>
         /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
+        [Obsolete( "Use an overload that takes PICSRequest instead of uint. In SteamKit 2.3, this overload had four parameters, but onlyPublic was removed. Audit your code." )]
         public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( IEnumerable<uint> apps, IEnumerable<uint> packages, bool metaDataOnly = false )
         {
             return PICSGetProductInfo( apps.Select( app => new PICSRequest( app ) ), packages.Select( package => new PICSRequest( package ) ), metaDataOnly );

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -16,16 +16,10 @@ namespace SteamKit2
     /// </summary>
     public sealed partial class SteamApps : ClientMsgHandler
     {
-
-        // Ambiguous reference in cref attribute: 'SteamApps.PICSGetProductInfo'. Assuming 'SteamKit2.SteamApps.PICSGetProductInfo(uint?, uint?, bool, bool)',
-        // but could have also matched other overloads including 'SteamKit2.SteamApps.PICSGetProductInfo(System.Collections.Generic.IEnumerable<SteamKit2.SteamApps.PICSRequest>, System.Collections.Generic.IEnumerable<SteamKit2.SteamApps.PICSRequest>, bool)'.
-#pragma warning disable 0419
-
         /// <summary>
-        /// Represents a PICS request used for <see cref="SteamApps.PICSGetProductInfo"/>
+        /// Represents a PICS request used for <see cref="o:SteamApps.PICSGetProductInfo"/>
         /// </summary>
         public struct PICSRequest
-#pragma warning restore 0419
         {
             /// <summary>
             /// Gets or sets the ID of the app or package being requested
@@ -181,27 +175,6 @@ namespace SteamKit2
         /// Results are returned in a <see cref="PICSProductInfoCallback"/> callback.
         /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
         /// </summary>
-        /// <param name="app">App id requested.</param>
-        /// <param name="package">Package id requested.</param>
-        /// <param name="metaDataOnly">Whether to send only meta data.</param>
-        /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
-        [Obsolete( "Use an overload that takes PICSRequest instead of uint. In SteamKit 2.3, this overload had four parameters, but onlyPublic was removed. Audit your code." )]
-        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo(uint? app, uint? package, bool metaDataOnly = false)
-        {
-            List<uint> apps = new List<uint>();
-            List<uint> packages = new List<uint>();
-
-            if ( app.HasValue ) apps.Add( app.Value );
-            if ( package.HasValue ) packages.Add( package.Value );
-
-            return PICSGetProductInfo( apps, packages, metaDataOnly );
-        }
-
-        /// <summary>
-        /// Request product information for an app or package
-        /// Results are returned in a <see cref="PICSProductInfoCallback"/> callback.
-        /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
-        /// </summary>
         /// <param name="app"><see cref="PICSRequest"/> request for an app.</param>
         /// <param name="package"><see cref="PICSRequest"/> request for a package.</param>
         /// <param name="metaDataOnly">Whether to send only meta data.</param>
@@ -215,21 +188,6 @@ namespace SteamKit2
             if ( package.HasValue ) packages.Add( package.Value );
 
             return PICSGetProductInfo( apps, packages, metaDataOnly );
-        }
-
-        /// <summary>
-        /// Request product information for a list of apps or packages
-        /// Results are returned in a <see cref="PICSProductInfoCallback"/> callback.
-        /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
-        /// </summary>
-        /// <param name="apps">List of app ids requested.</param>
-        /// <param name="packages">List of package ids requested.</param>
-        /// <param name="metaDataOnly">Whether to send only meta data.</param>
-        /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
-        [Obsolete( "Use an overload that takes PICSRequest instead of uint. In SteamKit 2.3, this overload had four parameters, but onlyPublic was removed. Audit your code." )]
-        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( IEnumerable<uint> apps, IEnumerable<uint> packages, bool metaDataOnly = false )
-        {
-            return PICSGetProductInfo( apps.Select( app => new PICSRequest( app ) ), packages.Select( package => new PICSRequest( package ) ), metaDataOnly );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamApps/SteamApps.cs
@@ -197,6 +197,26 @@ namespace SteamKit2
         }
 
         /// <summary>
+        /// Request product information for an app or package
+        /// Results are returned in a <see cref="PICSProductInfoCallback"/> callback.
+        /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
+        /// </summary>
+        /// <param name="app"><see cref="PICSRequest"/> request for an app.</param>
+        /// <param name="package"><see cref="PICSRequest"/> request for a package.</param>
+        /// <param name="metaDataOnly">Whether to send only meta data.</param>
+        /// <returns>The Job ID of the request. This can be used to find the appropriate <see cref="PICSProductInfoCallback"/>.</returns>
+        public AsyncJobMultiple<PICSProductInfoCallback> PICSGetProductInfo( PICSRequest? app, PICSRequest? package, bool metaDataOnly = false )
+        {
+            var apps = new List<PICSRequest>();
+            var packages = new List<PICSRequest>();
+
+            if ( app.HasValue ) apps.Add( app.Value );
+            if ( package.HasValue ) packages.Add( package.Value );
+
+            return PICSGetProductInfo( apps, packages, metaDataOnly );
+        }
+
+        /// <summary>
         /// Request product information for a list of apps or packages
         /// Results are returned in a <see cref="PICSProductInfoCallback"/> callback.
         /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.


### PR DESCRIPTION
@JustArchi had a good suggestion to deprecate these overloads, as you really should be requesting app info while providing a token.

I also added an overload that takes one PICSRequest to make migrating easier.