### PR TITLE
fix: handle disposed socket on close attempt

### DIFF
--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
@@ -87,18 +87,14 @@ namespace SteamKit2
                     }
                 }
 
-                if (socket.State == WebSocketState.Open)
+                if (socket.State == WebSocketState.Open && disposed == 0)
                 {
                     connection.log.LogDebug( nameof(WebSocketContext), "Closing connection...");
                     try
                     {
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, default).ConfigureAwait(false);
                     }
-                    catch ( ObjectDisposedException ex )
-                    {
-                        connection.log.LogDebug( nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
-                    }
-                    catch ( Win32Exception ex )
+                    catch (Win32Exception ex)
                     {
                         connection.log.LogDebug( nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
                     }

--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
@@ -94,7 +94,11 @@ namespace SteamKit2
                     {
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, default).ConfigureAwait(false);
                     }
-                    catch (Win32Exception ex)
+                    catch ( ObjectDisposedException ex )
+                    {
+                        connection.log.LogDebug( nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
+                    }
+                    catch ( Win32Exception ex )
                     {
                         connection.log.LogDebug( nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
                     }

--- a/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
+++ b/SteamKit2/SteamKit2/Networking/Steam3/WebSocketContext.cs
@@ -21,14 +21,12 @@ namespace SteamKit2
 
                 cts = new CancellationTokenSource();
                 socket = new ClientWebSocket();
-                semaphore = new SemaphoreSlim( 1, 1 );
                 connectionUri = ConstructUri(endPoint);
             }
 
             readonly WebSocketConnection connection;
             readonly CancellationTokenSource cts;
             readonly ClientWebSocket socket;
-            readonly SemaphoreSlim semaphore;
             readonly Uri connectionUri;
             Task? runloopTask;
             int disposed;
@@ -68,47 +66,25 @@ namespace SteamKit2
                 connection.log.LogDebug( nameof(WebSocketContext), "Connected to {0}", connectionUri);
                 connection.Connected?.Invoke(connection, EventArgs.Empty);
 
-                await semaphore.WaitAsync(CancellationToken.None).ConfigureAwait( false );
-
-                try
+                while (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
                 {
-                    while (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
+                    byte[]? packet = null;
+
+                    try
                     {
-                        byte[]? packet = null;
-
-                        try
-                        {
-                            packet = await ReadMessageAsync( cancellationToken ).ConfigureAwait( false );
-                        }
-                        catch ( Exception ex )
-                        {
-                            connection.log.LogDebug( nameof( WebSocketContext ), "Exception reading from websocket: {0} - {1}", ex.GetType().FullName, ex.Message );
-                            connection.DisconnectCore( userInitiated: false, specificContext: this );
-                            return;
-                        }
-
-                        if (packet != null && packet.Length > 0)
-                        {
-                            connection.NetMsgReceived?.Invoke(connection, new NetMsgEventArgs(packet, EndPoint));
-                        }
+                        packet = await ReadMessageAsync( cancellationToken ).ConfigureAwait( false );
+                    }
+                    catch ( Exception ex )
+                    {
+                        connection.log.LogDebug( nameof( WebSocketContext ), "Exception reading from websocket: {0} - {1}", ex.GetType().FullName, ex.Message );
+                        connection.DisconnectCore( userInitiated: false, specificContext: this );
+                        return;
                     }
 
-                    if (!cancellationToken.IsCancellationRequested && socket.State == WebSocketState.Open)
+                    if (packet != null && packet.Length > 0)
                     {
-                        connection.log.LogDebug( nameof(WebSocketContext), "Closing connection...");
-                        try
-                        {
-                            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, default).ConfigureAwait(false);
-                        }
-                        catch (Win32Exception ex)
-                        {
-                            connection.log.LogDebug( nameof(WebSocketContext), "Error closing connection: {0}", ex.Message);
-                        }
+                        connection.NetMsgReceived?.Invoke(connection, new NetMsgEventArgs(packet, EndPoint));
                     }
-                }
-                finally
-                {
-                    semaphore.Release();
                 }
             }
 
@@ -128,24 +104,27 @@ namespace SteamKit2
 
             public void Dispose()
             {
-                if ( Interlocked.Exchange( ref disposed, 1 ) == 1 )
+                if (Interlocked.Exchange(ref disposed, 1) == 1)
                 {
                     return;
                 }
 
                 cts.Cancel();
-                semaphore.Wait();
-                try
-                {
-                    cts.Dispose();
-                    runloopTask = null;
+                cts.Dispose();
+                runloopTask = null;
 
-                    socket.Dispose();
-                }
-                finally
+                if (socket.State == WebSocketState.Open)
                 {
-                    semaphore.Dispose();
+                    try
+                    {
+                        socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None).RunSynchronously();
+                    }
+                    catch ( WebSocketException )
+                    {
+                    }
                 }
+
+                socket.Dispose();
             }
 
             async Task<byte[]?> ReadMessageAsync( CancellationToken cancellationToken )


### PR DESCRIPTION
Fixes #524.

### Some investigation
Originally I had the following stacktrace for ArchiSteamFarm:
```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.WebSockets.ClientWebSocket'.
   at System.Net.WebSockets.ClientWebSocket.get_ConnectedWebSocket()
   at SteamKit2.WebSocketConnection.WebSocketContext.RunCore(HttpMessageInvoker invoker, TimeSpan connectionTimeout, CancellationToken cancellationToken)
   at SteamKit2.TaskExtensions.IgnoringCancellation(Task task, CancellationToken token)
```

`ConnectedWebSocket` is a private property and there is no mention of it in SteamKit codebase whatsoever, so there is definitely some method that got inlined and its stackframe was omitted.
`ClientWebSocket` accesses that property in 7 methods:
- `SendAsync` (+2 overloads),
- `ReceiveAsync` (+1 overload),
- `CloseAsync`,
- `CloseOutputAsync`.

`WebSocketContext` calls these methods in these cases:
- `SendAsync` is called from `WebSocketContext.SendAsync` <- `WebSocketConnection.Send`, which doesn't match our stacktrace,
- `ReceiveAsync` is called from `ReadMessageAsync`, but the `ObjectDisposedException` is explicitly handled there,
- `CloseAsync` seems to be the only suitable candidate.