### PR TITLE
Name threads so they fit on Linux

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -126,8 +126,10 @@ namespace SteamKit2
                     netReader = new BinaryReader(netStream);
                     netWriter = new BinaryWriter(netStream);
 
-                    netThread = new Thread(NetLoop);
-                    netThread.Name = "TcpConnection Thread";
+                    netThread = new Thread( NetLoop )
+                    {
+                        Name = "SK2-TcpConn"
+                    };
 
                     CurrentEndPoint = socket!.RemoteEndPoint;
                 }

--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
@@ -137,8 +137,10 @@ namespace SteamKit2
             inSeqAcked = 0;
             inSeqHandled = 0;
 
-            netThread = new Thread(NetLoop);
-            netThread.Name = "UdpConnection Thread";
+            netThread = new Thread( NetLoop )
+            {
+                Name = "SK2-UdpConn"
+            };
             netThread.Start(endPoint);
         }
 

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -18,7 +18,10 @@ namespace Tests
             
             for ( var i = 0; i < threads.Length; i++)
             {
-                threads[i] = new Thread(ThreadStart);
+                threads[ i ] = new Thread( ThreadStart )
+                {
+                    Name = $"SK2-Test-{i}"
+                };
                 threads[i].Start(i);
             }
 


### PR DESCRIPTION
Thread names on Linux are limited to 15 characters.