### PR TITLE
Optimize DepotManifest Serialization

### DIFF
--- a/SteamKit2/SteamKit2/Types/DepotManifest.cs
+++ b/SteamKit2/SteamKit2/Types/DepotManifest.cs
@@ -220,25 +220,6 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Serializes depot manifest and saves the output to a file.
-        /// </summary>
-        /// <param name="filename">Output file name.</param>
-        /// <returns><c>true</c> if serialization was successful; otherwise, <c>false</c>.</returns>
-        public bool SaveToFile( string filename )
-        {
-            try
-            {
-                using var fs = File.Open( filename, FileMode.Create );
-                Serialize( fs ); // Directly pass the FileStream to the Serialize method
-                return true; // If serialization completes without throwing an exception, return true
-            }
-            catch ( Exception )
-            {
-                return false; // Return false if an error occurs
-            }
-        }
-
-        /// <summary>
         /// Loads binary manifest from a file and deserializes it.
         /// </summary>
         /// <param name="filename">Input file name.</param>

--- a/SteamKit2/SteamKit2/Types/DepotManifest.cs
+++ b/SteamKit2/SteamKit2/Types/DepotManifest.cs
@@ -389,7 +389,11 @@ namespace SteamKit2
             }
         }
 
-        byte[]? Serialize()
+        /// <summary>
+        /// Serializes the depot manifest into a byte array.
+        /// </summary>
+        /// <returns>A byte array containing the serialized depot manifest. Returns <c>null</c> if serialization fails.</returns>
+        public byte[]? Serialize()
         {
             DebugLog.Assert( Files != null, nameof( DepotManifest ), "Files was null when attempting to serialize manifest." );
 


### PR DESCRIPTION
This PR builds on PR #1113, introducing a `HashSet` with `ChunkIdComparer` to manage unique chunks in `DepotManifest` serialization, significantly reducing processing time.

[My comment](https://github.com/SteamRE/SteamKit/pull/1113#issuecomment-1958688449)

### Changes:
- Replaced `List<byte[]>` with `HashSet<byte[]>` for unique chunks.
- Added `ChunkIdComparer` for efficient byte array comparison.

### Impact:
- **Before**: Serialization took up to 10 minutes.
- **After**: Reduced to ~0.61 seconds.

This optimization streamlines serialization, especially for large manifests, enhancing performance without data integrity loss.