### PR TITLE
Add WebAPI overload that fetches protobuf instead of vdf

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CDNClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CDNClient.cs
@@ -87,7 +87,10 @@ namespace SteamKit2
             /// Gets the preferred server status.
             /// </summary>
             public bool PreferredServer { get; internal set; }
-
+            /// <summary>
+            /// Gets the flag whether this server is for Steam China only.
+            /// </summary>
+            public bool SteamChinaOnly { get; internal set; }
             /// <summary>
             /// Gets the download proxy status.
             /// </summary>

--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
+using ProtoBuf;
 
 namespace SteamKit2
 {
@@ -25,9 +26,9 @@ namespace SteamKit2
         /// A different base address can be specified in a <see cref="SteamConfiguration"/> object, or
         /// as a function argument where overloads are available.
         /// </summary>
-        public static Uri DefaultBaseAddress { get; } = new Uri("https://api.steampowered.com/", UriKind.Absolute);
+        public static Uri DefaultBaseAddress { get; } = new Uri( "https://api.steampowered.com/", UriKind.Absolute );
 
-        internal static TimeSpan DefaultTimeout { get; } = TimeSpan.FromSeconds(100);
+        internal static TimeSpan DefaultTimeout { get; } = TimeSpan.FromSeconds( 100 );
 
         /// <summary>
         /// Represents a single interface that exists within the Web API.
@@ -181,8 +182,8 @@ namespace SteamKit2
             /// </value>
             public TimeSpan Timeout
             {
-                    get => httpClient.Timeout;
-                    set => httpClient.Timeout = value;
+                get => httpClient.Timeout;
+                set => httpClient.Timeout = value;
             }
 
             static Regex funcNameRegex = new Regex(
@@ -197,6 +198,30 @@ namespace SteamKit2
                 this.apiKey = apiKey;
             }
 
+            /// <summary>
+            /// Manually calls the specified Web API function with the provided details.
+            /// </summary>
+            /// <param name="func">The function name to call.</param>
+            /// <param name="version">The version of the function to call.</param>
+            /// <param name="args">A dictionary of string key value pairs representing arguments to be passed to the API.</param>
+            /// <param name="method">The http request method. Either "POST" or "GET".</param>
+            /// <returns>A <see cref="Task{T}"/> that contains object representing the results of the Web API call.</returns>
+            /// <exception cref="ArgumentNullException">The function name or request method provided were <c>null</c>.</exception>
+            /// <exception cref="HttpRequestException">An network error occurred when performing the request.</exception>
+            /// <exception cref="WebAPIRequestException">A network error occurred when performing the request.</exception>
+            /// <exception cref="ProtoException">An error occured when parsing the response from the WebAPI.</exception>
+            public async Task<T> CallAsync<T>( HttpMethod method, string func, int version = 1, Dictionary<string, object>? args = null )
+            {
+                var response = await CallAsyncInternal( method, func, version, args, "protobuf_raw" );
+
+                var t = await response.Content.ReadAsStringAsync().ConfigureAwait( false );
+
+                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait( false );
+
+                var body = Serializer.Deserialize<T>( stream );
+
+                return body;
+            }
 
             /// <summary>
             /// Manually calls the specified Web API function with the provided details.
@@ -212,21 +237,46 @@ namespace SteamKit2
             /// <exception cref="InvalidDataException">An error occured when parsing the response from the WebAPI.</exception>
             public async Task<KeyValue> CallAsync( HttpMethod method, string func, int version = 1, Dictionary<string, object>? args = null )
             {
+                var response = await CallAsyncInternal( method, func, version, args, "vdf" );
+
+                using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait( false );
+
+                try
+                {
+                    var kv = new KeyValue();
+                    kv.ReadAsText( stream );
+                    return kv;
+                }
+                catch ( Exception ex )
+                {
+                    throw new InvalidDataException(
+                        "An internal error occurred when attempting to parse the response from the WebAPI server. This can indicate a change in the VDF format.",
+                        ex
+                    );
+                }
+            }
+
+            private async Task<HttpResponseMessage> CallAsyncInternal( HttpMethod method, string func, int version, Dictionary<string, object>? args, string expectedFormat )
+            {
                 if ( method == null )
                 {
-                    throw new ArgumentNullException( nameof(method) );
+                    throw new ArgumentNullException( nameof( method ) );
                 }
 
                 if ( func == null )
                 {
-                    throw new ArgumentNullException( nameof(func) );
+                    throw new ArgumentNullException( nameof( func ) );
                 }
+
+                var formatProvided = false;
 
                 if ( args != null && args.TryGetValue( "format", out var format ) )
                 {
+                    formatProvided = true;
+
                     if ( !( format is string formatText ) || formatText != "vdf" )
                     {
-                        throw new ArgumentException( $"Unsupported 'format' value '{format}'. Format must either be 'vdf' or omitted.", nameof(args) );
+                        throw new ArgumentException( $"Unsupported 'format' value '{format}'. Format must either be '{expectedFormat}' or omitted.", nameof( args ) );
                     }
                 }
 
@@ -237,7 +287,7 @@ namespace SteamKit2
                 var urlBuilder = paramsGoInQueryString ? paramBuilder : new StringBuilder();
                 urlBuilder.AppendFormat( "{0}/{1}/v{2}", iface, func, version );
 
-                if (paramsGoInQueryString)
+                if ( paramsGoInQueryString )
                 {
                     urlBuilder.Append( "/?" );
                 }
@@ -249,7 +299,11 @@ namespace SteamKit2
                     paramBuilder.Append( "&" );
                 }
 
-                paramBuilder.Append( "format=vdf" );
+                if ( !formatProvided )
+                {
+                    paramBuilder.Append( "format=" );
+                    paramBuilder.Append( expectedFormat );
+                }
 
                 if ( args != null )
                 {
@@ -274,7 +328,7 @@ namespace SteamKit2
                         }
                     }
                 }
-                
+
                 var request = new HttpRequestMessage( method, urlBuilder.ToString() );
 
                 if ( !paramsGoInQueryString )
@@ -290,24 +344,7 @@ namespace SteamKit2
                     throw new WebAPIRequestException( $"Response status code does not indicate success: {response.StatusCode:D} ({response.ReasonPhrase}).", response );
                 }
 
-                var kv = new KeyValue();
-
-                using ( var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait( false ) )
-                {
-                    try
-                    {
-                        kv.ReadAsText( stream );
-                    }
-                    catch ( Exception ex )
-                    {
-                        throw new InvalidDataException(
-                            "An internal error occurred when attempting to parse the response from the WebAPI server. This can indicate a change in the VDF format.",
-                            ex
-                        );
-                    }
-                }
-
-                return kv;
+                return response;
             }
 
             /// <summary>
@@ -366,7 +403,7 @@ namespace SteamKit2
                 else
                 {
                     methodArgs = Enumerable.Range( 0, args.Length )
-                        .ToDictionary( 
+                        .ToDictionary(
                             x => binder.CallInfo.ArgumentNames[ x ],
                             x => args[ x ] );
                 }
@@ -374,7 +411,7 @@ namespace SteamKit2
                 var apiArgs = new Dictionary<string, object>();
                 var requestMethod = HttpMethod.Get;
 
-                foreach ( var ( argName, argValue ) in methodArgs )
+                foreach ( var (argName, argValue) in methodArgs )
                 {
                     // method is a reserved param for selecting the http request method
                     if ( argName.Equals( "method", StringComparison.OrdinalIgnoreCase ) )
@@ -439,12 +476,12 @@ namespace SteamKit2
         {
             if ( baseAddress == null )
             {
-                throw new ArgumentNullException( nameof(baseAddress) );
+                throw new ArgumentNullException( nameof( baseAddress ) );
             }
 
             if ( iface == null )
             {
-                throw new ArgumentNullException( nameof(iface) );
+                throw new ArgumentNullException( nameof( iface ) );
             }
 
             return new Interface( CreateDefaultHttpClient( baseAddress ), iface, apiKey );
@@ -460,7 +497,7 @@ namespace SteamKit2
         {
             if ( iface == null )
             {
-                throw new ArgumentNullException( nameof(iface) );
+                throw new ArgumentNullException( nameof( iface ) );
             }
 
             return new Interface( CreateDefaultHttpClient( DefaultBaseAddress ), iface, apiKey );
@@ -476,7 +513,7 @@ namespace SteamKit2
         {
             if ( iface == null )
             {
-                throw new ArgumentNullException( nameof(iface) );
+                throw new ArgumentNullException( nameof( iface ) );
             }
 
             return new AsyncInterface( CreateDefaultHttpClient( DefaultBaseAddress ), iface, apiKey );
@@ -493,14 +530,14 @@ namespace SteamKit2
         {
             if ( baseAddress == null )
             {
-                throw new ArgumentNullException( nameof(baseAddress) );
+                throw new ArgumentNullException( nameof( baseAddress ) );
             }
 
             if ( iface == null )
             {
-                throw new ArgumentNullException( nameof(iface) );
+                throw new ArgumentNullException( nameof( iface ) );
             }
-            
+
             return new AsyncInterface( CreateDefaultHttpClient( baseAddress ), iface, apiKey );
         }
 


### PR DESCRIPTION
I only changed the response, not the input.

The api accepts `input_protobuf_encoded` which means the overload could be changed to accept a proto request.

I updated `ContentServerDirectoryService` to use this (which by the way, could actually be executed as a service call over CMClient instead).