### PR TITLE
Update to xunit v3, allow running tests in release build

### DIFF
--- a/.github/workflows/steamkit2-build.yaml
+++ b/.github/workflows/steamkit2-build.yaml
@@ -49,8 +49,16 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Run Tests
-      if: matrix.configuration == 'Debug'
-      run: dotnet test --verbosity normal SteamKit2/Tests/Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput='./Coverage/lcov.info' /p:Include="[SteamKit2]SteamKit*" /p:Exclude="[SteamKit2]SteamKit2*Internal*"
+      run: >
+        dotnet test 
+        --configuration ${{ matrix.configuration }}
+        --verbosity normal
+        SteamKit2/Tests/Tests.csproj
+        /p:CollectCoverage=true
+        /p:CoverletOutputFormat=lcov
+        /p:CoverletOutput='./Coverage/lcov.info'
+        /p:Include="[SteamKit2]SteamKit*"
+        /p:Exclude="[SteamKit2]SteamKit2*Internal*"
 
     - name: Upload test coverage
       uses: codecov/codecov-action@v4

--- a/SteamKit2/Tests/AsyncJobFacts.cs
+++ b/SteamKit2/Tests/AsyncJobFacts.cs
@@ -76,7 +76,7 @@ namespace Tests
             AsyncJob<Callback> asyncJob = new AsyncJob<Callback>( client, 123 );
             asyncJob.Timeout = TimeSpan.FromMilliseconds( 50 );
 
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
             client.jobManager.CancelTimedoutJobs();
 
             Assert.False( client.jobManager.asyncJobs.ContainsKey( asyncJob ), "Async job dictionary should no longer contain jobid key after timeout" );
@@ -110,7 +110,7 @@ namespace Tests
 
             Task<Callback> asyncTask = asyncJob.ToTask();
 
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
             client.jobManager.CancelTimedoutJobs();
 
             Assert.True( asyncTask.IsCompleted, "Async job should be completed yet" );
@@ -207,7 +207,7 @@ namespace Tests
             AsyncJobMultiple<Callback> asyncJob = new AsyncJobMultiple<Callback>( client, 123, ccall => true );
             asyncJob.Timeout = TimeSpan.FromMilliseconds( 50 );
 
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
             client.jobManager.CancelTimedoutJobs();
 
             Assert.False( client.jobManager.asyncJobs.ContainsKey( asyncJob ), "Async job dictionary should no longer contain jobid key after timeout" );
@@ -233,7 +233,7 @@ namespace Tests
             asyncJob.AddResult( new Callback { JobID = 123, IsFinished = false } );
 
             // delay for what the original timeout would have been
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
 
             client.jobManager.CancelTimedoutJobs();
 
@@ -260,7 +260,7 @@ namespace Tests
 
             Task<AsyncJobMultiple<Callback>.ResultSet> asyncTask = asyncJob.ToTask();
 
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
             client.jobManager.CancelTimedoutJobs();
 
             Assert.True( asyncTask.IsCompleted, "AsyncJobMultiple should be completed after job timeout" );
@@ -287,7 +287,7 @@ namespace Tests
             // adding a result will extend the job's timeout, but we'll cheat here and decrease it
             asyncJob.Timeout = TimeSpan.FromMilliseconds( 50 );
 
-            await Task.Delay( TimeSpan.FromMilliseconds( 70 ) );
+            await Task.Delay( TimeSpan.FromMilliseconds( 70 ), TestContext.Current.CancellationToken );
             client.jobManager.CancelTimedoutJobs();
 
             Assert.True( asyncTask.IsCompleted, "AsyncJobMultiple should be completed on partial (timed out) result set" );

--- a/SteamKit2/Tests/CDNClientFacts.cs
+++ b/SteamKit2/Tests/CDNClientFacts.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class CDNClientFacts
     {
         [Fact]
@@ -124,4 +125,5 @@ namespace Tests
                 => Task.FromResult( new HttpResponseMessage( ( HttpStatusCode )418 ) );
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/CMClientFacts.cs
+++ b/SteamKit2/Tests/CMClientFacts.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class CMClientFacts
     {
         [Fact]
@@ -78,4 +79,5 @@ namespace Tests
             return ms.ToArray();
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/CMClientFacts.cs
+++ b/SteamKit2/Tests/CMClientFacts.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace Tests
 {
 #if DEBUG
+    [Collection( nameof( NotThreadSafeResourceCollection ) )]
     public class CMClientFacts
     {
         [Fact]

--- a/SteamKit2/Tests/CallbackManagerFacts.cs
+++ b/SteamKit2/Tests/CallbackManagerFacts.cs
@@ -222,7 +222,7 @@ namespace Tests
 
                 for ( var i = 1; i <= callbacks.Length; i++ )
                 {
-                    await mgr.RunWaitCallbackAsync();
+                    await mgr.RunWaitCallbackAsync( TestContext.Current.CancellationToken );
                     Assert.Equal( i, numCallbacksRun );
                 }
 

--- a/SteamKit2/Tests/ClientMsgFacts.cs
+++ b/SteamKit2/Tests/ClientMsgFacts.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class ClientMsgFacts
     {
         // this test vector is a packet meant for a ClientMsg<MsgClientChatEnter>
@@ -67,4 +68,5 @@ namespace Tests
             return CMClient.GetPacketMsg( structMsgData, DebugLogContext.Instance );
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/DebugLogFacts.cs
+++ b/SteamKit2/Tests/DebugLogFacts.cs
@@ -1,6 +1,7 @@
-﻿using SteamKit2;
+﻿using System.Threading.Tasks;
+using SteamKit2;
 using Xunit;
-using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Tests
 {
@@ -16,19 +17,21 @@ namespace Tests
 
     class DebugLogSetupTeardownAttribute : BeforeAfterTestAttribute
     {
-        public override void Before( System.Reflection.MethodInfo methodUnderTest )
+        public override ValueTask Before( System.Reflection.MethodInfo methodUnderTest, IXunitTest test )
         {
             DebugLog.ClearListeners();
+            return ValueTask.CompletedTask;
         }
 
-        public override void After( System.Reflection.MethodInfo methodUnderTest )
+        public override ValueTask After( System.Reflection.MethodInfo methodUnderTest, IXunitTest test )
         {
             DebugLog.Enabled = false;
             DebugLog.ClearListeners();
+            return ValueTask.CompletedTask;
         }
     }
 
-    [CollectionDefinition( nameof( DebugLogFacts ), DisableParallelization = true )]
+    [Collection( nameof( NotThreadSafeResourceCollection ) )]
     public class DebugLogFacts
     {
         [Fact, DebugLogSetupTeardown]

--- a/SteamKit2/Tests/DebugLogFacts.cs
+++ b/SteamKit2/Tests/DebugLogFacts.cs
@@ -4,6 +4,7 @@ using Xunit.Sdk;
 
 namespace Tests
 {
+#if DEBUG
     class TestListener : IDebugListener
     {
         public void WriteLine( string category, string msg )
@@ -163,4 +164,5 @@ namespace Tests
             Assert.Equal( "My 1st message", message );
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/KeyValueFacts.cs
+++ b/SteamKit2/Tests/KeyValueFacts.cs
@@ -286,7 +286,7 @@ namespace Tests
         [Fact]
         public void KeyValues_TryReadAsBinary_ReadsBinary()
         {
-            var binary = Utils.DecodeHexString( TestObjectHex );
+            var binary = Convert.FromHexString( TestObjectHex );
             var kv = new KeyValue();
             bool success;
             using ( var ms = new MemoryStream( binary ) )
@@ -305,7 +305,7 @@ namespace Tests
         [Fact]
         public void KeyValuesReadsBinaryWithLeftoverData()
         {
-            var binary = Utils.DecodeHexString( TestObjectHex + Guid.NewGuid().ToString().Replace("-", "", StringComparison.Ordinal) );
+            var binary = Convert.FromHexString( TestObjectHex + Guid.NewGuid().ToString().Replace("-", "", StringComparison.Ordinal) );
             var kv = new KeyValue();
             bool success;
             using ( var ms = new MemoryStream( binary ) )
@@ -328,7 +328,7 @@ namespace Tests
             // Test every possible truncation boundary we have.
             for ( int i = 0; i < TestObjectHex.Length; i += 2 )
             {
-                var binary = Utils.DecodeHexString( TestObjectHex[ ..i ] );
+                var binary = Convert.FromHexString( TestObjectHex[ ..i ] );
                 var kv = new KeyValue();
                 bool success;
                 using ( var ms = new MemoryStream( binary ) )
@@ -345,7 +345,7 @@ namespace Tests
         public void KeyValuesReadsBinaryWithMultipleChildren()
         {
             var hex = "00546573744f626a65637400016b6579310076616c75653100016b6579320076616c756532000808";
-            var binary = Utils.DecodeHexString( hex );
+            var binary = Convert.FromHexString( hex );
             var kv = new KeyValue();
             bool success;
             using ( var ms = new MemoryStream( binary ) )
@@ -603,7 +603,7 @@ namespace Tests
         public void DecodesBinaryWithFieldType10()
         {
             var hex = "00546573744F626A656374000A6B65790001020304050607080808";
-            var binary = Utils.DecodeHexString( hex );
+            var binary = Convert.FromHexString( hex );
             var kv = new KeyValue();
             using (var ms = new MemoryStream(binary))
             {

--- a/SteamKit2/Tests/MachineInfoFacts.cs
+++ b/SteamKit2/Tests/MachineInfoFacts.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class MachineInfoFacts
     {
         [Fact]
@@ -201,4 +202,5 @@ namespace Tests
             public byte[] GetMachineGuid() => throw new InvalidOperationException("This provider only throws.");
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/MachineInfoFacts.cs
+++ b/SteamKit2/Tests/MachineInfoFacts.cs
@@ -91,7 +91,7 @@ namespace Tests
                 threads[i] = new Thread(state =>
                 {
                    var provider = (IMachineInfoProvider)state;
-                   trigger.Wait();
+                   trigger.Wait( TestContext.Current.CancellationToken );
                    HardwareUtils.Init(provider);
                    HardwareUtils.GetMachineID(provider);
                 });

--- a/SteamKit2/Tests/NetHelpersFacts.cs
+++ b/SteamKit2/Tests/NetHelpersFacts.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class NetHelpersFacts
     {
         [Fact]
@@ -67,4 +68,5 @@ namespace Tests
             Assert.Equal( new IPEndPoint( IPAddress.IPv6Loopback, 1337 ), parsedIpv6 );
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/NotThreadSafeResourceCollection.cs
+++ b/SteamKit2/Tests/NotThreadSafeResourceCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace Tests;
+
+[CollectionDefinition( nameof( NotThreadSafeResourceCollection ), DisableParallelization = true )]
+public class NotThreadSafeResourceCollection
+{
+    // DebugLog is not thread-safe.
+}

--- a/SteamKit2/Tests/SmartCMServerListFacts.cs
+++ b/SteamKit2/Tests/SmartCMServerListFacts.cs
@@ -70,6 +70,51 @@ namespace Tests
         }
 
         [Fact]
+        public void GetNextServerCandidate_OnlyReturnsMatchingServerOfType()
+        {
+            var record = ServerRecord.CreateWebSocketServer( "localhost:443" );
+            serverList.ReplaceList( new List<ServerRecord>() { record } );
+
+            var endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp );
+            Assert.Null( endPoint );
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Udp );
+            Assert.Null( endPoint );
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp | ProtocolTypes.Udp );
+            Assert.Null( endPoint );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.WebSocket );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.WebSocket, endPoint.ProtocolTypes );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.All );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.WebSocket, endPoint.ProtocolTypes );
+
+            record = ServerRecord.CreateSocketServer( new IPEndPoint( IPAddress.Loopback, 27015 ) );
+            serverList.ReplaceList( new List<ServerRecord>() { record } );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.WebSocket );
+            Assert.Null( endPoint );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Udp );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.Udp, endPoint.ProtocolTypes );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp | ProtocolTypes.Udp );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
+
+            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.All );
+            Assert.Equal( record.EndPoint, endPoint.EndPoint );
+            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
+        }
+
+#if DEBUG
+        [Fact]
         public void GetNextServerCandidate_ReturnsServer_IfListHasServers_EvenIfAllServersAreBad()
         {
             serverList.GetAllEndPoints();
@@ -137,50 +182,6 @@ namespace Tests
             var nextRecord = serverList.GetNextServerCandidate( ProtocolTypes.Tcp );
             Assert.Equal( serverBRecord.EndPoint, nextRecord.EndPoint );
             Assert.Equal( ProtocolTypes.Tcp, nextRecord.ProtocolTypes );
-        }
-        
-        [Fact]
-        public void GetNextServerCandidate_OnlyReturnsMatchingServerOfType()
-        {
-            var record = ServerRecord.CreateWebSocketServer( "localhost:443" );
-            serverList.ReplaceList( new List<ServerRecord>() { record } );
-
-            var endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp );
-            Assert.Null( endPoint );
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Udp );
-            Assert.Null( endPoint );
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp | ProtocolTypes.Udp);
-            Assert.Null( endPoint );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.WebSocket );
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.WebSocket, endPoint.ProtocolTypes );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.All );
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.WebSocket, endPoint.ProtocolTypes );
-
-            record = ServerRecord.CreateSocketServer( new IPEndPoint( IPAddress.Loopback, 27015 ) );
-            serverList.ReplaceList( new List<ServerRecord>() { record } );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.WebSocket );
-            Assert.Null( endPoint );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp );
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Udp);
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.Udp, endPoint.ProtocolTypes );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.Tcp | ProtocolTypes.Udp );
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
-
-            endPoint = serverList.GetNextServerCandidate( ProtocolTypes.All );
-            Assert.Equal( record.EndPoint, endPoint.EndPoint );
-            Assert.Equal( ProtocolTypes.Tcp, endPoint.ProtocolTypes );
         }
 
         [Fact]
@@ -263,5 +264,6 @@ namespace Tests
             var marked = serverList.TryMark( new IPEndPoint( IPAddress.Loopback, 27016 ), record.ProtocolTypes, ServerQuality.Good );
             Assert.False( marked );
         }
+#endif
     }
 }

--- a/SteamKit2/Tests/SmartCMServerListFacts.cs
+++ b/SteamKit2/Tests/SmartCMServerListFacts.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Tests
 {
+    [Collection( nameof( NotThreadSafeResourceCollection ) )]
     public class SmartCMServerListFacts
     {
         public SmartCMServerListFacts()

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -57,12 +57,14 @@ namespace Tests
             Assert.Equal( "SteamKit/" + steamKitAssemblyVersion.ToString( fieldCount: 3 ), client.DefaultRequestHeaders.UserAgent.ToString() );
         }
 
+#if DEBUG
         [Fact]
         public void DefaultMachineInfoProvider()
         {
             Assert.NotNull(configuration.MachineInfoProvider);
             Assert.IsNotType<DefaultMachineInfoProvider>(configuration.MachineInfoProvider);
         }
+#endif
 
         [Fact]
         public void ServerListProviderIsNothingFancy()

--- a/SteamKit2/Tests/StreamHelpersFacts.cs
+++ b/SteamKit2/Tests/StreamHelpersFacts.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class StreamHelpersFacts
     {
         [Fact]
@@ -125,4 +126,5 @@ namespace Tests
             }
         }
     }
+#endif
 }

--- a/SteamKit2/Tests/Tests.csproj
+++ b/SteamKit2/Tests/Tests.csproj
@@ -5,6 +5,7 @@
     <RollForward>LatestMajor</RollForward>
     <SignAssembly>true</SignAssembly>
     <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,11 +14,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.analyzers" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="0.4.0-pre.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -212,7 +212,7 @@ namespace Tests
                 Assert.Equal( "/IFooService/PerformFooOperation/v2/", request.RequestUri.AbsolutePath );
                 Assert.Equal( HttpMethod.Put, request.Method );
 
-                var content = await request.Content.ReadAsStringAsync(); // This technically should be ReadAsFormDataAsync
+                var content = await request.Content.ReadAsStringAsync( TestContext.Current.CancellationToken ); // This technically should be ReadAsFormDataAsync
                 var formData = HttpUtility.ParseQueryString( content );
                 Assert.Equal( 3, formData.Count );
                 Assert.Equal( "foo", formData[ "f" ] );

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -28,6 +28,7 @@ namespace Tests
             Assert.Equal( iface.Timeout, TimeSpan.FromSeconds( 100 ) );
         }
 
+#if DEBUG
         [Fact]
         public void SteamConfigWebAPIInterface()
         {
@@ -41,6 +42,7 @@ namespace Tests
             Assert.Equal( "hello world", iface.apiKey );
             Assert.Equal( new Uri( "http://example.com" ), iface.httpClient.BaseAddress );
         }
+#endif
 
         [Fact]
         public async Task ThrowsWebAPIRequestExceptionIfRequestUnsuccessful()

--- a/SteamKit2/Tests/WebSocketUriFacts.cs
+++ b/SteamKit2/Tests/WebSocketUriFacts.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Tests
 {
+#if DEBUG
     public class WebSocketUriFacts
     {
         [Fact]
@@ -38,4 +39,5 @@ namespace Tests
         {
         }
     }
+#endif
 }


### PR DESCRIPTION
Obviously have to skip tests in release that use internals, but I think this is better than nothing.

I also created a separate collection for tests that log into DebugLog to fix race conditions.
