### PR TITLE
Reduce allocations

### DIFF
--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
@@ -367,6 +367,7 @@ namespace SteamKit2.Internal
 
 			Msg = (EMsg)MsgUtil.GetMsg( (uint)br.ReadInt32() );
 			HeaderLength = br.ReadInt32();
+			ArgumentOutOfRangeException.ThrowIfNegative( HeaderLength );
 			Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.Internal.CMsgProtoBufHeader>( stream, length: HeaderLength );
 		}
 	}
@@ -410,6 +411,7 @@ namespace SteamKit2.Internal
 
 			Msg = MsgUtil.GetGCMsg( (uint)br.ReadUInt32() );
 			HeaderLength = br.ReadInt32();
+			ArgumentOutOfRangeException.ThrowIfNegative( HeaderLength );
 			Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.GC.Internal.CMsgProtoBufHeader>( stream, length: HeaderLength );
 		}
 	}

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguageInternal.cs
@@ -367,8 +367,7 @@ namespace SteamKit2.Internal
 
 			Msg = (EMsg)MsgUtil.GetMsg( (uint)br.ReadInt32() );
 			HeaderLength = br.ReadInt32();
-			using( MemoryStream msProto = new MemoryStream( br.ReadBytes( HeaderLength ) ) )
-				Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.Internal.CMsgProtoBufHeader>( msProto );
+			Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.Internal.CMsgProtoBufHeader>( stream, length: HeaderLength );
 		}
 	}
 
@@ -411,8 +410,7 @@ namespace SteamKit2.Internal
 
 			Msg = MsgUtil.GetGCMsg( (uint)br.ReadUInt32() );
 			HeaderLength = br.ReadInt32();
-			using( MemoryStream msProto = new MemoryStream( br.ReadBytes( HeaderLength ) ) )
-				Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.GC.Internal.CMsgProtoBufHeader>( msProto );
+			Proto = ProtoBuf.Serializer.Deserialize<SteamKit2.GC.Internal.CMsgProtoBufHeader>( stream, length: HeaderLength );
 		}
 	}
 

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -473,7 +473,7 @@ namespace SteamKit2.Internal
         {
             if ( data.Length < sizeof( uint ) )
             {
-                log.LogDebug( nameof( CMClient ), "PacketMsg too small to contain a message, was only {0} bytes. Message: 0x{1}", data.Length, BitConverter.ToString( data ).Replace( "-", string.Empty ) );
+                log.LogDebug( nameof( CMClient ), "PacketMsg too small to contain a message, was only {0} bytes. Message: 0x{1}", data.Length, Utils.EncodeHexString( data ) );
                 return null;
             }
 

--- a/SteamKit2/SteamKit2/Types/DepotManifest.cs
+++ b/SteamKit2/SteamKit2/Types/DepotManifest.cs
@@ -262,23 +262,17 @@ namespace SteamKit2
 
                         case DepotManifest.PROTOBUF_PAYLOAD_MAGIC:
                             uint payload_length = br.ReadUInt32();
-                            byte[] payload_bytes = br.ReadBytes( (int)payload_length );
-                            using ( var ms_payload = new MemoryStream( payload_bytes ) ) 
-                                payload = Serializer.Deserialize<ContentManifestPayload>( ms_payload );
+                            payload = Serializer.Deserialize<ContentManifestPayload>( ms, length: payload_length );
                             break;
 
                         case DepotManifest.PROTOBUF_METADATA_MAGIC:
                             uint metadata_length = br.ReadUInt32();
-                            byte[] metadata_bytes = br.ReadBytes( (int)metadata_length );
-                            using ( var ms_metadata = new MemoryStream( metadata_bytes ) )
-                                metadata = Serializer.Deserialize<ContentManifestMetadata>( ms_metadata );
+                            metadata = Serializer.Deserialize<ContentManifestMetadata>( ms, length: metadata_length );
                             break;
 
                         case DepotManifest.PROTOBUF_SIGNATURE_MAGIC:
                             uint signature_length = br.ReadUInt32();
-                            byte[] signature_bytes = br.ReadBytes( (int)signature_length );
-                            using ( var ms_signature = new MemoryStream( signature_bytes ) )
-                                signature = Serializer.Deserialize<ContentManifestSignature>( ms_signature );
+                            signature = Serializer.Deserialize<ContentManifestSignature>( ms, length: signature_length );
                             break;
 
                         case DepotManifest.PROTOBUF_ENDOFMANIFEST_MAGIC:

--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -418,9 +418,7 @@ namespace SteamKit2
         {
             data = SHA1.HashData( data );
 
-            return BitConverter.ToString( data )
-                .Replace( "-", "" )
-                .ToLower();
+            return Utils.EncodeHexString( data );
         }
     }
 }


### PR DESCRIPTION
- **Serialize protobuf directly from the stream without a temporary alloc**
- **Make PICSProductInfo.HttpUri a getter to avoid an alloc if it is unused**
