### PR TITLE
HardwareUtils.cs: Fix Android support

### DIFF
--- a/SteamKit2/SteamKit2/Util/HardwareUtils.cs
+++ b/SteamKit2/SteamKit2/Util/HardwareUtils.cs
@@ -300,12 +300,19 @@ namespace SteamKit2
                         continue;
                     }
 
-                    // ioctl could be attempted to read the mac address here
-                    // Loopback mac address will be decoded to zero here
-                    var addressText = File.ReadAllText( $"/sys/class/net/{iface}/address" );
-                    var macAddress = Convert.FromHexString( addressText.Replace( ":", "" ).AsSpan().Trim() );
+                    try
+                    {
+                        // ioctl could be attempted to read the mac address here
+                        // Loopback mac address will be decoded to zero here
+                        var addressText = File.ReadAllText( $"/sys/class/net/{iface}/address" );
+                        var macAddress = Convert.FromHexString( addressText.Replace( ":", "" ).AsSpan().Trim() );
 
-                    macs.Add( macAddress );
+                        macs.Add( macAddress );
+                    }
+                    catch
+                    {
+                        // if we can't access to a directory, continue to next
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
I ran DepotDownloader in Android using Termux and proot, after 2.7.3 update alongside with SteamKit2 update, it break Android support due to probably improper MAC address detection (Trying to get access to /sys/class/net but Android restricted it). I added nested to it. It passed without problem.

This is my first pull request ever, let me know if I'm doing it wrong.