### PR TITLE
chore: GitHub should be spelled with a capital H

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ To compile SteamKit, [.NET 8.0 SDK](https://dot.net/) is required.
 
 ## Discussions
 
-If you have questions, [use the Github discussions](https://github.com/SteamRE/SteamKit/discussions) section,
+If you have questions, [use the GitHub discussions](https://github.com/SteamRE/SteamKit/discussions) section,
 also try searching for an existing discussion.
 
 IRC: irc.libera.chat / #steamre ([join via webchat](https://web.libera.chat/#steamre))

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ To compile SteamKit, [.NET 8.0 SDK](https://dot.net/) is required.
 
 ## Discussions
 
-If you have questions, [use the GitHub discussions](https://github.com/SteamRE/SteamKit/discussions) section,
+If you have questions, [use the GitHub Discussions](https://github.com/SteamRE/SteamKit/discussions) section,
 also try searching for an existing discussion.
 
 IRC: irc.libera.chat / #steamre ([join via webchat](https://web.libera.chat/#steamre))


### PR DESCRIPTION
This is such a tiny minor issue I hesitate to even bother with it, but folks at GitHub tend to care about it, so let's use the correct naming.