### PR TITLE
Allow awaiting LogOn

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamUser/Callbacks.cs
@@ -120,6 +120,7 @@ namespace SteamKit2
                 var logonResp = new ClientMsgProtobuf<CMsgClientLogonResponse>( packetMsg );
                 var resp = logonResp.Body;
 
+                this.JobID = logonResp.TargetJobID;
                 this.Result = ( EResult )resp.eresult;
                 this.ExtendedResult = ( EResult )resp.eresult_extended;
 
@@ -161,6 +162,7 @@ namespace SteamKit2
                 var logonResp = new ClientMsg<MsgClientLogOnResponse>( packetMsg );
                 var resp = logonResp.Body;
 
+                this.JobID = logonResp.TargetJobID;
                 this.Result = resp.Result;
 
                 this.OutOfGameSecsPerHeartbeat = resp.OutOfGameHeartbeatRateSec;
@@ -197,11 +199,13 @@ namespace SteamKit2
                 if ( packetMsg.IsProto )
                 {
                     var loggedOff = new ClientMsgProtobuf<CMsgClientLoggedOff>( packetMsg );
+                    this.JobID = loggedOff.TargetJobID;
                     this.Result = ( EResult )loggedOff.Body.eresult;
                 }
                 else
                 {
                     var loggedOff = new ClientMsg<MsgClientLoggedOff>( packetMsg );
+                    this.JobID = loggedOff.TargetJobID;
                     this.Result = loggedOff.Body.Result;
                 }
             }


### PR DESCRIPTION
I'm not 100% confident that it will work for all cases because we still handle the "non proto" path, but that should still have the jobids if its even sent (I don't think it is anymore).