### PR TITLE
Fix CA2022 warnings ahead of .NET 9

### DIFF
--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -11,7 +11,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(Int16)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToInt16( data );
         }
 
@@ -19,7 +19,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(UInt16)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToUInt16( data );
         }
 
@@ -27,7 +27,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(Int32)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToInt32( data );
         }
 
@@ -35,7 +35,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(Int64)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToInt64( data );
         }
 
@@ -43,7 +43,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(UInt32)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToUInt32( data );
         }
 
@@ -51,7 +51,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(UInt64)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToUInt64( data );
         }
 
@@ -59,7 +59,7 @@ namespace SteamKit2
         {
             Span<byte> data = stackalloc byte[sizeof(float)];
 
-            stream.Read( data );
+            stream.ReadExactly( data );
             return BitConverter.ToSingle( data );
         }
 
@@ -80,7 +80,7 @@ namespace SteamKit2
             while ( true )
             {
                 data.Clear();
-                stream.Read( data );
+                stream.ReadExactly( data );
 
                 if ( encoding.GetString( data ) == NullTerminator )
                 {

--- a/SteamKit2/SteamKit2/Util/StreamHelpers.cs
+++ b/SteamKit2/SteamKit2/Util/StreamHelpers.cs
@@ -80,9 +80,10 @@ namespace SteamKit2
             while ( true )
             {
                 data.Clear();
-                stream.ReadExactly( data );
 
-                if ( encoding.GetString( data ) == NullTerminator )
+                var bytesRead = stream.ReadAtLeast( data, data.Length, throwOnEndOfStream: false );
+
+                if ( bytesRead == 0 || encoding.GetString( data ) == NullTerminator )
                 {
                     break;
                 }

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -93,7 +93,7 @@ namespace Tests
                 var threadNumber = (int)o;
 
                 using var ms = new MemoryStream();
-                var bytes = BitConverter.GetBytes( threadNumber );
+                var bytes = BitConverter.GetBytes( ( long )threadNumber );
                 ms.Write( bytes, 0, bytes.Length );
 
                 for ( var i = 0; i < 1000; i++ )


### PR DESCRIPTION
The .NET 9 SDK introduces a new analyzer warning CA2022 that shows up when targeting .NET 9.

This fixes warnings about possible partial reads by using a new API from .NET 7, `ReadExactly`, rather than `Read` which can perform a partial read and relies on the caller to read in a loop.