### PR TITLE
Mark SentryFileHash in log on details as obsolete

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -378,8 +378,10 @@ namespace SteamKit2
 
             logon.Body.access_token = details.AccessToken;
 
+#pragma warning disable CS0618 // SentryFileHash is obsolete
             logon.Body.sha_sentryfile = details.SentryFileHash;
             logon.Body.eresult_sentryfile = ( int )( details.SentryFileHash != null ? EResult.OK : EResult.FileNotFound );
+#pragma warning restore CS0618 // SentryFileHash is obsolete
 
 
             this.Client.Send( logon );

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/SteamUser.cs
@@ -74,6 +74,7 @@ namespace SteamKit2
             /// Gets or sets the sentry file hash for this logon attempt, or null if no sentry file is available.
             /// </summary>
             /// <value>The sentry file hash.</value>
+            [Obsolete( "Steam no longer accepts machine auth as of 2023, use SteamAuthentication." )]
             public byte[]? SentryFileHash { get; set; }
             /// <summary>
             /// Gets or sets the access token used to login. This a token that has been provided after a successful login using <see cref="Authentication"/>.


### PR DESCRIPTION
If we deprecated machine auth callback, then (correct me if I'm wrong) this should be marked obsolete as well.