### PR TITLE
Less allocations in non-utf8 string reads, fix non-utf8 string writes, optimize both with stack / pool alloc

### DIFF
--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -195,13 +195,13 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Writes the specified string to the message payload using default encoding.
+        /// Writes the specified string to the message payload using UTF-8 encoding.
         /// This function does not write a terminating null character.
         /// </summary>
         /// <param name="data">The string to write.</param>
         public void Write( string data )
         {
-            Write( data, Encoding.GetEncoding( 0 ) );
+            Write( data, Encoding.UTF8 );
         }
         /// <summary>
         /// Writes the specified string to the message payload using the specified encoding.
@@ -227,8 +227,9 @@ namespace SteamKit2
         /// <param name="data">The string to write.</param>
         public void WriteNullTermString( string data )
         {
-            WriteNullTermString( data, Encoding.GetEncoding( 0 ) );
+            WriteNullTermString( data, Encoding.UTF8 );
         }
+
         /// <summary>
         /// Writes the specified string and a null terminator to the message payload using the specified encoding.
         /// </summary>
@@ -403,12 +404,12 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Reads a null terminated string from the message payload with the default encoding.
+        /// Reads a null terminated string from the message payload with UTF-8 encoding.
         /// </summary>
         /// <returns>The string.</returns>
         public string ReadNullTermString()
         {
-            return ReadNullTermString( Encoding.GetEncoding( 0 ) );
+            return ReadNullTermString( Encoding.UTF8 );
         }
         /// <summary>
         /// Reads a null terminated string from the message payload with the specified encoding.

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -237,8 +237,9 @@ namespace SteamKit2
         /// <param name="encoding">The encoding to use.</param>
         public void WriteNullTermString( string data, Encoding encoding )
         {
-            Write( data, encoding );
-            Write( encoding.GetBytes( "\0" ) );
+            ArgumentNullException.ThrowIfNull( encoding );
+
+            Payload.WriteNullTermString( data, encoding );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Base/MsgBase.cs
+++ b/SteamKit2/SteamKit2/Base/MsgBase.cs
@@ -222,7 +222,7 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Writes the secified string and a null terminator to the message payload using default encoding.
+        /// Writes the secified string and a null terminator to the message payload using UTF-8 encoding.
         /// </summary>
         /// <param name="data">The string to write.</param>
         public void WriteNullTermString( string data )

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -70,20 +70,22 @@ namespace SteamKit2
                 return ReadNullTermUtf8String( stream );
             }
 
-            int characterSize = encoding.GetByteCount( "e" );
+            using MemoryStream ms = new MemoryStream( capacity: 32 );
 
-            using MemoryStream ms = new MemoryStream();
+            int characterSize = encoding.GetByteCount( "e" );
+            Span<byte> data = stackalloc byte[ characterSize ];
 
             while ( true )
             {
-                byte[] data = new byte[ characterSize ];
-                stream.Read( data, 0, characterSize );
+                data.Clear();
+                stream.Read( data );
 
-                if ( encoding.GetString( data, 0, characterSize ) == "\0" )
+                if ( encoding.GetString( data ) == "\0" )
                 {
                     break;
                 }
-                ms.Write( data, 0, data.Length );
+
+                ms.Write( data );
             }
 
             return encoding.GetString( ms.GetBuffer(), 0, ( int )ms.Length );

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -66,33 +66,11 @@ namespace SteamKit2
 
         public static string ReadNullTermString( this Stream stream, Encoding encoding )
         {
-            if ( encoding == Encoding.UTF8 )
-            {
-                return ReadNullTermUtf8String( stream );
-            }
+            var nullTermStride = encoding switch {
+                _ when encoding == Encoding.UTF8 => 1,
+                _ => encoding.GetByteCount( "e" ),
+            };
 
-            int characterSize = encoding.GetByteCount( "e" );
-
-            using MemoryStream ms = new MemoryStream();
-
-            while ( true )
-            {
-                byte[] data = new byte[ characterSize ];
-                stream.Read( data, 0, characterSize );
-
-                if ( encoding.GetString( data, 0, characterSize ) == "\0" )
-                {
-                    break;
-                }
-
-                ms.Write( data, 0, data.Length );
-            }
-
-            return encoding.GetString( ms.GetBuffer(), 0, ( int )ms.Length );
-        }
-
-        private static string ReadNullTermUtf8String( Stream stream )
-        {
             var buffer = ArrayPool<byte>.Shared.Rent( 32 );
 
             try
@@ -103,7 +81,12 @@ namespace SteamKit2
                 {
                     var b = stream.ReadByte();
 
-                    if ( b <= 0 ) // null byte or stream ended
+                    if ( b == -1 )
+                    {
+                        break;
+                    }
+
+                    if ( b == 0 && position % nullTermStride == 0 )
                     {
                         break;
                     }
@@ -120,7 +103,7 @@ namespace SteamKit2
                 }
                 while ( true );
 
-                return Encoding.UTF8.GetString( buffer[ ..position ] );
+                return encoding.GetString( buffer[ ..position ] );
             }
             finally
             {

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -125,12 +124,12 @@ namespace SteamKit2
 
             try
             {
-                Span<byte> byteSpan = isLargeBuffer ? rented.AsSpan( 0, totalByteCount ) : stackalloc byte[totalByteCount];
+                Span<byte> encodedSpan = isLargeBuffer ? rented.AsSpan( 0, totalByteCount ) : stackalloc byte[ totalByteCount ];
 
-                encoding.GetBytes( value.AsSpan(), byteSpan[ ..stringByteCount ] );
-                encoding.GetBytes( NullTerm.AsSpan(), byteSpan[ stringByteCount.. ] );
+                encoding.GetBytes( value.AsSpan(), encodedSpan[ ..stringByteCount ] );
+                encoding.GetBytes( NullTerm.AsSpan(), encodedSpan[ stringByteCount.. ] );
 
-                stream.Write( byteSpan );
+                stream.Write( encodedSpan );
             }
             finally
             {

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -63,6 +63,8 @@ namespace SteamKit2
             return BitConverter.ToSingle( data );
         }
 
+        const string NullTerminator = "\0";
+
         public static string ReadNullTermString( this Stream stream, Encoding encoding )
         {
             if ( encoding == Encoding.UTF8 )
@@ -80,7 +82,7 @@ namespace SteamKit2
                 data.Clear();
                 stream.Read( data );
 
-                if ( encoding.GetString( data ) == "\0" )
+                if ( encoding.GetString( data ) == NullTerminator )
                 {
                     break;
                 }
@@ -108,7 +110,6 @@ namespace SteamKit2
                         break;
                     }
 
-
                     if ( position >= buffer.Length )
                     {
                         var newBuffer = ArrayPool<byte>.Shared.Rent( buffer.Length * 2 );
@@ -131,11 +132,10 @@ namespace SteamKit2
 
         public static void WriteNullTermString( this Stream stream, string value, Encoding encoding )
         {
-            const string NullTerm = "\0";
             value ??= string.Empty;
 
             var stringByteCount = encoding.GetByteCount( value );
-            var nullTermByteCount = encoding.GetByteCount( NullTerm );
+            var nullTermByteCount = encoding.GetByteCount( NullTerminator );
             var totalByteCount = stringByteCount + nullTermByteCount;
 
             var isLargeBuffer = totalByteCount > 256;
@@ -146,7 +146,7 @@ namespace SteamKit2
                 Span<byte> encodedSpan = isLargeBuffer ? rented.AsSpan( 0, totalByteCount ) : stackalloc byte[ totalByteCount ];
 
                 encoding.GetBytes( value.AsSpan(), encodedSpan[ ..stringByteCount ] );
-                encoding.GetBytes( NullTerm.AsSpan(), encodedSpan[ stringByteCount.. ] );
+                encoding.GetBytes( NullTerminator.AsSpan(), encodedSpan[ stringByteCount.. ] );
 
                 stream.Write( encodedSpan );
             }

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -19,7 +19,7 @@ namespace Tests
                 (Encoding.ASCII, "Hello, World!"),
                 (Encoding.UTF8, "Hello, 世界!"),
                 (Encoding.Unicode, "Hello, 世界!"),
-                (Encoding.GetEncoding( 0 ), "Whats this"),
+                (Encoding.GetEncoding( 0 ), "System default encoding."),
                 (Encoding.Default, "Hello, World!"),
             ];
 
@@ -44,9 +44,9 @@ namespace Tests
             // unicode case where first byte is null, but its not nullterm
             using var msUnicode = new MemoryStream([64, 0, 0, 64]);
             var resultStandardImplementation = Encoding.Unicode.GetString(msUnicode.ToArray());
-            var resultUnicode = msUnicode.ReadNullTermString(Encoding.Unicode);
+            var resultSteamKitImplementation = msUnicode.ReadNullTermString(Encoding.Unicode);
             Assert.Equal(2, resultStandardImplementation.Length);
-            Assert.Equal(2, resultUnicode.Length);
+            Assert.Equal(2, resultSteamKitImplementation.Length);
         }
 
         [Fact]

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -40,6 +40,13 @@ namespace Tests
                 var resultNullTerm = msNullTerm.ReadNullTermString(testCase.Encoding);
                 Assert.Equal(testCase.String, resultNullTerm);
             }
+
+            // unicode case where first byte is null, but its not nullterm
+            using var msUnicode = new MemoryStream([64, 0, 0, 64]);
+            var resultStandardImplementation = Encoding.Unicode.GetString(msUnicode.ToArray());
+            var resultUnicode = msUnicode.ReadNullTermString(Encoding.Unicode);
+            Assert.Equal(2, resultStandardImplementation.Length);
+            Assert.Equal(2, resultUnicode.Length);
         }
 
         [Fact]


### PR DESCRIPTION
* MsgBase string writes and reads default to `Encoding.UTF8` instead of `Encoding.GetEncoding( 0 )`
* Optimize allocations in WriteNullTermString, ReadNullTermString (non-utf8).
* Fix WriteNullTermString logic for non-utf8 encoding (doing ReadNullTermString back would not previously work).