### PR TITLE
Specify just major version for microsoft/setup-msbuild

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -112,7 +112,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Cache Native Dependencies
       id: cache-dependencies


### PR DESCRIPTION
That'll get the latest update to get rid of remaining deprecations.