### PR TITLE
Fix Protobufs path case-sensitivity

### DIFF
--- a/Resources/ProtobufGen/generate-all.ps1
+++ b/Resources/ProtobufGen/generate-all.ps1
@@ -13,7 +13,7 @@ param([string[]]$ProtoDir)
 
 $ProtoGenSrc = Join-Path $PSScriptRoot 'ProtobufGen'
 $ProtoGenDll = Join-Path $ProtoGenSrc '\bin\Debug\ProtobufGen.dll'
-$ProtoBase = Join-Path $PSScriptRoot '..\ProtoBufs'
+$ProtoBase = Join-Path $PSScriptRoot '..\Protobufs'
 $SK2Base = Join-Path $PSScriptRoot '..\..\SteamKit2\SteamKit2\Base\Generated'
 
 & dotnet build --configuration Debug $ProtoGenSrc


### PR DESCRIPTION
The folder is named "Protobufs", so if you execute this script in linux, it will fail with "ProtoBufs"