### PR TITLE
Optimize gzip in HandleMulti

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -532,12 +532,12 @@ namespace SteamKit2.Internal
             {
                 Span<byte> length = stackalloc byte[ sizeof( int ) ];
 
-                while ( stream.Read( length ) == length.Length )
+                while ( stream.ReadAll( length ) > 0 )
                 {
                     var subSize = BitConverter.ToInt32( length );
                     var subData = new byte[ subSize ];
 
-                    var read = stream.ReadAll( subData );
+                    stream.ReadAll( subData );
 
                     if ( !OnClientMsgReceived( GetPacketMsg( subData, this ) ) )
                     {

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -140,7 +140,7 @@ namespace SteamKit2
 
         public static int ReadAll( this Stream stream, Span<byte> buffer )
         {
-            return stream.ReadAtLeast( buffer, minimumBytes: 0, throwOnEndOfStream: false );
+            return stream.ReadAtLeast( buffer, minimumBytes: buffer.Length, throwOnEndOfStream: false );
         }
     }
 }

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -138,15 +138,9 @@ namespace SteamKit2
             stream.Write( data, 0, data.Length );
         }
 
-        public static int ReadAll( this Stream stream, byte[] buffer )
+        public static int ReadAll( this Stream stream, Span<byte> buffer )
         {
-            int bytesRead;
-            int totalRead = 0;
-            while ( ( bytesRead = stream.Read( buffer, totalRead, buffer.Length - totalRead ) ) != 0 )
-            {
-                totalRead += bytesRead;
-            }
-            return totalRead;
+            return stream.ReadAtLeast( buffer, minimumBytes: 0, throwOnEndOfStream: false );
         }
     }
 }


### PR DESCRIPTION
An attempt to optimize it by not copying the entire decompressed buffer into byte array, but instead consume it directly.