### PR TITLE
Create ContextMenuStrip on demand

### DIFF
--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.Designer.cs
@@ -53,7 +53,7 @@
 			this.inRadioButton = new System.Windows.Forms.RadioButton();
 			this.inOutRadioButton = new System.Windows.Forms.RadioButton();
 			this.listViewContainerPanel = new System.Windows.Forms.Panel();
-			this.itemsListView = new ListViewDoubleBuffered();
+			this.itemsListView = new NetHookAnalyzer2.ListViewDoubleBuffered();
 			this.itemExplorerTreeView = new System.Windows.Forms.TreeView();
 			sequenceColumnHeader = new System.Windows.Forms.ColumnHeader();
 			directionColumnHeader = new System.Windows.Forms.ColumnHeader();
@@ -329,6 +329,7 @@
 			this.itemExplorerTreeView.ShowRootLines = false;
 			this.itemExplorerTreeView.Size = new System.Drawing.Size(530, 494);
 			this.itemExplorerTreeView.TabIndex = 0;
+			this.itemExplorerTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.OnItemExplorerTreeViewNodeMouseClick);
 			// 
 			// MainForm
 			// 

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.cs
@@ -436,7 +436,7 @@ namespace NetHookAnalyzer2
 
 		TreeNode BuildTree(NetHookItem item)
 		{
-			return new NetHookItemTreeBuilder(item) { Specializations = specializations }.BuildTree(showAllCheckBox.Checked);
+			return NetHookItemTreeBuilder.BuildTree( item, specializations, showAllCheckBox.Checked );
 		}
 
 		void OnAutomaticallySelectNewItemsCheckedChanged(object sender, EventArgs e)
@@ -462,6 +462,14 @@ namespace NetHookAnalyzer2
 				lastItem.Selected = true;
 				lastItem.Focused = true;
 				lastItem.EnsureVisible();
+			}
+		}
+
+		private void OnItemExplorerTreeViewNodeMouseClick( object sender, TreeNodeMouseClickEventArgs e )
+		{
+			if ( e.Button == MouseButtons.Right && e.Node is TreeNodeObjectExplorer objectExplorer )
+			{
+				objectExplorer.CreateContextMenu();
 			}
 		}
 	}

--- a/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.resx
+++ b/Resources/NetHookAnalyzer2/NetHookAnalyzer2/MainForm.resx
@@ -82,7 +82,7 @@
   <data name="openToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wQAADsEBuJFr7QAAAlhJREFUOE+9kVtIE1Ach/fQQ08WaVEIRZaEPQwDQ6qHkKSbopRmhZEmlLcuGIpt
+        wAAADsABataJCQAAAlhJREFUOE+9kVtIE1Ach/fQQ08WaVEIRZaEPQwDQ6qHkKSbopRmhZEmlLcuGIpt
         U9u8Tndz6kqHuU3X1Gm1MgwrhEKRCC11lJiaBUWlmBkqefsam2iSQQ/RH34v55zvOz/OEfyXySkxI9Na
         uJJvIk9nRaI0Mr/1dxOdrCMsXuWELogqyHTIUrINRCWXIKg3a1gujbXyP96SICklPFFFaHyhS9DbZWRy
         tM6ZHyMWpocMWE0qbObsZSVhCWpC47QExxYjqKtUMzFSvQSe/VTKtD2J6op8qspyMZRkoi/M4LpSTLE8


### PR DESCRIPTION
Opening big payloads creates a bunch of objects, this PR changes to only create them on right click. Previous code already did this for elements in the context menu, but `ContextMenuStrip` itself consumes plenty of memory.

Before:
![before](https://user-images.githubusercontent.com/613331/214353709-1131acfb-da76-45c5-8831-8eb4ab0e0de1.png)

After:
![after](https://user-images.githubusercontent.com/613331/214353718-ba30db8f-2a1e-42c4-b621-e78096f76fe1.png)
