### PR TITLE
Make dependabot update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,23 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
 - package-ecosystem: nuget
   directory: "/Resources/ProtobufGen"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
 - package-ecosystem: nuget
   directory: "/Resources/ProtobufDumper"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
This will only make PRs for major version bumps.

There's some deprecations in actions that warrant updating versions (one of them is node 12 -> 16 bump).

Example from another repo: https://github.com/SteamDatabase/ValveKeyValue/pull/67

---

> [SteamKit2 on windows-latest - Debug (SDK 6.0.x)](https://github.com/SteamRE/SteamKit/actions/runs/3288551486/jobs/5419024409)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-dotnet, actions/checkout