### PR TITLE
Use `HttpClientFactory` for websocket connections, add `HttpClientPurpose`

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketConnection.cs
@@ -1,17 +1,20 @@
 ﻿using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 
 namespace SteamKit2
 {
-    partial class WebSocketConnection : IConnection
+    partial class WebSocketConnection : IConnection, IDisposable
     {
-        public WebSocketConnection(ILogContext log)
+        public WebSocketConnection(ILogContext log, HttpMessageInvoker invoker)
         {
             this.log = log ?? throw new ArgumentNullException( nameof( log ) );
+            this.invoker = invoker ?? throw new ArgumentNullException( nameof( invoker ) );
         }
 
         readonly ILogContext log;
+        readonly HttpMessageInvoker invoker;
 
         WebSocketContext? currentContext;
 
@@ -36,7 +39,7 @@ namespace SteamKit2
             }
 
             CurrentEndPoint = newContext.EndPoint;
-            newContext.Start(TimeSpan.FromMilliseconds(timeout));
+            newContext.Start(invoker, TimeSpan.FromMilliseconds(timeout));
         }
 
         public void Disconnect(bool userInitiated)
@@ -71,6 +74,11 @@ namespace SteamKit2
             {
                 specificContext?.Dispose();
             }
+        }
+
+        public void Dispose()
+        {
+            invoker.Dispose();
         }
     }
 }

--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.ComponentModel;
 using System.Net;
+using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -32,12 +33,12 @@ namespace SteamKit2
 
             public EndPoint EndPoint { get; }
 
-            public void Start(TimeSpan connectionTimeout)
+            public void Start(HttpMessageInvoker invoker, TimeSpan connectionTimeout)
             {
-                runloopTask = RunCore(connectionTimeout, cts.Token).IgnoringCancellation(cts.Token);
+                runloopTask = RunCore(invoker, connectionTimeout, cts.Token).IgnoringCancellation(cts.Token);
             }
 
-            async Task RunCore(TimeSpan connectionTimeout, CancellationToken cancellationToken)
+            async Task RunCore(HttpMessageInvoker invoker, TimeSpan connectionTimeout, CancellationToken cancellationToken)
             {
                 using (var timeout = new CancellationTokenSource())
                 using (var combinedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token))
@@ -46,7 +47,7 @@ namespace SteamKit2
 
                     try
                     {
-                        await socket.ConnectAsync(connectionUri, combinedCancellation.Token).ConfigureAwait(false);
+                        await socket.ConnectAsync(connectionUri, invoker, combinedCancellation.Token).ConfigureAwait(false);
                     }
                     catch (TaskCanceledException) when (timeout.IsCancellationRequested)
                     {

--- a/SteamKit2/SteamKit2/Steam/CDN/Client.cs
+++ b/SteamKit2/SteamKit2/Steam/CDN/Client.cs
@@ -39,7 +39,7 @@ namespace SteamKit2.CDN
         {
             ArgumentNullException.ThrowIfNull( steamClient );
 
-            this.httpClient = steamClient.Configuration.HttpClientFactory();
+            this.httpClient = steamClient.Configuration.HttpClientFactory( HttpClientPurpose.CDN );
         }
 
         /// <summary>

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -405,7 +405,7 @@ namespace SteamKit2.Internal
         {
             if ( protocol.HasFlagsFast( ProtocolTypes.WebSocket ) )
             {
-                return new WebSocketConnection( this, Configuration.HttpClientFactory() );
+                return new WebSocketConnection( this, Configuration.HttpClientFactory( HttpClientPurpose.CMWebSocket ) );
             }
             else if ( protocol.HasFlagsFast( ProtocolTypes.Tcp ) )
             {

--- a/SteamKit2/SteamKit2/Steam/CMClient.cs
+++ b/SteamKit2/SteamKit2/Steam/CMClient.cs
@@ -405,7 +405,7 @@ namespace SteamKit2.Internal
         {
             if ( protocol.HasFlagsFast( ProtocolTypes.WebSocket ) )
             {
-                return new WebSocketConnection( this );
+                return new WebSocketConnection( this, Configuration.HttpClientFactory() );
             }
             else if ( protocol.HasFlagsFast( ProtocolTypes.Tcp ) )
             {
@@ -472,6 +472,11 @@ namespace SteamKit2.Internal
             connectionRelease.NetMsgReceived -= NetMsgReceived;
             connectionRelease.Connected -= Connected;
             connectionRelease.Disconnected -= Disconnected;
+
+            if ( connectionRelease is IDisposable disposableConnection )
+            {
+                disposableConnection.Dispose();
+            }
 
             heartBeatFunc.Stop();
 

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfiguration.cs
@@ -11,11 +11,34 @@ using SteamKit2.Discovery;
 namespace SteamKit2
 {
     /// <summary>
-    /// Factory function to create a user-configured HttpClient.
+    /// Specifies the intended purpose or target for an HttpClient to enable appropriate configuration.
+    /// </summary>
+    public enum HttpClientPurpose
+    {
+        /// <summary>
+        /// HttpClient configured for WebSocket communication with CM services.
+        /// </summary>
+        /// <see cref="WebSocketConnection"/>
+        CMWebSocket,
+        /// <summary>
+        /// HttpClient configured for interacting with the Steam Web API.
+        /// </summary>
+        /// <see cref="SteamKit2.WebAPI"/>
+        WebAPI,
+        /// <summary>
+        /// HttpClient configured for downloading game content from the Steam servers.
+        /// </summary>
+        /// <see cref="CDN.Client"/>
+        CDN,
+    }
+
+    /// <summary>
+    /// Factory function to create a user-configured HttpClient based on its intended purpose.
     /// The HttpClient will be disposed of after use.
     /// </summary>
+    /// <param name="purpose">The purpose for which the HttpClient will be used.</param>
     /// <returns>A new <see cref="HttpClient"/> to be used to send HTTP requests.</returns>
-    public delegate HttpClient HttpClientFactory();
+    public delegate HttpClient HttpClientFactory( HttpClientPurpose purpose );
 
     /// <summary>
     /// Configuration object to use.

--- a/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
+++ b/SteamKit2/SteamKit2/Steam/SteamClient/Configuration/SteamConfigurationBuilder.cs
@@ -116,7 +116,7 @@ namespace SteamKit2
             return this;
         }
 
-        static HttpClient DefaultHttpClientFactory()
+        static HttpClient DefaultHttpClientFactory( HttpClientPurpose purpose )
         {
             var client = new HttpClient();
 

--- a/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
+++ b/SteamKit2/SteamKit2/Steam/WebAPI/SteamConfigurationWebAPIExtensions.cs
@@ -36,7 +36,7 @@ namespace SteamKit2
 
         internal static HttpClient GetHttpClientForWebAPI(this SteamConfiguration config)
         {
-            var client = config.HttpClientFactory();
+            var client = config.HttpClientFactory( HttpClientPurpose.WebAPI );
 
             client.BaseAddress = config.WebAPIBaseAddress;
             client.Timeout = WebAPI.DefaultTimeout;

--- a/SteamKit2/Tests/CDNClientFacts.cs
+++ b/SteamKit2/Tests/CDNClientFacts.cs
@@ -15,7 +15,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsSteamKitWebExceptionOnUnsuccessfulWebResponseForManifest()
         {
-            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( () => new HttpClient( new TeapotHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( ( purpose ) => new HttpClient( new TeapotHttpMessageHandler() ) ) );
             var steam = new SteamClient( configuration );
             using var client = new Client( steam );
             var server = new Server
@@ -33,7 +33,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsSteamKitWebExceptionOnUnsuccessfulWebResponseForChunk()
         {
-            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( () => new HttpClient( new TeapotHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( ( purpose ) => new HttpClient( new TeapotHttpMessageHandler() ) ) );
             var steam = new SteamClient( configuration );
             using var client = new Client( steam );
             var server = new Server
@@ -55,7 +55,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsWhenNoChunkIDIsSet()
         {
-            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( () => new HttpClient( new TeapotHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( ( purpose ) => new HttpClient( new TeapotHttpMessageHandler() ) ) );
             var steam = new SteamClient( configuration );
             using var client = new Client( steam );
             var server = new Server
@@ -74,7 +74,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsWhenDestinationBufferSmaller()
         {
-            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( () => new HttpClient( new TeapotHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( ( purpose ) => new HttpClient( new TeapotHttpMessageHandler() ) ) );
             var steam = new SteamClient( configuration );
             using var client = new Client( steam );
             var server = new Server
@@ -98,7 +98,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsWhenDestinationBufferSmallerWithDepotKey()
         {
-            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( () => new HttpClient( new TeapotHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( x => x.WithHttpClientFactory( ( purpose ) => new HttpClient( new TeapotHttpMessageHandler() ) ) );
             var steam = new SteamClient( configuration );
             using var client = new Client( steam );
             var server = new Server

--- a/SteamKit2/Tests/HttpClientPurposeConfiguredFacts.cs
+++ b/SteamKit2/Tests/HttpClientPurposeConfiguredFacts.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Net.Http;
+using SteamKit2;
+using Xunit;
+
+namespace Tests
+{
+    public class HttpClientPurposeConfiguredFacts
+    {
+        public HttpClientPurposeConfiguredFacts()
+        {
+            configuration = SteamConfiguration.Create( b =>
+                b.WithHttpClientFactory( purpose =>
+                {
+                    var client = new HttpClient();
+                    client.DefaultRequestHeaders.Add( "X-Purpose", purpose.ToString() );
+                    return client;
+                } ) );
+        }
+
+        readonly SteamConfiguration configuration;
+
+        [Fact]
+        public void WebAPIPurposeReceivesCorrectParameter()
+        {
+            using var client = configuration.HttpClientFactory( HttpClientPurpose.WebAPI );
+            Assert.Equal( nameof( HttpClientPurpose.WebAPI ), client.DefaultRequestHeaders.GetValues( "X-Purpose" ).FirstOrDefault() );
+        }
+
+        [Fact]
+        public void CMWebSocketPurposeReceivesCorrectParameter()
+        {
+            using var client = configuration.HttpClientFactory( HttpClientPurpose.CMWebSocket );
+            Assert.Equal( nameof( HttpClientPurpose.CMWebSocket ), client.DefaultRequestHeaders.GetValues( "X-Purpose" ).FirstOrDefault() );
+        }
+
+        [Fact]
+        public void CDNPurposeReceivesCorrectParameter()
+        {
+            using var client = configuration.HttpClientFactory( HttpClientPurpose.CDN );
+            Assert.Equal( nameof( HttpClientPurpose.CDN ), client.DefaultRequestHeaders.GetValues( "X-Purpose" ).FirstOrDefault() );
+        }
+
+        [Fact]
+        public void DifferentPurposesReceiveDifferentConfigurations()
+        {
+            using var webApiClient = configuration.HttpClientFactory( HttpClientPurpose.WebAPI );
+            using var cdnClient = configuration.HttpClientFactory( HttpClientPurpose.CDN );
+
+            Assert.Equal( nameof( HttpClientPurpose.WebAPI ), webApiClient.DefaultRequestHeaders.GetValues( "X-Purpose" ).FirstOrDefault() );
+            Assert.Equal( nameof( HttpClientPurpose.CDN ), cdnClient.DefaultRequestHeaders.GetValues( "X-Purpose" ).FirstOrDefault() );
+        }
+    }
+}

--- a/SteamKit2/Tests/SteamConfigurationFacts.cs
+++ b/SteamKit2/Tests/SteamConfigurationFacts.cs
@@ -49,7 +49,7 @@ namespace Tests
         [Fact]
         public void DefaultHttpClientFactory()
         {
-            using var client = configuration.HttpClientFactory();
+            using var client = configuration.HttpClientFactory( HttpClientPurpose.WebAPI );
             Assert.NotNull( client );
             Assert.IsType<HttpClient>( client );
 
@@ -112,7 +112,7 @@ namespace Tests
                  .WithCellID(123)
                  .WithConnectionTimeout(TimeSpan.FromMinutes(1))
                  .WithDefaultPersonaStateFlags(EClientPersonaStateFlag.SourceID)
-                 .WithHttpClientFactory(() => { var c = new HttpClient(); c.DefaultRequestHeaders.Add("X-SteamKit-Tests", "true"); return c; })
+                 .WithHttpClientFactory((purpose) => { var c = new HttpClient(); c.DefaultRequestHeaders.Add("X-SteamKit-Tests", "true"); return c; })
                  .WithMachineInfoProvider(new CustomMachineInfoProvider())
                  .WithProtocolTypes(ProtocolTypes.WebSocket | ProtocolTypes.Udp)
                  .WithServerListProvider(new CustomServerListProvider())
@@ -144,7 +144,7 @@ namespace Tests
         [Fact]
         public void HttpClientFactoryIsConfigured()
         {
-            using var client = configuration.HttpClientFactory();
+            using var client = configuration.HttpClientFactory( HttpClientPurpose.WebAPI );
             Assert.Equal( "true", client.DefaultRequestHeaders.GetValues( "X-SteamKit-Tests" ).FirstOrDefault() );
         }
 

--- a/SteamKit2/Tests/WebAPIFacts.cs
+++ b/SteamKit2/Tests/WebAPIFacts.cs
@@ -47,7 +47,7 @@ namespace Tests
         [Fact]
         public async Task ThrowsWebAPIRequestExceptionIfRequestUnsuccessful()
         {
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( new ServiceUnavailableHttpMessageHandler() ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( new ServiceUnavailableHttpMessageHandler() ) ) );
             dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
             await Assert.ThrowsAsync<WebAPIRequestException>( () => ( Task )iface.PerformFooOperation() );
@@ -57,7 +57,7 @@ namespace Tests
         public async Task ThrowsOnIncorrectFormatInArgsProvided()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -75,7 +75,7 @@ namespace Tests
         public async Task DoesntThrowWhenCorrectFormatInArgsProvided()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -93,7 +93,7 @@ namespace Tests
         public async Task DoesntThrowWhenKeyInArgsProvided()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithWebAPIKey( "test1" ).WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithWebAPIKey( "test1" ).WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -113,7 +113,7 @@ namespace Tests
         public async Task DoesntThrowOnArgumentsReuse()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             WebAPI.AsyncInterface iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -131,7 +131,7 @@ namespace Tests
         public async Task UsesArgsAsQueryStringParams()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -166,7 +166,7 @@ namespace Tests
         public async Task SupportsNullArgsDictionary()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -194,7 +194,7 @@ namespace Tests
         public async Task UsesSingleParameterArgumentsDictionary()
         {
             using var hookableHandler = new HookableHandler();
-            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( () => new HttpClient( hookableHandler ) ) );
+            var configuration = SteamConfiguration.Create( c => c.WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) ) );
 
             dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );
 
@@ -231,7 +231,7 @@ namespace Tests
         {
             using var hookableHandler = new HookableHandler();
             var configuration = SteamConfiguration.Create( c => c
-                .WithHttpClientFactory( () => new HttpClient( hookableHandler ) )
+                .WithHttpClientFactory( ( purpose ) => new HttpClient( hookableHandler ) )
                 .WithWebAPIKey( "MySecretApiKey" ) );
 
             dynamic iface = configuration.GetAsyncWebAPIInterface( "IFooService" );


### PR DESCRIPTION
This allows consumers to provide custom http clients for connecting to websockets.