### PR TITLE
Fix byte[] nullability annotations in PersonaStateCallback

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
@@ -133,7 +133,7 @@ namespace SteamKit2
             /// Gets the game data blob.
             /// </summary>
             /// <value>The game data blob.</value>
-            public byte[] GameDataBlob { get; private set; }
+            public byte[]? GameDataBlob { get; private set; }
 
             /// <summary>
             /// Gets the name.
@@ -145,7 +145,7 @@ namespace SteamKit2
             /// Gets the avatar hash.
             /// </summary>
             /// <value>The avatar hash.</value>
-            public byte[] AvatarHash { get; private set; }
+            public byte[]? AvatarHash { get; private set; }
 
             /// <summary>
             /// Gets the last log off.


### PR DESCRIPTION
After recent code edit in my project I started making use of `AvatarHash` field in `PersonaStateCallback`. Despite current nullability which states that `AvatarHash` is non-null, my program has failed numerous times with exception similar to below:

```
ArchiBot|OnUnhandledException() System.NullReferenceException: Object reference not set to an instance of an object.
   at ArchiBot.Platform.Steam.SteamBot.OnPersonaState(PersonaStateCallback callback)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__127_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```

I've confirmed my theory that `AvatarHash` is null by ensuring that this `if` executes despite my IDE warning that it's always false:

![obraz](https://user-images.githubusercontent.com/1069029/146919474-9cce0b45-2d4c-4a45-a7c7-39955297fd5a.png)

I'm not sure under what exact circumstance this happens, and if it's warranted/intentional, but as it stands today the nullability is simply wrong and I'm only correcting it to what it should be to begin with. I've noticed that `AvatarHash` in `ClanStateCallback` below is correctly declared as `byte[]?`, therefore this could be simply annotation mistake, as the logic looks similar.

As a side note I've corrected `GameDataBlob` as it uses the same proto declaration and is likely also wrong.

Thank you in advance for accepting this PR.

/cc @yaakov-h @xPaw 