### PR TITLE
Improve finding proto descriptors

### DIFF
--- a/Resources/ProtobufDumper/ProtobufDumper/Program.cs
+++ b/Resources/ProtobufDumper/ProtobufDumper/Program.cs
@@ -79,25 +79,21 @@ namespace ProtobufDumper
             {
                 Console.WriteLine( "Loading binary '{0}'...", target );
 
-                ExecutableScanner.ScanFile( target, ( name, buffer ) =>
+                ExecutableScanner.ScanFile( target, ( string name, Stream buffer, out long bytesConsumed ) =>
                 {
+                    bytesConsumed = 0;
+
                     if ( collector.Candidates.Find( c => c.name == name ) != null ) return true;
 
                     Console.Write( "{0}... ", name );
 
-                    var complete = collector.TryParseCandidate( buffer, out var result, out var error );
+                    var complete = collector.TryParseCandidate( buffer, out var result, out var error, out bytesConsumed );
 
                     switch ( result )
                     {
                         case ProtobufCollector.CandidateResult.OK:
                             Console.ForegroundColor = ConsoleColor.Green;
                             Console.WriteLine( "OK!" );
-                            Console.ResetColor();
-                            break;
-
-                        case ProtobufCollector.CandidateResult.Rescan:
-                            Console.ForegroundColor = ConsoleColor.Cyan;
-                            Console.WriteLine( "needs rescan: {0}", error.Message );
                             Console.ResetColor();
                             break;
 

--- a/Resources/ProtobufDumper/ProtobufDumper/ProtobufCollector.cs
+++ b/Resources/ProtobufDumper/ProtobufDumper/ProtobufCollector.cs
@@ -13,7 +13,6 @@ namespace ProtobufDumper
         public enum CandidateResult
         {
             OK,
-            Rescan,
             Invalid
         }
 
@@ -22,19 +21,25 @@ namespace ProtobufDumper
             Candidates = [];
         }
 
-        public bool TryParseCandidate( Stream data, out CandidateResult result, out Exception error )
+        public bool TryParseCandidate( Stream data, out CandidateResult result, out Exception error, out long bytesConsumed )
         {
             FileDescriptorProto candidate;
+            bytesConsumed = 0;
 
             try
             {
-                candidate = Serializer.Deserialize<FileDescriptorProto>( data );
-            }
-            catch ( EndOfStreamException ex )
-            {
-                result = CandidateResult.Rescan;
-                error = ex;
-                return false;
+                bytesConsumed = ConsumeOneMessage( data );
+
+                if ( bytesConsumed == 0 )
+                {
+                    throw new InvalidDataException( "No data was consumed" );
+                }
+
+                data.Position = 0;
+                var buffer = new byte[ bytesConsumed ];
+                data.Read( buffer, 0, ( int )bytesConsumed );
+
+                candidate = Serializer.Deserialize<FileDescriptorProto>( buffer.AsSpan() );
             }
             catch ( Exception ex )
             {
@@ -48,6 +53,46 @@ namespace ProtobufDumper
             result = CandidateResult.OK;
             error = null;
             return true;
+        }
+
+        private static long ConsumeOneMessage( Stream data )
+        {
+            bool consumedFieldOne = false;
+
+            using var state = ProtoReader.State.Create( data, null, null );
+
+            while ( true )
+            {
+                long positionBeforeField = state.GetPosition();
+
+                try
+                {
+                    var fieldNumber = state.ReadFieldHeader();
+
+                    if ( fieldNumber == 0 )
+                    {
+                        return positionBeforeField;
+                    }
+
+                    // Field 1 is the "name" field in FileDescriptorProto
+                    // If we see it twice, we've hit the next message
+                    if ( fieldNumber == 1 )
+                    {
+                        if ( consumedFieldOne )
+                        {
+                            return positionBeforeField;
+                        }
+
+                        consumedFieldOne = true;
+                    }
+
+                    state.SkipField();
+                }
+                catch
+                {
+                    return positionBeforeField;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes dumping protos from binaries where they come one after another (so the deserializer keeps seeing fields and stomping over the previous one -- this even crashed on libcef).



This also removes the need to rescan the data, since it knows when the proto ends.



The fix is to try to consume the fields until it reads the field 1 again, or it fails to read a field.

