### PR TITLE
Release notes for 2.4.0-Beta.1 release

### DIFF
--- a/SteamKit2/SteamKit2/SteamKit2.csproj
+++ b/SteamKit2/SteamKit2/SteamKit2.csproj
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>..\..\SteamKit.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Description>.NET library that aims to interoperate with the Steam network.</Description>
-    <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.4.0-Alpha.3</PackageReleaseNotes>
+    <PackageReleaseNotes>Release notes are available at https://github.com/SteamRE/SteamKit/releases/tag/2.4.0-Beta.1</PackageReleaseNotes>
     <PackageIcon>steamkit_logo_128.png</PackageIcon>
     <PackageProjectUrl>https://github.com/SteamRE/SteamKit</PackageProjectUrl>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -16,6 +16,7 @@ v 2.4.0			November 17 2021 (Beta 1)
 * Fixed `IDebugNetworkListener` not being given encryption handshake messages.
 * Fixed a possible unhandled exception when opening a TCP connection.
 * Fixed the `UnobservedTaskException` event being triggered on .NET 6 if a TCP connection times out.
+* Fixed WebSocket connections constructing an incorrect IPv6 URI.
 * Removed some DebugLog spam from WebSocket connections.
 * Updated Protobufs.
 

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -1,4 +1,33 @@
 ------------------------------------------------------------------------------
+v 2.4.0			November 17 2021 (Beta 1)
+------------------------------------------------------------------------------
+* Added `CallProtobufAsync<T>` method to WebAPI to deserialize response as Protobuf instead of KeyValues.
+* Added `SteamChinaOnly` flag to CDN server objects.
+* Added new APIs to allow consumers to provide their own machine info.
+* Added `SteamUser.VanityUrlChangedCallback`.
+* Added `SteamApps.PurchaseResponseCallback`.
+* Added `SteamApps.RedeemGuestPassResponseCallback`.
+* SteamKit2 now ships a net6.0 assembly as well as a netstandard2.0 assembly.
+* Changed thread names to not get truncated on Linux.
+* Changed message handler exception handling to log the full `Exception` object rather than just the message.
+* Changed the implementation of `SteamUnifiedMessages` to use the newer message protocol under the hood.
+* Fixed `IDebugNetworkListener` not being given encryption handshake messages.
+* Fixed a possible unhandled exception when opening a TCP connection.
+* Fixed the `UnobservedTaskException` event being triggered on .NET 6 if a TCP connection times out.
+* Removed some DebugLog spam from WebSocket connections.
+* Updated Protobufs.
+
+BREAKING CHANGES
+* Changed `SteamApps.GetPICSProductInfo` signature to now use `PICSRequest` objects.
+* Removed some old non-Protobuf messages.
+* Updated nullability to match latest BCL annotations to fix .NET 6 SDK analysis warnings.
+* `SteamClient.AddHandler` will now throw an `ArgumentNullException` if the handler is null, rather than crashing on a `NullReferenceException`.
+* WebAPI will now throw an `ArgumentException` if the `method` parameter is `null`, rather than crashing on a `NullReferenceException`.
+* CDN timeouts options are now properties instead of fields.
+* `CDNClient` has been heavily refactored and is now `SteamKit2.CDN.Client`.
+
+
+------------------------------------------------------------------------------
 v 2.4.0			July 29 2021 (Alpha 3)
 ------------------------------------------------------------------------------
 * Fixed throwing an exception when calling WebAPI twice with the same arguments. 
@@ -20,17 +49,17 @@ BREAKING CHANGES
 ------------------------------------------------------------------------------
 v 2.4.0			March 9, 2021 (Alpha 2)
 ------------------------------------------------------------------------------
-- CDN: Updated interface to capture `preferred_server`, `use_as_proxy`, `proxy_request_path` and `allowed_app_ids`.
-- CDN: CDNClient methods now accept an optional `proxyServer` parameter.
-- CDN: Separated the request timeout into configurable request/response timeouts.
-- Added a MemoryServerListProvider implementation.
-- Enabled strong name signing on the SteamKit2 assembly.
-- Protocol/definition updates.
+* CDN: Updated interface to capture `preferred_server`, `use_as_proxy`, `proxy_request_path` and `allowed_app_ids`.
+* CDN: CDNClient methods now accept an optional `proxyServer` parameter.
+* CDN: Separated the request timeout into configurable request/response timeouts.
+* Added a MemoryServerListProvider implementation.
+* Enabled strong name signing on the SteamKit2 assembly.
+* Protocol/definition updates.
 
 Bug Fixes
-- Fixed a race in CMClient.Send.
-- Fixed a race in AsyncJob registration.
-- Fixed an issue opening files in IsolatedStorageServerListProvider.
+* Fixed a race in CMClient.Send.
+* Fixed a race in AsyncJob registration.
+* Fixed an issue opening files in IsolatedStorageServerListProvider.
 
 
 ------------------------------------------------------------------------------

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -23,7 +23,7 @@ v 2.4.0			November 17 2021 (Beta 1)
 BREAKING CHANGES
 * Changed `SteamApps.GetPICSProductInfo` signature to now use `PICSRequest` objects.
 * Removed some old non-Protobuf messages.
-* Updated nullability to match latest BCL annotations to fix .NET 6 SDK analysis warnings.
+* Updated nullability to match latest BCL annotations and to fix .NET 6 SDK analysis warnings.
 * `SteamClient.AddHandler` will now throw an `ArgumentNullException` if the handler is null, rather than crashing on a `NullReferenceException`.
 * WebAPI will now throw an `ArgumentException` if the `method` parameter is `null`, rather than crashing on a `NullReferenceException`.
 * CDN timeouts options are now properties instead of fields.

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -17,6 +17,7 @@ v 2.4.0			November 17 2021 (Beta 1)
 * Fixed a possible unhandled exception when opening a TCP connection.
 * Fixed the `UnobservedTaskException` event being triggered on .NET 6 if a TCP connection times out.
 * Fixed WebSocket connections constructing an incorrect IPv6 URI.
+* Fixed `DisconnectedCallback.UserInitiated` being true when a connection was terminated due to an internal error.
 * Removed some DebugLog spam from WebSocket connections.
 * Updated Protobufs.
 

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -31,6 +31,8 @@ BREAKING CHANGES
 * `ClientMsgProtobuf` can now only be constructed from a `PacketClientMsgProtobuf`.
 * Removed `IClientMsg.Deserialize(...)` and implementations.
 * Removed `ServiceMethodResponse.ResponseRaw`.
+* `CDN.Server.AllowedAppIds` is now not-nullable. Check for empty instead.
+
 
 ------------------------------------------------------------------------------
 v 2.4.0			July 29 2021 (Alpha 3)

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -7,6 +7,8 @@ v 2.4.0			November 17 2021 (Beta 1)
 * Added `SteamUser.VanityUrlChangedCallback`.
 * Added `SteamApps.PurchaseResponseCallback`.
 * Added `SteamApps.RedeemGuestPassResponseCallback`.
+* Added new `SteamContent` handler.
+* Added the ability to set `ClientMsgProtoBuf<T>.Body`.
 * SteamKit2 now ships a net6.0 assembly as well as a netstandard2.0 assembly.
 * Changed thread names to not get truncated on Linux.
 * Changed message handler exception handling to log the full `Exception` object rather than just the message.
@@ -25,7 +27,9 @@ BREAKING CHANGES
 * WebAPI will now throw an `ArgumentException` if the `method` parameter is `null`, rather than crashing on a `NullReferenceException`.
 * CDN timeouts options are now properties instead of fields.
 * `CDNClient` has been heavily refactored and is now `SteamKit2.CDN.Client`.
-
+* `ClientMsgProtobuf` can now only be constructed from a `PacketClientMsgProtobuf`.
+* Removed `IClientMsg.Deserialize(...)` and implementations.
+* Removed `ServiceMethodResponse.ResponseRaw`.
 
 ------------------------------------------------------------------------------
 v 2.4.0			July 29 2021 (Alpha 3)


### PR DESCRIPTION
Anyone want to nitpick it?

Full version for GitHub Releases page (i.e. with PR links):

```
* Added `CallProtobufAsync<T>` method to WebAPI to deserialize response as Protobuf instead of KeyValues. (#1021)
* Added `SteamChinaOnly` flag to CDN server objects. (#1021)
* Added new APIs to allow consumers to provide their own machine info. (#1028)
* Added `SteamUser.VanityUrlChangedCallback`. (#1035)
* Added `SteamApps.PurchaseResponseCallback`. (#1033)
* Added `SteamApps.RedeemGuestPassResponseCallback`. (#1033)
* Added new `SteamContent` handler. (#1022, #1060)
* Added the ability to set `ClientMsgProtoBuf<T>.Body`. (#1036)
* SteamKit2 now ships a net6.0 assembly as well as a netstandard2.0 assembly. (#1049)
* Changed thread names to not get truncated on Linux. (#1015)
* Changed message handler exception handling to log the full `Exception` object rather than just the message. (#1052)
* Changed the implementation of `SteamUnifiedMessages` to use the newer message protocol under the hood. (#1036)
* Fixed `IDebugNetworkListener` not being given encryption handshake messages. (#1038)
* Fixed a possible unhandled exception when opening a TCP connection. (#1047)
* Fixed the `UnobservedTaskException` event being triggered on .NET 6 if a TCP connection times out. (#1050)
* Fixed WebSocket connections constructing an incorrect IPv6 URI. (#1055)
* Fixed `DisconnectedCallback.UserInitiated` being true when a connection was terminated due to an internal error. (#1053)
* Removed some DebugLog spam from WebSocket connections. (#1040)
* Updated Protobufs. (#1008, #1020, #1025, #1059)

BREAKING CHANGES
* Changed `SteamApps.GetPICSProductInfo` signature to now use `PICSRequest` objects. (#1009)
* Removed some old non-Protobuf messages. (#1037)
* Updated nullability to match latest BCL annotations and to fix .NET 6 SDK analysis warnings. (#1049)
* `SteamClient.AddHandler` will now throw an `ArgumentNullException` if the handler is null, rather than crashing on a `NullReferenceException`. (#1049)
* WebAPI will now throw an `ArgumentException` if the `method` parameter is `null`, rather than crashing on a `NullReferenceException`. (#1049)
* CDN timeouts options are now properties instead of fields. (#1049)
* `CDNClient` has been heavily refactored and is now `SteamKit2.CDN.Client`. (#1022)
* `ClientMsgProtobuf` can now only be constructed from a `PacketClientMsgProtobuf`. (#1036)
* Removed `IClientMsg.Deserialize(...)` and implementations. (#1036)
* Removed `ServiceMethodResponse.ResponseRaw`. (#1036)
* `CDN.Server.AllowedAppIds` is now not-nullable. Check for empty instead. (#1021)
```