### PR TITLE
Post client disconnection callback before cancelling async jobs

### DIFF
--- a/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/SteamClient.cs
@@ -340,14 +340,14 @@ namespace SteamKit2
         {
             base.OnClientDisconnected( userInitiated );
 
+            PostCallback( new DisconnectedCallback( userInitiated ) );
+
             // if we are disconnected, cancel all pending jobs
             jobManager.CancelPendingJobs();
 
             jobManager.SetTimeoutsEnabled( false );
 
             ClearHandlerCaches();
-
-            PostCallback( new DisconnectedCallback( userInitiated ) );
         }
 
 


### PR DESCRIPTION
After #1532, if you have some jobs running in a loop that gets cancelled on a disconnected callback, it is now possible to get into a loop where it will keep trying to send jobs, and instantly fail them.

Posting early should give consumers a better control over this (besides always checking IsConnected).