### PR TITLE
Add WebAPI `CallProtobufAsync` that accepts protobuf request message

### DIFF
--- a/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/WebAPI.cs
@@ -26,12 +26,12 @@ namespace SteamKit2
         public sealed class WebAPIResponse<TResponse>
         {
             /// <summary>
-            /// Gets the result of the request.
+            /// Gets the result of the response.
             /// </summary>
             public EResult Result { get; }
 
             /// <summary>
-            /// Gets the body of the request.
+            /// Gets the body of the response.
             /// </summary>
             public TResponse Body { get; }
 


### PR DESCRIPTION
Example:
```csharp
var service = Client.Configuration.GetAsyncWebAPIInterface( "IAuthenticationService" );
var response = await service.CallProtobufAsync<CAuthentication_BeginAuthSessionViaQR_Response, CAuthentication_BeginAuthSessionViaQR_Request>( HttpMethod.Post, "BeginAuthSessionViaQR", request );

response.Result == EResult.OK
response.Body // proto
```

WebAPIResponse could be an interesting breaking change because this would allow any other API calls to also access EResult.