### PR TITLE
Fix crashes in SteamLanguageParser

### DIFF
--- a/Resources/SteamLanguageParser/Generator/ObjCInterfaceGen.cs
+++ b/Resources/SteamLanguageParser/Generator/ObjCInterfaceGen.cs
@@ -105,17 +105,17 @@ namespace SteamLanguageParser
                 }
             }
 
-            long maxlong = 0;
-
-            if (lastValue.StartsWith("0x"))
-                maxlong = Convert.ToInt64(lastValue.Substring(2, lastValue.Length - 2), 16);
-            else
-                maxlong = Int64.Parse(lastValue);
-
-            maxlong++;
-
             if (!hasMax && enode.Flags != "flags")
             {
+                long maxlong = 0;
+
+                if (lastValue.StartsWith("0x"))
+                    maxlong = Convert.ToInt64(lastValue.Substring(2, lastValue.Length - 2), 16);
+                else
+                    maxlong = Int64.Parse(lastValue);
+
+                maxlong++;
+
                 sb.AppendLine(padding + "\t" + enode.Name + "Max = " + maxlong + ",");
             }
             sb.AppendLine(padding + "};");

--- a/Resources/SteamLanguageParser/Program.cs
+++ b/Resources/SteamLanguageParser/Program.cs
@@ -19,8 +19,8 @@ namespace SteamLanguageParser
 
             ParseFile( projectPath, Path.Combine( "Resources", "SteamLanguage" ), "steammsg.steamd", "SteamKit2", Path.Combine( "SteamKit2", "SteamKit2", "Base", "Generated"), "SteamLanguage", true, new CSharpGen(), "cs" );
 
-            //ParseFile( projectPath, @"Resources\SteamLanguage", "steammsg.steamd", "SteamKit2", @"SteamKit2\ObjC\", "SteamLanguage", true, new ObjCInterfaceGen(), "h" );
-            //ParseFile( projectPath, @"Resources\SteamLanguage", "steammsg.steamd", "SteamKit2", @"SteamKit2\ObjC\", "SteamLanguage", true, new ObjCImplementationGen(), "m" );
+            //ParseFile( projectPath, Path.Combine("Resources", "SteamLanguage"), "steammsg.steamd", "SteamKit2", Path.Combine("SteamKit2", "ObjC"), "SteamLanguage", true, new ObjCInterfaceGen(), "h" );
+            //ParseFile( projectPath, Path.Combine("Resources", "SteamLanguage"), "steammsg.steamd", "SteamKit2", Path.Combine("SteamKit2", "ObjC"), "SteamLanguage", true, new ObjCImplementationGen(), "m" );
 
         }
 
@@ -51,8 +51,13 @@ namespace SteamLanguageParser
             string outputEnumFile = Path.Combine( outputPath, outFile + "." + fileNameSuffix );
             string outputMessageFile = Path.Combine( outputPath, outFile + "Internal." + fileNameSuffix );
 
-            File.WriteAllText( Path.Combine( projectPath, outputEnumFile ), enumBuilder.ToString() );
-            File.WriteAllText( Path.Combine( projectPath, outputMessageFile ), messageBuilder.ToString() );
+            string enumFilePath = Path.Combine( projectPath, outputEnumFile );
+            Directory.CreateDirectory( Path.GetDirectoryName( enumFilePath ) );
+            File.WriteAllText( enumFilePath, enumBuilder.ToString() );
+
+            string messageFilePath = Path.Combine( projectPath, outputMessageFile );
+            Directory.CreateDirectory( Path.GetDirectoryName( messageFilePath ) );
+            File.WriteAllText( messageFilePath, messageBuilder.ToString() );
         }
     }
 }


### PR DESCRIPTION
Fixes #1092: integers parse failure using the old ObjC generator classes on any platform

Also fixes I/O errors when running ObjC gen on *nix