### PR TITLE
Bump target to net6 in protobufdumper

### DIFF
--- a/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
+++ b/Resources/ProtobufDumper/ProtobufDumper/ProtobufDumper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageProjectUrl>https://github.com/SteamRE/SteamKit/tree/master/Resources/ProtobufDumper</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/license.txt</PackageLicenseUrl>


### PR DESCRIPTION
It is current LTS, other projects target it.