### PR TITLE
Fix typo

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamGameCoordinator/SteamGameCoordinator.cs
@@ -37,7 +37,7 @@ namespace SteamKit2
         /// <param name="packetMsg">The packet message that contains the data.</param>
         public override void HandleMsg( IPacketMsg packetMsg )
         {
-            if ( packetMsg.MsgType == EMsg.ClientToGC )
+            if ( packetMsg.MsgType == EMsg.ClientFromGC )
             {
                 var callback = new MessageCallback( packetMsg );
                 this.Client.PostCallback( callback );


### PR DESCRIPTION
I haven't been able to get responses from messages sent to GameCoordinator since 3.0.0-Alpha.3.  In the 022_DotaMatchRequest sample, nothing currently happens after launching DOTA.  Narrowed the cause down to what looks to be just a typo.  Correcting it resolves my issue.