### PR TITLE
Fix CWebSocketConnection::BBuildAndAsyncSendFrame pattern

### DIFF
--- a/Resources/NetHook2/NetHook2/net.cpp
+++ b/Resources/NetHook2/NetHook2/net.cpp
@@ -24,8 +24,8 @@ CNet::CNet() noexcept
 
 	BBuildAndAsyncSendFrameFn pBuildFunc = nullptr;
 	const bool bFoundBuildFunc = steamClientScan.FindFunction(
-		"\x55\x8B\xEC\x83\xEC\x70\xA1\x2A\x2A\x2A\x2A\x53",
-		"xxxxxxx????x",
+		"\x55\x8B\xEC\x83\xEC\x70\xA1\x2A\x2A\x2A\x2A\x53\x8B\xD9",
+		"xxxxxxx????xxx",
 		(void**)&pBuildFunc
 	);
 


### PR DESCRIPTION
In the Steam beta client 2 functions with the same pattern. Extended by 2 additional bytes. Working on current and beta updates.