### PR TITLE
Add global.json to use .NET 6 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
GitHub Actions seems to have a mix of machines or platforms with and without .NET 7 SDK.

This enforces consistency in both CI and developer environments.

When we're ready (a.k.a when someone has the time and can be bothered; pull requests welcome) then we can update everything to .NET 7 SDK in a controlled manner.