### PR TITLE
Remove some of the old messages

### DIFF
--- a/Resources/SteamLanguage/steammsg.steamd
+++ b/Resources/SteamLanguage/steammsg.steamd
@@ -30,13 +30,13 @@ class MsgChannelEncryptResult<EMsg::ChannelEncryptResult>
 	EResult result = EResult::Invalid;
 };
 
-class MsgClientNewLoginKey<EMsg::ClientNewLoginKey>
+class MsgClientNewLoginKey<EMsg::ClientNewLoginKey> removed
 {
 	uint uniqueID;
 	byte<20> loginKey;
 };
 
-class MsgClientNewLoginKeyAccepted<EMsg::ClientNewLoginKeyAccepted>
+class MsgClientNewLoginKeyAccepted<EMsg::ClientNewLoginKeyAccepted> removed
 {
 	uint uniqueID;
 };
@@ -86,7 +86,7 @@ class MsgClientAppUsageEvent<EMsg::ClientAppUsageEvent>
 	ushort offline;
 };
 
-class MsgClientEmailAddrInfo<EMsg::ClientEmailAddrInfo>
+class MsgClientEmailAddrInfo<EMsg::ClientEmailAddrInfo> removed
 {
 	uint passwordStrength;
 	uint flagsAccountSecurityPolicy;
@@ -100,7 +100,7 @@ class MsgClientUpdateGuestPassesList<EMsg::ClientUpdateGuestPassesList>
 	int countGuestPassesToRedeem;
 };
 
-class MsgClientRequestedClientStats<EMsg::ClientRequestedClientStats>
+class MsgClientRequestedClientStats<EMsg::ClientRequestedClientStats> removed
 {
 	int countStats;
 };

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
@@ -596,67 +596,6 @@ namespace SteamKit2.Internal
 		}
 	}
 
-	public class MsgClientNewLoginKey : ISteamSerializableMessage
-	{
-		public EMsg GetEMsg() { return EMsg.ClientNewLoginKey; }
-
-		// Static size: 4
-		public uint UniqueID { get; set; }
-		// Static size: 20
-		public byte[] LoginKey { get; set; }
-
-		public MsgClientNewLoginKey()
-		{
-			UniqueID = 0;
-			LoginKey = new byte[20];
-		}
-
-		public void Serialize(Stream stream)
-		{
-			BinaryWriter bw = new BinaryWriter( stream );
-
-			bw.Write( UniqueID );
-			bw.Write( LoginKey );
-
-		}
-
-		public void Deserialize( Stream stream )
-		{
-			BinaryReader br = new BinaryReader( stream );
-
-			UniqueID = br.ReadUInt32();
-			LoginKey = br.ReadBytes( 20 );
-		}
-	}
-
-	public class MsgClientNewLoginKeyAccepted : ISteamSerializableMessage
-	{
-		public EMsg GetEMsg() { return EMsg.ClientNewLoginKeyAccepted; }
-
-		// Static size: 4
-		public uint UniqueID { get; set; }
-
-		public MsgClientNewLoginKeyAccepted()
-		{
-			UniqueID = 0;
-		}
-
-		public void Serialize(Stream stream)
-		{
-			BinaryWriter bw = new BinaryWriter( stream );
-
-			bw.Write( UniqueID );
-
-		}
-
-		public void Deserialize( Stream stream )
-		{
-			BinaryReader br = new BinaryReader( stream );
-
-			UniqueID = br.ReadUInt32();
-		}
-	}
-
 	public class MsgClientLogon : ISteamSerializableMessage
 	{
 		public EMsg GetEMsg() { return EMsg.ClientLogon; }
@@ -772,45 +711,6 @@ namespace SteamKit2.Internal
 		}
 	}
 
-	public class MsgClientEmailAddrInfo : ISteamSerializableMessage
-	{
-		public EMsg GetEMsg() { return EMsg.ClientEmailAddrInfo; }
-
-		// Static size: 4
-		public uint PasswordStrength { get; set; }
-		// Static size: 4
-		public uint FlagsAccountSecurityPolicy { get; set; }
-		// Static size: 1
-		private byte validated;
-		public bool Validated { get { return ( validated == 1 ); } set { validated = ( byte )( value ? 1 : 0 ); } }
-
-		public MsgClientEmailAddrInfo()
-		{
-			PasswordStrength = 0;
-			FlagsAccountSecurityPolicy = 0;
-			validated = 0;
-		}
-
-		public void Serialize(Stream stream)
-		{
-			BinaryWriter bw = new BinaryWriter( stream );
-
-			bw.Write( PasswordStrength );
-			bw.Write( FlagsAccountSecurityPolicy );
-			bw.Write( validated );
-
-		}
-
-		public void Deserialize( Stream stream )
-		{
-			BinaryReader br = new BinaryReader( stream );
-
-			PasswordStrength = br.ReadUInt32();
-			FlagsAccountSecurityPolicy = br.ReadUInt32();
-			validated = br.ReadByte();
-		}
-	}
-
 	public class MsgClientUpdateGuestPassesList : ISteamSerializableMessage
 	{
 		public EMsg GetEMsg() { return EMsg.ClientUpdateGuestPassesList; }
@@ -846,34 +746,6 @@ namespace SteamKit2.Internal
 			Result = (EResult)br.ReadInt32();
 			CountGuestPassesToGive = br.ReadInt32();
 			CountGuestPassesToRedeem = br.ReadInt32();
-		}
-	}
-
-	public class MsgClientRequestedClientStats : ISteamSerializableMessage
-	{
-		public EMsg GetEMsg() { return EMsg.ClientRequestedClientStats; }
-
-		// Static size: 4
-		public int CountStats { get; set; }
-
-		public MsgClientRequestedClientStats()
-		{
-			CountStats = 0;
-		}
-
-		public void Serialize(Stream stream)
-		{
-			BinaryWriter bw = new BinaryWriter( stream );
-
-			bw.Write( CountStats );
-
-		}
-
-		public void Deserialize( Stream stream )
-		{
-			BinaryReader br = new BinaryReader( stream );
-
-			CountStats = br.ReadInt32();
 		}
 	}
 


### PR DESCRIPTION
MsgClientLoggedOff still happens if you connect and don't login after a minute. (result is Fail).

OGS messages, guest pass list, chat messages, MsgClientServerUnavailable, MsgClientMarketingMessageUpdate2 are still used.

SK handles `MsgClientLogOnResponse`, but I don't know when that can happen.

