### PR TITLE
Set rollForward to major

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestMinor"
+    "rollForward": "major"
   }
 }


### PR DESCRIPTION
Replaces #1274

Ref: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward



> Uses the latest patch level for the specified major, minor, and feature band.

if not found, it will try rolling forward. For CI builds it should use the specified version since that's what will be installed I think.



It's really annoying to just keep deleting global.json locally.



