### PR TITLE
Use Stopwatch instead of wall clock for async job timeouts

### DIFF
--- a/SteamKit2/SteamKit2/Types/JobID.cs
+++ b/SteamKit2/SteamKit2/Types/JobID.cs
@@ -6,10 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
+using SteamKit2.Util;
 
 namespace SteamKit2
 {
@@ -94,7 +93,7 @@ namespace SteamKit2
     /// </summary>
     public abstract class AsyncJob
     {
-        DateTime jobStart;
+        ValueStopwatch jobStart;
 
 
         /// <summary>
@@ -109,7 +108,7 @@ namespace SteamKit2
 
         internal bool IsTimedout
         {
-            get { return DateTime.UtcNow >= jobStart + Timeout; }
+            get { return jobStart.GetElapsedTime() >= Timeout; }
         }
 
 
@@ -125,10 +124,8 @@ namespace SteamKit2
                 throw new ArgumentNullException( nameof(jobId) );
             }
 
-            jobStart = DateTime.UtcNow;
+            jobStart = ValueStopwatch.StartNew();
             JobID = jobId;
-
-            
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Util/ValueStopwatch.cs
+++ b/SteamKit2/SteamKit2/Util/ValueStopwatch.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace SteamKit2.Util
+{
+    readonly struct ValueStopwatch
+    {
+        private static readonly double s_timestampToTicks = TimeSpan.TicksPerSecond / ( double )Stopwatch.Frequency;
+
+        private readonly long _startTimestamp;
+
+        private ValueStopwatch( long startTimestamp )
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch( Stopwatch.GetTimestamp() );
+
+        public TimeSpan GetElapsedTime()
+        {
+            if ( _startTimestamp == 0 )
+            {
+                throw new InvalidOperationException( "An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time." );
+            }
+
+            long end = Stopwatch.GetTimestamp();
+            long timestampDelta = end - _startTimestamp;
+            long ticks = ( long )( s_timestampToTicks * timestampDelta );
+            return new TimeSpan( ticks );
+        }
+    }
+}


### PR DESCRIPTION
Seems like a better thing to do, should also hopefully improve randomness in tests.