### PR TITLE
Enable warnings as errors in CI builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,5 +32,6 @@
         <DebugType>portable</DebugType>
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+        <TreatWarningsAsErrors Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR enables warnings as errors in CI builds only.