### PR TITLE
Fix sending service notifications

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -64,7 +64,7 @@ namespace SteamKit2
             /// <param name="isNotification">Whether this message is a notification or not.</param>
             /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
             [Obsolete( "Use SendNotification() instead of passing 'true' bool in SendMessage. SendMessage incorrectly returned AsyncJob for notifications, they have no response by design." )]
-            public AsyncJob<ServiceMethodResponse>? SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr, bool isNotification = false )
+            public AsyncJob<ServiceMethodResponse>? SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr, bool isNotification )
             {
                 return SendMessageOrNotification( expr, isNotification );
             }
@@ -205,7 +205,7 @@ namespace SteamKit2
         /// <param name="isNotification">Whether this message is a notification or not.</param>
         /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
         [Obsolete( "Use SendNotification() instead of passing 'true' bool in SendMessage. SendMessage incorrectly returned AsyncJob for notifications, they have no response by design." )]
-        public AsyncJob<ServiceMethodResponse>? SendMessage<TRequest>( string name, TRequest message, bool isNotification = false )
+        public AsyncJob<ServiceMethodResponse>? SendMessage<TRequest>( string name, TRequest message, bool isNotification )
             where TRequest : IExtensible, new()
         {
             if ( !isNotification )

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -107,7 +107,10 @@ namespace SteamKit2
                     return null;
                 }
 
-                var method = typeof( SteamUnifiedMessages ).GetMethod( nameof( SteamUnifiedMessages.SendMessage ) )!.MakeGenericMethod( message.GetType() );
+                // When the obsolete overload is removed, then this code be used, instead of GetMethods().
+                // var method = typeof( SteamUnifiedMessages ).GetMethod( nameof( SteamUnifiedMessages.SendMessage ) )!.MakeGenericMethod( message.GetType() );
+
+                var method = typeof( SteamUnifiedMessages ).GetMethods().First( x => x.Name == nameof( SteamUnifiedMessages.SendMessage ) ).MakeGenericMethod( message.GetType() );
                 var result = method.Invoke( this.steamUnifiedMessages, new[] { rpcName, message } )!;
                 return ( AsyncJob<ServiceMethodResponse> )result;
             }

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -39,9 +39,9 @@ namespace SteamKit2
             /// <typeparam name="TResponse">The type of the protobuf object which is the response to the RPC call.</typeparam>
             /// <param name="expr">RPC call expression, e.g. x => x.SomeMethodCall(message);</param>
             /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
-            public AsyncJob<ServiceMethodResponse>? SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr )
+            public AsyncJob<ServiceMethodResponse> SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr )
             {
-                return SendMessageOrNotification( expr, false );
+                return SendMessageOrNotification( expr, false )!;
             }
 
             /// <summary>

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -117,23 +117,68 @@ namespace SteamKit2
         /// <typeparam name="TRequest">The type of a protobuf object.</typeparam>
         /// <param name="name">Name of the RPC endpoint. Takes the format ServiceName.RpcName</param>
         /// <param name="message">The message to send.</param>
-        /// <param name="isNotification">Whether this message is a notification or not.</param>
         /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
-        public AsyncJob<ServiceMethodResponse> SendMessage<TRequest>( string name, TRequest message, bool isNotification = false )
+        public AsyncJob<ServiceMethodResponse> SendMessage<TRequest>( string name, TRequest message )
             where TRequest : IExtensible, new()
         {
             if ( message == null )
             {
-                throw new ArgumentNullException( nameof(message) );
+                throw new ArgumentNullException( nameof( message ) );
             }
 
-            var msg = new ClientMsgProtobuf<TRequest>( isNotification ? EMsg.ServiceMethodSendToClient : EMsg.ServiceMethodCallFromClient );
+            var msg = new ClientMsgProtobuf<TRequest>( EMsg.ServiceMethodCallFromClient );
             msg.SourceJobID = Client.GetNextJobID();
             msg.Header.Proto.target_job_name = name;
             msg.Body = message;
             Client.Send( msg );
 
             return new AsyncJob<ServiceMethodResponse>( this.Client, msg.SourceJobID );
+        }
+
+        /// <summary>
+        /// Sends a notification.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of a protobuf object.</typeparam>
+        /// <param name="name">Name of the RPC endpoint. Takes the format ServiceName.RpcName</param>
+        /// <param name="message">The message to send.</param>
+        public void SendNotification<TRequest>( string name, TRequest message )
+            where TRequest : IExtensible, new()
+        {
+            if ( message == null )
+            {
+                throw new ArgumentNullException( nameof( message ) );
+            }
+
+            // Notifications do not set source jobid, otherwise Steam server will actively reject this message
+            // if the method being used is a "Notification"
+            var msg = new ClientMsgProtobuf<TRequest>( EMsg.ServiceMethodCallFromClient );
+            msg.Header.Proto.target_job_name = name;
+            msg.Body = message;
+            Client.Send( msg );
+        }
+
+        /// <summary>
+        /// Sends a message.
+        /// Results are returned in a <see cref="ServiceMethodResponse"/>.
+        /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of a protobuf object.</typeparam>
+        /// <param name="name">Name of the RPC endpoint. Takes the format ServiceName.RpcName</param>
+        /// <param name="message">The message to send.</param>
+        /// <param name="isNotification">Whether this message is a notification or not.</param>
+        /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
+        [Obsolete( "Use SendNotification() instead of passing 'true' bool in SendMessage. SendMessage incorrectly returned AsyncJob for notifications, they have no response by design." )]
+        public AsyncJob<ServiceMethodResponse>? SendMessage<TRequest>( string name, TRequest message, bool isNotification = false )
+            where TRequest : IExtensible, new()
+        {
+            if ( !isNotification )
+            {
+                return SendMessage( name, message );
+            }
+
+            SendNotification( name, message );
+
+            return null;
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUnifiedMessages/SteamUnifiedMessages.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using ProtoBuf;
 
 namespace SteamKit2
@@ -37,16 +38,45 @@ namespace SteamKit2
             /// </summary>
             /// <typeparam name="TResponse">The type of the protobuf object which is the response to the RPC call.</typeparam>
             /// <param name="expr">RPC call expression, e.g. x => x.SomeMethodCall(message);</param>
+            /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
+            public AsyncJob<ServiceMethodResponse>? SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr )
+            {
+                return SendMessageOrNotification( expr, false );
+            }
+
+            /// <summary>
+            /// Sends a notification.
+            /// </summary>
+            /// <typeparam name="TResponse">The type of the protobuf object which is the response to the RPC call.</typeparam>
+            /// <param name="expr">RPC call expression, e.g. x => x.SomeMethodCall(message);</param>
+            public void SendNotification<TResponse>( Expression<Func<TService, TResponse>> expr )
+            {
+                SendMessageOrNotification( expr, true );
+            }
+
+            /// <summary>
+            /// Sends a message.
+            /// Results are returned in a <see cref="ServiceMethodResponse"/>.
+            /// The returned <see cref="AsyncJob{T}"/> can also be awaited to retrieve the callback result.
+            /// </summary>
+            /// <typeparam name="TResponse">The type of the protobuf object which is the response to the RPC call.</typeparam>
+            /// <param name="expr">RPC call expression, e.g. x => x.SomeMethodCall(message);</param>
             /// <param name="isNotification">Whether this message is a notification or not.</param>
             /// <returns>The JobID of the request. This can be used to find the appropriate <see cref="ServiceMethodResponse"/>.</returns>
-            public AsyncJob<ServiceMethodResponse> SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr, bool isNotification = false )
+            [Obsolete( "Use SendNotification() instead of passing 'true' bool in SendMessage. SendMessage incorrectly returned AsyncJob for notifications, they have no response by design." )]
+            public AsyncJob<ServiceMethodResponse>? SendMessage<TResponse>( Expression<Func<TService, TResponse>> expr, bool isNotification = false )
+            {
+                return SendMessageOrNotification( expr, isNotification );
+            }
+
+            AsyncJob<ServiceMethodResponse>? SendMessageOrNotification<TResponse>( Expression<Func<TService, TResponse>> expr, bool isNotification )
             {
                 if ( expr == null )
                 {
-                    throw new ArgumentNullException( nameof(expr) );
+                    throw new ArgumentNullException( nameof( expr ) );
                 }
 
-                var call = ExtractMethodCallExpression( expr, nameof(expr) );
+                var call = ExtractMethodCallExpression( expr, nameof( expr ) );
                 var methodInfo = call.Method;
 
                 var argument = call.Arguments.Single();
@@ -54,7 +84,7 @@ namespace SteamKit2
 
                 if ( argument.NodeType == ExpressionType.MemberAccess )
                 {
-                    var unary = Expression.Convert( argument, typeof(object) );
+                    var unary = Expression.Convert( argument, typeof( object ) );
                     var lambda = Expression.Lambda<Func<object>>( unary );
                     var getter = lambda.Compile();
                     message = getter();
@@ -64,14 +94,21 @@ namespace SteamKit2
                     throw new NotSupportedException( "Unknown Expression type" );
                 }
 
-                var serviceName = typeof(TService).Name.Substring( 1 ); // IServiceName - remove 'I'
+                var serviceName = typeof( TService ).Name.Substring( 1 ); // IServiceName - remove 'I'
                 var methodName = methodInfo.Name;
                 var version = 1;
 
                 var rpcName = string.Format( "{0}.{1}#{2}", serviceName, methodName, version );
 
-                var method = typeof(SteamUnifiedMessages).GetMethod( nameof(SteamUnifiedMessages.SendMessage) )!.MakeGenericMethod( message.GetType() );
-                var result = method.Invoke( this.steamUnifiedMessages, new[] { rpcName, message, isNotification } )!;
+                if( isNotification )
+                {
+                    var notification = typeof( SteamUnifiedMessages ).GetMethod( nameof( SteamUnifiedMessages.SendNotification ) )!.MakeGenericMethod( message.GetType() );
+                    notification.Invoke( this.steamUnifiedMessages, new[] { rpcName, message } );
+                    return null;
+                }
+
+                var method = typeof( SteamUnifiedMessages ).GetMethod( nameof( SteamUnifiedMessages.SendMessage ) )!.MakeGenericMethod( message.GetType() );
+                var result = method.Invoke( this.steamUnifiedMessages, new[] { rpcName, message } )!;
                 return ( AsyncJob<ServiceMethodResponse> )result;
             }
             


### PR DESCRIPTION
- Fix notification servicemethods not working
- Add SendNotification and deprecate SendMessage(..., true)

This was broken in #1036, `ServiceMethodSendToClient` was not the correct call. Notifications are sent by Steam by not setting the source jobid.

This logic can be verified by looking at the new chat's javascript. it has `SendMsg`/`SendNotification` on service transport. `SendMsg` uses `SendMsgAndAwaitResponse` which sets the `jobid_source`.

@Netshroud which notification message did you test?