### PR TITLE
Update renamed filename in protos.csv

### DIFF
--- a/Resources/ProtobufGen/protos.csv
+++ b/Resources/ProtobufGen/protos.csv
@@ -89,7 +89,6 @@ deadlock,steammessages.proto,GC\Deadlock\SteamMsgBase.cs,SteamKit2.GC.Deadlock.I
 dota2,base_gcmessages.proto,GC\Dota\SteamMsgGC.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_client_enums.proto,GC\Dota\MsgClientEnums.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_client.proto,GC\Dota\MsgGCClient.cs,SteamKit2.GC.Dota.Internal
-dota2,dota_gcmessages_client_battle_report.proto,GC\Dota\MsgMCClientBattleReport.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_client_chat.proto,GC\Dota\MsgGCClientChat.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_client_coaching.proto,GC\Dota\MsgGCClientCoaching.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_client_craftworks.proto,GC\Dota\MSGGCClientCraftworks.cs,SteamKit2.GC.Dota.Internal
@@ -101,6 +100,7 @@ dota2,dota_gcmessages_client_team.proto,GC\Dota\MsgGCClientTeam.cs,SteamKit2.GC.
 dota2,dota_gcmessages_client_tournament.proto,GC\Dota\MsgGCClientTournament.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_client_watch.proto,GC\Dota\MsgGCClientWatch.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_common.proto,GC\Dota\MsgGCCommon.cs,SteamKit2.GC.Dota.Internal
+dota2,dota_gcmessages_common_battle_report.proto,GC\Dota\MsgMCClientBattleReport.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_common_craftworks.proto,GC\Dota\MSGGCCommonCraftworks.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_common_league.proto,GC\Dota\MsgGCCommonLeague.cs,SteamKit2.GC.Dota.Internal
 dota2,dota_gcmessages_common_lobby.proto,GC\Dota\MsgGCCommonLobby.cs,SteamKit2.GC.Dota.Internal


### PR DESCRIPTION
The renaming happened between 1348c75...269a4de
[dota2/{dota_gcmessages_client_battle_report.proto → dota_gcmessages_common_battle_report.proto}](https://github.com/SteamDatabase/Protobufs/compare/1348c75...269a4de)