### PR TITLE
Resolve DnsEndPoint in UdpConnection

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/UdpConnection.cs
@@ -137,6 +137,18 @@ namespace SteamKit2
             inSeqAcked = 0;
             inSeqHandled = 0;
 
+            if (endPoint is DnsEndPoint dnsEndPoint)
+            {
+                var resolved = Dns.GetHostAddresses(dnsEndPoint.Host, AddressFamily.InterNetwork);
+
+                if (resolved == null || resolved.Length == 0)
+                {
+                    throw new ArgumentException("Failed to resolve given dns endpoint.", nameof(endPoint));
+                }
+
+                endPoint = new IPEndPoint(resolved[0], dnsEndPoint.Port);
+            }
+
             netThread = new Thread( NetLoop )
             {
                 Name = "SK2-UdpConn"


### PR DESCRIPTION
I changed Steam directory api to return DNS servers recently in #1422, and it works fine for TCP connections, but UDP connections throw that they can't send a packet to a DNS endpoint.

I also removed manual resolution of DNS for default server in #1452.