### PR TITLE
Use `BufferBlock` for the callbacks queue

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -44,7 +44,7 @@ namespace SteamKit2
         /// </summary>
         public void RunCallbacks()
         {
-            var call = client.GetCallback( true );
+            var call = client.GetCallback();
 
             if ( call == null )
                 return;
@@ -58,7 +58,7 @@ namespace SteamKit2
         /// <param name="timeout">The length of time to block.</param>
         public void RunWaitCallbacks( TimeSpan timeout )
         {
-            var call = client.WaitForCallback( true, timeout );
+            var call = client.WaitForCallback( timeout );
 
             if ( call == null )
                 return;
@@ -72,7 +72,7 @@ namespace SteamKit2
         /// <param name="timeout">The length of time to block.</param>
         public void RunWaitAllCallbacks( TimeSpan timeout )
         {
-            var calls = client.GetAllCallbacks( true, timeout );
+            var calls = client.GetAllCallbacks( timeout );
             foreach ( var call in calls )
             {
                 Handle( call );

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -84,7 +84,12 @@ namespace SteamKit2
         /// </summary>
         public void RunWaitCallbacks()
         {
-            RunWaitCallbacks( TimeSpan.FromMilliseconds( -1 ) );
+            var call = client.WaitForCallback();
+
+            if ( call == null )
+                return;
+
+            Handle( call );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -101,9 +101,9 @@ namespace SteamKit2
         }
         /// <summary>
         /// Blocks the current thread to run a single queued callback.
-        /// If no callback is queued, the method will block until one is posted.
+        /// If no callback is queued, the method will asynchronously await until one is posted.
         /// </summary>
-        public async Task RunWaitCallbacksAsync( CancellationToken cancellationToken = default )
+        public async Task RunWaitCallbackAsync( CancellationToken cancellationToken = default )
         {
             var call = await client.WaitForCallbackAsync( cancellationToken );
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using SteamKit2.Internal;
 
 namespace SteamKit2
@@ -91,6 +93,19 @@ namespace SteamKit2
         public void RunWaitCallbacks()
         {
             var call = client.WaitForCallback();
+
+            if ( call == null )
+                return;
+
+            Handle( call );
+        }
+        /// <summary>
+        /// Blocks the current thread to run a single queued callback.
+        /// If no callback is queued, the method will block until one is posted.
+        /// </summary>
+        public async Task RunWaitCallbacksAsync( CancellationToken cancellationToken = default )
+        {
+            var call = await client.WaitForCallbackAsync( cancellationToken );
 
             if ( call == null )
                 return;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -42,28 +42,30 @@ namespace SteamKit2
         /// Runs a single queued callback.
         /// If no callback is queued, this method will instantly return.
         /// </summary>
-        public void RunCallbacks()
+        public bool RunCallbacks()
         {
             var call = client.GetCallback();
 
             if ( call == null )
-                return;
+                return false;
 
             Handle( call );
+            return true;
         }
         /// <summary>
         /// Blocks the current thread to run a single queued callback.
         /// If no callback is queued, the method will block for the given timeout.
         /// </summary>
         /// <param name="timeout">The length of time to block.</param>
-        public void RunWaitCallbacks( TimeSpan timeout )
+        public bool RunWaitCallbacks( TimeSpan timeout )
         {
             var call = client.WaitForCallback( timeout );
 
             if ( call == null )
-                return;
+                return false;
 
             Handle( call );
+            return true;
         }
         /// <summary>
         /// Blocks the current thread to run all queued callbacks.
@@ -72,10 +74,14 @@ namespace SteamKit2
         /// <param name="timeout">The length of time to block.</param>
         public void RunWaitAllCallbacks( TimeSpan timeout )
         {
-            var calls = client.GetAllCallbacks( timeout );
-            foreach ( var call in calls )
+            if ( !RunWaitCallbacks( timeout ) )
             {
-                Handle( call );
+                return;
+            }
+
+            while ( RunCallbacks() )
+            {
+                //
             }
         }
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -56,7 +56,7 @@ namespace SteamKit2
         }
         /// <summary>
         /// Blocks the current thread to run a single queued callback.
-        /// If no callback is queued, the method will block for the given timeout.
+        /// If no callback is queued, the method will block for the given timeout or until a callback becomes available.
         /// </summary>
         /// <param name="timeout">The length of time to block.</param>
         public bool RunWaitCallbacks( TimeSpan timeout )
@@ -71,7 +71,8 @@ namespace SteamKit2
         }
         /// <summary>
         /// Blocks the current thread to run all queued callbacks.
-        /// If no callback is queued, the method will block for the given timeout.
+        /// If no callback is queued, the method will block for the given timeout or until a callback becomes available.
+        /// This method returns once the queue has been emptied.
         /// </summary>
         /// <param name="timeout">The length of time to block.</param>
         public void RunWaitAllCallbacks( TimeSpan timeout )
@@ -88,7 +89,7 @@ namespace SteamKit2
         }
         /// <summary>
         /// Blocks the current thread to run a single queued callback.
-        /// If no callback is queued, the method will block until one is posted.
+        /// If no callback is queued, the method will block until one becomes available.
         /// </summary>
         public void RunWaitCallbacks()
         {
@@ -97,7 +98,7 @@ namespace SteamKit2
         }
         /// <summary>
         /// Blocks the current thread to run a single queued callback.
-        /// If no callback is queued, the method will asynchronously await until one is posted.
+        /// If no callback is queued, the method will asynchronously await until one becomes available.
         /// </summary>
         public async Task RunWaitCallbackAsync( CancellationToken cancellationToken = default )
         {

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -93,10 +93,6 @@ namespace SteamKit2
         public void RunWaitCallbacks()
         {
             var call = client.WaitForCallback();
-
-            if ( call == null )
-                return;
-
             Handle( call );
         }
         /// <summary>
@@ -106,10 +102,6 @@ namespace SteamKit2
         public async Task RunWaitCallbackAsync( CancellationToken cancellationToken = default )
         {
             var call = await client.WaitForCallbackAsync( cancellationToken );
-
-            if ( call == null )
-                return;
-
             Handle( call );
         }
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -44,6 +44,7 @@ namespace SteamKit2
         /// Runs a single queued callback.
         /// If no callback is queued, this method will instantly return.
         /// </summary>
+        /// <returns>Returns true if a callback has been run, false otherwise.</returns>
         public bool RunCallbacks()
         {
             var call = client.GetCallback();
@@ -59,6 +60,7 @@ namespace SteamKit2
         /// If no callback is queued, the method will block for the given timeout or until a callback becomes available.
         /// </summary>
         /// <param name="timeout">The length of time to block.</param>
+        /// <returns>Returns true if a callback has been run, false otherwise.</returns>
         public bool RunWaitCallbacks( TimeSpan timeout )
         {
             var call = client.WaitForCallback( timeout );

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -10,7 +10,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -205,6 +205,15 @@ namespace SteamKit2
         }
 
         /// <summary>
+        /// Asynchronously awaits until a callback object is posted to the queue, and removes it.
+        /// </summary>
+        /// <returns>The callback object from the queue.</returns>
+        public Task<ICallbackMsg> WaitForCallbackAsync( CancellationToken cancellationToken = default )
+        {
+            return callbackQueue.ReceiveAsync( cancellationToken );
+        }
+
+        /// <summary>
         /// Blocks the calling thread until a callback object is posted to the queue, and removes it.
         /// </summary>
         /// <param name="timeout">The length of time to block.</param>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -223,37 +223,6 @@ namespace SteamKit2
         }
 
         /// <summary>
-        /// Blocks the calling thread until the queue contains a callback object. Returns all callbacks, and removes them.
-        /// </summary>
-        /// <param name="timeout">The length of time to block.</param>
-        /// <returns>All current callback objects in the queue.</returns>
-        public IEnumerable<ICallbackMsg> GetAllCallbacks( TimeSpan timeout )
-        {
-            ICallbackMsg msg;
-
-            try
-            {
-                msg = callbackQueue.Receive( timeout );
-            }
-            catch ( TimeoutException )
-            {
-                return [];
-            }
-
-            var callbacks = new List<ICallbackMsg>
-            {
-                msg
-            };
-
-            while ( callbackQueue.TryReceive( out msg! ) )
-            {
-                callbacks.Add( msg );
-            }
-
-            return callbacks;
-        }
-
-        /// <summary>
         /// Posts a callback to the queue. This is normally used directly by client message handlers.
         /// </summary>
         /// <param name="msg">The message.</param>

--- a/SteamKit2/SteamKit2/changes.txt
+++ b/SteamKit2/SteamKit2/changes.txt
@@ -10,6 +10,9 @@ v 3.0.0			July 18 2024
 
 BREAKING CHANGES
 * SteamKit now targets .NET 8
+* `SteamClient` callback queue is now backed by `BufferBlock`:
+  * `FreeLastCallback` and `GetAllCallbacks` have been removed
+  * Calling  `GetCallback` and `WaitForCallback` now always dequeues a callback, there is no more peek and "freeLast"
 * Removed obsolete methods and enum values
 * Removed Artifact and Underlords generated protobufs
 * Removed `DepotManifest.SaveToFile`

--- a/SteamKit2/Tests/CallbackManagerFacts.cs
+++ b/SteamKit2/Tests/CallbackManagerFacts.cs
@@ -218,7 +218,7 @@ namespace Tests
 
                 for ( var i = 1; i <= 10; i++ )
                 {
-                    await mgr.RunWaitCallbacksAsync();
+                    await mgr.RunWaitCallbackAsync();
                     Assert.Equal( i, numCallbacksRun );
                 }
 

--- a/SteamKit2/Tests/CallbackManagerFacts.cs
+++ b/SteamKit2/Tests/CallbackManagerFacts.cs
@@ -200,23 +200,27 @@ namespace Tests
         [Fact]
         public async Task PostedCallbacksTriggerActionsAsync()
         {
-            var callback = new CallbackForTest { UniqueID = Guid.NewGuid() };
+            var callbacks = new CallbackForTest[ 10 ];
 
             var numCallbacksRun = 0;
             void action( CallbackForTest cb )
             {
+                Assert.True( numCallbacksRun < callbacks.Length );
+                var callback = callbacks[ numCallbacksRun ];
                 Assert.Equal( callback.UniqueID, cb.UniqueID );
                 numCallbacksRun++;
             }
 
             using ( mgr.Subscribe<CallbackForTest>( action ) )
             {
-                for ( var i = 0; i < 10; i++ )
+                for ( var i = 0; i < callbacks.Length; i++ )
                 {
+                    var callback = new CallbackForTest { UniqueID = Guid.NewGuid() };
+                    callbacks[ i ] = callback;
                     client.PostCallback( callback );
                 }
 
-                for ( var i = 1; i <= 10; i++ )
+                for ( var i = 1; i <= callbacks.Length; i++ )
                 {
                     await mgr.RunWaitCallbackAsync();
                     Assert.Equal( i, numCallbacksRun );

--- a/SteamKit2/Tests/SteamGameServerFacts.cs
+++ b/SteamKit2/Tests/SteamGameServerFacts.cs
@@ -13,7 +13,7 @@ namespace Tests
                 Token = "SuperSecretToken"
             });
 
-            var callback = SteamClient.GetCallback( freeLast: true );
+            var callback = SteamClient.GetCallback( );
             Assert.NotNull( callback );
             Assert.IsType<SteamUser.LoggedOnCallback>( callback );
 
@@ -26,7 +26,7 @@ namespace Tests
         {
             Handler.LogOnAnonymous();
 
-            var callback = SteamClient.GetCallback( freeLast: true );
+            var callback = SteamClient.GetCallback( );
             Assert.NotNull( callback );
             Assert.IsType<SteamUser.LoggedOnCallback>( callback );
 

--- a/SteamKit2/Tests/SteamUserFacts.cs
+++ b/SteamKit2/Tests/SteamUserFacts.cs
@@ -15,7 +15,7 @@ namespace Tests
                 Password = "lamepassword"
             });
 
-            var callback = SteamClient.GetCallback( freeLast: true );
+            var callback = SteamClient.GetCallback( );
             Assert.NotNull( callback );
             Assert.IsType<SteamUser.LoggedOnCallback>( callback );
 
@@ -104,7 +104,7 @@ namespace Tests
         {
             Handler.LogOnAnonymous();
 
-            var callback = SteamClient.GetCallback( freeLast: true );
+            var callback = SteamClient.GetCallback( );
             Assert.NotNull( callback );
             Assert.IsType<SteamUser.LoggedOnCallback>( callback );
 


### PR DESCRIPTION
Breaking change: this removes `freeLast` and `FreeLastCallback`, which silently changes the behaviour of overloads that had no parameters, perhaps they should be renamed.

I removed `GetAllCallbacks` from `SteamClient` and added `WaitForCallbackAsync(cts)`.

With `RunWaitCallbackAsync` consumers should be able to spin up tasks in TPL that run this in a loop without requering a thread for every manager (or having to loop over them).

@JustArchi 