### PR TITLE
Fix unobserved task exception under .NET 6 runtime

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/TcpConnection.cs
@@ -145,11 +145,10 @@ namespace SteamKit2
             }
         }
 
-        private void TryConnect(object sender)
+        private void TryConnect(int timeout)
         {
             DebugLog.Assert( cancellationToken != null, nameof( TcpConnection ), "null CancellationToken in TryConnect" );
 
-            int timeout = (int)sender;
             if (cancellationToken.IsCancellationRequested)
             {
                 log.LogDebug( nameof( TcpConnection ), "Connection to {0} cancelled by user", CurrentEndPoint );


### PR DESCRIPTION
Fixes bug identified by #1047 / https://github.com/dotnet/runtime/issues/61411 in what seems to be the only practical approach that doesn't require targeting the .NET 6.0 TFM.