### PR TITLE
Remove `CMList`

### DIFF
--- a/Resources/SteamLanguage/emsg.steamd
+++ b/Resources/SteamLanguage/emsg.steamd
@@ -328,7 +328,7 @@ enum EMsg
 	ClientLicenseList = 780;
 	ClientCancelLicenseResponse = 781; removed
 	ClientVACBanStatus = 782;
-	ClientCMList = 783;
+	ClientCMList = 783; removed
 	ClientEncryptPct = 784;
 	ClientGetLegacyGameKeyResponse = 785;
 	ClientFavoritesList = 786; removed

--- a/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamLanguage.cs
@@ -301,7 +301,6 @@ namespace SteamKit2
 		ClientGameConnectTokens = 779,
 		ClientLicenseList = 780,
 		ClientVACBanStatus = 782,
-		ClientCMList = 783,
 		ClientEncryptPct = 784,
 		ClientGetLegacyGameKeyResponse = 785,
 		ClientAddFriend = 791,

--- a/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer.cs
+++ b/SteamKit2/SteamKit2/Base/Generated/SteamMsgClientServer.cs
@@ -138,34 +138,6 @@ namespace SteamKit2.Internal
     }
 
     [global::ProtoBuf.ProtoContract()]
-    public partial class CMsgClientCMList : global::ProtoBuf.IExtensible
-    {
-        private global::ProtoBuf.IExtension __pbn__extensionData;
-        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-            => global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
-
-        [global::ProtoBuf.ProtoMember(1)]
-        public global::System.Collections.Generic.List<uint> cm_addresses { get; } = new global::System.Collections.Generic.List<uint>();
-
-        [global::ProtoBuf.ProtoMember(2)]
-        public global::System.Collections.Generic.List<uint> cm_ports { get; } = new global::System.Collections.Generic.List<uint>();
-
-        [global::ProtoBuf.ProtoMember(3)]
-        public global::System.Collections.Generic.List<string> cm_websocket_addresses { get; } = new global::System.Collections.Generic.List<string>();
-
-        [global::ProtoBuf.ProtoMember(4)]
-        public uint percent_default_to_websocket
-        {
-            get => __pbn__percent_default_to_websocket.GetValueOrDefault();
-            set => __pbn__percent_default_to_websocket = value;
-        }
-        public bool ShouldSerializepercent_default_to_websocket() => __pbn__percent_default_to_websocket != null;
-        public void Resetpercent_default_to_websocket() => __pbn__percent_default_to_websocket = null;
-        private uint? __pbn__percent_default_to_websocket;
-
-    }
-
-    [global::ProtoBuf.ProtoContract()]
     public partial class CMsgClientP2PConnectionInfo : global::ProtoBuf.IExtensible
     {
         private global::ProtoBuf.IExtension __pbn__extensionData;

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -9,7 +9,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -378,10 +377,6 @@ namespace SteamKit2.Internal
                     HandleServerUnavailable( packetMsg );
                     break;
 
-                case EMsg.ClientCMList:
-                    HandleCMList( packetMsg );
-                    break;
-
                 case EMsg.ClientSessionToken: // am session token
                     HandleSessionToken( packetMsg );
                     break;
@@ -627,19 +622,6 @@ namespace SteamKit2.Internal
             Disconnect( userInitiated: false );
         }
 
-        void HandleCMList( IPacketMsg packetMsg )
-        {
-            var cmMsg = new ClientMsgProtobuf<CMsgClientCMList>( packetMsg );
-            DebugLog.Assert( cmMsg.Body.cm_addresses.Count == cmMsg.Body.cm_ports.Count, "CMClient", "HandleCMList received malformed message" );
-
-            var cmList = cmMsg.Body.cm_addresses
-                .Zip( cmMsg.Body.cm_ports, ( addr, port ) => ServerRecord.CreateSocketServer( new IPEndPoint( NetHelpers.GetIPAddress( addr ), ( int )port ) ) );
-
-            var webSocketList = cmMsg.Body.cm_websocket_addresses.Select( addr => ServerRecord.CreateWebSocketServer( addr ) );
-
-            // update our list with steam's list of CMs
-            Servers.ReplaceList( cmList.Concat( webSocketList ) );
-        }
         void HandleSessionToken( IPacketMsg packetMsg )
         {
             var sessToken = new ClientMsgProtobuf<CMsgClientSessionToken>( packetMsg );

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Callbacks.cs
@@ -3,10 +3,6 @@
  * file 'license.txt', which is part of this source code package.
  */
 
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Net;
-using SteamKit2.Discovery;
 using SteamKit2.Internal;
 
 namespace SteamKit2
@@ -39,29 +35,6 @@ namespace SteamKit2
             internal DisconnectedCallback( bool userInitiated )
             {
                 this.UserInitiated = userInitiated;
-            }
-        }
-
-
-        /// <summary>
-        /// This callback is received when the client has received the CM list from Steam.
-        /// </summary>
-        public sealed class CMListCallback : CallbackMsg
-        {
-            /// <summary>
-            /// Gets the CM server list.
-            /// </summary>
-            public ReadOnlyCollection<ServerRecord> Servers { get; private set; }
-
-
-            internal CMListCallback( CMsgClientCMList cmMsg )
-            {
-                var cmList = cmMsg.cm_addresses
-                    .Zip( cmMsg.cm_ports, ( addr, port ) => ServerRecord.CreateSocketServer( new IPEndPoint( NetHelpers.GetIPAddress( addr ), ( int )port ) ) );
-
-                var websocketList = cmMsg.cm_websocket_addresses.Select( ( addr ) => ServerRecord.CreateWebSocketServer( addr ) );
-
-                Servers = new ReadOnlyCollection<ServerRecord>( cmList.Concat( websocketList ).ToList() );
             }
         }
     }

--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -284,10 +284,6 @@ namespace SteamKit2
             // we want to handle some of the clientmsgs before we pass them along to registered handlers
             switch ( packetMsg.MsgType )
             {
-                case EMsg.ClientCMList:
-                    HandleCMList( packetMsg );
-                    break;
-
                 case EMsg.JobHeartbeat:
                     HandleJobHeartbeat( packetMsg );
                     break;
@@ -352,13 +348,6 @@ namespace SteamKit2
         void ClearHandlerCaches()
         {
             GetHandler<SteamMatchmaking>()?.ClearLobbyCache();
-        }
-
-        void HandleCMList( IPacketMsg packetMsg )
-        {
-            var cmMsg = new ClientMsgProtobuf<CMsgClientCMList>( packetMsg );
-
-            PostCallback( new CMListCallback( cmMsg.Body ) );
         }
 
         void HandleJobHeartbeat( IPacketMsg packetMsg )


### PR DESCRIPTION
@yaakov-h They removed this msg. My steam client logs seem to indicate that after September 11 it never wanted less than 100% of connections to be websockets (I'm not sure where it would even be getting this value from).

[2024-09-06 10:00:26] CM Directory list says 93% of connections should be websockets
[2024-09-07 10:33:59] CM Directory list says 100% of connections should be websockets
[2024-09-11 01:08:04] CM Directory list says 86% of connections should be websockets 
[2024-09-12 10:21:29] CM Directory list says 100% of connections should be websockets

We also need a mechanism for our CM list to refresh stale data via the API, as it previously relied on a successful connection to refresh the list.

Ref: #1421