### PR TITLE
Fix nethook builds not to break on new zlib releases

### DIFF
--- a/Resources/NetHook2/InstallDependencies.ps1
+++ b/Resources/NetHook2/InstallDependencies.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop'
 $ThisDirectory = Split-Path -Parent $PSCommandPath
 $NativeDependenciesDirectory = Join-Path $ThisDirectory 'native-dependencies'
 $NetHook2DependenciesTemporaryDirectory = Join-Path ([System.IO.Path]::GetTempPath()) 'nethook2-dependencies'
-$ZLibSourceZipUrl = "https://zlib.net/zlib1212.zip"
-$ZLibSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "zlib-1.2.12.zip")
+$ZLibSourceZipUrl = "https://zlib.net/fossils/zlib-1.2.12.tar.gz"
+$ZLibSourceFile = [System.IO.Path]::Combine($NetHook2DependenciesTemporaryDirectory, "zlib-1.2.12.tar.gz")
 $ZLibSourceInnerFolderName = "zlib-1.2.12"
 $ProtobufVersion = "3.15.6"
 $ProtobufSourceZipUrl = "https://github.com/protocolbuffers/protobuf/releases/download/v$ProtobufVersion/protobuf-cpp-$ProtobufVersion.zip"
@@ -38,9 +38,7 @@ if (-Not (Test-Path $ZLibFolderPath))
     }
 
     Write-Host Extracting ZLib...
-    $zip = [IO.Compression.ZipFile]::Open($ZLibSourceFile, [System.IO.Compression.ZipArchiveMode]::Read)
-    [IO.Compression.ZipFileExtensions]::ExtractToDirectory($zip, $NativeDependenciesDirectory)
-    $zip.Dispose()
+    tar --extract --gzip --file $ZLibSourceFile --directory $NativeDependenciesDirectory
 }
 
 $ProtobufFolderPath = [IO.Path]::Combine($NativeDependenciesDirectory, $ProtobufSourceInnerFolderName)

--- a/Resources/NetHook2/InstallDependencies.ps1
+++ b/Resources/NetHook2/InstallDependencies.ps1
@@ -1,4 +1,5 @@
 $ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
 
 $ThisDirectory = Split-Path -Parent $PSCommandPath
 $NativeDependenciesDirectory = Join-Path $ThisDirectory 'native-dependencies'


### PR DESCRIPTION
`tar` is available on Windows since Build 17063, unfortunately there is no zip archive in the fossils folder.