### PR TITLE
Simplify info in nethook analyzer

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
@@ -300,6 +300,7 @@
 			this.itemExplorerTreeView.Name = "itemExplorerTreeView";
 			this.itemExplorerTreeView.Size = new System.Drawing.Size(455, 426);
 			this.itemExplorerTreeView.TabIndex = 0;
+			this.itemExplorerTreeView.ShowRootLines = false;
 			// 
 			// timestampColumnHeader
 			// 

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
@@ -388,7 +388,7 @@ namespace NetHookAnalyzer2
 			}
 
 			itemExplorerTreeView.Nodes.Clear();
-			itemExplorerTreeView.Nodes.AddRange(BuildTree(item).Nodes.Cast<TreeNode>().ToArray());
+			itemExplorerTreeView.Nodes.Add(BuildTree(item));
 			itemExplorerTreeView.Nodes[0].EnsureVisible(); // Scroll to top
 		}
 

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/NetHookItemTreeBuilder.cs
@@ -55,47 +55,44 @@ namespace NetHookAnalyzer2
 		{
 			var configuration = new TreeNodeObjectExplorerConfiguration { ShowUnsetFields = displayUnsetFields };
 
-			var node = new TreeNode();
+			using var stream = item.OpenStream();
 
-			using (var stream = item.OpenStream())
+			var rawEMsg = PeekUInt(stream);
+			var node = BuildInfoNode(rawEMsg);
+			node.Expand();
+
+			var header = ReadHeader(rawEMsg, stream);
+			node.Nodes.Add(new TreeNodeObjectExplorer("Header", header, configuration).TreeNode);
+
+			var body = ReadBody(rawEMsg, stream, header);
+			var bodyNode = new TreeNodeObjectExplorer("Body", body, configuration).TreeNode;
+			node.Nodes.Add(bodyNode);
+
+			var payload = ReadPayload(stream);
+			if (payload != null && payload.Length > 0)
 			{
-				var rawEMsg = PeekUInt(stream);
+				node.Nodes.Add(new TreeNodeObjectExplorer("Payload", payload, configuration).TreeNode);
+			}
 
-				node.Nodes.Add(BuildInfoNode(rawEMsg));
-
-				var header = ReadHeader(rawEMsg, stream);
-				node.Nodes.Add(new TreeNodeObjectExplorer("Header", header, configuration).TreeNode);
-
-				var body = ReadBody(rawEMsg, stream, header);
-				var bodyNode = new TreeNodeObjectExplorer("Body", body, configuration).TreeNode;
-				node.Nodes.Add(bodyNode);
-
-				var payload = ReadPayload(stream);
-				if (payload != null && payload.Length > 0)
+			if (Specializations != null)
+			{
+				var objectsToSpecialize = new[] { body };
+				while (objectsToSpecialize.Any())
 				{
-					node.Nodes.Add(new TreeNodeObjectExplorer("Payload", payload, configuration).TreeNode);
-				}
+					var specializations = objectsToSpecialize.SelectMany(o => Specializations.SelectMany(x => x.ReadExtraObjects(o)));
 
-				if (Specializations != null)
-				{
-					var objectsToSpecialize = new[] { body };
-					while (objectsToSpecialize.Any())
+					if (!specializations.Any())
 					{
-						var specializations = objectsToSpecialize.SelectMany(o => Specializations.SelectMany(x => x.ReadExtraObjects(o)));
-
-						if (!specializations.Any())
-						{
-							break;
-						}
-
-						bodyNode.Collapse(ignoreChildren: true);
-
-						var extraNodes = specializations.Select(x => new TreeNodeObjectExplorer(x.Key, x.Value, configuration).TreeNode).ToArray();
-						node.Nodes.AddRange(extraNodes);
-
-						// Let the specializers examine any new message objects.
-						objectsToSpecialize = specializations.Select(x => x.Value).ToArray();
+						break;
 					}
+
+					bodyNode.Collapse(ignoreChildren: true);
+
+					var extraNodes = specializations.Select(x => new TreeNodeObjectExplorer(x.Key, x.Value, configuration).TreeNode).ToArray();
+					node.Nodes.AddRange(extraNodes);
+
+					// Let the specializers examine any new message objects.
+					objectsToSpecialize = specializations.Select(x => x.Value).ToArray();
 				}
 			}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/613331/136693717-1a0bb0c5-41d7-4b52-a021-536cd888c9d4.png)

I tried to make it the root node, but it wouldn't render properly.

You need to expand Info before, since all it says is the name and whether it's a proto, it's much simpler to just say that straight away.