### PR TITLE
Issue:  #1329 - switching matchId from uint to ulong

### DIFF
--- a/Samples/10.DotaMatchRequest/DotaClient.cs
+++ b/Samples/10.DotaMatchRequest/DotaClient.cs
@@ -21,7 +21,7 @@ class DotaClient
     string userName;
     string password;
 
-    uint matchId;
+    ulong matchId;
 
     bool gotMatch;
 
@@ -33,7 +33,7 @@ class DotaClient
     const int APPID = 570;
 
 
-    public DotaClient( string userName, string password, uint matchId )
+    public DotaClient( string userName, string password, ulong matchId )
     {
         this.userName = userName;
         this.password = password;

--- a/Samples/10.DotaMatchRequest/Program.cs
+++ b/Samples/10.DotaMatchRequest/Program.cs
@@ -13,8 +13,8 @@ if ( args.Length < 3 )
 string username = args[ 0 ];
 string password = args[ 1 ];
 
-uint matchId;
-if ( !uint.TryParse( args[ 2 ], out matchId ) )
+ulong matchId;
+if ( !ulong.TryParse( args[ 2 ], out matchId ) )
 {
     Console.WriteLine( "Invalid Match ID!" );
     return;


### PR DESCRIPTION
https://github.com/SteamRE/SteamKit/issues/1329 thought this might be a simple correction and trying to help because I appreciate this repo

edit: Sorry to be more descriptive, I confirmed CMsgGCMatchDetailsRequest.match_id is ulong so I think it was doing an unnecessary cast from uint to ulong, I didn't have to change any of that downstream but got the command to work for matchid `7566780127` with this.