### PR TITLE
Improve NetHook2 64-bit support

### DIFF
--- a/Resources/NetHook2/NetHook2/crypto.cpp
+++ b/Resources/NetHook2/NetHook2/crypto.cpp
@@ -14,10 +14,12 @@
 SymmetricEncryptChosenIVFn Encrypt_Orig = nullptr;
 PchMsgNameFromEMsgFn PchMsgNameFromEMsg = nullptr;
 
-#if __x86_64__
-static_assert(sizeof(MsgInfo_t) == 24, "Wrong size of MsgInfo_t");
+#ifdef X64BITS
+static_assert(sizeof(void*) == 8, "Unexpected pointer size on 64-bit");
+static_assert(sizeof(MsgInfo_t) == 24, "Wrong size of MsgInfo_t on 64-bit");
 #else
-static_assert(sizeof(MsgInfo_t) == 20, "Wrong size of MsgInfo_t");
+static_assert(sizeof(void*) == 4, "Unexpected pointer size on 32-bit");
+static_assert(sizeof(MsgInfo_t) == 20, "Wrong size of MsgInfo_t on 32-bit");
 #endif
 static_assert(offsetof(MsgInfo_t, eMsg) == 0, "Wrong offset of MsgInfo_t::eMsg");
 static_assert(offsetof(MsgInfo_t, nFlags) == 4, "Wrong offset of MsgInfo_t::nFlags");
@@ -35,7 +37,7 @@ CCrypto::CCrypto() noexcept
 
 	SymmetricEncryptChosenIVFn pEncrypt = nullptr;
 	const bool bEncrypt = steamClientScan.FindFunction(
-#if __x86_64__
+#ifdef X64BITS
 		"\x48\x83\xEC\x58\x8B\x84\x24\xCC\xCC\xCC\xCC\xC6\x44\x24",
 		"xxxxxxx????xxx",
 #else
@@ -50,7 +52,7 @@ CCrypto::CCrypto() noexcept
 	g_pLogger->LogConsole( "CCrypto::SymmetricEncryptChosenIV = 0x%p\n", Encrypt_Orig );
 
 	const bool bPchMsgNameFromEMsg = steamClientScan.FindFunction(
-#if __x86_64__
+#ifdef X64BITS
 		"\x48\x89\x5C\x24\xCC\x57\x48\x83\xEC\x20\x8B\xD9\xE8",
 		"xxxx?xxxxxxxx",
 #else

--- a/Resources/NetHook2/NetHook2/injector.cpp
+++ b/Resources/NetHook2/NetHook2/injector.cpp
@@ -53,14 +53,14 @@ BOOL InjectEjection(const HWND hWindow, const int iSteamProcessID, const char * 
 // rundll32.exe C:\Path\To\NetHook2.dll,Eject <process name>
 //
 
-#if __x86_64__
+#ifdef X64BITS
 #pragma comment(linker, "/EXPORT:Inject=?Inject@@YAXPEAUHWND__@@PEAUHINSTANCE__@@PEADH@Z")
 #else
 #pragma comment(linker, "/EXPORT:Inject=?Inject@@YGXPAUHWND__@@PAUHINSTANCE__@@PADH@Z")
 #endif
 __declspec(dllexport) void CALLBACK Inject(HWND hWindow, HINSTANCE hInstance, LPSTR lpszCommandLine, int nCmdShow);
 
-#if __x86_64__
+#ifdef X64BITS
 #pragma comment(linker, "/EXPORT:Eject=?Eject@@YAXPEAUHWND__@@PEAUHINSTANCE__@@PEADH@Z")
 #else
 #pragma comment(linker, "/EXPORT:Eject=?Eject@@YGXPAUHWND__@@PAUHINSTANCE__@@PADH@Z")

--- a/Resources/NetHook2/NetHook2/net.cpp
+++ b/Resources/NetHook2/NetHook2/net.cpp
@@ -25,7 +25,7 @@ CNet::CNet() noexcept
 
 	BBuildAndAsyncSendFrameFn pBuildFunc = nullptr;
 	const bool bFoundBuildFunc = steamClientScan.FindFunction(
-#if __x86_64__
+#ifdef X64BITS
 		"\x48\x8B\xC4\x55\x53\x48\x8D\x68\xA1\x48\x81\xEC\xCC\xCC\xCC\xCC\x48\x89\x70\x10\x33",
 		"xxxxxxxxxxxx????xxxxx",
 #else
@@ -41,7 +41,7 @@ CNet::CNet() noexcept
 
 	RecvPktFn pRecvPktFunc = nullptr;
 	const bool bFoundRecvPktFunc = steamClientScan.FindFunction(
-#if __x86_64__
+#ifdef X64BITS
 		"\x48\x8B\xC4\x55\x48\x8D\xA8\xCC\xCC\xCC\xCC\x48\x81\xEC\xCC\xCC\xCC\xCC\x48\x89\x58\x08\x48\x8B",
 		"xxxxxxx????xxx????xxxxxx",
 #else
@@ -104,7 +104,7 @@ CNet::~CNet()
 
 bool CNet::BBuildAndAsyncSendFrame(
 	void *webSocketConnection,
-#ifndef __x86_64__
+#ifndef X64BITS
 	void *,
 #endif
 	EWebSocketOpCode eWebSocketOpCode, 
@@ -127,7 +127,7 @@ bool CNet::BBuildAndAsyncSendFrame(
 
 void CNet::RecvPkt(
 	void *cmConnection,
-#ifndef __x86_64__
+#ifndef X64BITS
 	void *,
 #endif
 	CNetPacket *pPacket)

--- a/Resources/NetHook2/NetHook2/net.h
+++ b/Resources/NetHook2/NetHook2/net.h
@@ -30,7 +30,7 @@ public:
 	// CWebSocketConnection::BBuildAndAsyncSendFrame(EWebSocketOpCode, uchar const*, int)
 	static bool __fastcall BBuildAndAsyncSendFrame(
 		void *webSocketConnection,
-#ifndef __x86_64__
+#ifndef X64BITS
 		void *unused, 
 #endif
 		EWebSocketOpCode eWebSocketOpCode,
@@ -40,7 +40,7 @@ public:
 	// CCMInterface::RecvPkt(CNetPacket *)
 	static void __fastcall RecvPkt(
 		void *cmConnection,
-#ifndef __x86_64__
+#ifndef X64BITS
 		void *unused,
 #endif
 		CNetPacket *pPacket);

--- a/Resources/NetHook2/NetHook2/steamclient.h
+++ b/Resources/NetHook2/NetHook2/steamclient.h
@@ -3,8 +3,9 @@
 #ifndef NETHOOK_STEAMCLIENT_H_
 #define NETHOOK_STEAMCLIENT_H_
 
+#include "steam/steamtypes.h"
 
-#ifdef __x86_64
+#ifdef X64BITS
 #define STEAMCLIENT_DLL "steamclient64.dll"
 #else
 #define STEAMCLIENT_DLL "steamclient.dll"


### PR DESCRIPTION
It seems like `__x86_64__` is not actually defined when building with a 64-bit MSVC, so this pull request switches those checks added in #1235 to steam's own `X64BITS` (defined in steamtypes.h).
It also adds a more useful error message when trying to use a 32-bit NetHook2 with a 64-bit process or vice versa. Before, you would be hit with "Unable to acquire SeDebug privilege" or "Target process does not have steamclient.dll loaded".