### PR TITLE
Fix list view flickering

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/ListViewDoubleBuffered.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/ListViewDoubleBuffered.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace NetHookAnalyzer2
+{
+	[ToolboxItem( true )]
+	[ToolboxBitmap( typeof( ListView ) )]
+	class ListViewDoubleBuffered : ListView
+	{
+		public ListViewDoubleBuffered()
+		{
+			this.DoubleBuffered = true;
+		}
+	}
+}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
@@ -53,7 +53,7 @@
 			this.inRadioButton = new System.Windows.Forms.RadioButton();
 			this.inOutRadioButton = new System.Windows.Forms.RadioButton();
 			this.listViewContainerPanel = new System.Windows.Forms.Panel();
-			this.itemsListView = new System.Windows.Forms.ListView();
+			this.itemsListView = new ListViewDoubleBuffered();
 			this.itemExplorerTreeView = new System.Windows.Forms.TreeView();
 			sequenceColumnHeader = new System.Windows.Forms.ColumnHeader();
 			directionColumnHeader = new System.Windows.Forms.ColumnHeader();
@@ -366,7 +366,7 @@
 		private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
 		private System.Windows.Forms.SplitContainer splitContainer;
 		private System.Windows.Forms.TextBox searchTextBox;
-		private System.Windows.Forms.ListView itemsListView;
+		private ListViewDoubleBuffered itemsListView;
 		private System.Windows.Forms.Panel listViewContainerPanel;
 		private System.Windows.Forms.Panel filterContainerPanel;
 		private System.Windows.Forms.TreeView itemExplorerTreeView;

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
@@ -141,8 +141,10 @@ namespace NetHookAnalyzer2
 		{
 			var listViewItems = Dump.Items.Where(GetFilterPredicate()).Select(x => x.AsListViewItem());
 
+			itemsListView.BeginUpdate();
 			itemsListView.Items.Clear();
 			itemsListView.Items.AddRange(listViewItems.ToArray());
+			itemsListView.EndUpdate();
 		}
 
 		#endregion
@@ -223,18 +225,17 @@ namespace NetHookAnalyzer2
 			selectedListViewItem = null;
 			RepopulateInterface();
 
-			if ( itemsListView.Items.Count > 0 )
+			if (automaticallySelectNewItemsToolStripMenuItem.Checked)
+			{
+				SelectLastItem();
+			}
+			else if (itemsListView.Items.Count > 0)
 			{
 				itemsListView.Select();
 				itemsListView.Items[ 0 ].Selected = true;
 			}
 
-			InitializeFileSystemWatcher( dumpDirectory );
-
-			if ( automaticallySelectNewItemsToolStripMenuItem.Checked )
-			{
-				SelectLastItem();
-			}
+			InitializeFileSystemWatcher(dumpDirectory);
 		}
 
 		void OnDirectionFilterCheckedChanged(object sender, EventArgs e)
@@ -354,12 +355,16 @@ namespace NetHookAnalyzer2
 				}
 
 				var listViewItem = item.AsListViewItem();
+
+				itemsListView.BeginUpdate();
 				itemsListView.Items.Add( listViewItem );
 
 				if ( automaticallySelectNewItemsToolStripMenuItem.Checked )
 				{
 					SelectLastItem();
 				}
+
+				itemsListView.EndUpdate();
 			} );
 		}
 
@@ -422,9 +427,11 @@ namespace NetHookAnalyzer2
 				return;
 			}
 
+			itemExplorerTreeView.BeginUpdate();
 			itemExplorerTreeView.Nodes.Clear();
 			itemExplorerTreeView.Nodes.Add(BuildTree(item));
 			itemExplorerTreeView.Nodes[0].EnsureVisible(); // Scroll to top
+			itemExplorerTreeView.EndUpdate();
 		}
 
 		TreeNode BuildTree(NetHookItem item)


### PR DESCRIPTION
When a new item was added (and many other cases), listview really likes to flicker, making it double buffered seemingly fixes it.

Adding Begin/EndUpdate also fixes expand animation when switching items.