### PR TITLE
Allow `DuplicateRequest` in `SendSteamGuardCodeAsync`

### DIFF
--- a/Samples/1.Logon/Program.cs
+++ b/Samples/1.Logon/Program.cs
@@ -15,6 +15,12 @@ using SteamKit2;
 // callback type to a function, whilst CallbackMgr routes the callback objects to the functions that
 // you have specified. a Callback<T> is bound to a specific callback manager.
 //
+//
+// WARNING!
+// This the old login flow, we keep this sample around because it still currently works
+// for simple cases where you do not need to remember password.
+// See Sample1a_Authentication for the new flow.
+//
 
 if ( args.Length < 2 )
 {

--- a/SteamKit2/SteamKit2/Steam/Authentication/CredentialsAuthSession.cs
+++ b/SteamKit2/SteamKit2/Steam/Authentication/CredentialsAuthSession.cs
@@ -44,8 +44,10 @@ namespace SteamKit2.Authentication
             var message = await Authentication.AuthenticationService.SendMessage( api => api.UpdateAuthSessionWithSteamGuardCode( request ) );
             var response = message.GetDeserializedResponse<CAuthentication_UpdateAuthSessionWithSteamGuardCode_Response>();
 
-            // can be InvalidLoginAuthCode, TwoFactorCodeMismatch, Expired
-            if ( message.Result != EResult.OK )
+            // Observed results can be InvalidLoginAuthCode, TwoFactorCodeMismatch, Expired, DuplicateRequest.
+            // DuplicateRequest happens when accepting the prompt in the mobile app, and then trying to send guard code here,
+            // we do not throw on it here because authentication will succeed on the next poll.
+            if ( message.Result != EResult.OK && message.Result != EResult.DuplicateRequest )
             {
                 throw new AuthenticationException( "Failed to send steam guard code", message.Result );
             }


### PR DESCRIPTION
`DuplicateRequest` happens when accepting the prompt in the mobile app, and then trying to send guard code here, do not throw on it here because authentication will succeed on the next poll.

This makes it easier for users because even if 2FA code is asked, Steam will send a confirmation prompt to the app regardless.

cc @JustArchi