### PR TITLE
Fix NetHook2 builds failing CI

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -106,7 +106,7 @@ jobs:
         configuration: [ Debug, Release ]
       fail-fast: false
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Builds fail when run with MSBuild from VS2022. I don't yet know why.