### PR TITLE
Fix PersonaStateCallback.StatusFlags

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/Callbacks.cs
@@ -176,9 +176,9 @@ namespace SteamKit2
             public uint OnlineSessionInstances { get; private set; }
 
 
-            internal PersonaStateCallback( CMsgClientPersonaState.Friend friend )
+            internal PersonaStateCallback( CMsgClientPersonaState.Friend friend, EClientPersonaStateFlag statusFlags )
             {
-                this.StatusFlags = ( EClientPersonaStateFlag )friend.persona_state_flags;
+                this.StatusFlags = statusFlags;
 
                 this.FriendID = friend.friendid;
                 this.State = ( EPersonaState )friend.persona_state;

--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamFriends/SteamFriends.cs
@@ -837,7 +837,7 @@ namespace SteamKit2
 
             foreach ( var friend in perState.Body.friends )
             {
-                var callback = new PersonaStateCallback( friend );
+                var callback = new PersonaStateCallback( friend, flags );
                 this.Client.PostCallback( callback );
             }
         }


### PR DESCRIPTION
`PersonaStateCallback.StatusFlags` and `PersonaStateCallback.StateFlags` were being set to `CMsgClientPersonaState.Friend.persona_state_flags` when only `.StateFlags` should be.

So just a small change to pass the `EClientPersonaStateFlag` to the `PersonaStateCallback` constructor.

(`EClientPersonaStateFlag` should maybe be called `EClientPersonaStatusFlag` or something...)