### PR TITLE
Allow consumers to specify a custom Machine Info Provider

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameServer/SteamGameServer.cs
@@ -125,7 +125,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )details.AppID;
-            logon.Body.machine_id = HardwareUtils.GetMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID( Client.Configuration.MachineInfoProvider );
 
             logon.Body.game_server_token = details.Token;
 
@@ -159,7 +159,7 @@ namespace SteamKit2
 
             logon.Body.client_os_type = ( uint )Utils.GetOSType();
             logon.Body.game_server_app_id = ( int )appId;
-            logon.Body.machine_id = HardwareUtils.GetMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID( Client.Configuration.MachineInfoProvider );
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -273,11 +273,6 @@ namespace SteamKit2
             };
         }
 
-        static SteamUser()
-        {
-            HardwareUtils.Init();
-        }
-
 
         /// <summary>
         /// Logs the client into the Steam3 network.
@@ -350,7 +345,7 @@ namespace SteamKit2
             // we're now using the latest steamclient package version, this is required to get a proper sentry file for steam guard
             logon.Body.client_package_version = 1771; // todo: determine if this is still required
             logon.Body.supports_rate_limit_response = true;
-            logon.Body.machine_id = HardwareUtils.GetMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID( Client.Configuration.MachineInfoProvider );
 
             // steam guard 
             logon.Body.auth_code = details.AuthCode;
@@ -405,7 +400,7 @@ namespace SteamKit2
             logon.Body.client_language = details.ClientLanguage;
             logon.Body.cell_id = details.CellID ?? Client.Configuration.CellID;
 
-            logon.Body.machine_id = HardwareUtils.GetMachineID();
+            logon.Body.machine_id = HardwareUtils.GetMachineID( Client.Configuration.MachineInfoProvider );
 
             this.Client.Send( logon );
         }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/IMachineInfoProvider.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/IMachineInfoProvider.cs
@@ -1,0 +1,29 @@
+namespace SteamKit2
+{
+    /// <summary>
+    /// Provides information about the machine that the application is running on.
+    /// For Steam Guard purposes, these values must return consistent results when run
+    /// on the same machine / in the same container / etc., otherwise it will be treated
+    /// as a separate machine and you may need to reauthenticate.
+    /// </summary>
+    public interface IMachineInfoProvider
+    {
+        /// <summary>
+        /// Provides a unique machine ID as binary data.
+        /// </summary>
+        /// <returns>The unique machine ID, or <c>null</c> if no such value could be found.</returns>
+        byte[]? GetMachineGuid();
+
+        /// <summary>
+        /// Provides the primary MAC address as binary data.
+        /// </summary>
+        /// <returns>The primary MAC address, or <c>null</c> if no such value could be found.</returns>
+        byte[]? GetMacAddress();
+
+        /// <summary>
+        /// Provides the boot disk's unique ID as binary data.
+        /// </summary>
+        /// <returns>The boot disk's unique ID, or <c>null</c> if no such value could be found.</returns>
+        byte[]? GetDiskId();
+    }
+}

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -53,6 +53,13 @@ namespace SteamKit2
         ISteamConfigurationBuilder WithHttpClientFactory(HttpClientFactory factoryFunction);
 
         /// <summary>
+        /// Configures this <see cref="SteamConfiguration" /> with custom machine information.
+        /// </summary>
+        /// <param name="machineInfoProvider">A custom machine information provider.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithMachineInfoProvider(IMachineInfoProvider machineInfoProvider);
+
+        /// <summary>
         /// Configures how this <see cref="SteamConfiguration" /> will be used to connect to Steam.
         /// </summary>
         /// <param name="protocolTypes">The supported protocol types to use when attempting to connect to Steam.</param>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -81,6 +81,12 @@ namespace SteamKit2
         public HttpClientFactory HttpClientFactory => state.HttpClientFactory;
 
         /// <summary>
+        /// The machine info provider to be used during the login process. This can be substituted with a custom implementation
+        /// when running SteamKit2 in new and novel environments that do not have an appropriate default implementation.
+        /// </summary>
+        public IMachineInfoProvider MachineInfoProvider => state.MachineInfoProvider;
+
+        /// <summary>
         /// The supported protocol types to use when attempting to connect to Steam.
         /// </summary>
         public ProtocolTypes ProtocolTypes => state.ProtocolTypes;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -32,6 +32,8 @@ namespace SteamKit2
                     EClientPersonaStateFlag.LastSeen,
 
                 HttpClientFactory = DefaultHttpClientFactory,
+                
+                MachineInfoProvider = DefaultMachineInfoProvider.Instance,
 
                 ProtocolTypes = ProtocolTypes.Tcp,
 
@@ -75,6 +77,12 @@ namespace SteamKit2
         public ISteamConfigurationBuilder WithHttpClientFactory(HttpClientFactory factoryFunction)
         {
             state.HttpClientFactory = factoryFunction;
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithMachineInfoProvider(IMachineInfoProvider machineInfoProvider)
+        {
+            state.MachineInfoProvider = machineInfoProvider;
             return this;
         }
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
@@ -16,6 +16,7 @@ namespace SteamKit2
         public TimeSpan ConnectionTimeout;
         public EClientPersonaStateFlag DefaultPersonaStateFlags;
         public HttpClientFactory HttpClientFactory;
+        public IMachineInfoProvider MachineInfoProvider;
         public ProtocolTypes ProtocolTypes;
         public IServerListProvider ServerListProvider;
         public EUniverse Universe;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -76,6 +76,9 @@ namespace SteamKit2
 
             this.handlers = new OrderedDictionary();
 
+            // Start calculating machine info so that it is (hopefully) ready by the time we get to logging in.
+            HardwareUtils.Init( configuration.MachineInfoProvider );
+
             // add this library's handlers
             // notice: SteamFriends should be added before SteamUser due to AccountInfoCallback
             this.AddHandler( new SteamFriends() );

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -370,8 +370,8 @@ namespace SteamKit2
 
             // Custom implementations can fail for any particular field, in which case we fall back to DefaultMachineInfoProvider.
             machineId.SetBB3( GetHexString( provider.GetMachineGuid() ?? DefaultMachineInfoProvider.Instance.GetMachineGuid() ) );
-            machineId.SetFF2( GetHexString( provider.GetMacAddress() ?? DefaultMachineInfoProvider.Instance.GetMachineGuid() ) );
-            machineId.Set3B3( GetHexString( provider.GetDiskId() ?? DefaultMachineInfoProvider.Instance.GetMachineGuid() ) );
+            machineId.SetFF2( GetHexString( provider.GetMacAddress() ?? DefaultMachineInfoProvider.Instance.GetMacAddress() ) );
+            machineId.Set3B3( GetHexString( provider.GetDiskId() ?? DefaultMachineInfoProvider.Instance.GetDiskId() ) );
 
             // 333 is some sort of user supplied data and is currently unused
 

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -322,7 +322,7 @@ namespace SteamKit2
             }
         }
 
-        static ConditionalWeakTable<IMachineInfoProvider, Task<MachineID>> generationTable;
+        static ConditionalWeakTable<IMachineInfoProvider, Task<MachineID>> generationTable = new ConditionalWeakTable<IMachineInfoProvider, Task<MachineID>>();
 
         public static void Init(IMachineInfoProvider machineInfoProvider)
         {


### PR DESCRIPTION
This allows consumers to specify a custom Machine Info Provider. If they do not specify one, we continue to use a SteamKit-supplied default based on the current operating system.

Whilst this can open the door to shady behaviour that we do not support, it also meets the legitimate case of allowing users to provide implementations on platforms that we do not neccesarily yet support (such as FreeBSD), or cannot easily support from a pure .NET Standard (or `net5.0`/`net6.0`) assembly - such as iOS, Android, or perhaps Blazor.

We retain the existing behaviour of running the generation in the background (in case it is a bit heavy/expensive), and caching the result.

It is the responsibility of the `IMachineInfoProvider` to either return a valid byte array containing a (consistent) value, or null. If the provider returns null, we fall back to `DefaultMachineInfoProvider` (formerly `DefaultInfoProvider`), which is guaranteed to return a non-null value.

It remains the responsibility of SteamKit to hash these values, build the message object, and attach the message object to login requests.

This closes #719 and supersedes #720.