### PR TITLE
Handle CMClient.OnClientConnected() throwing (probably from a derived class)

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -438,7 +438,16 @@ namespace SteamKit2.Internal
             Servers.TryMark( connection.CurrentEndPoint, connection.ProtocolTypes, ServerQuality.Good );
 
             IsConnected = true;
-            OnClientConnected();
+
+            try
+            {
+                OnClientConnected();
+            }
+            catch ( Exception ex )
+            {
+                DebugLog.WriteLine( nameof(CMClient), "Unhandled exception after connecting: {0}", ex );
+                Disconnect(userInitiated: false);
+            }
         }
 
         void Disconnected( object? sender, DisconnectedEventArgs e )


### PR DESCRIPTION
When playing around with NativeAOT, this can easily throw an exception as this is the first point at which we touch protobuf serialization, particularly when working with websockets.

At the moment this exception gets captured in the WebSocketContext task and does not get printed to DebugLog, so the program has the appearance of hanging.

This prints the exception to DebugLog and then triggers a non-user-initiated Disconnect call to close the connection, rather than just hanging forever on an open connection that we cannot do anything with.