### PR TITLE
Changing default Protocol from TCP to WebSockets. 

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -35,7 +35,7 @@ namespace SteamKit2
 
                 MachineInfoProvider = MachineInfoProvider.GetDefaultProvider(),
 
-                ProtocolTypes = ProtocolTypes.Tcp,
+                ProtocolTypes = ProtocolTypes.WebSocket,
 
                 ServerListProvider = new MemoryServerListProvider(),
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -35,7 +35,7 @@ namespace SteamKit2
 
                 MachineInfoProvider = MachineInfoProvider.GetDefaultProvider(),
 
-                ProtocolTypes = ProtocolTypes.WebSocket,
+                ProtocolTypes = ProtocolTypes.Tcp | ProtocolTypes.WebSocket,
 
                 ServerListProvider = new MemoryServerListProvider(),
 

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -79,7 +79,7 @@ namespace Tests
         [Fact]
         public void DefaultProtocols()
         {
-            Assert.Equal(ProtocolTypes.Tcp, configuration.ProtocolTypes);
+            Assert.Equal(ProtocolTypes.Tcp | ProtocolTypes.WebSocket, configuration.ProtocolTypes);
         }
 
         [Fact]


### PR DESCRIPTION
After Valve's maintenance on 2024/08/27 some servers in affected regions will no longer accept TCP connections, which can prevent clients from ever making a successful connection in some cases.  

For example CellId 63 (Washington DC) will endlessly retry the same servers without ever making a successful connection.  I have tested and confirmed that other regions are affected by this issue, however I don't remember which ones off the top of my head.
![image](https://github.com/user-attachments/assets/19ceecce-b800-495a-b9c9-e6bcf05dd43e)

