### PR TITLE
Set rollForward to latestMajor in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.100",
-    "rollForward": "latestMinor"
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
Readme says:

> To compile SteamKit2, the following is required: .NET 6.0 SDK or higher.

which is not true.