### PR TITLE
Fix CallbackManager to be thread-safe

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/CallbackMgr/CallbackMgr.cs
@@ -140,7 +140,7 @@ namespace SteamKit2
 
         void ICallbackMgrInternals.Register( CallbackBase call )
         {
-            lock ( registeredCallbacks )
+            lock ( this )
             {
                 if ( Array.IndexOf( registeredCallbacks, call ) != -1 )
                 {
@@ -158,7 +158,7 @@ namespace SteamKit2
 
         void ICallbackMgrInternals.Unregister( CallbackBase call )
         {
-            lock ( registeredCallbacks )
+            lock ( this )
             {
                 var index = Array.IndexOf( registeredCallbacks, call );
 

--- a/SteamKit2/Tests/CallbackManagerFacts.cs
+++ b/SteamKit2/Tests/CallbackManagerFacts.cs
@@ -232,6 +232,49 @@ namespace Tests
             }
         }
 
+        [Fact]
+        public void CorrectlyUnsubscribesFromInsideOfCallback()
+        {
+            static void nothing( CallbackForTest cb )
+            {
+                //
+            }
+
+            using var s1 = mgr.Subscribe<CallbackForTest>( nothing );
+
+            IDisposable subscription = null;
+
+            void unsubscribe( CallbackForTest cb )
+            {
+                Assert.NotNull( subscription );
+                subscription.Dispose();
+                subscription = null;
+            }
+
+            subscription = mgr.Subscribe<CallbackForTest>( unsubscribe );
+
+            PostAndRunCallback( new CallbackForTest { UniqueID = Guid.NewGuid() } );
+        }
+
+        [Fact]
+        public void CorrectlysubscribesFromInsideOfCallback()
+        {
+            static void nothing( CallbackForTest cb )
+            {
+                //
+            }
+
+            void subscribe( CallbackForTest cb )
+            {
+                using var s2 = mgr.Subscribe<CallbackForTest>( nothing );
+            }
+
+            using var s1 = mgr.Subscribe<CallbackForTest>( nothing );
+            using var se = mgr.Subscribe<CallbackForTest>( subscribe );
+
+            PostAndRunCallback( new CallbackForTest { UniqueID = Guid.NewGuid() } );
+        }
+
         void PostAndRunCallback(CallbackMsg callback)
         {
             client.PostCallback(callback);


### PR DESCRIPTION
I think Add/Remove methods allocating new arrays is a worthwhile cost versus allocating in Handle.

To be extra safe I could add lock in add/remove.