### PR TITLE
Use System.TimeProvider to control time

### DIFF
--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -142,10 +142,12 @@ namespace SteamKit2.Internal
 
             ID = identifier;
 
-            heartBeatFunc = new ScheduledFunction( () =>
-            {
-                Send( new ClientMsgProtobuf<CMsgClientHeartBeat>( EMsg.ClientHeartBeat ) );
-            } );
+            heartBeatFunc = new ScheduledFunction(
+                configuration.TimeProvider,
+                () =>
+                {
+                    Send( new ClientMsgProtobuf<CMsgClientHeartBeat>( EMsg.ClientHeartBeat ) );
+                } );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/SteamClient/AsyncJobManager.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/AsyncJobManager.cs
@@ -8,11 +8,11 @@ namespace SteamKit2
         internal ConcurrentDictionary<JobID, AsyncJob> asyncJobs;
         internal ScheduledFunction jobTimeoutFunc;
 
-        public AsyncJobManager()
+        public AsyncJobManager( TimeProvider timeProvider )
         {
             asyncJobs = new ConcurrentDictionary<JobID, AsyncJob>();
 
-            jobTimeoutFunc = new ScheduledFunction( CancelTimedoutJobs, TimeSpan.FromSeconds( 1 ) );
+            jobTimeoutFunc = new ScheduledFunction( timeProvider, CancelTimedoutJobs, TimeSpan.FromSeconds( 1 ) );
         }
 
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/ISteamConfigurationBuilder.cs
@@ -73,6 +73,14 @@ namespace SteamKit2
         ISteamConfigurationBuilder WithServerListProvider(IServerListProvider provider);
 
         /// <summary>
+        /// Configures the <see cref="TimeProvider"/> for this <see cref="SteamConfiguration" />.
+        /// This can be changed for testing and diagnostic purposes.
+        /// </summary>
+        /// <param name="timeProvider">The time provider to use.</param>
+        /// <returns>A builder with modified configuration.</returns>
+        ISteamConfigurationBuilder WithTimeProvider(TimeProvider timeProvider);
+
+        /// <summary>
         /// Configures the Universe that this <see cref="SteamConfiguration" /> belongs to.
         /// </summary>
         /// <param name="universe">The Universe to connect to. This should always be <see cref="EUniverse.Public"/> unless

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -94,6 +94,12 @@ namespace SteamKit2
         public IServerListProvider ServerListProvider => state.ServerListProvider;
 
         /// <summary>
+        /// The <see cref="TimeProvider"/> used to control the flow of time.
+        /// This can be changed for testing and diagnostic purposes.
+        /// </summary>
+        public TimeProvider TimeProvider => state.TimeProvider;
+
+        /// <summary>
         /// The Universe to connect to. This should always be <see cref="EUniverse.Public"/> unless
         /// you work at Valve and are using this internally. If this is you, hello there.
         /// </summary>
@@ -106,7 +112,7 @@ namespace SteamKit2
         public Uri WebAPIBaseAddress => state.WebAPIBaseAddress;
 
         /// <summary>
-        /// An  API key to be used for authorized requests.
+        /// An API key to be used for authorized requests.
         /// Keys can be obtained from https://steamcommunity.com/dev or the Steamworks Partner site.
         /// </summary>
         public string WebAPIKey => state.WebAPIKey;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -39,6 +39,8 @@ namespace SteamKit2
 
                 ServerListProvider = new MemoryServerListProvider(),
 
+                TimeProvider = TimeProvider.System,
+
                 Universe = EUniverse.Public,
 
                 WebAPIBaseAddress = WebAPI.DefaultBaseAddress
@@ -95,6 +97,13 @@ namespace SteamKit2
         public ISteamConfigurationBuilder WithServerListProvider(IServerListProvider provider)
         {
             state.ServerListProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+            return this;
+        }
+
+        public ISteamConfigurationBuilder WithTimeProvider(TimeProvider timeProvider)
+        {
+            ArgumentNullException.ThrowIfNull(timeProvider);
+            state.TimeProvider = timeProvider;
             return this;
         }
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationState.cs
@@ -19,6 +19,7 @@ namespace SteamKit2
         public IMachineInfoProvider MachineInfoProvider;
         public ProtocolTypes ProtocolTypes;
         public IServerListProvider ServerListProvider;
+        public TimeProvider TimeProvider;
         public EUniverse Universe;
         public Uri WebAPIBaseAddress;
         public string WebAPIKey;

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -106,7 +106,7 @@ namespace SteamKit2
                 this.processStartTime = process.StartTime;
             }
 
-            jobManager = new AsyncJobManager();
+            jobManager = new AsyncJobManager( configuration.TimeProvider );
         }
 
 

--- a/SteamKit2/SteamKit2/Util/ScheduledFunction.cs
+++ b/SteamKit2/SteamKit2/Util/ScheduledFunction.cs
@@ -17,19 +17,19 @@ namespace SteamKit2
         Action func;
 
         bool bStarted;
-        Timer timer;
+        ITimer timer;
 
-        public ScheduledFunction( Action func )
-            : this( func, TimeSpan.FromMilliseconds( -1 ) )
+        public ScheduledFunction( TimeProvider timeProvider, Action func )
+            : this( timeProvider, func, TimeSpan.FromMilliseconds( -1 ) )
         {
         }
 
-        public ScheduledFunction( Action func, TimeSpan delay )
+        public ScheduledFunction( TimeProvider timeProvider, Action func, TimeSpan delay )
         {
             this.func = func;
             this.Delay = delay;
 
-            timer = new Timer( Tick, null, TimeSpan.FromMilliseconds( -1 ), delay );
+            timer = timeProvider.CreateTimer( Tick, null, TimeSpan.FromMilliseconds( -1 ), delay );
         }
         ~ScheduledFunction()
         {

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -89,6 +89,12 @@ namespace Tests
         }
 
         [Fact]
+        public void TimeProviderIsSystemTime()
+        {
+            Assert.Equal(TimeProvider.System, configuration.TimeProvider);
+        }
+
+        [Fact]
         public void WebAPIAddress()
         {
             Assert.Equal("https://api.steampowered.com/", configuration.WebAPIBaseAddress?.AbsoluteUri);
@@ -114,6 +120,7 @@ namespace Tests
                  .WithMachineInfoProvider(new CustomMachineInfoProvider())
                  .WithProtocolTypes(ProtocolTypes.WebSocket | ProtocolTypes.Udp)
                  .WithServerListProvider(new CustomServerListProvider())
+                 .WithTimeProvider(new CustomTimeProvider())
                  .WithUniverse(EUniverse.Internal)
                  .WithWebAPIBaseAddress(new Uri("http://foo.bar.com/api/"))
                  .WithWebAPIKey("T0PS3kR1t"));
@@ -178,6 +185,12 @@ namespace Tests
         }
 
         [Fact]
+        public void TimeProviderIsConfigured()
+        {
+            Assert.IsType<CustomTimeProvider>(configuration.TimeProvider);
+        }
+
+        [Fact]
         public void UniverseIsConfigured()
         {
             Assert.Equal(EUniverse.Internal, configuration.Universe);
@@ -212,6 +225,10 @@ namespace Tests
 
             Task IServerListProvider.UpdateServerListAsync(IEnumerable<ServerRecord> endpoints)
                 => throw new NotImplementedException();
+        }
+
+        class CustomTimeProvider : TimeProvider
+        {
         }
     }
 }


### PR DESCRIPTION
This PR introduces use of TimeProvider (hooray for `net8.0`) to control time.

This can be configured via `SteamConfiguration` and allows for time to be slowed, sped up, paused, skipped, etc. to make some functions easier to test.