### PR TITLE
Automatically update protos

### DIFF
--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
     - yaakov/auto-protos # temporary trigger during development
-  schedule:
-  - cron: '0 17 * * SUN'
+  #schedule:
+  #- cron: '0 17 * * SUN'
 
 jobs:
   update-protobufs:
@@ -27,12 +27,12 @@ jobs:
 
     # TODO: We need a new GitHub Machine Account (or maybe an existing one?) to generate a PAT that we can use as the token here
     # otherwise, our new changes will not trigger further Actions (on:push or on:pull_request, i.e. CI/CD builds).
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3.10.1
-      with:
-          #token: ${{ secrets.PAT }}
-          commit-message: Update protobufs
-          title: Update protobufs
-          body: |
-            - Update protobufs
-          branch: auto/protobufs
+    #- name: Create Pull Request
+    #  uses: peter-evans/create-pull-request@v3.10.1
+    #  with:
+    #      #token: ${{ secrets.PAT }}
+    #      commit-message: Update protobufs
+    #      title: Update protobufs
+    #      body: |
+    #        - Update protobufs
+    #      branch: auto/protobufs

--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -1,4 +1,4 @@
-name: Update Dependencies
+name: Update Protobufs
 on:
   push:
     branches:

--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -27,12 +27,12 @@ jobs:
 
     # TODO: We need a new GitHub Machine Account (or maybe an existing one?) to generate a PAT that we can use as the token here
     # otherwise, our new changes will not trigger further Actions (on:push or on:pull_request, i.e. CI/CD builds).
-    #- name: Create Pull Request
-    #  uses: peter-evans/create-pull-request@v3.10.1
-    #  with:
-    #      token: ${{ secrets.PAT }}
-    #      commit-message: Update protobufs
-    #      title: Update protobufs
-    #      body: |
-    #        - Update protobufs
-    #      branch: auto/protobufs
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3.10.1
+      with:
+          #token: ${{ secrets.PAT }}
+          commit-message: Update protobufs
+          title: Update protobufs
+          body: |
+            - Update protobufs
+          branch: auto/protobufs

--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -13,12 +13,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.4
-      with:
-        submodules: true
 
     - name: Fetch latest protobufs
       run: |
-        git submodule foreach git pull origin master
+        git config pull.ff only
+        git submodule update --init --recursive
+        ( cd Resources/Protobufs && git pull origin master )
 
     - name: Regenerate C# Code
       shell: pwsh

--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -13,7 +13,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2.3.4
-      submodules: true
+      with:
+        submodules: true
 
     - name: Fetch latest protobufs
       run: |

--- a/.github/workflows/update-protobufs.yaml
+++ b/.github/workflows/update-protobufs.yaml
@@ -1,0 +1,37 @@
+name: Update Dependencies
+on:
+  push:
+    branches:
+    - yaakov/auto-protos # temporary trigger during development
+  schedule:
+  - cron: '0 17 * * SUN'
+
+jobs:
+  update-protobufs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      submodules: true
+
+    - name: Fetch latest protobufs
+      run: |
+        git submodule foreach git pull origin master
+
+    - name: Regenerate C# Code
+      shell: pwsh
+      run: |
+        Resources/ProtobufGen/generate-all.ps1
+
+    # TODO: We need a new GitHub Machine Account (or maybe an existing one?) to generate a PAT that we can use as the token here
+    # otherwise, our new changes will not trigger further Actions (on:push or on:pull_request, i.e. CI/CD builds).
+    #- name: Create Pull Request
+    #  uses: peter-evans/create-pull-request@v3.10.1
+    #  with:
+    #      token: ${{ secrets.PAT }}
+    #      commit-message: Update protobufs
+    #      title: Update protobufs
+    #      body: |
+    #        - Update protobufs
+    #      branch: auto/protobufs

--- a/Resources/ProtobufGen/generate-all.ps1
+++ b/Resources/ProtobufGen/generate-all.ps1
@@ -13,7 +13,7 @@ param([string[]]$ProtoDir)
 
 $ProtoGenSrc = Join-Path $PSScriptRoot 'ProtobufGen'
 $ProtoGenDll = Join-Path $ProtoGenSrc '\bin\Debug\ProtobufGen.dll'
-$ProtoBase = Join-Path $PSScriptRoot '..\ProtoBufs'
+$ProtoBase = Join-Path $PSScriptRoot '..\Protobufs'
 $SK2Base = Join-Path $PSScriptRoot '..\..\SteamKit2\SteamKit2\Base\Generated'
 
 & dotnet build --configuration Debug $ProtoGenSrc


### PR DESCRIPTION
Here's quick late-night hack: use GitHub Actions to automatically update our protos regularly.

(I picked Sunday morning in my time zone, I think.)

The complication here is that the repository's automatic GITHUB_TOKEN can push code and create the pull request, but that [will not trigger subsequent Actions](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token) - i.e. building and testing the new code.

IMO that part is pretty important - we need to know at a glance if a protobuf update contains any breaking changes, we can't blindly merge them if they remove or rename something that we're using.

The recommendation from the various docs I've come across is to use a Personal Access Token (PAT) from either a particular developer (to whom all the PRs will be attributed to), or a new Machine Account.

According to the GitHub user terms, everyone can create at most one actual personal account plus one Machine Account, which is basically a personal account used solely for automation.

Does anyone have a machine account that we can re-use for this, or do I need to create a new one?