### PR TITLE
Use non-legacy service methods (and some refactoring of messages/packets handling)

### DIFF
--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -191,8 +191,9 @@ namespace SteamKit2
 
             Header = packetMsg.Header;
 
-            using MemoryStream ms = new MemoryStream( packetMsg.GetData() );
-            ms.Seek( packetMsg.BodyOffset, SeekOrigin.Begin );
+            var data = packetMsg.GetData();
+            var offset = (int)packetMsg.BodyOffset;
+            using MemoryStream ms = new MemoryStream( data, offset, data.Length - offset );
 
             Body = Serializer.Deserialize<TBody>( ms );
 
@@ -353,8 +354,9 @@ namespace SteamKit2
 
             Header = packetMsg.Header;
 
-            using MemoryStream ms = new MemoryStream( packetMsg.GetData() );
-            ms.Seek( packetMsg.BodyOffset, SeekOrigin.Begin );
+            var data = packetMsg.GetData();
+            var offset = (int)packetMsg.BodyOffset;
+            using MemoryStream ms = new MemoryStream( data, offset, data.Length - offset );
 
             Body.Deserialize( ms );
 
@@ -506,8 +508,9 @@ namespace SteamKit2
 
             Header = packetMsg.Header;
 
-            using MemoryStream ms = new MemoryStream( packetMsg.GetData() );
-            ms.Seek( packetMsg.BodyOffset, SeekOrigin.Begin );
+            var data = packetMsg.GetData();
+            var offset = (int)packetMsg.BodyOffset;
+            using MemoryStream ms = new MemoryStream( data, offset, data.Length - offset );
 
             Body.Deserialize( ms );
 

--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -150,7 +150,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the body structure of this message.
         /// </summary>
-        public TBody Body { get; private set; }
+        public TBody Body { get; internal set; }
 
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/ClientMsg.cs
+++ b/SteamKit2/SteamKit2/Base/ClientMsg.cs
@@ -126,21 +126,6 @@ namespace SteamKit2
         {
             throw new NotSupportedException( "ClientMsgProtobuf is for reading only. Use ClientMsgProtobuf<T> for serializing messages." );
         }
-
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        public override void Deserialize( byte[] data )
-        {
-            if ( data == null )
-            {
-                throw new ArgumentNullException( nameof(data) );
-            }
-
-            using MemoryStream ms = new MemoryStream( data );
-            Header.Deserialize( ms );
-        }
     }
 
     /// <summary>
@@ -235,30 +220,6 @@ namespace SteamKit2
             Payload.WriteTo( ms );
 
             return ms.ToArray();
-        }
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        public override void Deserialize( byte[] data )
-        {
-            if ( data == null )
-            {
-                throw new ArgumentNullException( nameof(data) );
-            }
-
-            using MemoryStream ms = new MemoryStream( data );
-            Header.Deserialize( ms );
-            Body = Serializer.Deserialize<TBody>( ms );
-
-            // the rest of the data is the payload
-            int payloadLen = ( int )( ms.Length - ms.Position );
-
-            if ( payloadLen > 0 )
-            {
-                ms.CopyTo( Payload, payloadLen );
-                Payload.Seek( 0, SeekOrigin.Begin );
-            }
         }
     }
 
@@ -422,28 +383,6 @@ namespace SteamKit2
 
             return ms.ToArray();
         }
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        public override void Deserialize( byte[] data )
-        {
-            if ( data == null )
-            {
-                throw new ArgumentNullException( nameof(data) );
-            }
-
-            using MemoryStream ms = new MemoryStream( data );
-            Header.Deserialize( ms );
-            Body.Deserialize( ms );
-
-            // the rest of the data is the payload
-            int payloadOffset = ( int )ms.Position;
-            int payloadLen = ( int )( ms.Length - ms.Position );
-
-            Payload.Write( data, payloadOffset, payloadLen );
-            Payload.Seek( 0, SeekOrigin.Begin );
-        }
     }
 
     /// <summary>
@@ -598,28 +537,5 @@ namespace SteamKit2
 
             return ms.ToArray();
         }
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        public override void Deserialize( byte[] data )
-        {
-            if ( data == null )
-            {
-                throw new ArgumentNullException( nameof(data) );
-            }
-
-            using MemoryStream ms = new MemoryStream( data );
-            Header.Deserialize( ms );
-            Body.Deserialize( ms );
-
-            // the rest of the data is the payload
-            int payloadOffset = ( int )ms.Position;
-            int payloadLen = ( int )( ms.Length - ms.Position );
-
-            Payload.Write( data, payloadOffset, payloadLen );
-            Payload.Seek( 0, SeekOrigin.Begin );
-        }
-
     }
 }

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -65,11 +65,6 @@ namespace SteamKit2
         /// </summary>
         /// <returns>Data representing a client message.</returns>
         byte[] Serialize();
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        void Deserialize( byte[] data );
     }
 
     /// <summary>
@@ -513,11 +508,5 @@ namespace SteamKit2
         /// Data representing a client message.
         /// </returns>
         public abstract byte[] Serialize();
-        /// <summary>
-        /// Initializes this client message by deserializing the specified data.
-        /// </summary>
-        /// <param name="data">The data representing a client message.</param>
-        public abstract void Deserialize( byte[] data );
-
     }
 }

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -492,7 +492,7 @@ namespace SteamKit2
         /// <summary>
         /// Gets the header for this message type. 
         /// </summary>
-        public THeader Header { get; }
+        public THeader Header { get; internal set; }
 
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -47,6 +47,13 @@ namespace SteamKit2
         /// The source job id.
         /// </value>
         ulong SourceJobID { get; }
+        /// <summary>
+        /// Gets the offset in payload to the body after the header.
+        /// </summary>
+        /// <value>
+        /// The offset in payload after the header.
+        /// </value>
+        long BodyOffset { get; }
 
         /// <summary>
         /// Gets the underlying data that represents this client message.
@@ -195,6 +202,20 @@ namespace SteamKit2
         /// The source job id.
         /// </value>
         public ulong SourceJobID { get; }
+        /// <summary>
+        /// Gets the header for this packet message.
+        /// </summary>
+        /// <value>
+        /// The header.
+        /// </value>
+        public ExtendedClientMsgHdr Header { get; }
+        /// <summary>
+        /// Gets the offset in payload to the body after the header.
+        /// </summary>
+        /// <value>
+        /// The offset in payload after the header.
+        /// </value>
+        public long BodyOffset { get; }
 
         byte[] payload;
 
@@ -214,16 +235,17 @@ namespace SteamKit2
             MsgType = eMsg;
             payload = data;
 
-            ExtendedClientMsgHdr extendedHdr = new ExtendedClientMsgHdr();
+            Header = new ExtendedClientMsgHdr();
 
             // deserialize the extended header to get our hands on the job ids
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
-                extendedHdr.Deserialize( ms );
+                Header.Deserialize( ms );
+                BodyOffset = ms.Position;
             }
 
-            TargetJobID = extendedHdr.TargetJobID;
-            SourceJobID = extendedHdr.SourceJobID;
+            TargetJobID = Header.TargetJobID;
+            SourceJobID = Header.SourceJobID;
         }
 
 
@@ -272,6 +294,20 @@ namespace SteamKit2
         /// The source job id.
         /// </value>
         public ulong SourceJobID { get; }
+        /// <summary>
+        /// Gets the header for this packet message.
+        /// </summary>
+        /// <value>
+        /// The header.
+        /// </value>
+        public MsgHdr Header { get; }
+        /// <summary>
+        /// Gets the offset in payload to the body after the header.
+        /// </summary>
+        /// <value>
+        /// The offset in payload after the header.
+        /// </value>
+        public long BodyOffset { get; }
 
         byte[] payload;
 
@@ -291,16 +327,17 @@ namespace SteamKit2
             MsgType = eMsg;
             payload = data;
 
-            MsgHdr msgHdr = new MsgHdr();
+            Header = new MsgHdr();
 
             // deserialize the header to get our hands on the job ids
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
-                msgHdr.Deserialize( ms );
+                Header.Deserialize( ms );
+                BodyOffset = ms.Position;
             }
 
-            TargetJobID = msgHdr.TargetJobID;
-            SourceJobID = msgHdr.SourceJobID;
+            TargetJobID = Header.TargetJobID;
+            SourceJobID = Header.SourceJobID;
         }
 
 

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -104,10 +104,10 @@ namespace SteamKit2
         /// </value>
         public ulong SourceJobID { get; }
         /// <summary>
-        /// Gets the source job id for this packet message.
+        /// Gets the header for this packet message.
         /// </summary>
         /// <value>
-        /// The source job id.
+        /// The header.
         /// </value>
         public MsgHdrProtoBuf Header { get; }
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -102,14 +102,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; }
+        public ulong TargetJobID => Header.Proto.jobid_target;
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; }
+        public ulong SourceJobID => Header.Proto.jobid_source;
         /// <summary>
         /// Gets the header for this packet message.
         /// </summary>
@@ -146,14 +146,9 @@ namespace SteamKit2
             Header = new MsgHdrProtoBuf();
 
             // we need to pull out the job ids, so we deserialize the protobuf header
-            using ( MemoryStream ms = new MemoryStream( data ) )
-            {
-                Header.Deserialize( ms );
-                BodyOffset = ms.Position;
-            }
-
-            TargetJobID = Header.Proto.jobid_target;
-            SourceJobID = Header.Proto.jobid_source;
+            using MemoryStream ms = new MemoryStream( data );
+            Header.Deserialize( ms );
+            BodyOffset = ms.Position;
         }
 
 
@@ -194,14 +189,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; }
+        public ulong TargetJobID => Header.TargetJobID;
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; }
+        public ulong SourceJobID => Header.SourceJobID;
         /// <summary>
         /// Gets the header for this packet message.
         /// </summary>
@@ -238,14 +233,9 @@ namespace SteamKit2
             Header = new ExtendedClientMsgHdr();
 
             // deserialize the extended header to get our hands on the job ids
-            using ( MemoryStream ms = new MemoryStream( data ) )
-            {
-                Header.Deserialize( ms );
-                BodyOffset = ms.Position;
-            }
-
-            TargetJobID = Header.TargetJobID;
-            SourceJobID = Header.SourceJobID;
+            using MemoryStream ms = new MemoryStream( data );
+            Header.Deserialize( ms );
+            BodyOffset = ms.Position;
         }
 
 
@@ -286,14 +276,14 @@ namespace SteamKit2
         /// <value>
         /// The target job id.
         /// </value>
-        public ulong TargetJobID { get; }
+        public ulong TargetJobID => Header.TargetJobID;
         /// <summary>
         /// Gets the source job id for this packet message.
         /// </summary>
         /// <value>
         /// The source job id.
         /// </value>
-        public ulong SourceJobID { get; }
+        public ulong SourceJobID => Header.SourceJobID;
         /// <summary>
         /// Gets the header for this packet message.
         /// </summary>
@@ -330,14 +320,9 @@ namespace SteamKit2
             Header = new MsgHdr();
 
             // deserialize the header to get our hands on the job ids
-            using ( MemoryStream ms = new MemoryStream( data ) )
-            {
-                Header.Deserialize( ms );
-                BodyOffset = ms.Position;
-            }
-
-            TargetJobID = Header.TargetJobID;
-            SourceJobID = Header.SourceJobID;
+            using MemoryStream ms = new MemoryStream( data );
+            Header.Deserialize( ms );
+            BodyOffset = ms.Position;
         }
 
 

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -103,7 +103,20 @@ namespace SteamKit2
         /// The source job id.
         /// </value>
         public ulong SourceJobID { get; }
-
+        /// <summary>
+        /// Gets the source job id for this packet message.
+        /// </summary>
+        /// <value>
+        /// The source job id.
+        /// </value>
+        public MsgHdrProtoBuf Header { get; }
+        /// <summary>
+        /// Gets the offset in payload to the body after the header.
+        /// </summary>
+        /// <value>
+        /// The offset in payload after the header.
+        /// </value>
+        public long BodyOffset { get; }
 
         byte[] payload;
 
@@ -123,16 +136,17 @@ namespace SteamKit2
             MsgType = eMsg;
             payload = data;
 
-            MsgHdrProtoBuf protobufHeader = new MsgHdrProtoBuf();
+            Header = new MsgHdrProtoBuf();
 
             // we need to pull out the job ids, so we deserialize the protobuf header
             using ( MemoryStream ms = new MemoryStream( data ) )
             {
-                protobufHeader.Deserialize( ms );
+                Header.Deserialize( ms );
+                BodyOffset = ms.Position;
             }
 
-            TargetJobID = protobufHeader.Proto.jobid_target;
-            SourceJobID = protobufHeader.Proto.jobid_source;
+            TargetJobID = Header.Proto.jobid_target;
+            SourceJobID = Header.Proto.jobid_source;
         }
 
 

--- a/SteamKit2/SteamKit2/Base/PacketBase.cs
+++ b/SteamKit2/SteamKit2/Base/PacketBase.cs
@@ -47,13 +47,6 @@ namespace SteamKit2
         /// The source job id.
         /// </value>
         ulong SourceJobID { get; }
-        /// <summary>
-        /// Gets the offset in payload to the body after the header.
-        /// </summary>
-        /// <value>
-        /// The offset in payload after the header.
-        /// </value>
-        long BodyOffset { get; }
 
         /// <summary>
         /// Gets the underlying data that represents this client message.
@@ -87,7 +80,7 @@ namespace SteamKit2
         /// <value>
         /// 	<c>true</c> if this instance is protobuf backed; otherwise, <c>false</c>.
         /// </value>
-        public bool IsProto { get { return true; } }
+        public bool IsProto => true;
         /// <summary>
         /// Gets the network message type of this packet message.
         /// </summary>
@@ -116,14 +109,14 @@ namespace SteamKit2
         /// <value>
         /// The header.
         /// </value>
-        public MsgHdrProtoBuf Header { get; }
+        internal MsgHdrProtoBuf Header;
         /// <summary>
         /// Gets the offset in payload to the body after the header.
         /// </summary>
         /// <value>
         /// The offset in payload after the header.
         /// </value>
-        public long BodyOffset { get; }
+        internal long BodyOffset;
 
         byte[] payload;
 
@@ -203,14 +196,14 @@ namespace SteamKit2
         /// <value>
         /// The header.
         /// </value>
-        public ExtendedClientMsgHdr Header { get; }
+        internal ExtendedClientMsgHdr Header;
         /// <summary>
         /// Gets the offset in payload to the body after the header.
         /// </summary>
         /// <value>
         /// The offset in payload after the header.
         /// </value>
-        public long BodyOffset { get; }
+        internal long BodyOffset;
 
         byte[] payload;
 
@@ -290,14 +283,14 @@ namespace SteamKit2
         /// <value>
         /// The header.
         /// </value>
-        public MsgHdr Header { get; }
+        internal MsgHdr Header;
         /// <summary>
         /// Gets the offset in payload to the body after the header.
         /// </summary>
         /// <value>
         /// The offset in payload after the header.
         /// </value>
-        public long BodyOffset { get; }
+        internal long BodyOffset;
 
         byte[] payload;
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
@@ -4,10 +4,8 @@
  */
 
 using System;
-using System.IO;
 using System.Reflection;
 using ProtoBuf;
-using SteamKit2.Internal;
 
 namespace SteamKit2
 {
@@ -24,16 +22,11 @@ namespace SteamKit2
             public EResult Result { get; private set; }
 
             /// <summary>
-            /// Gets the packet.
-            /// </summary>
-            public IPacketMsg PacketMsg { get; private set; }
-
-            /// <summary>
             /// Gets the name of the Service.
             /// </summary>
             public string ServiceName
             {
-                get { return MethodName.Split( '.' )[0]; }
+                get { return MethodName.Split( '.' )[ 0 ]; }
             }
 
             /// <summary>
@@ -41,7 +34,7 @@ namespace SteamKit2
             /// </summary>
             public string RpcName
             {
-                get { return MethodName.Substring( ServiceName.Length + 1 ).Split( '#' )[0]; }
+                get { return MethodName.Substring( ServiceName.Length + 1 ).Split( '#' )[ 0 ]; }
             }
 
             /// <summary>
@@ -49,14 +42,15 @@ namespace SteamKit2
             /// </summary>
             public string MethodName { get; private set; }
 
+            private PacketClientMsgProtobuf PacketMsg;
 
-            internal ServiceMethodResponse( JobID jobID, EResult result, ClientMsgProtobuf response, IPacketMsg packetMsg )
+            internal ServiceMethodResponse( PacketClientMsgProtobuf packetMsg )
             {
-                JobID = jobID;
-
-                Result = result;
+                var protoHeader = packetMsg.Header.Proto;
+                JobID = protoHeader.jobid_target;
+                Result = ( EResult )protoHeader.eresult;
+                MethodName = protoHeader.target_job_name;
                 PacketMsg = packetMsg;
-                MethodName = response.ProtoHeader.target_job_name;
             }
 
 
@@ -83,7 +77,7 @@ namespace SteamKit2
             /// </summary>
             public string ServiceName
             {
-                get { return MethodName.Split( '.' )[0]; }
+                get { return MethodName.Split( '.' )[ 0 ]; }
             }
 
             /// <summary>
@@ -91,7 +85,7 @@ namespace SteamKit2
             /// </summary>
             public string RpcName
             {
-                get { return MethodName.Substring( ServiceName.Length + 1 ).Split( '#' )[0]; }
+                get { return MethodName.Substring( ServiceName.Length + 1 ).Split( '#' )[ 0 ]; }
             }
 
             /// <summary>

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/Callbacks.cs
@@ -24,9 +24,9 @@ namespace SteamKit2
             public EResult Result { get; private set; }
 
             /// <summary>
-            /// Gets the raw binary response.
+            /// Gets the packet.
             /// </summary>
-            public byte[] ResponseRaw { get; private set; }
+            public IPacketMsg PacketMsg { get; private set; }
 
             /// <summary>
             /// Gets the name of the Service.
@@ -50,13 +50,13 @@ namespace SteamKit2
             public string MethodName { get; private set; }
 
 
-            internal ServiceMethodResponse( JobID jobID, EResult result, CMsgClientServiceMethodLegacyResponse resp )
+            internal ServiceMethodResponse( JobID jobID, EResult result, ClientMsgProtobuf response, IPacketMsg packetMsg )
             {
                 JobID = jobID;
 
                 Result = result;
-                ResponseRaw = resp.serialized_method_response;
-                MethodName = resp.method_name ?? string.Empty;
+                PacketMsg = packetMsg;
+                MethodName = response.ProtoHeader.target_job_name;
             }
 
 
@@ -66,10 +66,10 @@ namespace SteamKit2
             /// <typeparam name="T">Protobuf type of the response message.</typeparam>
             /// <returns>The response to the message sent through <see cref="SteamUnifiedMessages"/>.</returns>
             public T GetDeserializedResponse<T>()
-                where T : IExtensible
+                where T : IExtensible, new()
             {
-                using var ms = new MemoryStream( ResponseRaw );
-                return Serializer.Deserialize<T>( ms );
+                var msg = new ClientMsgProtobuf<T>( PacketMsg );
+                return msg.Body;
             }
         }
 

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using ProtoBuf;
-using SteamKit2.Internal;
 
 namespace SteamKit2
 {
@@ -172,16 +171,23 @@ namespace SteamKit2
         #region ClientMsg Handlers
         void HandleServiceMethodResponse( IPacketMsg packetMsg )
         {
-            var response = new ClientMsgProtobuf( packetMsg );
-            var callback = new ServiceMethodResponse( response.TargetJobID, (EResult)response.ProtoHeader.eresult, response, packetMsg );
+            if ( !( packetMsg is PacketClientMsgProtobuf packetMsgProto ) )
+            {
+                throw new InvalidDataException( "Packet message is expected to be protobuf." );
+            }
+
+            var callback = new ServiceMethodResponse( packetMsgProto );
             Client.PostCallback( callback );
         }
 
         void HandleServiceMethod( IPacketMsg packetMsg )
         {
-            var notification = new ClientMsgProtobuf( packetMsg );
+            if ( !( packetMsg is PacketClientMsgProtobuf packetMsgProto ) )
+            {
+                throw new InvalidDataException( "Packet message is expected to be protobuf." );
+            }
 
-            var jobName = notification.Header.Proto.target_job_name;
+            var jobName = packetMsgProto.Header.Proto.target_job_name;
             if ( !string.IsNullOrEmpty( jobName ) )
             {
                 var splitByDot = jobName.Split( '.' );


### PR DESCRIPTION
Ref: #909

This appears to work, but the implementation is questionable at best. I haven't tested ServiceMethodSendToClient.

`GetDeserializedResponse` could be removed if responses were handled similarly to how they're done for notifications here: https://github.com/xPaw/SteamKit/blob/c3964e89564575083dfd30c354394ec13131301c/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs#L182

However, it will not work if consumers have their own protobufs that SK doesn't have.

