### PR TITLE
Store depot chunk crc as uint to avoid converting to bytes

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CDN/DepotChunk.cs
+++ b/SteamKit2/SteamKit2/Steam/CDN/DepotChunk.cs
@@ -73,11 +73,9 @@ namespace SteamKit2.CDN
                 processedData = ZipUtil.Decompress( processedData );
             }
 
-            DebugLog.Assert( ChunkInfo.Checksum != null, nameof( DepotChunk ), "Expected data chunk to have a checksum." );
+            var dataCrc = Utils.AdlerHash( processedData );
 
-            byte[] dataCrc = Utils.AdlerHash( processedData );
-
-            if ( !dataCrc.SequenceEqual( ChunkInfo.Checksum ) )
+            if ( dataCrc != ChunkInfo.Checksum )
             {
                 throw new InvalidDataException( "Processed data checksum is incorrect! Downloaded depot chunk is corrupt or invalid/wrong depot key?" );
             }

--- a/SteamKit2/SteamKit2/Types/DepotManifest.cs
+++ b/SteamKit2/SteamKit2/Types/DepotManifest.cs
@@ -40,7 +40,7 @@ namespace SteamKit2
             /// <summary>
             /// Gets or sets the expected Adler32 checksum of this chunk.
             /// </summary>
-            public byte[]? Checksum { get; set; }
+            public uint Checksum { get; set; }
             /// <summary>
             /// Gets or sets the chunk offset.
             /// </summary>
@@ -63,7 +63,7 @@ namespace SteamKit2
             {
             }
 
-            internal ChunkData( byte[] id, byte[] checksum, ulong offset, uint comp_length, uint uncomp_length )
+            internal ChunkData( byte[] id, uint checksum, ulong offset, uint comp_length, uint uncomp_length )
             {
                 this.ChunkID = id;
                 this.Checksum = checksum;
@@ -317,7 +317,7 @@ namespace SteamKit2
 
                 foreach (var chunk in file_mapping.Chunks)
                 {
-                    filedata.Chunks.Add( new ChunkData( chunk.ChunkGID!, chunk.Checksum!, chunk.Offset, chunk.CompressedSize, chunk.DecompressedSize ) );
+                    filedata.Chunks.Add( new ChunkData( chunk.ChunkGID!, chunk.Checksum, chunk.Offset, chunk.CompressedSize, chunk.DecompressedSize ) );
                 }
 
                 Files.Add(filedata);
@@ -334,7 +334,7 @@ namespace SteamKit2
 
                 foreach (var chunk in file_mapping.chunks)
                 {
-                    filedata.Chunks.Add( new ChunkData( chunk.sha, BitConverter.GetBytes(chunk.crc), chunk.offset, chunk.cb_compressed, chunk.cb_original ) );
+                    filedata.Chunks.Add( new ChunkData( chunk.sha, chunk.crc, chunk.offset, chunk.cb_compressed, chunk.cb_original ) );
                 }
 
                 Files.Add(filedata);
@@ -406,7 +406,7 @@ namespace SteamKit2
                 {
                     var protochunk = new ContentManifestPayload.FileMapping.ChunkData();
                     protochunk.sha = chunk.ChunkID;
-                    protochunk.crc = BitConverter.ToUInt32( chunk.Checksum!, 0 );
+                    protochunk.crc = chunk.Checksum;
                     protochunk.offset = chunk.Offset;
                     protochunk.cb_original = chunk.UncompressedLength;
                     protochunk.cb_compressed = chunk.CompressedLength;

--- a/SteamKit2/SteamKit2/Types/Manifest.cs
+++ b/SteamKit2/SteamKit2/Types/Manifest.cs
@@ -22,7 +22,7 @@ namespace SteamKit2
             {
                 public byte[]? ChunkGID { get; set; } // sha1 hash for this chunk
 
-                public byte[]? Checksum { get; set; }
+                public uint Checksum { get; set; }
                 public ulong Offset { get; set; }
 
                 public uint DecompressedSize { get; set; }
@@ -33,7 +33,7 @@ namespace SteamKit2
                 {
                     ChunkGID = ds.ReadBytes( 20 );
 
-                    Checksum = ds.ReadBytes( 4 );
+                    Checksum = ds.ReadUInt32();
 
                     Offset = ds.ReadUInt64();
 

--- a/SteamKit2/SteamKit2/Util/Utils.cs
+++ b/SteamKit2/SteamKit2/Util/Utils.cs
@@ -17,7 +17,7 @@ namespace SteamKit2
         /// <summary>
         /// Performs an Adler32 on the given input
         /// </summary>
-        public static byte[] AdlerHash( byte[] input )
+        public static uint AdlerHash( byte[] input )
         {
             ArgumentNullException.ThrowIfNull( input );
 
@@ -28,7 +28,7 @@ namespace SteamKit2
                 b = ( b + a ) % 65521;
             }
 
-            return BitConverter.GetBytes( a | ( b << 16 ) );
+            return a | ( b << 16 );
         }
 
         public static string EncodeHexString(byte[] input)


### PR DESCRIPTION
avoid this:
![image](https://github.com/user-attachments/assets/231ca3fe-0b54-401f-9c9f-b7bbfcfb9a8a)
