### PR TITLE
Add BalanceDelayed and LongBalanceDelayed in wallet callback

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -331,10 +331,19 @@ namespace SteamKit2
             public int Balance { get; private set; }
 
             /// <summary>
+            /// Gets the delayed (pending) balance of the wallet as a 32-bit integer, in cents.
+            /// </summary>
+            public int BalanceDelayed { get; private set; }
+
+            /// <summary>
             /// Gets the balance of the wallet as a 64-bit integer, in cents.
             /// </summary>
             public long LongBalance { get; private set; }
 
+            /// <summary>
+            /// Gets the delayed (pending) balance of the wallet as a 64-bit integer, in cents.
+            /// </summary>
+            public long LongBalanceDelayed { get; private set; }
 
             internal WalletInfoCallback( CMsgClientWalletInfoUpdate wallet )
             {
@@ -342,7 +351,9 @@ namespace SteamKit2
 
                 Currency = ( ECurrencyCode )wallet.currency;
                 Balance = wallet.balance;
+                BalanceDelayed = wallet.balance_delayed;
                 LongBalance = wallet.balance64;
+                LongBalanceDelayed = wallet.balance64_delayed;
             }
         }
 


### PR DESCRIPTION
Pending balance happens when Steam comes to conclusion the change is suspicious, e.g. buying/selling item on market for unusually high/low price.

Temporary working implementation I did in ASF as a test: https://github.com/JustArchiNET/ArchiSteamFarm/commit/cc4532af838043cd3f42341395fbbcfd1a120c6e
More info: https://steamcommunity.com/groups/archiasf/discussions/6/3803904095534461380/